### PR TITLE
feat(pid_longitudinal_controller): transit state from emergency under the looser condition on manual driving

### DIFF
--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -542,6 +542,8 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     }
 
     if (!is_under_control && stopped_condition && keep_stopped_condition) {
+      // NOTE: When the ego is stopped on manual driving, since the driving state may transit to
+      //       autonomous, keep_stopped_condition should be checked.
       return changeState(ControlState::STOPPED);
     }
 

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -541,6 +541,10 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
       return changeState(ControlState::EMERGENCY);
     }
 
+    if (!is_under_control && stopped_condition && keep_stopped_condition) {
+      return changeState(ControlState::STOPPED);
+    }
+
     if (m_enable_smooth_stop) {
       if (stopping_condition) {
         // predictions after input time delay
@@ -608,14 +612,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
   // in EMERGENCY state
   if (m_control_state == ControlState::EMERGENCY) {
     if (!emergency_condition) {
-      if (is_under_control) {
-        if (stopped_condition) {
-          return changeState(ControlState::STOPPED);
-        }
-      } else {
-        if (stopped_condition) {
-          return changeState(ControlState::STOPPED);
-        }
+      if (stopped_condition) {
+        return changeState(ControlState::STOPPED);
+      }
+      if (!is_under_control) {
+        // NOTE: On manual driving, no need stopping to exit the emergency.
         return changeState(ControlState::DRIVE);
       }
     }


### PR DESCRIPTION
## Description

This PR
1. adds a feature that the state transits from EMERGENCY under the looser condition on manual driving.
2. changes the implementation of the PR: https://github.com/autowarefoundation/autoware.universe/pull/3644

**Regarding 1**
If the state transits to EMERGENCY for some reason on manual driving, the state cannot exit EMERGENCY unless the vehicle stops once even if the situation is not an emergency.
In this case, when we use engage-on-driving to transit to autonomous driving, since the state is EMERGENCY, the ego tries to stop once which is unnecessary.

To avoid this behavior, on manual driving, the emergency state should be able to transit to DRIVE without stopping.


**Regarding 2**
To implement the feature 1, this change is necessary.
Additionally, this feature should be applied to the usual manual driving when the operation mode is AUTONOMOUS and is_autoware_control_enabled is false.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

nothing

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
