### PR TITLE
feat(motion_utils): add debug backtrace print

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -18,6 +18,7 @@
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 #include "tier4_autoware_utils/geometry/pose_deviation.hpp"
 #include "tier4_autoware_utils/math/constants.hpp"
+#include "tier4_autoware_utils/system/backtrace.hpp"
 
 #include <Eigen/Geometry>
 
@@ -43,6 +44,7 @@ template <class T>
 void validateNonEmpty(const T & points)
 {
   if (points.empty()) {
+    tier4_autoware_utils::print_backtrace();
     throw std::invalid_argument("Points is empty.");
   }
 }
@@ -80,6 +82,7 @@ void validateNonSharpAngle(
 
   constexpr double epsilon = 1e-3;
   if (std::cos(angle_threshold) < product / dist_1to2 / dist_3to2 + epsilon) {
+    tier4_autoware_utils::print_backtrace();
     throw std::invalid_argument("Sharp angle.");
   }
 }
@@ -396,6 +399,7 @@ double calcLongitudinalOffsetToSegment(
 {
   if (seg_idx >= points.size() - 1) {
     const std::out_of_range e("Segment index is invalid.");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }
@@ -418,6 +422,7 @@ double calcLongitudinalOffsetToSegment(
 
   if (seg_idx >= overlap_removed_points.size() - 1) {
     const std::runtime_error e("Same points are given.");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }
@@ -574,6 +579,7 @@ double calcLateralOffset(
 
   if (overlap_removed_points.size() == 1) {
     const std::runtime_error e("Same points are given.");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }
@@ -635,6 +641,7 @@ double calcLateralOffset(
 
   if (overlap_removed_points.size() == 1) {
     const std::runtime_error e("Same points are given.");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }
@@ -1037,6 +1044,7 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
 
   if (points.size() - 1 < src_idx) {
     const auto e = std::out_of_range("Invalid source index");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }
@@ -1161,6 +1169,7 @@ boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
 
   if (points.size() - 1 < src_idx) {
     const auto e = std::out_of_range("Invalid source index");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }
@@ -2375,6 +2384,7 @@ double calcYawDeviation(
 
   if (overlap_removed_points.size() <= 1) {
     const std::runtime_error e("points size is less than 2");
+    tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
       throw e;
     }

--- a/common/tier4_autoware_utils/CMakeLists.txt
+++ b/common/tier4_autoware_utils/CMakeLists.txt
@@ -14,6 +14,7 @@ ament_auto_add_library(tier4_autoware_utils SHARED
   src/math/trigonometry.cpp
   src/ros/msg_operation.cpp
   src/ros/marker_helper.cpp
+  src/system/backtrace.cpp
 )
 
 if(BUILD_TESTING)

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
@@ -15,40 +15,10 @@
 #ifndef TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_
 #define TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_
 
-#include "rclcpp/rclcpp.hpp"
-
-#include <execinfo.h>
-
-#include <iostream>
-#include <memory>
-#include <sstream>
-#include <vector>
-
 namespace tier4_autoware_utils
 {
 
-inline void print_backtrace()
-{
-  constexpr size_t max_frames = 100;
-  void * addrlist[max_frames + 1];
-
-  int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void *));
-
-  if (addrlen == 0) {
-    return;
-  }
-
-  char ** symbol_list = backtrace_symbols(addrlist, addrlen);
-
-  std::stringstream ss;
-  ss << "  ********** back trace **********" << std::endl;
-  for (int i = 1; i < addrlen; i++) {
-    ss << "   @   " << symbol_list[i] << std::endl;
-  }
-  RCLCPP_DEBUG_STREAM(rclcpp::get_logger("tier4_autoware_utils"), ss.str());
-
-  free(symbol_list);
-}
+void print_backtrace();
 
 }  // namespace tier4_autoware_utils
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
@@ -15,13 +15,14 @@
 #ifndef TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_
 #define TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_
 
+#include "rclcpp/rclcpp.hpp"
+
 #include <execinfo.h>
 
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <vector>
-#include "rclcpp/rclcpp.hpp"
 
 namespace tier4_autoware_utils
 {

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <sstream>
 #include <vector>
+#include "rclcpp/rclcpp.hpp"
 
 namespace tier4_autoware_utils
 {
@@ -43,7 +44,7 @@ inline void print_backtrace()
   for (int i = 1; i < addrlen; i++) {
     ss << "   @   " << symbol_list[i] << std::endl;
   }
-  std::cerr << ss.str() << std::endl;
+  RCLCPP_DEBUG_STREAM(rclcpp::get_logger("tier4_autoware_utils"), ss.str());
 
   free(symbol_list);
 }

--- a/common/tier4_autoware_utils/src/system/backtrace.cpp
+++ b/common/tier4_autoware_utils/src/system/backtrace.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "tier4_autoware_utils/system/backtrace.hpp"
+
 #include "rclcpp/rclcpp.hpp"
 
 #include <execinfo.h>
@@ -20,9 +22,6 @@
 #include <memory>
 #include <sstream>
 #include <vector>
-
-#include "tier4_autoware_utils/system/backtrace.hpp"
-
 
 namespace tier4_autoware_utils
 {
@@ -51,4 +50,3 @@ void print_backtrace()
 }
 
 }  // namespace tier4_autoware_utils
-

--- a/common/tier4_autoware_utils/src/system/backtrace.cpp
+++ b/common/tier4_autoware_utils/src/system/backtrace.cpp
@@ -1,0 +1,54 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+
+#include <execinfo.h>
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include "tier4_autoware_utils/system/backtrace.hpp"
+
+
+namespace tier4_autoware_utils
+{
+
+void print_backtrace()
+{
+  constexpr size_t max_frames = 100;
+  void * addrlist[max_frames + 1];
+
+  int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void *));
+
+  if (addrlen == 0) {
+    return;
+  }
+
+  char ** symbol_list = backtrace_symbols(addrlist, addrlen);
+
+  std::stringstream ss;
+  ss << "\n   @   ********** back trace **********" << std::endl;
+  for (int i = 1; i < addrlen; i++) {
+    ss << "   @   " << symbol_list[i] << std::endl;
+  }
+  RCLCPP_DEBUG_STREAM(rclcpp::get_logger("tier4_autoware_utils"), ss.str());
+
+  free(symbol_list);
+}
+
+}  // namespace tier4_autoware_utils
+


### PR DESCRIPTION
## Description

- Change backtrace logging level  to debug
- add backtrace print in the motion_util functions

Note: how to change the logging level

```
ros2 component load /planning/scenario_planning/lane_driving/behavior_planning/behavior_planning_container logging_demo logging_demo::LoggerConfig

ros2 service call /config_logger logging_demo/srv/ConfigLogger "{logger_name: 'tier4_autoware_utils', level: DEBUG}"
```


## Related links

None

## Tests performed

run psim.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/cef23c24-29d2-4e69-836c-91c6370643c9)


## Notes for reviewers

None

## Interface changes

None
## Effects on system behavior

None
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
