### PR TITLE
fix(traffic_light_fine_detector): add data_path arg and update default model path

### DIFF
--- a/perception/traffic_light_fine_detector/README.md
+++ b/perception/traffic_light_fine_detector/README.md
@@ -51,7 +51,7 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 ### Node Parameters
 
 | Name                       | Type   | Default Value               | Description                                                        |
-| -------------------------- | ------ | -------------               | ------------------------------------------------------------------ |
+| -------------------------- | ------ | --------------------------- | ------------------------------------------------------------------ |
 | `data_path`                | string | "$(env HOME)/autoware_data" | packages data and artifacts directory path                         |
 | `fine_detector_model_path` | string | ""                          | The onnx file name for yolo model                                  |
 | `fine_detector_label_path` | string | ""                          | The label file with label names for detected objects written on it |

--- a/perception/traffic_light_fine_detector/README.md
+++ b/perception/traffic_light_fine_detector/README.md
@@ -50,12 +50,13 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 
 ### Node Parameters
 
-| Name                       | Type   | Default Value | Description                                                        |
-| -------------------------- | ------ | ------------- | ------------------------------------------------------------------ |
-| `fine_detector_model_path` | string | ""            | The onnx file name for yolo model                                  |
-| `fine_detector_label_path` | string | ""            | The label file with label names for detected objects written on it |
-| `fine_detector_precision`  | string | "fp32"        | The inference mode: "fp32", "fp16"                                 |
-| `approximate_sync`         | bool   | false         | Flag for whether to ues approximate sync policy                    |
+| Name                       | Type   | Default Value               | Description                                                        |
+| -------------------------- | ------ | -------------               | ------------------------------------------------------------------ |
+| `data_path`                | string | "$(env HOME)/autoware_data" | packages data and artifacts directory path                         |
+| `fine_detector_model_path` | string | ""                          | The onnx file name for yolo model                                  |
+| `fine_detector_label_path` | string | ""                          | The label file with label names for detected objects written on it |
+| `fine_detector_precision`  | string | "fp32"                      | The inference mode: "fp32", "fp16"                                 |
+| `approximate_sync`         | bool   | false                       | Flag for whether to ues approximate sync policy                    |
 
 ## Assumptions / Known limits
 

--- a/perception/traffic_light_fine_detector/launch/traffic_light_fine_detector.launch.xml
+++ b/perception/traffic_light_fine_detector/launch/traffic_light_fine_detector.launch.xml
@@ -1,6 +1,7 @@
 <launch>
-  <arg name="fine_detector_label_path" default="$(find-pkg-share traffic_light_fine_detector)/data/tlr_labels.txt" description="fine detector label path"/>
-  <arg name="fine_detector_model_path" default="$(find-pkg-share traffic_light_fine_detector)/data/tlr_yolox_s_batch_6.onnx" description="fine detector onnx model path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="fine_detector_label_path" default="$(var data_path)/traffic_light_fine_detector/tlr_labels.txt" description="fine detector label path"/>
+  <arg name="fine_detector_model_path" default="$(var data_path)/traffic_light_fine_detector/tlr_yolox_s_batch_6.onnx" description="fine detector onnx model path"/>
   <arg name="fine_detector_precision" default="fp16"/>
   <arg name="fine_detector_score_thresh" default="0.3"/>
   <arg name="fine_detector_nms_thresh" default="0.65"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Belongs to [Standardize a strategy for packages with downloaded artifacts](https://github.com/orgs/autowarefoundation/discussions/3649)
This PR introduces new launch argument data_path in the form:
  `<arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>`
It also updates default model and data paths. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
