### PR TITLE
fix(behavior_path_planner): add empty guard to combinePath

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/util.hpp
@@ -44,8 +44,6 @@ using geometry_msgs::msg::Twist;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 
-// TODO(sugahara) move to util
-PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 lanelet::ConstLanelets getPullOverLanes(
   const RouteHandler & route_handler, const bool left_side, const double backward_distance,
   const double forward_distance);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -88,8 +88,6 @@ std::vector<std::vector<int64_t>> getSortedLaneIds(
   const RouteHandler & route_handler, const Pose & current_pose,
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes);
 
-PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
-
 lanelet::ConstLanelets getTargetPreferredLanes(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes, const Direction & direction,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
@@ -102,6 +102,8 @@ PathWithLaneId calcCenterLinePath(
   const std::shared_ptr<const PlannerData> & planner_data, const Pose & ref_pose,
   const double longest_dist_to_shift_line,
   const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
+
+PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 }  // namespace behavior_path_planner::utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__PATH_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/util.hpp
@@ -44,7 +44,6 @@ using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using route_handler::RouteHandler;
 
-PathWithLaneId combineReferencePath(const PathWithLaneId path1, const PathWithLaneId path2);
 PathWithLaneId getBackwardPath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & current_pose, const Pose & backed_pose, const double velocity);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -125,7 +125,7 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
 
   const auto found_extended_path = extendPath();
   if (found_extended_path) {
-    *output.path = utils::lane_change::combineReferencePath(*output.path, *found_extended_path);
+    *output.path = utils::combinePath(*output.path, *found_extended_path);
   }
   extendOutputDrivableArea(output);
   output.reference_path = std::make_shared<PathWithLaneId>(getReferencePath());

--- a/planning/behavior_path_planner/src/utils/goal_planner/util.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/util.cpp
@@ -44,16 +44,6 @@ namespace behavior_path_planner
 {
 namespace goal_planner_utils
 {
-PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2)
-{
-  PathWithLaneId path;
-  path.points.insert(path.points.end(), path1.points.begin(), path1.points.end());
-
-  // skip overlapping point
-  path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
-
-  return path;
-}
 
 lanelet::ConstLanelets getPullOverLanes(
   const RouteHandler & route_handler, const bool left_side, const double backward_distance,

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -180,17 +180,6 @@ std::vector<double> getAccelerationValues(
   return sampled_values;
 }
 
-PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2)
-{
-  PathWithLaneId path;
-  path.points.insert(path.points.end(), path1.points.begin(), path1.points.end());
-
-  // skip overlapping point
-  path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
-
-  return path;
-}
-
 lanelet::ConstLanelets getTargetPreferredLanes(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes, const Direction & direction,
@@ -355,7 +344,7 @@ std::optional<LaneChangePath> constructCandidatePath(
     return std::nullopt;
   }
 
-  candidate_path.path = combineReferencePath(prepare_segment, shifted_path.path);
+  candidate_path.path = utils::combinePath(prepare_segment, shifted_path.path);
   candidate_path.shifted_path = shifted_path;
 
   return std::optional<LaneChangePath>{candidate_path};

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -561,4 +561,25 @@ PathWithLaneId calcCenterLinePath(
 
   return centerline_path;
 }
+
+PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2)
+{
+  if (path1.points.empty()) {
+    return path2;
+  }
+  if (path2.points.empty()) {
+    return path1;
+  }
+
+  PathWithLaneId path{};
+  path.points.insert(path.points.end(), path1.points.begin(), path1.points.end());
+
+  // skip overlapping point
+  path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
+
+  PathWithLaneId filtered_path = path;
+  filtered_path.points = motion_utils::removeOverlapPoints(filtered_path.points);
+  return filtered_path;
+}
+
 }  // namespace behavior_path_planner::utils

--- a/planning/behavior_path_planner/src/utils/start_planner/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/freespace_pull_out.cpp
@@ -97,8 +97,7 @@ boost::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, con
 
   const auto road_center_line_path = route_handler->getCenterLinePath(road_lanes, s_start, s_end);
   last_path = utils::resamplePathWithSpline(
-    start_planner_utils::combineReferencePath(last_path, road_center_line_path),
-    parameters_.center_line_path_interval);
+    utils::combinePath(last_path, road_center_line_path), parameters_.center_line_path_interval);
 
   const double original_terminal_velocity = last_path.points.back().point.longitudinal_velocity_mps;
   utils::correctDividedPathVelocity(partial_paths);

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -15,6 +15,7 @@
 #include "behavior_path_planner/utils/start_planner/geometric_pull_out.hpp"
 
 #include "behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp"
+#include "behavior_path_planner/utils/path_utils.hpp"
 #include "behavior_path_planner/utils/start_planner/util.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
 
@@ -26,7 +27,6 @@ using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcOffsetPose;
 namespace behavior_path_planner
 {
-using start_planner_utils::combineReferencePath;
 using start_planner_utils::getPullOutLanes;
 
 GeometricPullOut::GeometricPullOut(rclcpp::Node & node, const StartPlannerParameters & parameters)
@@ -106,7 +106,7 @@ boost::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, con
       std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_second_arc_path)));
   } else {
     const auto partial_paths = planner_.getPaths();
-    const auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));
+    const auto combined_path = utils::combinePath(partial_paths.at(0), partial_paths.at(1));
     output.partial_paths.push_back(combined_path);
 
     // Calculate the acceleration required to reach the forward parking velocity at the center of

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -32,7 +32,6 @@ using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcOffsetPose;
 namespace behavior_path_planner
 {
-using start_planner_utils::combineReferencePath;
 using start_planner_utils::getPullOutLanes;
 
 ShiftPullOut::ShiftPullOut(

--- a/planning/behavior_path_planner/src/utils/start_planner/util.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/util.cpp
@@ -38,19 +38,6 @@
 
 namespace behavior_path_planner::start_planner_utils
 {
-PathWithLaneId combineReferencePath(const PathWithLaneId path1, const PathWithLaneId path2)
-{
-  PathWithLaneId path;
-  path.points.insert(path.points.end(), path1.points.begin(), path1.points.end());
-
-  // skip overlapping point
-  path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
-
-  PathWithLaneId filtered_path = path;
-  filtered_path.points = motion_utils::removeOverlapPoints(filtered_path.points);
-  return filtered_path;
-}
-
 PathWithLaneId getBackwardPath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & shoulder_lanes,
   const Pose & current_pose, const Pose & backed_pose, const double velocity)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

add empty guard to combinePath

fix freespace pull out dying

```
(gdb) p path2.points
$4 = std::vector of length 0, capacity 0
(gdb) f 15
#15 0x00007f5c9b673d94 in behavior_path_planner::FreespacePullOut::plan (this=<optimized out>, start_pose=..., end_pose=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/utils/start_planner/freespace_pull_out.cpp:100
100         start_planner_utils::combineReferencePath(last_path, road_center_line_path),
(gdb) f 14
#14 behavior_path_planner::start_planner_utils::combineReferencePath (path1=..., path2=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/utils/start_planner/util.cpp:47
47        path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
(gdb) l
42      {
43        PathWithLaneId path;
44        path.points.insert(path.points.end(), path1.points.begin(), path1.points.end());
45
46        // skip overlapping point
47        path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
48
49        PathWithLaneId filtered_path = path;
50        filtered_path.points = motion_utils::removeOverlapPoints(filtered_path.points);
51        return filtered_path;
(gdb) f 15
#15 0x00007f5c9b673d94 in behavior_path_planner::FreespacePullOut::plan (this=<optimized out>, start_pose=..., end_pose=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/utils/start_planner/freespace_pull_out.cpp:100
100         start_planner_utils::combineReferencePath(last_path, road_center_line_path),
(gdb) p road_center_line_path
$5 = {header = {stamp = {sec = 0, nanosec = 0}, frame_id = ""}, points = std::vector of length 0, capacity 0, left_bound = std::vector of length 0, capacity 0, right_bound = std::vector of length 0, capacity 0}
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
none

## Tests performed

<!-- Describe how you have tested this PR. -->

2023/09/27 https://evaluation.tier4.jp/evaluation/reports/1165d183-1910-5451-a816-41d1da57d444/?project_id=prd_jt

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
