### PR TITLE
feat(intersection): consider amber traffic signal for collision detection level

### DIFF
--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -24,12 +24,15 @@
         state_transit_margin_time: 1.0
         min_predicted_path_confidence: 0.05
         minimum_ego_predicted_velocity: 1.388 # [m/s]
-        normal:
-          collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
-          collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
-        relaxed:
+        fully_protected:
           collision_start_margin_time: 2.0
           collision_end_margin_time: 0.0
+        partially_protected:
+          collision_start_margin_time: 2.0
+          collision_end_margin_time: 2.0
+        unprotected:
+          collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
+          collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
 
       occlusion:

--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -24,13 +24,13 @@
         state_transit_margin_time: 1.0
         min_predicted_path_confidence: 0.05
         minimum_ego_predicted_velocity: 1.388 # [m/s]
-        fully_protected:
+        fully_prioritized:
           collision_start_margin_time: 2.0
           collision_end_margin_time: 0.0
-        partially_protected:
+        partially_prioritized:
           collision_start_margin_time: 2.0
           collision_end_margin_time: 2.0
-        unprotected:
+        not_prioritized:
           collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
           collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -84,14 +84,21 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".collision_detection.minimum_ego_predicted_velocity");
   ip.collision_detection.state_transit_margin_time =
     getOrDeclareParameter<double>(node, ns + ".collision_detection.state_transit_margin_time");
-  ip.collision_detection.normal.collision_start_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.normal.collision_start_margin_time");
-  ip.collision_detection.normal.collision_end_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.normal.collision_end_margin_time");
-  ip.collision_detection.relaxed.collision_start_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.relaxed.collision_start_margin_time");
-  ip.collision_detection.relaxed.collision_end_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.relaxed.collision_end_margin_time");
+  ip.collision_detection.fully_protected.collision_start_margin_time =
+    getOrDeclareParameter<double>(
+      node, ns + ".collision_detection.fully_protected.collision_start_margin_time");
+  ip.collision_detection.fully_protected.collision_end_margin_time = getOrDeclareParameter<double>(
+    node, ns + ".collision_detection.fully_protected.collision_end_margin_time");
+  ip.collision_detection.partially_protected.collision_start_margin_time =
+    getOrDeclareParameter<double>(
+      node, ns + ".collision_detection.partially_protected.collision_start_margin_time");
+  ip.collision_detection.partially_protected.collision_end_margin_time =
+    getOrDeclareParameter<double>(
+      node, ns + ".collision_detection.partially_protected.collision_end_margin_time");
+  ip.collision_detection.unprotected.collision_start_margin_time = getOrDeclareParameter<double>(
+    node, ns + ".collision_detection.unprotected.collision_start_margin_time");
+  ip.collision_detection.unprotected.collision_end_margin_time = getOrDeclareParameter<double>(
+    node, ns + ".collision_detection.unprotected.collision_end_margin_time");
   ip.collision_detection.keep_detection_vel_thr =
     getOrDeclareParameter<double>(node, ns + ".collision_detection.keep_detection_vel_thr");
 

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -84,21 +84,23 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".collision_detection.minimum_ego_predicted_velocity");
   ip.collision_detection.state_transit_margin_time =
     getOrDeclareParameter<double>(node, ns + ".collision_detection.state_transit_margin_time");
-  ip.collision_detection.fully_protected.collision_start_margin_time =
+  ip.collision_detection.fully_prioritized.collision_start_margin_time =
     getOrDeclareParameter<double>(
-      node, ns + ".collision_detection.fully_protected.collision_start_margin_time");
-  ip.collision_detection.fully_protected.collision_end_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.fully_protected.collision_end_margin_time");
-  ip.collision_detection.partially_protected.collision_start_margin_time =
+      node, ns + ".collision_detection.fully_prioritized.collision_start_margin_time");
+  ip.collision_detection.fully_prioritized.collision_end_margin_time =
     getOrDeclareParameter<double>(
-      node, ns + ".collision_detection.partially_protected.collision_start_margin_time");
-  ip.collision_detection.partially_protected.collision_end_margin_time =
+      node, ns + ".collision_detection.fully_prioritized.collision_end_margin_time");
+  ip.collision_detection.partially_prioritized.collision_start_margin_time =
     getOrDeclareParameter<double>(
-      node, ns + ".collision_detection.partially_protected.collision_end_margin_time");
-  ip.collision_detection.unprotected.collision_start_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.unprotected.collision_start_margin_time");
-  ip.collision_detection.unprotected.collision_end_margin_time = getOrDeclareParameter<double>(
-    node, ns + ".collision_detection.unprotected.collision_end_margin_time");
+      node, ns + ".collision_detection.partially_prioritized.collision_start_margin_time");
+  ip.collision_detection.partially_prioritized.collision_end_margin_time =
+    getOrDeclareParameter<double>(
+      node, ns + ".collision_detection.partially_prioritized.collision_end_margin_time");
+  ip.collision_detection.not_prioritized.collision_start_margin_time =
+    getOrDeclareParameter<double>(
+      node, ns + ".collision_detection.not_prioritized.collision_start_margin_time");
+  ip.collision_detection.not_prioritized.collision_end_margin_time = getOrDeclareParameter<double>(
+    node, ns + ".collision_detection.not_prioritized.collision_end_margin_time");
   ip.collision_detection.keep_detection_vel_thr =
     getOrDeclareParameter<double>(node, ns + ".collision_detection.keep_detection_vel_thr");
 

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -753,10 +753,11 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
       planner_param_.occlusion.occlusion_attention_area_length,
       planner_param_.common.consider_wrong_direction_vehicle);
   }
-  const auto traffic_protected_level =
-    util::getTrafficProtectedLevel(assigned_lanelet, planner_data_->traffic_light_id_map);
-  const bool is_protected = traffic_protected_level == util::TrafficProtectedLevel::FULLY_PROTECTED;
-  intersection_lanelets_.value().update(is_protected, interpolated_path_info);
+  const auto traffic_prioritized_level =
+    util::getTrafficPrioritizedLevel(assigned_lanelet, planner_data_->traffic_light_id_map);
+  const bool is_prioritized =
+    traffic_prioritized_level == util::TrafficPrioritizedLevel::FULLY_PRIORITIZED;
+  intersection_lanelets_.value().update(is_prioritized, interpolated_path_info);
 
   const auto & conflicting_lanelets = intersection_lanelets_.value().conflicting();
   const auto & first_conflicting_area_opt = intersection_lanelets_.value().first_conflicting_area();
@@ -887,7 +888,7 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   }
 
   // calculate dynamic collision around detection area
-  const double time_delay = (is_go_out_ || is_protected)
+  const double time_delay = (is_go_out_ || is_prioritized)
                               ? 0.0
                               : (planner_param_.collision_detection.state_transit_margin_time -
                                  collision_state_machine_.getDuration());
@@ -895,14 +896,14 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
     filterTargetObjects(attention_lanelets, adjacent_lanelets, intersection_area);
 
   const bool has_collision = checkCollision(
-    *path, target_objects, path_lanelets, closest_idx, time_delay, traffic_protected_level);
+    *path, target_objects, path_lanelets, closest_idx, time_delay, traffic_prioritized_level);
   collision_state_machine_.setStateWithMarginTime(
     has_collision ? StateMachine::State::STOP : StateMachine::State::GO,
     logger_.get_child("collision state_machine"), *clock_);
   const bool has_collision_with_margin =
     collision_state_machine_.getState() == StateMachine::State::STOP;
 
-  if (is_protected) {
+  if (is_prioritized) {
     return TrafficLightArrowSolidOn{
       has_collision_with_margin, closest_idx, collision_stop_line_idx, occlusion_stop_line_idx};
   }
@@ -928,7 +929,7 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
                object.kinematics.initial_twist_with_covariance.twist.linear.y) <= thresh;
     });
   const bool is_occlusion_cleared =
-    (enable_occlusion_detection_ && !occlusion_attention_lanelets.empty() && !is_protected)
+    (enable_occlusion_detection_ && !occlusion_attention_lanelets.empty() && !is_prioritized)
       ? isOcclusionCleared(
           *planner_data_->occupancy_grid, occlusion_attention_area, adjacent_lanelets,
           first_attention_area, interpolated_path_info, occlusion_attention_divisions,
@@ -1055,7 +1056,7 @@ bool IntersectionModule::checkCollision(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const autoware_auto_perception_msgs::msg::PredictedObjects & objects,
   const util::PathLanelets & path_lanelets, const int closest_idx, const double time_delay,
-  const util::TrafficProtectedLevel & traffic_protected_level)
+  const util::TrafficPrioritizedLevel & traffic_prioritized_level)
 {
   using lanelet::utils::getArcCoordinates;
   using lanelet::utils::getPolygonFromArcLength;
@@ -1079,19 +1080,19 @@ bool IntersectionModule::checkCollision(
   const auto ego_poly = ego_lane.polygon2d().basicPolygon();
   // check collision between predicted_path and ego_area
   const auto [collision_start_margin_time, collision_end_margin_time] = [&]() {
-    if (traffic_protected_level == util::TrafficProtectedLevel::FULLY_PROTECTED) {
+    if (traffic_prioritized_level == util::TrafficPrioritizedLevel::FULLY_PRIORITIZED) {
       return std::make_pair(
-        planner_param_.collision_detection.fully_protected.collision_start_margin_time,
-        planner_param_.collision_detection.fully_protected.collision_end_margin_time);
+        planner_param_.collision_detection.fully_prioritized.collision_start_margin_time,
+        planner_param_.collision_detection.fully_prioritized.collision_end_margin_time);
     }
-    if (traffic_protected_level == util::TrafficProtectedLevel::PARTIALLY_PROTECTED) {
+    if (traffic_prioritized_level == util::TrafficPrioritizedLevel::PARTIALLY_PRIORITIZED) {
       return std::make_pair(
-        planner_param_.collision_detection.partially_protected.collision_start_margin_time,
-        planner_param_.collision_detection.partially_protected.collision_end_margin_time);
+        planner_param_.collision_detection.partially_prioritized.collision_start_margin_time,
+        planner_param_.collision_detection.partially_prioritized.collision_end_margin_time);
     }
     return std::make_pair(
-      planner_param_.collision_detection.unprotected.collision_start_margin_time,
-      planner_param_.collision_detection.unprotected.collision_end_margin_time);
+      planner_param_.collision_detection.not_prioritized.collision_start_margin_time,
+      planner_param_.collision_detection.not_prioritized.collision_end_margin_time);
   }();
   bool collision_detected = false;
   for (const auto & object : target_objects.objects) {

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -79,16 +79,21 @@ public:
       //! minimum confidence value of predicted path to use for collision detection
       double minimum_ego_predicted_velocity;  //! used to calculate ego's future velocity profile
       double state_transit_margin_time;
-      struct Normal
+      struct FullyProtected
       {
         double collision_start_margin_time;  //! start margin time to check collision
         double collision_end_margin_time;    //! end margin time to check collision
-      } normal;
-      struct Relaxed
+      } fully_protected;
+      struct PartiallyProtected
       {
-        double collision_start_margin_time;
-        double collision_end_margin_time;
-      } relaxed;
+        double collision_start_margin_time;  //! start margin time to check collision
+        double collision_end_margin_time;    //! end margin time to check collision
+      } partially_protected;
+      struct Unprotected
+      {
+        double collision_start_margin_time;  //! start margin time to check collision
+        double collision_end_margin_time;    //! end margin time to check collision
+      } unprotected;
       double keep_detection_vel_thr;  //! keep detection if ego is ego.vel < keep_detection_vel_thr
     } collision_detection;
     struct Occlusion
@@ -250,7 +255,7 @@ private:
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
     const autoware_auto_perception_msgs::msg::PredictedObjects & target_objects,
     const util::PathLanelets & path_lanelets, const int closest_idx, const double time_delay,
-    const bool tl_arrow_solid_on);
+    const util::TrafficProtectedLevel & traffic_protected_level);
 
   bool isOcclusionCleared(
     const nav_msgs::msg::OccupancyGrid & occ_grid,

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -79,21 +79,21 @@ public:
       //! minimum confidence value of predicted path to use for collision detection
       double minimum_ego_predicted_velocity;  //! used to calculate ego's future velocity profile
       double state_transit_margin_time;
-      struct FullyProtected
+      struct FullyPrioritized
       {
         double collision_start_margin_time;  //! start margin time to check collision
         double collision_end_margin_time;    //! end margin time to check collision
-      } fully_protected;
-      struct PartiallyProtected
+      } fully_prioritized;
+      struct PartiallyPrioritized
       {
         double collision_start_margin_time;  //! start margin time to check collision
         double collision_end_margin_time;    //! end margin time to check collision
-      } partially_protected;
-      struct Unprotected
+      } partially_prioritized;
+      struct NotPrioritized
       {
         double collision_start_margin_time;  //! start margin time to check collision
         double collision_end_margin_time;    //! end margin time to check collision
-      } unprotected;
+      } not_prioritized;
       double keep_detection_vel_thr;  //! keep detection if ego is ego.vel < keep_detection_vel_thr
     } collision_detection;
     struct Occlusion
@@ -255,7 +255,7 @@ private:
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
     const autoware_auto_perception_msgs::msg::PredictedObjects & target_objects,
     const util::PathLanelets & path_lanelets, const int closest_idx, const double time_delay,
-    const util::TrafficProtectedLevel & traffic_protected_level);
+    const util::TrafficPrioritizedLevel & traffic_prioritized_level);
 
   bool isOcclusionCleared(
     const nav_msgs::msg::OccupancyGrid & occ_grid,

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -764,7 +764,7 @@ bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane)
   return tl_id.has_value();
 }
 
-TrafficProtectedLevel getTrafficProtectedLevel(
+TrafficPrioritizedLevel getTrafficPrioritizedLevel(
   lanelet::ConstLanelet lane, const std::map<int, TrafficSignalStamped> & tl_infos)
 {
   using TrafficSignalElement = autoware_perception_msgs::msg::TrafficSignalElement;
@@ -776,12 +776,12 @@ TrafficProtectedLevel getTrafficProtectedLevel(
   }
   if (!tl_id) {
     // this lane has no traffic light
-    return TrafficProtectedLevel::UNPROTECTED;
+    return TrafficPrioritizedLevel::NOT_PRIORITIZED;
   }
   const auto tl_info_it = tl_infos.find(tl_id.value());
   if (tl_info_it == tl_infos.end()) {
     // the info of this traffic light is not available
-    return TrafficProtectedLevel::UNPROTECTED;
+    return TrafficPrioritizedLevel::NOT_PRIORITIZED;
   }
   const auto & tl_info = tl_info_it->second;
   bool has_amber_signal{false};
@@ -791,13 +791,13 @@ TrafficProtectedLevel getTrafficProtectedLevel(
     }
     if (tl_light.color == TrafficSignalElement::RED) {
       // NOTE: Return here since the red signal has the highest priority.
-      return TrafficProtectedLevel::FULLY_PROTECTED;
+      return TrafficPrioritizedLevel::FULLY_PRIORITIZED;
     }
   }
   if (has_amber_signal) {
-    return TrafficProtectedLevel::PARTIALLY_PROTECTED;
+    return TrafficPrioritizedLevel::PARTIALLY_PRIORITIZED;
   }
-  return TrafficProtectedLevel::UNPROTECTED;
+  return TrafficPrioritizedLevel::NOT_PRIORITIZED;
 }
 
 std::vector<DiscretizedLane> generateDetectionLaneDivisions(
@@ -1180,9 +1180,9 @@ double calcDistanceUntilIntersectionLanelet(
 }
 
 void IntersectionLanelets::update(
-  const bool is_protected, const InterpolatedPathInfo & interpolated_path_info)
+  const bool is_prioritized, const InterpolatedPathInfo & interpolated_path_info)
 {
-  is_protected_ = is_protected;
+  is_prioritized_ = is_prioritized;
   // find the first conflicting/detection area polygon intersecting the path
   const auto & path = interpolated_path_info.path;
   const auto & lane_interval = interpolated_path_info.lane_id_interval.value();

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -764,12 +764,11 @@ bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane)
   return tl_id.has_value();
 }
 
-bool isTrafficLightArrowActivated(
+TrafficProtectedLevel getTrafficProtectedLevel(
   lanelet::ConstLanelet lane, const std::map<int, TrafficSignalStamped> & tl_infos)
 {
   using TrafficSignalElement = autoware_perception_msgs::msg::TrafficSignalElement;
 
-  const auto & turn_direction = lane.attributeOr("turn_direction", "else");
   std::optional<int> tl_id = std::nullopt;
   for (auto && tl_reg_elem : lane.regulatoryElementsAs<lanelet::TrafficLight>()) {
     tl_id = tl_reg_elem->id();
@@ -777,24 +776,28 @@ bool isTrafficLightArrowActivated(
   }
   if (!tl_id) {
     // this lane has no traffic light
-    return false;
+    return TrafficProtectedLevel::UNPROTECTED;
   }
   const auto tl_info_it = tl_infos.find(tl_id.value());
   if (tl_info_it == tl_infos.end()) {
     // the info of this traffic light is not available
-    return false;
+    return TrafficProtectedLevel::UNPROTECTED;
   }
   const auto & tl_info = tl_info_it->second;
+  bool has_amber_signal{false};
   for (auto && tl_light : tl_info.signal.elements) {
-    if (tl_light.color != TrafficSignalElement::GREEN) continue;
-    if (tl_light.status != TrafficSignalElement::SOLID_ON) continue;
-    if (turn_direction == std::string("left") && tl_light.shape == TrafficSignalElement::LEFT_ARROW)
-      return true;
-    if (
-      turn_direction == std::string("right") && tl_light.shape == TrafficSignalElement::RIGHT_ARROW)
-      return true;
+    if (tl_light.color == TrafficSignalElement::AMBER) {
+      has_amber_signal = true;
+    }
+    if (tl_light.color == TrafficSignalElement::RED) {
+      // NOTE: Return here since the red signal has the highest priority.
+      return TrafficProtectedLevel::FULLY_PROTECTED;
+    }
   }
-  return false;
+  if (has_amber_signal) {
+    return TrafficProtectedLevel::PARTIALLY_PROTECTED;
+  }
+  return TrafficProtectedLevel::UNPROTECTED;
 }
 
 std::vector<DiscretizedLane> generateDetectionLaneDivisions(
@@ -1177,9 +1180,9 @@ double calcDistanceUntilIntersectionLanelet(
 }
 
 void IntersectionLanelets::update(
-  const bool tl_arrow_solid_on, const InterpolatedPathInfo & interpolated_path_info)
+  const bool is_protected, const InterpolatedPathInfo & interpolated_path_info)
 {
-  tl_arrow_solid_on_ = tl_arrow_solid_on;
+  is_protected_ = is_protected;
   // find the first conflicting/detection area polygon intersecting the path
   const auto & path = interpolated_path_info.path;
   const auto & lane_interval = interpolated_path_info.lane_id_interval.value();

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -112,7 +112,7 @@ std::optional<Polygon2d> getIntersectionArea(
 
 bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane);
 
-TrafficProtectedLevel getTrafficProtectedLevel(
+TrafficPrioritizedLevel getTrafficPrioritizedLevel(
   lanelet::ConstLanelet lane, const std::map<int, TrafficSignalStamped> & tl_infos);
 
 std::vector<DiscretizedLane> generateDetectionLaneDivisions(

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -111,7 +111,8 @@ std::optional<Polygon2d> getIntersectionArea(
   lanelet::ConstLanelet assigned_lane, lanelet::LaneletMapConstPtr lanelet_map_ptr);
 
 bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane);
-bool isTrafficLightArrowActivated(
+
+TrafficProtectedLevel getTrafficProtectedLevel(
   lanelet::ConstLanelet lane, const std::map<int, TrafficSignalStamped> & tl_infos);
 
 std::vector<DiscretizedLane> generateDetectionLaneDivisions(

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -64,20 +64,20 @@ struct InterpolatedPathInfo
 struct IntersectionLanelets
 {
 public:
-  void update(const bool tl_arrow_solid_on, const InterpolatedPathInfo & interpolated_path_info);
+  void update(const bool is_protected, const InterpolatedPathInfo & interpolated_path_info);
   const lanelet::ConstLanelets & attention() const
   {
-    return tl_arrow_solid_on_ ? attention_non_preceding_ : attention_;
+    return is_protected_ ? attention_non_preceding_ : attention_;
   }
   const lanelet::ConstLanelets & conflicting() const { return conflicting_; }
   const lanelet::ConstLanelets & adjacent() const { return adjacent_; }
   const lanelet::ConstLanelets & occlusion_attention() const
   {
-    return tl_arrow_solid_on_ ? attention_non_preceding_ : occlusion_attention_;
+    return is_protected_ ? attention_non_preceding_ : occlusion_attention_;
   }
   const std::vector<lanelet::CompoundPolygon3d> & attention_area() const
   {
-    return tl_arrow_solid_on_ ? attention_non_preceding_area_ : attention_area_;
+    return is_protected_ ? attention_non_preceding_area_ : attention_area_;
   }
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_area() const
   {
@@ -110,7 +110,7 @@ public:
   // the first area intersecting with the path
   // even if lane change/re-routing happened on the intersection, these areas area are supposed to
   // be invariant under the 'associative' lanes.
-  bool tl_arrow_solid_on_ = false;
+  bool is_protected_ = false;
   std::optional<lanelet::CompoundPolygon3d> first_conflicting_area_ = std::nullopt;
   std::optional<lanelet::CompoundPolygon3d> first_attention_area_ = std::nullopt;
 };
@@ -151,6 +151,14 @@ struct PathLanelets
                                          // conflicting lanelets plus the next lane part of the path
 };
 
+enum class TrafficProtectedLevel {
+  // The target lane's traffic signal is red or the ego's traffic signal has an arrow.
+  FULLY_PROTECTED = 0,
+  // The target lane's traffic signal is amber
+  PARTIALLY_PROTECTED,
+  // The target lane's traffic signal is green
+  UNPROTECTED
+};
 }  // namespace behavior_velocity_planner::util
 
 #endif  // UTIL_TYPE_HPP_

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -64,20 +64,20 @@ struct InterpolatedPathInfo
 struct IntersectionLanelets
 {
 public:
-  void update(const bool is_protected, const InterpolatedPathInfo & interpolated_path_info);
+  void update(const bool is_prioritized, const InterpolatedPathInfo & interpolated_path_info);
   const lanelet::ConstLanelets & attention() const
   {
-    return is_protected_ ? attention_non_preceding_ : attention_;
+    return is_prioritized_ ? attention_non_preceding_ : attention_;
   }
   const lanelet::ConstLanelets & conflicting() const { return conflicting_; }
   const lanelet::ConstLanelets & adjacent() const { return adjacent_; }
   const lanelet::ConstLanelets & occlusion_attention() const
   {
-    return is_protected_ ? attention_non_preceding_ : occlusion_attention_;
+    return is_prioritized_ ? attention_non_preceding_ : occlusion_attention_;
   }
   const std::vector<lanelet::CompoundPolygon3d> & attention_area() const
   {
-    return is_protected_ ? attention_non_preceding_area_ : attention_area_;
+    return is_prioritized_ ? attention_non_preceding_area_ : attention_area_;
   }
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_area() const
   {
@@ -110,7 +110,7 @@ public:
   // the first area intersecting with the path
   // even if lane change/re-routing happened on the intersection, these areas area are supposed to
   // be invariant under the 'associative' lanes.
-  bool is_protected_ = false;
+  bool is_prioritized_ = false;
   std::optional<lanelet::CompoundPolygon3d> first_conflicting_area_ = std::nullopt;
   std::optional<lanelet::CompoundPolygon3d> first_attention_area_ = std::nullopt;
 };
@@ -151,13 +151,13 @@ struct PathLanelets
                                          // conflicting lanelets plus the next lane part of the path
 };
 
-enum class TrafficProtectedLevel {
+enum class TrafficPrioritizedLevel {
   // The target lane's traffic signal is red or the ego's traffic signal has an arrow.
-  FULLY_PROTECTED = 0,
+  FULLY_PRIORITIZED = 0,
   // The target lane's traffic signal is amber
-  PARTIALLY_PROTECTED,
+  PARTIALLY_PRIORITIZED,
   // The target lane's traffic signal is green
-  UNPROTECTED
+  NOT_PRIORITIZED
 };
 }  // namespace behavior_velocity_planner::util
 


### PR DESCRIPTION
## Description

Currently, the collision detection margin is prepared for the case where the traffic signal is green and red.
For more efficient intersection behavior, this PR added a collision detection margin for amber color.

Three traffic protected levels are defined.
- fully protected
    - The target lane's traffic signal is red or the ego's traffic signal has an arrow.
- partially protected
    - The target lane's traffic signal is amber
- unprotected
    - The target lane's traffic signal is green

https://star4.slack.com/archives/C03QW0GU6P7/p1695379403867969?thread_ts=1695378610.532759&cid=C03QW0GU6P7
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

More efficient intersection behavior considering amber traffic signal.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
