### PR TITLE
feat(crosswalk): stuck detection for original stop point

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -218,7 +218,7 @@ boost::optional<size_t> searchZeroVelocityIndex(
 
   constexpr double epsilon = 1e-3;
   for (size_t i = src_idx; i < dst_idx; ++i) {
-    if (std::fabs(points_with_twist.at(i).longitudinal_velocity_mps) < epsilon) {
+    if (tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.at(i)) < epsilon) {
       return i;
     }
   }
@@ -271,6 +271,9 @@ boost::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist)
 extern template boost::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist);
+extern template boost::optional<size_t>
+searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist);
 
 /**
  * @brief find nearest point index through points container for a given point.

--- a/common/motion_utils/src/trajectory/trajectory.cpp
+++ b/common/motion_utils/src/trajectory/trajectory.cpp
@@ -76,6 +76,9 @@ searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::Trajectory
 template boost::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist);
+template boost::optional<size_t>
+searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist);
 
 //
 template size_t findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -288,6 +288,10 @@ private:
     const std::vector<geometry_msgs::msg::Point> & path_intersects,
     const std::optional<geometry_msgs::msg::Pose> & stop_pose) const;
 
+  std::optional<StopFactor> checkStopForOriginalStopPoint(
+    const PathWithLaneId & ego_path, const std::vector<geometry_msgs::msg::Point> & path_intersects,
+    const std::optional<geometry_msgs::msg::Pose> & stop_pose) const;
+
   std::optional<CollisionPoint> getCollisionPoint(
     const PathWithLaneId & ego_path, const PredictedObject & object,
     const std::pair<double, double> & crosswalk_attention_range, const Polygon2d & attention_area);
@@ -295,7 +299,8 @@ private:
   std::optional<StopFactor> getNearestStopFactor(
     const PathWithLaneId & ego_path,
     const std::optional<StopFactor> & stop_factor_for_crosswalk_users,
-    const std::optional<StopFactor> & stop_factor_for_stuck_vehicles);
+    const std::optional<StopFactor> & stop_factor_for_stuck_vehicles,
+    const std::optional<StopFactor> & stop_factor_for_original_stop_point);
 
   void setDistanceToStop(
     const PathWithLaneId & ego_path,


### PR DESCRIPTION
## Description

Currently, stuck detection for not stopping on the crosswalk is applied only to the front vehicle.
Beside the front vehicle, if a stop point in the original path is around the crosswalk, the ego may stop on the crosswalk.

To address this issue, the stuck detection is applied to the original stop point as well.

 
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The ego will not stop on the crosswalk if the original path's stop point is around the crosswalk.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
