### PR TITLE
feat(behavior_velocity_planner): enable dynamic load/unload modules

### DIFF
--- a/planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/CMakeLists.txt
@@ -2,17 +2,35 @@ cmake_minimum_required(VERSION 3.14)
 project(behavior_velocity_planner)
 
 find_package(autoware_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(
+  ${PROJECT_NAME}
+  "srv/LoadPlugin.srv"
+  "srv/UnloadPlugin.srv"
+  DEPENDENCIES
+)
+
 autoware_package()
 
-ament_auto_add_library(${PROJECT_NAME} SHARED
+ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   src/node.cpp
   src/planner_manager.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}_lib
   PLUGIN "behavior_velocity_planner::BehaviorVelocityPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
+
+if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
+    rosidl_target_interfaces(${PROJECT_NAME}_lib
+    ${PROJECT_NAME} "rosidl_typesupport_cpp")
+else()
+    rosidl_get_typesupport_target(
+            cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+    target_link_libraries(${PROJECT_NAME}_lib "${cpp_typesupport_target}")
+endif()
 
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
@@ -20,7 +38,7 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_${PROJECT_NAME}
     gtest_main
-    ${PROJECT_NAME}
+    ${PROJECT_NAME}_lib
   )
   target_include_directories(test_${PROJECT_NAME} PRIVATE src)
 endif()

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -33,6 +33,8 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <build_depend>rosidl_default_generators</build_depend>
+
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
@@ -60,6 +62,8 @@
   <depend>tier4_v2x_msgs</depend>
   <depend>visualization_msgs</depend>
 
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
@@ -77,6 +81,8 @@
   <test_depend>behavior_velocity_traffic_light_module</test_depend>
   <test_depend>behavior_velocity_virtual_traffic_light_module</test_depend>
   <test_depend>behavior_velocity_walkway_module</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/behavior_velocity_planner/src/node.hpp
+++ b/planning/behavior_velocity_planner/src/node.hpp
@@ -17,6 +17,8 @@
 
 #include "planner_manager.hpp"
 
+#include <behavior_velocity_planner/srv/load_plugin.hpp>
+#include <behavior_velocity_planner/srv/unload_plugin.hpp>
 #include <behavior_velocity_planner_common/planner_data.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -38,11 +40,15 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace behavior_velocity_planner
 {
 using autoware_auto_mapping_msgs::msg::HADMapBin;
+using behavior_velocity_planner::srv::LoadPlugin;
+using behavior_velocity_planner::srv::UnloadPlugin;
 using tier4_planning_msgs::msg::VelocityLimit;
+
 class BehaviorVelocityPlannerNode : public rclcpp::Node
 {
 public:
@@ -102,6 +108,14 @@ private:
   bool is_driving_forward_{true};
   HADMapBin::ConstSharedPtr map_ptr_{nullptr};
   bool has_received_map_;
+
+  rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
+  rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;
+  void onUnloadPlugin(
+    const UnloadPlugin::Request::SharedPtr request,
+    const UnloadPlugin::Response::SharedPtr response);
+  void onLoadPlugin(
+    const LoadPlugin::Request::SharedPtr request, const LoadPlugin::Response::SharedPtr response);
 
   // mutex for planner_data_
   std::mutex mutex_;

--- a/planning/behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/src/planner_manager.cpp
@@ -60,9 +60,39 @@ void BehaviorVelocityPlannerManager::launchScenePlugin(
   if (plugin_loader_.isClassAvailable(name)) {
     const auto plugin = plugin_loader_.createSharedInstance(name);
     plugin->init(node);
+
+    // Check if the plugin is already registered. 
+    for (const auto & running_plugin : scene_manager_plugins_) {
+      if (plugin->getModuleName() == running_plugin->getModuleName()) {
+        RCLCPP_WARN_STREAM(node.get_logger(), "The plugin '" << name << "' is already loaded.");
+        return;
+      }
+    }
+
+    // register
     scene_manager_plugins_.push_back(plugin);
+    RCLCPP_INFO_STREAM(node.get_logger(), "The scene plugin '" << name << "' is loaded.");
   } else {
     RCLCPP_ERROR_STREAM(node.get_logger(), "The scene plugin '" << name << "' is not available.");
+  }
+}
+
+void BehaviorVelocityPlannerManager::removeScenePlugin(
+  rclcpp::Node & node, const std::string & name)
+{
+  auto it = std::remove_if(
+    scene_manager_plugins_.begin(), scene_manager_plugins_.end(),
+    [&](const std::shared_ptr<behavior_velocity_planner::PluginInterface> plugin) {
+      return plugin->getModuleName() == name;
+    });
+
+  if (it == scene_manager_plugins_.end()) {
+    RCLCPP_WARN_STREAM(
+      node.get_logger(),
+      "The scene plugin '" << name << "' is not found in the registered modules.");
+  } else {
+    scene_manager_plugins_.erase(it, scene_manager_plugins_.end());
+    RCLCPP_INFO_STREAM(node.get_logger(), "The scene plugin '" << name << "' is unloaded.");
   }
 }
 

--- a/planning/behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/src/planner_manager.cpp
@@ -61,7 +61,7 @@ void BehaviorVelocityPlannerManager::launchScenePlugin(
     const auto plugin = plugin_loader_.createSharedInstance(name);
     plugin->init(node);
 
-    // Check if the plugin is already registered. 
+    // Check if the plugin is already registered.
     for (const auto & running_plugin : scene_manager_plugins_) {
       if (plugin->getModuleName() == running_plugin->getModuleName()) {
         RCLCPP_WARN_STREAM(node.get_logger(), "The plugin '" << name << "' is already loaded.");

--- a/planning/behavior_velocity_planner/src/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/src/planner_manager.hpp
@@ -43,6 +43,7 @@ class BehaviorVelocityPlannerManager
 public:
   BehaviorVelocityPlannerManager();
   void launchScenePlugin(rclcpp::Node & node, const std::string & name);
+  void removeScenePlugin(rclcpp::Node & node, const std::string & name);
 
   autoware_auto_planning_msgs::msg::PathWithLaneId planPathVelocity(
     const std::shared_ptr<const PlannerData> & planner_data,

--- a/planning/behavior_velocity_planner/srv/LoadPlugin.srv
+++ b/planning/behavior_velocity_planner/srv/LoadPlugin.srv
@@ -1,0 +1,3 @@
+string plugin_name
+---
+bool success

--- a/planning/behavior_velocity_planner/srv/UnloadPlugin.srv
+++ b/planning/behavior_velocity_planner/srv/UnloadPlugin.srv
@@ -1,0 +1,3 @@
+string plugin_name
+---
+bool success


### PR DESCRIPTION
## Description

This PR enables dynamic load/unload behavior_velocity modules via service.

**Examples:** 

Load `stop_line` module
```
ros2 service call \
/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/service/load_plugin \
behavior_velocity_planner/srv/LoadPlugin "{plugin_name: "behavior_velocity_planner::StopLineModulePlugin"}"
```


Unload `stop_line` module

```
ros2 service call \
/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/service/unload_plugin \
behavior_velocity_planner/srv/UnloadPlugin "{plugin_name: "stop_line"}"
```


https://github.com/autowarefoundation/autoware.universe/assets/21360593/0c8dcac1-94a3-4778-b35e-f0aacf6878f1



## Related links

None

## Tests performed

run psim

## Notes for reviewers

None

## Interface changes

new service is added in the behavior_velocity_planner

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

we can load/unload modules dynamically.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
