### PR TITLE
feat(image_projection_based_fusion): introduce diag for monitoring time sync status

### DIFF
--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
@@ -90,6 +90,8 @@ protected:
   virtual void postprocess(Msg & output_msg);
 
   virtual void publish(const Msg & output_msg);
+  void publishDiagnostics(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
+    const std::size_t camera_id) const;
 
   void timer_callback();
   void setPeriod(const int64_t new_period);
@@ -105,6 +107,7 @@ protected:
   rclcpp::TimerBase::SharedPtr timer_;
   double timeout_ms_{};
   double match_threshold_ms_{};
+  double time_sync_tolerance_sec_{};
   std::vector<std::string> input_rois_topics_;
   std::vector<std::string> input_camera_info_topics_;
   std::vector<std::string> input_camera_topics_;
@@ -124,6 +127,7 @@ protected:
 
   // output publisher
   typename rclcpp::Publisher<Msg>::SharedPtr pub_ptr_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diag_;
 
   // debugger
   std::shared_ptr<Debugger> debugger_;

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
@@ -91,7 +91,8 @@ protected:
   virtual void postprocess(Msg & output_msg);
 
   virtual void publish(const Msg & output_msg);
-  void publishDiagnostics(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
+  void publishDiagnostics(
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
     const std::size_t camera_id) const;
 
   void timer_callback();

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
@@ -21,6 +21,7 @@
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>

--- a/perception/image_projection_based_fusion/package.xml
+++ b/perception/image_projection_based_fusion/package.xml
@@ -14,6 +14,7 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>cv_bridge</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>euclidean_cluster</depend>
   <depend>image_transport</depend>
   <depend>lidar_centerpoint</depend>

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -428,9 +428,9 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
   const std::size_t camera_id) const
 {
-  const double time_difference_sec =
-    rclcpp::Time(input_camera_info_msg->header.stamp) - rclcpp::Time(this->now());
-
+  const double time_difference_sec = (rclcpp::Time(input_camera_info_msg->header.stamp) -
+    rclcpp::Time(this->now())).seconds();
+  
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
   diagnostic_msgs::msg::DiagnosticStatus status;
@@ -439,8 +439,7 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
 
   if (time_difference_sec > time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    status.message =
-      "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
+    status.message = "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
   } else if (time_difference_sec > -time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     status.message = "Camera timestamp is valid: " + std::to_string(time_difference_sec) + " sec";

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -428,9 +428,9 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
   const std::size_t camera_id) const
 {
-  const double time_difference_sec = rclcpp::Time(input_camera_info_msg->header.stamp) -
-    rclcpp::Time(this->now());
-  
+  const double time_difference_sec =
+    rclcpp::Time(input_camera_info_msg->header.stamp) - rclcpp::Time(this->now());
+
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
   diagnostic_msgs::msg::DiagnosticStatus status;
@@ -445,8 +445,8 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
     status.message = "Camera timestamp is valid: " + std::to_string(time_difference_sec) + " sec";
   } else {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    status.message = "Camera timestamp is in the future: " + std::to_string(time_difference_sec) +
-      " sec";
+    status.message =
+      "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
   }
   diagnostic_msgs::msg::DiagnosticArray diag;
   diag.header.stamp = this->now();

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -428,9 +428,9 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
   const std::size_t camera_id) const
 {
-  const double time_difference_sec = (rclcpp::Time(input_camera_info_msg->header.stamp) -
-    rclcpp::Time(this->now())).seconds();
-  
+  const double time_difference_sec =
+    (rclcpp::Time(input_camera_info_msg->header.stamp) - rclcpp::Time(this->now())).seconds();
+
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
   diagnostic_msgs::msg::DiagnosticStatus status;
@@ -439,7 +439,8 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
 
   if (time_difference_sec > time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    status.message = "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
+    status.message =
+      "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
   } else if (time_difference_sec > -time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     status.message = "Camera timestamp is valid: " + std::to_string(time_difference_sec) + " sec";

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -428,9 +428,9 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
   const std::size_t camera_id) const
 {
-  const double time_difference_sec = rclcpp::Time(input_camera_info_msg->header.stamp) -
-    rclcpp::Time(this->now());
-  
+  const double time_difference_sec =
+    rclcpp::Time(input_camera_info_msg->header.stamp) - rclcpp::Time(this->now());
+
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
   diagnostic_msgs::msg::DiagnosticStatus status;
@@ -439,8 +439,8 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
 
   if (time_difference_sec > time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    status.message = "Camera timestamp is in the future: " + std::to_string(time_difference_sec) +
-      " sec";
+    status.message =
+      "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
   } else if (time_difference_sec > -time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     status.message = "Camera timestamp is valid: " + std::to_string(time_difference_sec) + " sec";

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -428,9 +428,9 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_camera_info_msg,
   const std::size_t camera_id) const
 {
-  const double time_difference_sec =
-    rclcpp::Time(input_camera_info_msg->header.stamp) - rclcpp::Time(this->now());
-
+  const double time_difference_sec = rclcpp::Time(input_camera_info_msg->header.stamp) -
+    rclcpp::Time(this->now());
+  
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
   diagnostic_msgs::msg::DiagnosticStatus status;
@@ -439,14 +439,14 @@ void FusionNode<Msg, Obj>::publishDiagnostics(
 
   if (time_difference_sec > time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    status.message = "Camera timestamp is too old: " + std::to_string(time_difference_sec) + " sec";
+    status.message = "Camera timestamp is in the future: " + std::to_string(time_difference_sec) +
+      " sec";
   } else if (time_difference_sec > -time_sync_tolerance_sec_) {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     status.message = "Camera timestamp is valid: " + std::to_string(time_difference_sec) + " sec";
   } else {
-    status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    status.message =
-      "Camera timestamp is in the future: " + std::to_string(time_difference_sec) + " sec";
+    status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    status.message = "Camera timestamp is too old: " + std::to_string(time_difference_sec) + " sec";
   }
   diagnostic_msgs::msg::DiagnosticArray diag;
   diag.header.stamp = this->now();


### PR DESCRIPTION
## Description

Introduce diag for camera timestamp difference. Primarily this is to avoid missing the PTP-related errors.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
