### PR TITLE
feat(intersection): modify occlusion distance calculation and publish projection line

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_intersection_module/src/debug.cpp
@@ -113,7 +113,33 @@ visualization_msgs::msg::MarkerArray createPoseMarkerArray(
   return msg;
 }
 
-visualization_msgs::msg::Marker createPointMarkerArray(
+visualization_msgs::msg::MarkerArray createLineMarkerArray(
+  const geometry_msgs::msg::Point & point_start, const geometry_msgs::msg::Point & point_end,
+  const std::string & ns, const int64_t id, const double r, const double g, const double b)
+{
+  visualization_msgs::msg::MarkerArray msg;
+
+  visualization_msgs::msg::Marker marker;
+  marker.header.frame_id = "map";
+  marker.ns = ns + "_line";
+  marker.id = id;
+  marker.lifetime = rclcpp::Duration::from_seconds(0.3);
+  marker.type = visualization_msgs::msg::Marker::ARROW;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  geometry_msgs::msg::Vector3 arrow;
+  arrow.x = 1.0;
+  arrow.y = 1.0;
+  arrow.z = 1.0;
+  marker.scale = arrow;
+  marker.color = createMarkerColor(r, g, b, 0.999);
+  marker.points.push_back(point_start);
+  marker.points.push_back(point_end);
+
+  msg.markers.push_back(marker);
+  return msg;
+}
+
+[[maybe_unused]] visualization_msgs::msg::Marker createPointMarkerArray(
   const geometry_msgs::msg::Point & point, const std::string & ns, const int64_t id, const double r,
   const double g, const double b)
 {
@@ -185,17 +211,6 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
-  if (debug_data_.nearest_occlusion_point) {
-    debug_marker_array.markers.push_back(createPointMarkerArray(
-      debug_data_.nearest_occlusion_point.value(), "nearest_occlusion", module_id_, 0.5, 0.5, 0.0));
-  }
-
-  if (debug_data_.nearest_occlusion_projection_point) {
-    debug_marker_array.markers.push_back(createPointMarkerArray(
-      debug_data_.nearest_occlusion_projection_point.value(), "nearest_occlusion_projection",
-      module_id_, 0.5, 0.5, 0.0));
-  }
-
   size_t i{0};
   for (const auto & p : debug_data_.candidate_collision_object_polygons) {
     appendMarkerArray(
@@ -238,6 +253,13 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
+  if (debug_data_.nearest_occlusion_projection) {
+    const auto [point_start, point_end] = debug_data_.nearest_occlusion_projection.value();
+    appendMarkerArray(
+      createLineMarkerArray(
+        point_start, point_end, "nearest_occlusion_projection", lane_id_, 0.5, 0.5, 0.0),
+      &debug_marker_array, now);
+  }
   return debug_marker_array;
 }
 

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -1430,7 +1430,7 @@ bool IntersectionModule::isOcclusionCleared(
         division_point_it = point_it;
       }
 
-      // find the intersecton point of lane_line and path
+      // find the intersection point of lane_line and path
       std::vector<Point2d> intersection_points;
       boost::geometry::intersection(division_linestring, path_linestring, intersection_points);
       if (intersection_points.empty()) {

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -903,8 +903,8 @@ std::vector<DiscretizedLane> generateDetectionLaneDivisions(
       }
       area += bg::area(lane.polygon2d().basicPolygon());
     }
-    lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, lefts).invert();
-    lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, rights).invert();
+    lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, lefts);
+    lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, rights);
     lanelet::Lanelet merged = lanelet::Lanelet(lanelet::InvalId, left, right);
     merged_branches[src] = std::make_pair(merged, area);
   }

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -903,8 +903,8 @@ std::vector<DiscretizedLane> generateDetectionLaneDivisions(
       }
       area += bg::area(lane.polygon2d().basicPolygon());
     }
-    lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, lefts);
-    lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, rights);
+    lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, lefts).invert();
+    lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, rights).invert();
     lanelet::Lanelet merged = lanelet::Lanelet(lanelet::InvalId, left, right);
     merged_branches[src] = std::make_pair(merged, area);
   }

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -34,22 +34,22 @@ namespace behavior_velocity_planner::util
 
 struct DebugData
 {
-  std::optional<geometry_msgs::msg::Pose> collision_stop_wall_pose = std::nullopt;
-  std::optional<geometry_msgs::msg::Pose> occlusion_stop_wall_pose = std::nullopt;
-  std::optional<geometry_msgs::msg::Pose> occlusion_first_stop_wall_pose = std::nullopt;
-  std::optional<geometry_msgs::msg::Pose> pass_judge_wall_pose = std::nullopt;
-  std::optional<std::vector<lanelet::CompoundPolygon3d>> attention_area = std::nullopt;
-  std::optional<geometry_msgs::msg::Polygon> intersection_area = std::nullopt;
-  std::optional<lanelet::CompoundPolygon3d> ego_lane = std::nullopt;
-  std::optional<std::vector<lanelet::CompoundPolygon3d>> adjacent_area = std::nullopt;
-  std::optional<geometry_msgs::msg::Polygon> stuck_vehicle_detect_area = std::nullopt;
-  std::optional<geometry_msgs::msg::Polygon> candidate_collision_ego_lane_polygon = std::nullopt;
+  std::optional<geometry_msgs::msg::Pose> collision_stop_wall_pose{std::nullopt};
+  std::optional<geometry_msgs::msg::Pose> occlusion_stop_wall_pose{std::nullopt};
+  std::optional<geometry_msgs::msg::Pose> occlusion_first_stop_wall_pose{std::nullopt};
+  std::optional<geometry_msgs::msg::Pose> pass_judge_wall_pose{std::nullopt};
+  std::optional<std::vector<lanelet::CompoundPolygon3d>> attention_area{std::nullopt};
+  std::optional<geometry_msgs::msg::Polygon> intersection_area{std::nullopt};
+  std::optional<lanelet::CompoundPolygon3d> ego_lane{std::nullopt};
+  std::optional<std::vector<lanelet::CompoundPolygon3d>> adjacent_area{std::nullopt};
+  std::optional<geometry_msgs::msg::Polygon> stuck_vehicle_detect_area{std::nullopt};
+  std::optional<geometry_msgs::msg::Polygon> candidate_collision_ego_lane_polygon{std::nullopt};
   std::vector<geometry_msgs::msg::Polygon> candidate_collision_object_polygons;
   autoware_auto_perception_msgs::msg::PredictedObjects conflicting_targets;
   autoware_auto_perception_msgs::msg::PredictedObjects stuck_targets;
-  std::optional<geometry_msgs::msg::Point> nearest_occlusion_point = std::nullopt;
-  std::optional<geometry_msgs::msg::Point> nearest_occlusion_projection_point = std::nullopt;
   std::vector<geometry_msgs::msg::Polygon> occlusion_polygons;
+  std::optional<std::pair<geometry_msgs::msg::Point, geometry_msgs::msg::Point>>
+    nearest_occlusion_projection{std::nullopt};
 };
 
 struct InterpolatedPathInfo


### PR DESCRIPTION
## Description

Modified intersection occlusion calculation to calculate the distance of each point on the `division` if the point is occluded on the occlusion mask. Also added a marker for the projection.

## Related links

https://tier4.atlassian.net/browse/RT1-3696

## Tests performed

Psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/152a0598-5596-4458-81f4-29aec8d0f42a)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
