### PR TITLE
fix(ndt_scan_matcher): removed duplicate parameter declarations "initial_pose_timeout_sec_"

### DIFF
--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -144,9 +144,6 @@ NDTScanMatcher::NDTScanMatcher()
   critical_upper_bound_exe_time_ms_ =
     this->declare_parameter("critical_upper_bound_exe_time_ms", critical_upper_bound_exe_time_ms_);
 
-  initial_pose_timeout_sec_ =
-    this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);
-
   initial_pose_timeout_sec_ = this->declare_parameter<double>("initial_pose_timeout_sec");
 
   initial_pose_distance_tolerance_m_ =


### PR DESCRIPTION
## Description

Removed duplicate parameter declarations `initial_pose_timeout_sec_`

https://github.com/autowarefoundation/autoware.universe/pull/4916

## Tests performed

logging_simulator on sample rosbag

## Effects on system behavior

The `ndt_scan_matcher` node will not crash.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
