### PR TITLE
fix(simple_planning_simulator): fix build error

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -269,7 +269,7 @@ private:
    * @brief ControlModeRequest server
    */
   void on_control_mode_request(
-    const ControlModeCommand::Request::SharedPtr request,
+    const ControlModeCommand::Request::ConstSharedPtr request,
     const ControlModeCommand::Response::SharedPtr response);
 
   /**

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -117,16 +117,18 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
     "input/initialtwist", QoS{1}, std::bind(&SimplePlanningSimulator::on_initialtwist, this, _1));
   sub_ackermann_cmd_ = create_subscription<AckermannControlCommand>(
     "input/ackermann_control_command", QoS{1},
-    [this](const AckermannControlCommand::SharedPtr msg) { current_ackermann_cmd_ = *msg; });
+    [this](const AckermannControlCommand::ConstSharedPtr msg) { current_ackermann_cmd_ = *msg; });
   sub_manual_ackermann_cmd_ = create_subscription<AckermannControlCommand>(
     "input/manual_ackermann_control_command", QoS{1},
-    [this](const AckermannControlCommand::SharedPtr msg) { current_manual_ackermann_cmd_ = *msg; });
+    [this](const AckermannControlCommand::ConstSharedPtr msg) {
+      current_manual_ackermann_cmd_ = *msg;
+    });
   sub_gear_cmd_ = create_subscription<GearCommand>(
     "input/gear_command", QoS{1},
-    [this](const GearCommand::SharedPtr msg) { current_gear_cmd_ = *msg; });
+    [this](const GearCommand::ConstSharedPtr msg) { current_gear_cmd_ = *msg; });
   sub_manual_gear_cmd_ = create_subscription<GearCommand>(
     "input/manual_gear_command", QoS{1},
-    [this](const GearCommand::SharedPtr msg) { current_manual_gear_cmd_ = *msg; });
+    [this](const GearCommand::ConstSharedPtr msg) { current_manual_gear_cmd_ = *msg; });
   sub_turn_indicators_cmd_ = create_subscription<TurnIndicatorsCommand>(
     "input/turn_indicators_command", QoS{1},
     std::bind(&SimplePlanningSimulator::on_turn_indicators_cmd, this, _1));
@@ -484,7 +486,7 @@ void SimplePlanningSimulator::on_engage(const Engage::ConstSharedPtr msg)
 }
 
 void SimplePlanningSimulator::on_control_mode_request(
-  const ControlModeCommand::Request::SharedPtr request,
+  const ControlModeCommand::Request::ConstSharedPtr request,
   const ControlModeCommand::Response::SharedPtr response)
 {
   const auto m = request->mode;

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -49,7 +49,7 @@ public:
   {
     current_odom_sub_ = create_subscription<Odometry>(
       "output/odometry", rclcpp::QoS{1},
-      [this](const Odometry::SharedPtr msg) { current_odom_ = msg; });
+      [this](const Odometry::ConstSharedPtr msg) { current_odom_ = msg; });
     pub_ackermann_command_ =
       create_publisher<AckermannControlCommand>("input/ackermann_control_command", rclcpp::QoS{1});
     pub_initialpose_ =
@@ -62,7 +62,7 @@ public:
   rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_cmd_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_initialpose_;
 
-  Odometry::SharedPtr current_odom_;
+  Odometry::ConstSharedPtr current_odom_;
 };
 
 /**


### PR DESCRIPTION
## Description

Fix following error.

```
/opt/ros/humble/include/rclcpp/rclcpp/node_impl.hpp:99:47:   required from ‘std::shared_ptr<ROSMessageT> rclcpp::Node::create_subscription(const string&, const rclcpp::QoS&, CallbackT&&, const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&, typename MessageMemoryStrategyT::SharedPtr) [with MessageT = autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> >; CallbackT = simulation::s
imple_planning_simulator::SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions&)::<lambda(autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> >::SharedPtr)>; AllocatorT = std::allocator<void>; SubscriptionT = rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> > >; MessageMemoryStrategyT = rclcpp::message_memory_strat
egy::MessageMemoryStrategy<autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> >, std::allocator<void> >; std::string = std::__cxx11::basic_string<char>; typename MessageMemoryStrategyT::SharedPtr = std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> >, std::allocator<void> > >]’           
/home/satoshi/pilot-auto/src/autoware/universe/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp:118:68:   required from here                                                                                                                                                                                                                                                
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:391:21: error: ‘void rclcpp::AnySubscriptionCallback<MessageT, AllocatorT>::set_deprecated(std::function<void(std::shared_ptr<_Yp>)>) [with SetT = autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> >; MessageT = autoware_auto_control_msgs::msg::AckermannControlCommand_<std::allocator<void> >; AllocatorT = std::allocato
r<void>]’ is deprecated: use 'void(std::shared_ptr<const MessageT>)' instead [-Werror=deprecated-declarations]                                                                                                                                                                                                                                                                                                                  
  391 |       set_deprecated(static_cast<typename scbth::callback_type>(callback));                                                                                                                                                                                                                                                                                                                                             
      |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                              
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:408:3: note: declared here                                                                                                                                                                                                                                                                                                                                  
  408 |   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)                                                                                                                                                                                                                                                                                                                                                   
      |   ^~~~~~~~~~~~~~ 
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
