### PR TITLE
fix(avoidance): fix bug in backward length calculation

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1939,7 +1939,6 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
 {
   const auto previous_path = helper_.getPreviousReferencePath();
 
-  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
   const auto longest_dist_to_shift_point = [&]() {
     double max_dist = 0.0;
     for (const auto & pnt : path_shifter_.getShiftLines()) {

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1432,8 +1432,9 @@ AvoidLineArray AvoidanceModule::applyFillGapProcess(
 
 AvoidLineArray AvoidanceModule::applyCombineProcess(
   const AvoidLineArray & shift_lines, const AvoidLineArray & registered_lines,
-  [[maybe_unused]] DebugData & debug) const
+  DebugData & debug) const
 {
+  debug.step1_registered_shift_line = registered_lines;
   return utils::avoidance::combineRawShiftLinesWithUniqueCheck(registered_lines, shift_lines);
 }
 
@@ -1936,14 +1937,18 @@ void AvoidanceModule::generateExpandDrivableLanes(BehaviorModuleOutput & output)
 
 PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & original_path) const
 {
+  const auto previous_path = helper_.getPreviousReferencePath();
+
   // special for avoidance: take behind distance upt ot shift-start-point if it exist.
   const auto longest_dist_to_shift_point = [&]() {
     double max_dist = 0.0;
     for (const auto & pnt : path_shifter_.getShiftLines()) {
-      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
+      max_dist = std::max(
+        max_dist, calcSignedArcLength(previous_path.points, pnt.start.position, getEgoPosition()));
     }
     for (const auto & sp : registered_raw_shift_lines_) {
-      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sp.start));
+      max_dist = std::max(
+        max_dist, calcSignedArcLength(previous_path.points, sp.start.position, getEgoPosition()));
     }
     return max_dist;
   }();
@@ -1951,11 +1956,11 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
   const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
   const auto backward_length = std::max(
     planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
-  const auto previous_path = helper_.getPreviousReferencePath();
 
   const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
-  const size_t prev_ego_idx =
-    findNearestSegmentIndex(previous_path.points, getPoint(original_path.points.at(orig_ego_idx)));
+  const size_t prev_ego_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+    previous_path.points, getPose(original_path.points.at(orig_ego_idx)),
+    std::numeric_limits<double>::max(), planner_data_->parameters.ego_nearest_yaw_threshold);
 
   size_t clip_idx = 0;
   for (size_t i = 0; i < prev_ego_idx; ++i) {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27610ff</samp>

Improve the avoidance module in `behavior_path_planner` by enhancing path calculation, ego index finding, and visualization methods. Use a parameter to filter out bad points in the previous path.

---

### Before this PR

Backward length is **NOT** extended properly at HIGH CURVERTURE route because it uses `calcDistance2d` to calculate distance between ego and shift start point.

```c++
  const auto longest_dist_to_shift_point = [&]() {
    double max_dist = 0.0;
    for (const auto & pnt : path_shifter_.getShiftLines()) {
      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
    }
    for (const auto & sp : registered_raw_shift_lines_) {
      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sp.start));
    }
    return max_dist;
  }();
```

![269207115-07d60b50-121e-443a-a0fd-4943aa618100](https://github.com/autowarefoundation/autoware.universe/assets/44889564/bf6b122d-4908-485b-b791-eac634a789af)

### After this PR

Use `calcSignArcLength` so that it can caluclate proper distance.

```c++
  const auto longest_dist_to_shift_point = [&]() {
    double max_dist = 0.0;
    for (const auto & pnt : path_shifter_.getShiftLines()) {
      max_dist = std::max(
        max_dist, calcSignedArcLength(previous_path.points, pnt.start.position, getEgoPosition()));
    }
    for (const auto & sp : registered_raw_shift_lines_) {
      max_dist = std::max(
        max_dist, calcSignedArcLength(previous_path.points, sp.start.position, getEgoPosition()));
    }
    return max_dist;
  }();
```

![269207103-cc3c98b1-a7f7-49e6-ae9f-15456cc25c96](https://github.com/autowarefoundation/autoware.universe/assets/44889564/2e899db2-0a43-434b-8229-1eb927125879)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/739d42ae-fef6-541b-915c-746fe2fa5244?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
