### PR TITLE
refactor(localization_error_monitor): rework parameters

### DIFF
--- a/localization/localization_error_monitor/src/node.cpp
+++ b/localization/localization_error_monitor/src/node.cpp
@@ -33,14 +33,14 @@
 LocalizationErrorMonitor::LocalizationErrorMonitor()
 : Node("localization_error_monitor"), updater_(this)
 {
-  scale_ = this->declare_parameter("scale", 3.0);
-  error_ellipse_size_ = this->declare_parameter("error_ellipse_size", 1.0);
-  warn_ellipse_size_ = this->declare_parameter("warn_ellipse_size", 0.8);
+  scale_ = this->declare_parameter<double>("scale");
+  error_ellipse_size_ = this->declare_parameter<double>("error_ellipse_size");
+  warn_ellipse_size_ = this->declare_parameter<double>("warn_ellipse_size");
 
   error_ellipse_size_lateral_direction_ =
-    this->declare_parameter("error_ellipse_size_lateral_direction", 0.3);
+    this->declare_parameter<double>("error_ellipse_size_lateral_direction");
   warn_ellipse_size_lateral_direction_ =
-    this->declare_parameter("warn_ellipse_size_lateral_direction", 0.2);
+    this->declare_parameter<double>("warn_ellipse_size_lateral_direction");
 
   odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
     "input/odom", 1, std::bind(&LocalizationErrorMonitor::onOdom, this, std::placeholders::_1));


### PR DESCRIPTION
## Description
Removed default parameters in the C++ codes in localization_error_monitor.

## Tests performed
It is able to build localization_error_monitor locally.
It is also confirmed that the [logging_simulator on the tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) works fine.

## Effects on system behavior

Less prone to unexpected behavior when parameter definitions are incomplete.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
