### PR TITLE
fix(pid_longitudinal_controller): better slope compensation

### DIFF
--- a/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -91,32 +91,22 @@ double getPitchByTraj(
     return 0.0;
   }
 
-  for (size_t i = nearest_idx + 1; i < trajectory.points.size(); ++i) {
-    const double dist = tier4_autoware_utils::calcDistance2d(
-      trajectory.points.at(nearest_idx), trajectory.points.at(i));
-    if (dist > wheel_base) {
-      // calculate pitch from trajectory between rear wheel (nearest) and front center (i)
-      return tier4_autoware_utils::calcElevationAngle(
-        trajectory.points.at(nearest_idx).pose.position, trajectory.points.at(i).pose.position);
+  const auto [prev_idx, next_idx] = [&]() {
+    for (size_t i = nearest_idx + 1; i < trajectory.points.size(); ++i) {
+      const double dist = tier4_autoware_utils::calcDistance2d(
+        trajectory.points.at(nearest_idx), trajectory.points.at(i));
+      if (dist > wheel_base) {
+        // calculate pitch from trajectory between rear wheel (nearest) and front center (i)
+        return std::make_pair(nearest_idx, i);
+      }
     }
-  }
+    // NOTE: The ego pose is close to the goal.
+    return std::make_pair(
+      std::min(nearest_idx, trajectory.points.size() - 2), trajectory.points.size() - 1);
+  }();
 
-  // close to goal
-  for (size_t i = trajectory.points.size() - 1; i > 0; --i) {
-    const double dist =
-      tier4_autoware_utils::calcDistance2d(trajectory.points.back(), trajectory.points.at(i));
-
-    if (dist > wheel_base) {
-      // calculate pitch from trajectory
-      // between wheelbase behind the end of trajectory (i) and the end of trajectory (back)
-      return tier4_autoware_utils::calcElevationAngle(
-        trajectory.points.at(i).pose.position, trajectory.points.back().pose.position);
-    }
-  }
-
-  // calculate pitch from trajectory between the beginning and end of trajectory
   return tier4_autoware_utils::calcElevationAngle(
-    trajectory.points.at(0).pose.position, trajectory.points.back().pose.position);
+    trajectory.points.at(prev_idx).pose.position, trajectory.points.at(next_idx).pose.position);
 }
 
 Pose calcPoseAfterTimeDelay(


### PR DESCRIPTION
## Description

Depends on https://github.com/autowarefoundation/autoware.universe/pull/5090

In the case where the slope angle is positive before the goal and negative after the goal as shown in the figure, the current slope compensation works in the opposite direction.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/e88e98bc-02e8-4b43-985a-0936aeeb3760)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Better slope compensation when arriving at the goal.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
