### PR TITLE
fix(autoware_auto_tf2): remove tf2 geometry function duplicated in tf2 geometry msgs

### DIFF
--- a/common/autoware_auto_geometry/CMakeLists.txt
+++ b/common/autoware_auto_geometry/CMakeLists.txt
@@ -12,12 +12,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/bounding_box.cpp
 )
 
-if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE
-    DEFINE_LEGACY_FUNCTION
-  )
-endif()
-
 if(BUILD_TESTING)
   set(GEOMETRY_GTEST geometry_gtest)
   set(GEOMETRY_SRC test/src/test_geometry.cpp

--- a/common/autoware_auto_tf2/CMakeLists.txt
+++ b/common/autoware_auto_tf2/CMakeLists.txt
@@ -17,11 +17,6 @@ if(BUILD_TESTING)
     "tf2_geometry_msgs"
     "tf2_ros"
   )
-  if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
-    target_compile_definitions(test_tf2_autoware_auto_msgs PRIVATE
-      DEFINE_LEGACY_FUNCTION
-    )
-  endif()
 endif()
 
 ament_auto_package()

--- a/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -45,56 +45,6 @@ using BoundingBox = autoware_auto_perception_msgs::msg::BoundingBox;
 
 namespace tf2
 {
-
-/*************/
-/** Point32 **/
-/*************/
-
-/** \brief Apply a geometry_msgs TransformStamped to a geometry_msgs Point32 type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The point to transform, as a Point32 message.
- * \param t_out The transformed point, as a Point32 message.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template <>
-inline void doTransform(
-  const geometry_msgs::msg::Point32 & t_in, geometry_msgs::msg::Point32 & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  const KDL::Vector v_out = gmTransformToKDL(transform) * KDL::Vector(t_in.x, t_in.y, t_in.z);
-  t_out.x = static_cast<float>(v_out[0]);
-  t_out.y = static_cast<float>(v_out[1]);
-  t_out.z = static_cast<float>(v_out[2]);
-}
-
-/*************/
-/** Polygon **/
-/*************/
-
-/** \brief Apply a geometry_msgs TransformStamped to a geometry_msgs Polygon type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The polygon to transform.
- * \param t_out The transformed polygon.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template <>
-inline void doTransform(
-  const geometry_msgs::msg::Polygon & t_in, geometry_msgs::msg::Polygon & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  // Don't call the Point32 doTransform to avoid doing this conversion every time
-  const auto kdl_frame = gmTransformToKDL(transform);
-  // We don't use std::back_inserter to allow aliasing between t_in and t_out
-  t_out.points.resize(t_in.points.size());
-  for (size_t i = 0; i < t_in.points.size(); ++i) {
-    const KDL::Vector v_out =
-      kdl_frame * KDL::Vector(t_in.points[i].x, t_in.points[i].y, t_in.points[i].z);
-    t_out.points[i].x = static_cast<float>(v_out[0]);
-    t_out.points[i].y = static_cast<float>(v_out[1]);
-    t_out.points[i].z = static_cast<float>(v_out[2]);
-  }
-}
-
 /******************/
 /** Quaternion32 **/
 /******************/

--- a/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -45,7 +45,7 @@ using BoundingBox = autoware_auto_perception_msgs::msg::BoundingBox;
 
 namespace tf2
 {
-#ifdef DEFINE_LEGACY_FUNCTION
+
 /*************/
 /** Point32 **/
 /*************/
@@ -94,7 +94,6 @@ inline void doTransform(
     t_out.points[i].z = static_cast<float>(v_out[2]);
   }
 }
-#endif
 
 /******************/
 /** Quaternion32 **/

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -58,12 +58,6 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/marker_utils/lane_change/debug.cpp
 )
 
-if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
-  target_compile_definitions(behavior_path_planner_node PRIVATE
-    DEFINE_LEGACY_FUNCTION
-  )
-endif()
-
 target_include_directories(behavior_path_planner_node SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}
 )

--- a/planning/surround_obstacle_checker/CMakeLists.txt
+++ b/planning/surround_obstacle_checker/CMakeLists.txt
@@ -18,12 +18,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/node.cpp
 )
 
-if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE
-    DEFINE_LEGACY_FUNCTION
-  )
-endif()
-
 target_link_libraries(${PROJECT_NAME}
   ${PCL_LIBRARIES}
 )


### PR DESCRIPTION
## Description

remove duplicated tf2 function introduced in [this PR](https://github.com/ros2/geometry2/pull/616).
This causes build error as below.
```
/home/daisuke/workspace/autoware/src/universe/autoware.universe/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp:60:13: error: redefinition of ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = geometry_msgs::msg::Point32_<std::allocator<void> >; geometry_msgs::msg::TransformStamped = geometry_msgs::msg::TransformStamped_<std::allocator<void> >]’
   60 | inline void doTransform(
```
This PR is necessary after next humble sync introduces tf2 geometry msgs 0.25.4.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
