### PR TITLE
feat(mission_planner): add param of check_footprint_inside_lanes

### DIFF
--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -9,3 +9,4 @@
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
+    check_footprint_inside_lanes: false

--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -9,4 +9,4 @@
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
-    check_footprint_inside_lanes: false
+    check_footprint_inside_lanes: true

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -152,6 +152,8 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
   param_.goal_angle_threshold_deg = node_->declare_parameter<double>("goal_angle_threshold_deg");
   param_.enable_correct_goal_pose = node_->declare_parameter<bool>("enable_correct_goal_pose");
   param_.consider_no_drivable_lanes = node_->declare_parameter<bool>("consider_no_drivable_lanes");
+  param_.check_footprint_inside_lanes =
+    node_->declare_parameter<bool>("check_footprint_inside_lanes");
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)
@@ -349,6 +351,7 @@ bool DefaultPlanner::is_goal_valid(
 
   // check if goal footprint exceeds lane when the goal isn't in parking_lot
   if (
+    param_.check_footprint_inside_lanes &&
     !check_goal_footprint(
       closest_lanelet, combined_prev_lanelet, polygon_footprint, next_lane_length) &&
     !is_in_parking_lot(

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -38,6 +38,7 @@ struct DefaultPlannerParameters
   double goal_angle_threshold_deg;
   bool enable_correct_goal_pose;
   bool consider_no_drivable_lanes;
+  bool check_footprint_inside_lanes;
 };
 
 class DefaultPlanner : public mission_planner::PlannerPlugin


### PR DESCRIPTION
## Description

add a parameter of `check_footprint_inside_lanes`.
When this parameter is set to false, the feature to cancel the route planning when the footprint on the goal is outside the lanes is disabled.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
