### PR TITLE
fix(object_merger): fixed sync_queue_size parameter

### DIFF
--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -15,7 +15,7 @@
     <param from="$(var data_association_matrix_path)"/>
     <param from="$(var distance_threshold_list_path)"/>
     <param name="priority_mode" value="$(var priority_mode)"/>
-    <param name="sync_queue_size" value="sync_queue_size"/>
+    <param name="sync_queue_size" value="$(var sync_queue_size)"/>
     <param name="precision_threshold_to_judge_overlapped" value="0.4"/>
     <param name="remove_overlapped_unknown_objects" value="true"/>
   </node>


### PR DESCRIPTION
## Description

 #4994 introduced a minor bug, because a new parameter was not passed appropriately:
```
[object_association_merger_node-45] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterTypeException'
[object_association_merger_node-45]   what():  parameter 'sync_queue_size' has invalid type: Wrong parameter type, parameter {sync_queue_size} is of type {integer}, setting it to {string} is not allowed.
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
