### PR TITLE
fix(lane_change): object filter other lane object

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -734,15 +734,9 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
       }
     }
 
-    const auto check_backward_polygon = [&](const auto & target_backward_polygon) {
-      if (
-        target_backward_polygon &&
-        boost::geometry::intersects(target_backward_polygon.value(), obj_polygon)) {
-        const auto lateral = tier4_autoware_utils::calcLateralDeviation(
-          current_pose, object.kinematics.initial_pose_with_covariance.pose.position);
-        return (std::abs(lateral) > common_parameters.vehicle_width);
-      }
-      return false;
+    const auto check_backward_polygon = [&obj_polygon](const auto & target_backward_polygon) {
+      return target_backward_polygon &&
+             boost::geometry::intersects(target_backward_polygon.value(), obj_polygon);
     };
 
     // check if the object intersects with target backward lanes

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -681,6 +681,7 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     lanelet::ConstLanelets lanelet{target_backward_lane};
     auto lane_polygon =
       utils::lane_change::createPolygon(lanelet, 0.0, std::numeric_limits<double>::max());
+    target_backward_polygons.push_back(lane_polygon);
   }
 
   auto filtered_objects = objects;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -674,10 +674,14 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     utils::lane_change::createPolygon(current_lanes, 0.0, std::numeric_limits<double>::max());
   const auto target_polygon =
     utils::lane_change::createPolygon(target_lanes, 0.0, std::numeric_limits<double>::max());
-  const auto target_backward_polygon = utils::lane_change::createPolygon(
-    target_backward_lanes, 0.0, std::numeric_limits<double>::max());
   const auto dist_ego_to_current_lanes_center =
     lanelet::utils::getLateralDistanceToClosestLanelet(current_lanes, current_pose);
+  std::vector<std::optional<lanelet::BasicPolygon2d>> target_backward_polygons;
+  for (const auto & target_backward_lane : target_backward_lanes) {
+    lanelet::ConstLanelets lanelet{target_backward_lane};
+    auto lane_polygon =
+      utils::lane_change::createPolygon(lanelet, 0.0, std::numeric_limits<double>::max());
+  }
 
   auto filtered_objects = objects;
 
@@ -730,10 +734,22 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
       }
     }
 
+    const auto check_backward_polygon = [&](const auto & target_backward_polygon) {
+      if (
+        target_backward_polygon &&
+        boost::geometry::intersects(target_backward_polygon.value(), obj_polygon)) {
+        const auto lateral = tier4_autoware_utils::calcLateralDeviation(
+          current_pose, object.kinematics.initial_pose_with_covariance.pose.position);
+        return (std::abs(lateral) > common_parameters.vehicle_width);
+      }
+      return false;
+    };
+
     // check if the object intersects with target backward lanes
     if (
-      target_backward_polygon &&
-      boost::geometry::intersects(target_backward_polygon.value(), obj_polygon)) {
+      !target_backward_polygons.empty() &&
+      std::any_of(
+        target_backward_polygons.begin(), target_backward_polygons.end(), check_backward_polygon)) {
       filtered_obj_indices.target_lane.push_back(i);
       continue;
     }


### PR DESCRIPTION
## Description

In the image below

![image](https://github.com/autowarefoundation/autoware.universe/assets/93502286/4df6007d-6dae-4f03-a1e9-706ef9f149c7)

lane change module has mistakenly assume the the incoming object belongs to the target lane.
In this PR, we aim to fix this issue.

#### Before PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/d5d9aa6d-7e47-476b-9902-75265aff85a8


#### After PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/05ad2b5b-e73a-44e4-8b4d-026f08f2686e

## Related links

None

## Tests performed

Test via PSIM

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
