### PR TITLE
refactor(pid_longitudinal_controller): use common elevetation angle calculation

### DIFF
--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -67,11 +67,6 @@ double getPitchByTraj(
   const Trajectory & trajectory, const size_t closest_idx, const double wheel_base);
 
 /**
- * @brief calculate elevation angle
- */
-double calcElevationAngle(const TrajectoryPoint & p_from, const TrajectoryPoint & p_to);
-
-/**
  * @brief calculate vehicle pose after time delay by moving the vehicle at current velocity and
  * acceleration for delayed time
  */

--- a/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -96,7 +96,8 @@ double getPitchByTraj(
       trajectory.points.at(nearest_idx), trajectory.points.at(i));
     if (dist > wheel_base) {
       // calculate pitch from trajectory between rear wheel (nearest) and front center (i)
-      return calcElevationAngle(trajectory.points.at(nearest_idx), trajectory.points.at(i));
+      return tier4_autoware_utils::calcElevationAngle(
+        trajectory.points.at(nearest_idx).pose.position, trajectory.points.at(i).pose.position);
     }
   }
 
@@ -108,24 +109,14 @@ double getPitchByTraj(
     if (dist > wheel_base) {
       // calculate pitch from trajectory
       // between wheelbase behind the end of trajectory (i) and the end of trajectory (back)
-      return calcElevationAngle(trajectory.points.at(i), trajectory.points.back());
+      return tier4_autoware_utils::calcElevationAngle(
+        trajectory.points.at(i).pose.position, trajectory.points.back().pose.position);
     }
   }
 
   // calculate pitch from trajectory between the beginning and end of trajectory
-  return calcElevationAngle(trajectory.points.at(0), trajectory.points.back());
-}
-
-double calcElevationAngle(const TrajectoryPoint & p_from, const TrajectoryPoint & p_to)
-{
-  const double dx = p_from.pose.position.x - p_to.pose.position.x;
-  const double dy = p_from.pose.position.y - p_to.pose.position.y;
-  const double dz = p_from.pose.position.z - p_to.pose.position.z;
-
-  const double dxy = std::max(std::hypot(dx, dy), std::numeric_limits<double>::epsilon());
-  const double pitch = std::atan2(dz, dxy);
-
-  return pitch;
+  return tier4_autoware_utils::calcElevationAngle(
+    trajectory.points.at(0).pose.position, trajectory.points.back().pose.position);
 }
 
 Pose calcPoseAfterTimeDelay(

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -817,7 +817,7 @@ double PidLongitudinalController::applySlopeCompensation(
   const double pitch_limited = std::min(std::max(pitch, m_min_pitch_rad), m_max_pitch_rad);
 
   // Acceleration command is always positive independent of direction (= shift) when car is running
-  double sign = (shift == Shift::Forward) ? -1 : (shift == Shift::Reverse ? 1 : 0);
+  double sign = (shift == Shift::Forward) ? 1.0 : (shift == Shift::Reverse ? -1.0 : 0);
   double compensated_acc = input_acc + sign * 9.81 * std::sin(pitch_limited);
   return compensated_acc;
 }

--- a/control/pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -158,33 +158,6 @@ TEST(TestLongitudinalControllerUtils, getPitchByTraj)
     std::atan2(0.5, 1));
 }
 
-TEST(TestLongitudinalControllerUtils, calcElevationAngle)
-{
-  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
-  TrajectoryPoint p_from;
-  p_from.pose.position.x = 0.0;
-  p_from.pose.position.y = 0.0;
-  TrajectoryPoint p_to;
-  p_to.pose.position.x = 1.0;
-  p_to.pose.position.y = 0.0;
-  EXPECT_DOUBLE_EQ(longitudinal_utils::calcElevationAngle(p_from, p_to), 0.0);
-  p_to.pose.position.x = 1.0;
-  p_to.pose.position.z = 1.0;
-  EXPECT_DOUBLE_EQ(longitudinal_utils::calcElevationAngle(p_from, p_to), -M_PI_4);
-  p_to.pose.position.x = -1.0;
-  p_to.pose.position.z = 1.0;
-  EXPECT_DOUBLE_EQ(longitudinal_utils::calcElevationAngle(p_from, p_to), -M_PI_4);
-  p_to.pose.position.x = 0.0;
-  p_to.pose.position.z = 1.0;
-  EXPECT_DOUBLE_EQ(longitudinal_utils::calcElevationAngle(p_from, p_to), -M_PI_2);
-  p_to.pose.position.x = 1.0;
-  p_to.pose.position.z = -1.0;
-  EXPECT_DOUBLE_EQ(longitudinal_utils::calcElevationAngle(p_from, p_to), M_PI_4);
-  p_to.pose.position.x = -1.0;
-  p_to.pose.position.z = -1.0;
-  EXPECT_DOUBLE_EQ(longitudinal_utils::calcElevationAngle(p_from, p_to), M_PI_4);
-}
-
 TEST(TestLongitudinalControllerUtils, calcPoseAfterTimeDelay)
 {
   using geometry_msgs::msg::Pose;


### PR DESCRIPTION
## Description

use tier4_autoware_utils::calcElevationAngle instead of an internally defined function.

NOTE:
**The sign of slope_angle will be opposite to the existing one.**
This is because the sign of calcElevationAngle in pid_longitudinal_controller and tier4_autoware_utils are different due to how the dz is calculated. "calcElevationAngle in pid_longitudinal_controller" is wrong.
- calcElevationAngle in pid_longitudinal_controller (wrong)
https://github.com/autowarefoundation/autoware.universe/blob/19114642146db7312a35f7b5841878207776ea6a/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp#L119-L129
- calcElevationAngle in tier4_autoware_utils (correct)
https://github.com/autowarefoundation/autoware.universe/blob/19114642146db7312a35f7b5841878207776ea6a/common/tier4_autoware_utils/src/geometry/geometry.cpp#L97-L103

**The sign of acceleration calculated by slope_angle will not change.** Therefore, the behavior of slope compensation will not change.
This is handled by the following change of this PR.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/29813cc2-55f7-40ef-a163-ccc119f9c517)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

unit test
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
