### PR TITLE
fix(utils): add flag check in drivable bound generation

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1675,6 +1675,13 @@ std::vector<geometry_msgs::msg::Point> calcBound(
       continue;
     }
 
+    if (!enable_expanding_hatched_road_markings) {
+      for (const auto & point : bound) {
+        output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(point));
+      }
+      continue;
+    }
+
     // expand drivable area by hatched road markings.
     for (size_t bound_point_idx = 0; bound_point_idx < bound.size(); ++bound_point_idx) {
       const auto & bound_point = bound[bound_point_idx];


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdc4da4</samp>

Add a parameter to control the expansion of hatched road markings in `utils.cpp`. This improves the behavior path planner's handling of different road marking types.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/1e4c98d1-6aa1-5576-82e4-618b037417d4?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
