### PR TITLE
fix(filt_vector): fix a problem of list index out of range in filt_vector

### DIFF
--- a/control/mpc_lateral_controller/src/lowpass_filter.cpp
+++ b/control/mpc_lateral_controller/src/lowpass_filter.cpp
@@ -120,10 +120,8 @@ bool filt_vector(const int num, std::vector<double> & u)
     double tmp = 0.0;
     int num_tmp = 0;
     double count = 0;
-    if (i - num < 0) {
-      num_tmp = i;
-    } else if (i + num > static_cast<int>(u.size()) - 1) {
-      num_tmp = static_cast<int>(u.size()) - i - 1;
+    if ((i - num < 0) || (i + num > static_cast<int>(u.size()) - 1)) {
+      num_tmp = std::min(i, static_cast<int>(u.size()) - i - 1);
     } else {
       num_tmp = num;
     }

--- a/control/mpc_lateral_controller/test/test_lowpass_filter.cpp
+++ b/control/mpc_lateral_controller/test/test_lowpass_filter.cpp
@@ -61,6 +61,30 @@ TEST(TestLowpassFilter, MoveAverageFilter)
     EXPECT_EQ(filtered_vec[4], 23.0 / 3);
     EXPECT_EQ(filtered_vec[5], original_vec[5]);
   }
+  {
+    const int window_size = 3;
+    const std::vector<double> original_vec = {1.0, 1.0, 1.0, 1.0};
+    std::vector<double> filtered_vec = original_vec;
+    EXPECT_TRUE(MoveAverageFilter::filt_vector(window_size, filtered_vec));
+    ASSERT_EQ(filtered_vec.size(), original_vec.size());
+    EXPECT_EQ(filtered_vec[0], original_vec[0]);
+    EXPECT_EQ(filtered_vec[1], 1.0);
+    EXPECT_EQ(filtered_vec[2], 1.0);
+    EXPECT_EQ(filtered_vec[3], original_vec[3]);
+  }
+  {
+    const int window_size = 4;
+    const std::vector<double> original_vec = {1.0, 3.0, 4.0, 6.0, 7.0, 10.0};
+    std::vector<double> filtered_vec = original_vec;
+    EXPECT_TRUE(MoveAverageFilter::filt_vector(window_size, filtered_vec));
+    ASSERT_EQ(filtered_vec.size(), original_vec.size());
+    EXPECT_EQ(filtered_vec[0], original_vec[0]);
+    EXPECT_EQ(filtered_vec[1], 8.0 / 3);
+    EXPECT_EQ(filtered_vec[2], 21.0 / 5);
+    EXPECT_EQ(filtered_vec[3], 30.0 / 5);
+    EXPECT_EQ(filtered_vec[4], 23.0 / 3);
+    EXPECT_EQ(filtered_vec[5], original_vec[5]);
+  }
 }
 TEST(TestLowpassFilter, Butterworth2dFilter)
 {


### PR DESCRIPTION
## Description

Bug fix: filt_vector in lowpass_filter.cpp

https://github.com/autowarefoundation/autoware.universe/blob/ec99b2f2218f6b27a0f9567480df73fe1ed2aea6/control/mpc_lateral_controller/src/lowpass_filter.cpp#L113-L139

case num=3 and u.size()=4 (e.g. u={1.0, 1.0, 1.0, 1.0})
if i=2, then num_tmp=i=2. So j in {-2,-1,0,1,2}.
When j=2, then i+j=4 and u[i+j] is list index out of range.
I have fixed the above problem.

## Tests performed

I added new tests to test_lowpass_filter.cpp.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
