### PR TITLE
perf(behavior_path_planner): add processing time publishers to output results from the timer

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -20,6 +20,8 @@
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/lane_following/module_data.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
+#include "tier4_autoware_utils/ros/debug_publisher.hpp"
+#include "tier4_debug_msgs/msg/float64_stamped.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -44,6 +46,8 @@ using tier4_autoware_utils::StopWatch;
 using tier4_planning_msgs::msg::StopReasonArray;
 using SceneModulePtr = std::shared_ptr<SceneModuleInterface>;
 using SceneModuleManagerPtr = std::shared_ptr<SceneModuleManagerInterface>;
+using DebugPublisher=tier4_autoware_utils::DebugPublisher;
+using DebugDoubleMsg=tier4_debug_msgs::msg::Float64Stamped;
 
 enum Action {
   ADD = 0,
@@ -420,6 +424,8 @@ private:
   std::vector<SceneModulePtr> approved_module_ptrs_;
 
   std::vector<SceneModulePtr> candidate_module_ptrs_;
+
+  std::unique_ptr<DebugPublisher> debug_publisher_ptr_;
 
   mutable rclcpp::Logger logger_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -19,12 +19,12 @@
 #include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/lane_following/module_data.hpp"
-#include "tier4_autoware_utils/system/stop_watch.hpp"
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
-#include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
+#include "tier4_debug_msgs/msg/float64_stamped.hpp"
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 
@@ -46,8 +46,8 @@ using tier4_autoware_utils::StopWatch;
 using tier4_planning_msgs::msg::StopReasonArray;
 using SceneModulePtr = std::shared_ptr<SceneModuleInterface>;
 using SceneModuleManagerPtr = std::shared_ptr<SceneModuleManagerInterface>;
-using DebugPublisher=tier4_autoware_utils::DebugPublisher;
-using DebugDoubleMsg=tier4_debug_msgs::msg::Float64Stamped;
+using DebugPublisher = tier4_autoware_utils::DebugPublisher;
+using DebugDoubleMsg = tier4_debug_msgs::msg::Float64Stamped;
 
 enum Action {
   ADD = 0,

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -17,6 +17,7 @@
 #include "behavior_path_planner/utils/path_utils.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
+#include "tier4_autoware_utils/ros/debug_publisher.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
 #include <magic_enum.hpp>
@@ -34,6 +35,7 @@ PlannerManager::PlannerManager(rclcpp::Node & node, const bool verbose)
   verbose_{verbose}
 {
   processing_time_.emplace("total_time", 0.0);
+  debug_publisher_ptr_ = std::make_unique<DebugPublisher>(&node, "behavior_planner_manager/debug");
 }
 
 BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & data)
@@ -884,6 +886,8 @@ void PlannerManager::print() const
     string_stream << std::right << "[" << std::setw(max_string_num + 1) << std::left << t.first
                   << ":" << std::setw(4) << std::right << t.second << "ms]\n"
                   << std::setw(21);
+    std::string name = std::string("processing_time/") + t.first;
+    debug_publisher_ptr_->publish<DebugDoubleMsg>(name, t.second);
   }
 
   RCLCPP_INFO_STREAM(logger_, string_stream.str());

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -16,8 +16,8 @@
 
 #include "behavior_path_planner/utils/path_utils.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
-#include "tier4_autoware_utils/system/stop_watch.hpp"
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
+#include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
 #include <magic_enum.hpp>


### PR DESCRIPTION

## Description

Publish the processing time of each module in behavior_path_planner to debug messages.

## Related links

None

## Tests performed

PSim

## Notes for reviewers


## Interface changes

When "verbose" is set to True, The behavior_path_planner_node will produce a topics in /planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/*

#### Demonstrations with Plotjuggler
```bash
ros2 run plotjuggler plotjuggler
```
and select /planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/*

![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/d3bbf5c4-c16c-44a9-b911-3c9841557b88)

#### Verbose Setting

The verbose parameter is an existing parameter in 

> autoware_launch/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml

![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/8d68ee94-65d1-4b75-8450-7828d4fbfafc)

This PR will log the processing time number as in this ros logging:
![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/cec4639f-56af-414d-bb52-415647858658)
into debugging topics.


## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
