### PR TITLE
fix(pid_longitudinal_control): slope definition

### DIFF
--- a/control/pid_longitudinal_controller/README.md
+++ b/control/pid_longitudinal_controller/README.md
@@ -75,6 +75,10 @@ For instance, if the vehicle is attempting to start with an acceleration of `1.0
 
 A suitable example of a vehicle system for the slope compensation function is one in which the output acceleration from the longitudinal_controller is converted into target accel/brake pedal input without any feedbacks. In this case, the output acceleration is just used as a feedforward term to calculate the target pedal, and hence the issue mentioned above does not arise.
 
+Note: The angle of the slope is defined as positive for an uphill slope, while the pitch angle of the ego pose is defined as negative when facing upward. They have an opposite definition.
+
+![slope_definition](./media/slope_definition.drawio.svg)
+
 #### PID control
 
 For deviations that cannot be handled by FeedForward control, such as model errors, PID control is used to construct a feedback system.

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -54,7 +54,7 @@ double calcStopDistance(
 /**
  * @brief calculate pitch angle from estimated current pose
  */
-double getPitchByPose(const Quaternion & quaternion);
+double getSlopeByPose(const Quaternion & quaternion);
 
 /**
  * @brief calculate pitch angle from trajectory on map
@@ -63,7 +63,7 @@ double getPitchByPose(const Quaternion & quaternion);
  * @param [in] closest_idx nearest index to current vehicle position
  * @param [in] wheel_base length of wheel base
  */
-double getPitchByTraj(
+double getSlopeByTraj(
   const Trajectory & trajectory, const size_t closest_idx, const double wheel_base);
 
 /**

--- a/control/pid_longitudinal_controller/media/slope_definition.drawio.svg
+++ b/control/pid_longitudinal_controller/media/slope_definition.drawio.svg
@@ -1,0 +1,165 @@
+<svg
+  host="65bd71144e"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  version="1.1"
+  width="352px"
+  height="183px"
+  viewBox="-0.5 -0.5 352 183"
+  content="&lt;mxfile&gt;&lt;diagram id=&quot;TbooNL80eO_aKRRhtfEq&quot; name=&quot;Page-1&quot;&gt;7VrLkps4FP0aV80s4kISz2XSjmc2U9VVvZjJKkWBDKrByAG5befrRwKBkYRt/MBjJ/GiG10kIc499yU0QS/L7R9FuEr/ojHOJtCKtxM0m0DoeAH/KwS7WmD7Ti1IChLXIrAXvJHvWAotKV2TGJdKR0ZpxshKFUY0z3HEFFlYFHSjdlvQTH3qKkywIXiLwsyU/k1iltZS37H28j8xSdLmycCSd5Zh01kKyjSM6aYjQp8n6KWglNVXy+0LzgR2DS71uPmBu+3CCpyzIQNgPeA9zNby3eS62K55WZzHHwVmvJXTnAs/pWyZ8RbglyUr6L8tCKiVvNCMFtV4VP/4nXpmHBvY7hcLWgg4dTBdYlbseJfNHuQG47SDbyMrcBYy8q5OH0pdJ+107RNeKeEPhpakJUJynoaVjZKaKUq6LiIsR3VB1SZygToRAtpELCwSzIyJOMzhrtNtJTqURxbsa8/xraPrsm1X7W+Do/0dqPWHSn9+Ua+4aXV0thdVhOsnHxpAvizjRi1It0kJw2+rMBJ3NtytqEQMy1Vt6QuyxXHLtndcMLw9l28NvjBQCQGkm+rw0TPp6B0mXge6o8jYj46M56nM8Pw7IeM8ODK2jVRk0L2QcR8cGQdqyIB7IeM9ODKuZavIWO6dkPFPI1PQdR6LN51Zp9EpKOMRmOa8+QG5U+dG3sbS4lzz6h182hSrLzG4BqLgwcmDkBakvR5wetgDbkCfJq95XHA8RwXHNn3OaOCAAeDsc+soC8uSRCom0bp4r2xPNOKwTNtGyXNIJisjm7f5TJ2WkYRb/DefP0MSbt8oCbedExMdSMIvyGPBeVXUL033K6jJrq/VdGvkI2h6SMlyjqb3yuytnVtlqnU2fAL1Ig9q9gcuUy9y1YlQMEy9Z1fTWk1jW77GluuqXWCWLm8ZXWHRhS/LivGC5JwY1Yq5ImlJKvjF/lQhpDn/s16lRMyqcY5HSNa3MdNQSW7cLPhYTRRmJBHpWsRZg7n8k4i3JAqzj/LGksRxdih8q8nhguZM2/jpeKKrAjn0dG8OjUAO7R42oxukgGBIaXXC6g3Tns+FcRumDY7geDwSHI4gD+8q9H0pX0u/BkcCpG7YIBCMFgmGFJW/OHEFJ7TM3Xcv4wQM7seJAeX05eXQYbbcwL8iWwuyvulfx9mCAEMK7NOfIO5mRXhL2D8y4InrLx35bNu5Mds1jZxDUg2Z+j5oBF8qAeCuTgr2g6uWMvoVF4QjKwL0zDrDejmKlZmo/KwZ35X9b1YO9Rrgwmqvzflb/qKxrBwO2fR4QMKCCwirkPUEUX8YTjpoakEHQBe6jm9r0SPwpoFn+x7yEC9YLy1pHH8KXM9qf9rOeICmyBotTMHzNqZMAp9TwR7gNqxHzkUxU9OnYrSZLlVi2U3fDXmKj8qO5piCiz2cFqHdkcpgR2O8G2h8u64MbsimsM/NmHR2E3Fqo2GP+20tDkJwJaPFouJRR+Qm4v9vr4RFKR9FF4IHCT1QTuc4CWU5vUmxKKUXYUTypKqpN2ER/96sgr9AvZD6AYZp/Pi1tgsUBrS1d8diEPSmjmk0t6i2e44FbJ9DCa2vE3Lpo/zb6MSuvqYpdmmZWoEjbYD0nEfY/fQqgZ7m2S3zdEifQqB/A4WYe4nff3qFtJV9+yUU3E8h5hZh/PVJVNJ+ZBjBbTmG25LpxF3clrlHF3/dPonnGlMr+nmKwB5LJ7y5P8xaZ4v7E8Ho838=&lt;/diagram&gt;&lt;/mxfile&gt;"
+>
+  <defs/>
+  <g>
+    <path
+      d="M 69 150 L 111.19 116.25 Q 119 110 127.61 104.91 L 176.39 76.09 Q 185 71 194.7 68.57 L 255.3 53.43 Q 265 51 274.92 49.7 L 349 40"
+      fill="none"
+      stroke="#333333"
+      stroke-width="3"
+      stroke-miterlimit="10"
+      pointer-events="stroke"
+    />
+    <ellipse cx="71.5" cy="148.5" rx="3.5" ry="3.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="119.5" cy="111.5" rx="3.5" ry="3.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="185.5" cy="71.5" rx="3.5" ry="3.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="265.5" cy="51.5" rx="3.5" ry="3.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="346.5" cy="39.5" rx="3.5" ry="3.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <rect x="39" y="57" width="100" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" transform="rotate(-36.5,89,82)" pointer-events="all"/>
+    <ellipse cx="83.5" cy="115.5" rx="8.5" ry="8.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="122.5" cy="86.5" rx="8.5" ry="8.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <path d="M 79 150 Q 79 150 184.13 150" fill="none" stroke="#0000ff" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+    <path d="M 187.88 150 L 182.88 152.5 L 184.13 150 L 182.88 147.5 Z" fill="#0000ff" stroke="#0000ff" stroke-miterlimit="10" pointer-events="all"/>
+    <path d="M 189 145 Q 189 145 189 82.87" fill="none" stroke="#0000ff" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+    <path d="M 189 79.12 L 191.5 84.12 L 189 82.87 L 186.5 84.12 Z" fill="#0000ff" stroke="#0000ff" stroke-miterlimit="10" pointer-events="all"/>
+    <path d="M 111 151 Q 116 138 105.98 131.32" fill="none" stroke="#0000ff" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+    <path d="M 102.86 129.24 L 108.41 129.93 L 105.98 131.32 L 105.63 134.09 Z" fill="#0000ff" stroke="#0000ff" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+    <rect x="9" y="152" width="240" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 167px; margin-left: 10px;"
+          >
+            <div data-drawio-colors="color: #3333FF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                Slope is defined as positive for an uphill
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="129" y="171" fill="#3333FF" font-family="Helvetica" font-size="12px" text-anchor="middle">Slope is defined as positive for an uphi...</text>
+      </switch>
+    </g>
+    <path d="M 85 117 Q 85 117 174.07 51.87" fill="none" stroke="#ff0000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+    <path d="M 177.1 49.66 L 174.54 54.63 L 174.07 51.87 L 171.59 50.59 Z" fill="#ff0000" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+    <path d="M 84 116 Q 84 116 40.76 53.01" fill="none" stroke="#ff0000" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+    <path d="M 38.63 49.92 L 43.52 52.63 L 40.76 53.01 L 39.4 55.46 Z" fill="#ff0000" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+    <ellipse cx="84.5" cy="115.5" rx="3.5" ry="3.5" fill="rgb(255, 255, 255)" stroke="#ff0000" pointer-events="all"/>
+    <path d="M 82.03 117.97 Q 82.03 117.97 87.17 113.31" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+    <path d="M 86.97 117.97 Q 86.97 117.97 82.03 113.03" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+    <path d="M 97.28 114.02 Q 98 99 81 98" fill="none" stroke="#ff0000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+    <path d="M 97.11 117.77 L 94.85 112.65 L 97.28 114.02 L 99.84 112.89 Z" fill="#ff0000" stroke="#ff0000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+    <rect x="0" y="0" width="327.5" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 326px; height: 1px; padding-top: 15px; margin-left: 1px;">
+            <div data-drawio-colors="color: #3333FF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                <font color="#ff0000">(Pitch of ego is defined as negative when facing upward)</font>
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="164" y="19" fill="#3333FF" font-family="Helvetica" font-size="12px" text-anchor="middle">(Pitch of ego is defined as negative when facing upwar...</text>
+      </switch>
+    </g>
+    <rect x="175.5" y="30" width="20" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 45px; margin-left: 177px;">
+            <div data-drawio-colors="color: #FF0000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 8px; font-family: Helvetica; color: rgb(255, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                x
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="186" y="47" fill="#FF0000" font-family="Helvetica" font-size="8px" text-anchor="middle">x</text>
+      </switch>
+    </g>
+    <rect x="17" y="35" width="20" height="28" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 49px; margin-left: 18px;">
+            <div data-drawio-colors="color: #FF0000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 8px; font-family: Helvetica; color: rgb(255, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                y
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="27" y="51" fill="#FF0000" font-family="Helvetica" font-size="8px" text-anchor="middle">y</text>
+      </switch>
+    </g>
+    <rect x="58" y="101" width="20" height="28" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 115px; margin-left: 59px;">
+            <div data-drawio-colors="color: #FF0000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 8px; font-family: Helvetica; color: rgb(255, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                z
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="68" y="117" fill="#FF0000" font-family="Helvetica" font-size="8px" text-anchor="middle">z</text>
+      </switch>
+    </g>
+    <rect x="195.5" y="99" width="20" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 114px; margin-left: 197px;"
+          >
+            <div data-drawio-colors="color: #0000FF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 8px; font-family: Helvetica; color: rgb(0, 0, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                d_z
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="206" y="116" fill="#0000FF" font-family="Helvetica" font-size="8px" text-anchor="middle">d_z</text>
+      </switch>
+    </g>
+    <rect x="139" y="124" width="20" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 139px; margin-left: 140px;"
+          >
+            <div data-drawio-colors="color: #0000FF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 8px; font-family: Helvetica; color: rgb(0, 0, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                d_xy
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="149" y="141" fill="#0000FF" font-family="Helvetica" font-size="8px" text-anchor="middle">d_xy</text>
+      </switch>
+    </g>
+  </g>
+  <switch>
+    <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+    <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+      <text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text>
+    </a>
+  </switch>
+</svg>

--- a/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -73,17 +73,25 @@ double calcStopDistance(
   return signed_length_on_traj;
 }
 
-double getPitchByPose(const Quaternion & quaternion_msg)
+// Calculate pitch angle from ego_pose information.
+// The angle of the slope is defined as positive for an uphill slope.
+double getSlopeByPose(const Quaternion & quaternion_msg)
 {
   double roll, pitch, yaw;
   tf2::Quaternion quaternion;
   tf2::fromMsg(quaternion_msg, quaternion);
   tf2::Matrix3x3{quaternion}.getRPY(roll, pitch, yaw);
 
-  return pitch;
+  // The pitch angle of the posture is defined as positive when facing downward.
+  // Thus, the definition is the opposite of the slope.
+  const auto slope = -pitch;
+
+  return slope;
 }
 
-double getPitchByTraj(
+// Calculate pitch angle from trajectory information.
+// The angle of the slope is defined as positive for an uphill slope.
+double getSlopeByTraj(
   const Trajectory & trajectory, const size_t nearest_idx, const double wheel_base)
 {
   // cannot calculate pitch

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -457,9 +457,9 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
     current_pose, m_trajectory, m_ego_nearest_dist_threshold, m_ego_nearest_yaw_threshold);
 
   // pitch
-  const double raw_pitch = longitudinal_utils::getPitchByPose(current_pose.orientation);
+  const double raw_pitch = longitudinal_utils::getSlopeByPose(current_pose.orientation);
   const double traj_pitch =
-    longitudinal_utils::getPitchByTraj(m_trajectory, control_data.nearest_idx, m_wheel_base);
+    longitudinal_utils::getSlopeByTraj(m_trajectory, control_data.nearest_idx, m_wheel_base);
   control_data.slope_angle = m_use_traj_for_pitch ? traj_pitch : m_lpf_pitch->filter(raw_pitch);
   updatePitchDebugValues(control_data.slope_angle, traj_pitch, raw_pitch);
 

--- a/control/pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -102,16 +102,20 @@ TEST(TestLongitudinalControllerUtils, calcStopDistance)
   EXPECT_EQ(longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw), 3.0);
 }
 
-TEST(TestLongitudinalControllerUtils, getPitchByPose)
+TEST(TestLongitudinalControllerUtils, getSlopeByPose)
 {
+  // NOTE: the slope is defined as positive for an uphill slope, while the pitch is defined as
+  // positive when facing downward. They are opposite.
   tf2::Quaternion quaternion_tf;
   quaternion_tf.setRPY(0.0, 0.0, 0.0);
-  EXPECT_EQ(longitudinal_utils::getPitchByPose(tf2::toMsg(quaternion_tf)), 0.0);
+  EXPECT_EQ(longitudinal_utils::getSlopeByPose(tf2::toMsg(quaternion_tf)), 0.0);
   quaternion_tf.setRPY(0.0, 1.0, 0.0);
-  EXPECT_EQ(longitudinal_utils::getPitchByPose(tf2::toMsg(quaternion_tf)), 1.0);
+  EXPECT_EQ(longitudinal_utils::getSlopeByPose(tf2::toMsg(quaternion_tf)), -1.0);
+  quaternion_tf.setRPY(0.0, 0.1, 0.0);
+  EXPECT_EQ(longitudinal_utils::getSlopeByPose(tf2::toMsg(quaternion_tf)), -0.1);
 }
 
-TEST(TestLongitudinalControllerUtils, getPitchByTraj)
+TEST(TestLongitudinalControllerUtils, getSlopeByTraj)
 {
   using autoware_auto_planning_msgs::msg::Trajectory;
   using autoware_auto_planning_msgs::msg::TrajectoryPoint;
@@ -144,17 +148,17 @@ TEST(TestLongitudinalControllerUtils, getPitchByTraj)
   traj.points.push_back(point);
   size_t closest_idx = 0;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)), M_PI_4);
+    std::abs(longitudinal_utils::getSlopeByTraj(traj, closest_idx, wheel_base)), M_PI_4);
   closest_idx = 1;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)), M_PI_4);
+    std::abs(longitudinal_utils::getSlopeByTraj(traj, closest_idx, wheel_base)), M_PI_4);
   closest_idx = 2;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)),
+    std::abs(longitudinal_utils::getSlopeByTraj(traj, closest_idx, wheel_base)),
     std::atan2(0.5, 1));
   closest_idx = 3;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)),
+    std::abs(longitudinal_utils::getSlopeByTraj(traj, closest_idx, wheel_base)),
     std::atan2(0.5, 1));
 }
 


### PR DESCRIPTION
## Description

Fix the wrong definition of the slope in the code coming from https://github.com/autowarefoundation/autoware.universe/pull/5090.

To remove the ambiguity in the definitions of pitch angle and slope angle, they have been defined in the readme. 

Additionally, because the function name getPitch was unclear, it has been unified to the function name getSlope.

## Related links

None

## Tests performed

run psim.

## Notes for reviewers

None
## Interface changes

None

## Effects on system behavior

The wrong slope compensation is fixed coming from https://github.com/autowarefoundation/autoware.universe/pull/5090.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
