### PR TITLE
fix(out_of_lane): lateral distance calculation for predicted path

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/decisions.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/decisions.cpp
@@ -78,17 +78,18 @@ std::optional<std::pair<double, double>> object_time_to_range(
   auto worst_exit_time = std::optional<double>();
 
   for (const auto & predicted_path : object.kinematics.predicted_paths) {
+    const auto unique_path_points = motion_utils::removeOverlapPoints(predicted_path.path);
     const auto time_step = rclcpp::Duration(predicted_path.time_step).seconds();
     const auto enter_point =
       geometry_msgs::msg::Point().set__x(range.entering_point.x()).set__y(range.entering_point.y());
     const auto enter_segment_idx =
-      motion_utils::findNearestSegmentIndex(predicted_path.path, enter_point);
+      motion_utils::findNearestSegmentIndex(unique_path_points, enter_point);
     const auto enter_offset = motion_utils::calcLongitudinalOffsetToSegment(
-      predicted_path.path, enter_segment_idx, enter_point);
-    const auto enter_lat_dist = std::abs(
-      motion_utils::calcLateralOffset(predicted_path.path, enter_point, enter_segment_idx));
+      unique_path_points, enter_segment_idx, enter_point);
+    const auto enter_lat_dist =
+      std::abs(motion_utils::calcLateralOffset(unique_path_points, enter_point, enter_segment_idx));
     const auto enter_segment_length = tier4_autoware_utils::calcDistance2d(
-      predicted_path.path[enter_segment_idx], predicted_path.path[enter_segment_idx + 1]);
+      unique_path_points[enter_segment_idx], unique_path_points[enter_segment_idx + 1]);
     const auto enter_offset_ratio = enter_offset / enter_segment_length;
     const auto enter_time =
       static_cast<double>(enter_segment_idx) * time_step + enter_offset_ratio * time_step;
@@ -96,13 +97,13 @@ std::optional<std::pair<double, double>> object_time_to_range(
     const auto exit_point =
       geometry_msgs::msg::Point().set__x(range.exiting_point.x()).set__y(range.exiting_point.y());
     const auto exit_segment_idx =
-      motion_utils::findNearestSegmentIndex(predicted_path.path, exit_point);
+      motion_utils::findNearestSegmentIndex(unique_path_points, exit_point);
     const auto exit_offset = motion_utils::calcLongitudinalOffsetToSegment(
-      predicted_path.path, exit_segment_idx, exit_point);
+      unique_path_points, exit_segment_idx, exit_point);
     const auto exit_lat_dist =
-      std::abs(motion_utils::calcLateralOffset(predicted_path.path, exit_point, exit_segment_idx));
+      std::abs(motion_utils::calcLateralOffset(unique_path_points, exit_point, exit_segment_idx));
     const auto exit_segment_length = tier4_autoware_utils::calcDistance2d(
-      predicted_path.path[exit_segment_idx], predicted_path.path[exit_segment_idx + 1]);
+      unique_path_points[exit_segment_idx], unique_path_points[exit_segment_idx + 1]);
     const auto exit_offset_ratio = exit_offset / static_cast<double>(exit_segment_length);
     const auto exit_time =
       static_cast<double>(exit_segment_idx) * time_step + exit_offset_ratio * time_step;

--- a/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
@@ -23,6 +23,9 @@
 
 namespace behavior_velocity_planner::out_of_lane
 {
+using motion_utils::calcLateralOffset;
+using tier4_autoware_utils::calcDistance2d;
+
 /// @brief filter predicted objects and their predicted paths
 /// @param [in] objects predicted objects to filter
 /// @param [in] ego_data ego data
@@ -44,8 +47,13 @@ autoware_auto_perception_msgs::msg::PredictedObjects filter_predicted_objects(
     auto filtered_object = object;
     const auto is_invalid_predicted_path = [&](const auto & predicted_path) {
       const auto is_low_confidence = predicted_path.confidence < params.objects_min_confidence;
+      const auto unique_path_points = motion_utils::removeOverlapPoints(predicted_path.path);
+
+      // Note: lateral offset can not be calculated for path with less than 2 unique points
       const auto lat_offset_to_current_ego =
-        std::abs(motion_utils::calcLateralOffset(predicted_path.path, ego_data.pose.position));
+        unique_path_points.size() > 1
+          ? std::abs(calcLateralOffset(unique_path_points, ego_data.pose.position))
+          : calcDistance2d(unique_path_points.front(), ego_data.pose.position);
       const auto is_crossing_ego =
         lat_offset_to_current_ego <=
         object.shape.dimensions.y / 2.0 + std::max(


### PR DESCRIPTION
## Description

When the `calcLateralOffset()` is called for an object's predicted_path, if the object velocity is zero, then all predicted_path points are in the same position, and the lateral distance can not be calculated appropriately. This PR fixes the issue.

## Related links

None

## Tests performed

run psim with out_of_lane module

## Notes for reviewers

None
## Interface changes

None

## Effects on system behavior

Some unstable behavior of the out_of_lane may be fixed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
