### PR TITLE
fix(crosswalk): fix module launch condition

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/manager.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.hpp
@@ -51,8 +51,6 @@ private:
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const PathWithLaneId & path) override;
-
-  std::optional<bool> opt_use_regulatory_element_{std::nullopt};
 };
 
 class CrosswalkModulePlugin : public PluginWrapper<CrosswalkModuleManager>

--- a/planning/behavior_velocity_walkway_module/src/manager.cpp
+++ b/planning/behavior_velocity_walkway_module/src/manager.cpp
@@ -45,7 +45,7 @@ void WalkwayModuleManager::launchNewModules(const PathWithLaneId & path)
 {
   const auto rh = planner_data_->route_handler_;
 
-  const auto launch = [this, &path](const auto & lanelet, const auto use_regulatory_element) {
+  const auto launch = [this, &path](const auto & lanelet, const auto & use_regulatory_element) {
     const auto attribute =
       lanelet.attributeOr(lanelet::AttributeNamesString::Subtype, std::string(""));
     if (attribute != lanelet::AttributeValueString::Walkway) {

--- a/planning/behavior_velocity_walkway_module/src/manager.hpp
+++ b/planning/behavior_velocity_walkway_module/src/manager.hpp
@@ -50,8 +50,6 @@ private:
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const PathWithLaneId & path) override;
-
-  std::optional<bool> opt_use_regulatory_element_{std::nullopt};
 };
 
 class WalkwayModulePlugin : public PluginWrapper<WalkwayModuleManager>


### PR DESCRIPTION
## Description

Applied the following fix to the crosswalk.
https://github.com/autowarefoundation/autoware.universe/pull/4823

---
Fix module launch condition so that it can activate crosswalk module in the map which has both regulatory element crosswalk and non regulatory element crosswalk.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
scenario test: https://evaluation.tier4.jp/evaluation/reports/4e7da0bf-e29b-5060-8c29-562bbbb7827a?project_id=prd_jt
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Make it possible to use crosswalk module in specific map.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
