### PR TITLE
feat(pose_twist_estimator): automatically initialize pose only with gnss

### DIFF
--- a/launch/tier4_localization_launch/launch/pose_twist_estimator/pose_twist_estimator.launch.xml
+++ b/launch/tier4_localization_launch/launch/pose_twist_estimator/pose_twist_estimator.launch.xml
@@ -20,7 +20,9 @@
         <arg name="config_file" value="$(var pose_initializer_param_path)"/>
         <arg name="sub_gnss_pose_cov" value="/sensing/gnss/pose_with_covariance"/>
       </include>
-      <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      <group if="$(var gnss_enabled)">
+        <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      </group>
       <include file="$(find-pkg-share tier4_localization_launch)/launch/util/util.launch.py"/>
     </group>
   </group>
@@ -42,7 +44,9 @@
         <arg name="config_file" value="$(var pose_initializer_param_path)"/>
         <arg name="sub_gnss_pose_cov" value="/sensing/gnss/pose_with_covariance"/>
       </include>
-      <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      <group if="$(var gnss_enabled)">
+        <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      </group>
     </group>
   </group>
 
@@ -74,7 +78,9 @@
         <arg name="config_file" value="$(var pose_initializer_param_path)"/>
         <arg name="sub_gnss_pose_cov" value="/localization/pose_estimator/pose_with_covariance"/>
       </include>
-      <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      <group if="$(var gnss_enabled)">
+        <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      </group>
     </group>
   </group>
 
@@ -99,7 +105,9 @@
         <arg name="config_file" value="$(var pose_initializer_param_path)"/>
         <arg name="sub_gnss_pose_cov" value="/localization/pose_estimator/pose_with_covariance"/>
       </include>
-      <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      <group if="$(var gnss_enabled)">
+        <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      </group>
     </group>
   </group>
 
@@ -131,7 +139,9 @@
         <arg name="config_file" value="$(var pose_initializer_param_path)"/>
         <arg name="sub_gnss_pose_cov" value="/sensing/gnss/pose_with_covariance"/>
       </include>
-      <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      <group if="$(var gnss_enabled)">
+        <include file="$(find-pkg-share automatic_pose_initializer)/launch/automatic_pose_initializer.launch.xml"/>
+      </group>
       <include file="$(find-pkg-share tier4_localization_launch)/launch/util/util.launch.py"/>
     </group>
   </group>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
`automatic_pose_initializer` should be executed only when `gnss_enabled` is true.
Otherwise, `pose_initializer` continuously says "GNSS is not supported"
Note that this PR does not affect any system behavior, but if you set `gnss_enabled:=false` manually, it helps you a lot.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

CI

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No effect. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
