### PR TITLE
refactor(ndt_scan_matcher): delete default parameters from ndt_scan_matcher_core.cpp

### DIFF
--- a/localization/ndt_scan_matcher/README.md
+++ b/localization/ndt_scan_matcher/README.md
@@ -244,7 +244,7 @@ Here is a split PCD map for `sample-map-rosbag` from Autoware tutorial: [`sample
 
 ### Abstract
 
-This is a function that uses de-grounded LiDAR scan estimate scan matching score.This score can more accurately reflect the current localization performance.
+This is a function that uses de-grounded LiDAR scan to estimate the scan matching score. This score can reflect the current localization performance more accurately.
 [related issue](https://github.com/autowarefoundation/autoware.universe/issues/2044).
 
 ### Parameters

--- a/localization/ndt_scan_matcher/README.md
+++ b/localization/ndt_scan_matcher/README.md
@@ -54,25 +54,25 @@ One optional function is regularization. Please see the regularization chapter i
 
 ### Core Parameters
 
-| Name                                                      | Type                   | Description                                                                                          |
-|-----------------------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
-| `base_frame`                                              | string                 | Vehicle reference frame                                                                              |
-| `ndt_base_frame`                                          | string                 | NDT reference frame                                                                                  |
-| `map_frame`                                               | string                 | map frame                                                                                            |
-| `input_sensor_points_queue_size`                          | int                    | Subscriber queue size                                                                                |
-| `trans_epsilon`                                           | double                 | The max difference between two consecutive transformations to consider convergence                   |
-| `step_size`                                               | double                 | The newton line search maximum step length                                                           |
-| `resolution`                                              | double                 | The ND voxel grid resolution [m]                                                                     |
-| `max_iterations`                                          | int                    | The number of iterations required to calculate alignment                                             |
-| `converged_param_type`                                    | int                    | The type of indicators for scan matching score (0: TP, 1: NVTL)                                      |
-| `converged_param_transform_probability`                   | double                 | TP threshold for deciding whether to trust the estimation result (when converged_param_type = 0)     |
-| `converged_param_nearest_voxel_transformation_likelihood` | double                 | NVTL threshold for deciding whether to trust the estimation result (when converged_param_type = 1)   |
-| `initial_estimate_particles_num`                          | int                    | The number of particles to estimate initial pose                                                     |
-| `lidar_topic_timeout_sec`                                 | double                 | Tolerance of timestamp difference between current time and sensor pointcloud                         |
-| `initial_pose_timeout_sec`                                | int                    | Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]                  |
-| `initial_pose_distance_tolerance_m`                       | double                 | Tolerance of distance difference between two initial poses used for linear interpolation. [m]        |
-| `num_threads`                                             | int                    | Number of threads used for parallel computing                                                        |
-| `output_pose_covariance`                                  | std::array<double, 36> | The covariance of output pose                                                                        |
+| Name                                                      | Type                   | Description                                                                                        |
+| --------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `base_frame`                                              | string                 | Vehicle reference frame                                                                            |
+| `ndt_base_frame`                                          | string                 | NDT reference frame                                                                                |
+| `map_frame`                                               | string                 | map frame                                                                                          |
+| `input_sensor_points_queue_size`                          | int                    | Subscriber queue size                                                                              |
+| `trans_epsilon`                                           | double                 | The max difference between two consecutive transformations to consider convergence                 |
+| `step_size`                                               | double                 | The newton line search maximum step length                                                         |
+| `resolution`                                              | double                 | The ND voxel grid resolution [m]                                                                   |
+| `max_iterations`                                          | int                    | The number of iterations required to calculate alignment                                           |
+| `converged_param_type`                                    | int                    | The type of indicators for scan matching score (0: TP, 1: NVTL)                                    |
+| `converged_param_transform_probability`                   | double                 | TP threshold for deciding whether to trust the estimation result (when converged_param_type = 0)   |
+| `converged_param_nearest_voxel_transformation_likelihood` | double                 | NVTL threshold for deciding whether to trust the estimation result (when converged_param_type = 1) |
+| `initial_estimate_particles_num`                          | int                    | The number of particles to estimate initial pose                                                   |
+| `lidar_topic_timeout_sec`                                 | double                 | Tolerance of timestamp difference between current time and sensor pointcloud                       |
+| `initial_pose_timeout_sec`                                | int                    | Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]                |
+| `initial_pose_distance_tolerance_m`                       | double                 | Tolerance of distance difference between two initial poses used for linear interpolation. [m]      |
+| `num_threads`                                             | int                    | Number of threads used for parallel computing                                                      |
+| `output_pose_covariance`                                  | std::array<double, 36> | The covariance of output pose                                                                      |
 
 (TP: Transform Probability, NVTL: Nearest Voxel Transform Probability)
 

--- a/localization/ndt_scan_matcher/README.md
+++ b/localization/ndt_scan_matcher/README.md
@@ -54,19 +54,25 @@ One optional function is regularization. Please see the regularization chapter i
 
 ### Core Parameters
 
-| Name                                    | Type   | Description                                                                                     |
-| --------------------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
-| `base_frame`                            | string | Vehicle reference frame                                                                         |
-| `ndt_base_frame`                        | string | NDT reference frame                                                                             |
-| `input_sensor_points_queue_size`        | int    | Subscriber queue size                                                                           |
-| `trans_epsilon`                         | double | The maximum difference between two consecutive transformations in order to consider convergence |
-| `step_size`                             | double | The newton line search maximum step length                                                      |
-| `resolution`                            | double | The ND voxel grid resolution [m]                                                                |
-| `max_iterations`                        | int    | The number of iterations required to calculate alignment                                        |
-| `converged_param_type`                  | int    | The type of indicators for scan matching score (0: TP, 1: NVTL)                                 |
-| `converged_param_transform_probability` | double | Threshold for deciding whether to trust the estimation result                                   |
-| `lidar_topic_timeout_sec`               | double | Tolerance of timestamp difference between current time and sensor pointcloud                    |
-| `num_threads`                           | int    | Number of threads used for parallel computing                                                   |
+| Name                                                      | Type                   | Description                                                                                          |
+|-----------------------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
+| `base_frame`                                              | string                 | Vehicle reference frame                                                                              |
+| `ndt_base_frame`                                          | string                 | NDT reference frame                                                                                  |
+| `map_frame`                                               | string                 | map frame                                                                                            |
+| `input_sensor_points_queue_size`                          | int                    | Subscriber queue size                                                                                |
+| `trans_epsilon`                                           | double                 | The max difference between two consecutive transformations to consider convergence                   |
+| `step_size`                                               | double                 | The newton line search maximum step length                                                           |
+| `resolution`                                              | double                 | The ND voxel grid resolution [m]                                                                     |
+| `max_iterations`                                          | int                    | The number of iterations required to calculate alignment                                             |
+| `converged_param_type`                                    | int                    | The type of indicators for scan matching score (0: TP, 1: NVTL)                                      |
+| `converged_param_transform_probability`                   | double                 | TP threshold for deciding whether to trust the estimation result (when converged_param_type = 0)     |
+| `converged_param_nearest_voxel_transformation_likelihood` | double                 | NVTL threshold for deciding whether to trust the estimation result (when converged_param_type = 1)   |
+| `initial_estimate_particles_num`                          | int                    | The number of particles to estimate initial pose                                                     |
+| `lidar_topic_timeout_sec`                                 | double                 | Tolerance of timestamp difference between current time and sensor pointcloud                         |
+| `initial_pose_timeout_sec`                                | int                    | Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]                  |
+| `initial_pose_distance_tolerance_m`                       | double                 | Tolerance of distance difference between two initial poses used for linear interpolation. [m]        |
+| `num_threads`                                             | int                    | Number of threads used for parallel computing                                                        |
+| `output_pose_covariance`                                  | std::array<double, 36> | The covariance of output pose                                                                        |
 
 (TP: Transform Probability, NVTL: Nearest Voxel Transform Probability)
 
@@ -238,7 +244,7 @@ Here is a split PCD map for `sample-map-rosbag` from Autoware tutorial: [`sample
 
 ### Abstract
 
-This is a function that using de-grounded LiDAR scan estimate scan matching score.This score can more accurately reflect the current localization performance.
+This is a function that uses de-grounded LiDAR scan estimate scan matching score.This score can more accurately reflect the current localization performance.
 [related issue](https://github.com/autowarefoundation/autoware.universe/issues/2044).
 
 ### Parameters

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -56,7 +56,7 @@
     num_threads: 4
 
     # The covariance of output pose
-    # Do note that this covariance matrix is empirically derived
+    # Note that this covariance matrix is empirically derived
     output_pose_covariance:
       [
         0.0225, 0.0,   0.0,   0.0,      0.0,      0.0,

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -9,6 +9,9 @@
     # NDT reference frame
     ndt_base_frame: "ndt_base_link"
 
+    # map frame
+    map_frame: "map"
+
     # Subscriber queue size
     input_sensor_points_queue_size: 1
 
@@ -67,7 +70,7 @@
     # Regularization switch
     regularization_enabled: false
 
-    # regularization scale factor
+    # Regularization scale factor
     regularization_scale_factor: 0.01
 
     # Dynamic map loading distance
@@ -86,5 +89,5 @@
     # If lidar_point.z - base_link.z <= this threshold , the point will be removed
     z_margin_for_ground_removal: 0.8
 
-    # The execution time which means probably NDT cannot matches scans properly
-    critical_upper_bound_exe_time_ms: 100 # [ms]
+    # The execution time which means probably NDT cannot matches scans properly. [ms]
+    critical_upper_bound_exe_time_ms: 100

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -84,23 +84,9 @@ NDTScanMatcher::NDTScanMatcher()
   tf2_broadcaster_(*this),
   ndt_ptr_(new NormalDistributionsTransform),
   state_ptr_(new std::map<std::string, std::string>),
-  base_frame_(),
-  ndt_base_frame_(),
-  map_frame_(),
-  converged_param_type_(),
-  converged_param_transform_probability_(),
-  converged_param_nearest_voxel_transformation_likelihood_(),
-  initial_estimate_particles_num_(),
-  lidar_topic_timeout_sec_(),
-  initial_pose_timeout_sec_(),
-  initial_pose_distance_tolerance_m_(),
   inversion_vector_threshold_(-0.9),  // Not necessary to extract to ndt_scan_matcher.param.yaml
   oscillation_threshold_(10),         // Not necessary to extract to ndt_scan_matcher.param.yaml
-  output_pose_covariance_(),
-  regularization_enabled_(declare_parameter<bool>("regularization_enabled")),
-  estimate_scores_for_degrounded_scan_(),
-  z_margin_for_ground_removal_(),
-  critical_upper_bound_exe_time_ms_()
+  regularization_enabled_(declare_parameter<bool>("regularization_enabled"))
 {
   (*state_ptr_)["state"] = "Initializing";
   is_activated_ = false;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -143,10 +143,10 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
-    
+
   critical_upper_bound_exe_time_ms_ =
     this->declare_parameter<int>("critical_upper_bound_exe_time_ms");
-    
+
   initial_pose_timeout_sec_ = this->declare_parameter<double>("initial_pose_timeout_sec");
 
   initial_pose_distance_tolerance_m_ =

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -94,8 +94,8 @@ NDTScanMatcher::NDTScanMatcher()
   lidar_topic_timeout_sec_(),
   initial_pose_timeout_sec_(),
   initial_pose_distance_tolerance_m_(),
-  inversion_vector_threshold_(-0.9),    // Not necessary to extract to ndt_scan_matcher.param.yaml 
-  oscillation_threshold_(10),           // Not necessary to extract to ndt_scan_matcher.param.yaml 
+  inversion_vector_threshold_(-0.9),  // Not necessary to extract to ndt_scan_matcher.param.yaml
+  oscillation_threshold_(10),         // Not necessary to extract to ndt_scan_matcher.param.yaml
   output_pose_covariance_(),
   regularization_enabled_(declare_parameter<bool>("regularization_enabled")),
   estimate_scores_for_degrounded_scan_(),
@@ -160,7 +160,7 @@ NDTScanMatcher::NDTScanMatcher()
 
   initial_estimate_particles_num_ = this->declare_parameter<int>("initial_estimate_particles_num");
 
-  estimate_scores_for_degrounded_scan_ = 
+  estimate_scores_for_degrounded_scan_ =
     this->declare_parameter<bool>("estimate_scores_for_degrounded_scan");
 
   z_margin_for_ground_removal_ = this->declare_parameter<double>("z_margin_for_ground_removal");

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -84,24 +84,23 @@ NDTScanMatcher::NDTScanMatcher()
   tf2_broadcaster_(*this),
   ndt_ptr_(new NormalDistributionsTransform),
   state_ptr_(new std::map<std::string, std::string>),
-  base_frame_("base_link"),
-  ndt_base_frame_("ndt_base_link"),
-  map_frame_("map"),
-  converged_param_type_(ConvergedParamType::TRANSFORM_PROBABILITY),
-  converged_param_transform_probability_(4.5),
-  converged_param_nearest_voxel_transformation_likelihood_(2.3),
-  initial_estimate_particles_num_(100),
-  lidar_topic_timeout_sec_(1.0),
-  initial_pose_timeout_sec_(1.0),
-  initial_pose_distance_tolerance_m_(10.0),
-  inversion_vector_threshold_(-0.9),
-  oscillation_threshold_(10),
+  base_frame_(),
+  ndt_base_frame_(),
+  map_frame_(),
+  converged_param_type_(),
+  converged_param_transform_probability_(),
+  converged_param_nearest_voxel_transformation_likelihood_(),
+  initial_estimate_particles_num_(),
+  lidar_topic_timeout_sec_(),
+  initial_pose_timeout_sec_(),
+  initial_pose_distance_tolerance_m_(),
+  inversion_vector_threshold_(-0.9),    // Not necessary to extract to ndt_scan_matcher.param.yaml 
+  oscillation_threshold_(10),           // Not necessary to extract to ndt_scan_matcher.param.yaml 
   output_pose_covariance_(),
   regularization_enabled_(declare_parameter<bool>("regularization_enabled")),
-  estimate_scores_for_degrounded_scan_(
-    declare_parameter("estimate_scores_for_degrounded_scan", false)),
-  z_margin_for_ground_removal_(declare_parameter("z_margin_for_ground_removal", 0.8)),
-  critical_upper_bound_exe_time_ms_(100)
+  estimate_scores_for_degrounded_scan_(),
+  z_margin_for_ground_removal_(),
+  critical_upper_bound_exe_time_ms_()
 {
   (*state_ptr_)["state"] = "Initializing";
   is_activated_ = false;
@@ -115,6 +114,9 @@ NDTScanMatcher::NDTScanMatcher()
 
   ndt_base_frame_ = this->declare_parameter<std::string>("ndt_base_frame");
   RCLCPP_INFO(get_logger(), "ndt_base_frame_id: %s", ndt_base_frame_.c_str());
+
+  map_frame_ = this->declare_parameter<std::string>("map_frame");
+  RCLCPP_INFO(get_logger(), "map_frame_id: %s", map_frame_.c_str());
 
   pclomp::NdtParams ndt_params{};
   ndt_params.trans_epsilon = this->declare_parameter<double>("trans_epsilon");
@@ -141,11 +143,9 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
-  critical_upper_bound_exe_time_ms_ =
-    this->declare_parameter("critical_upper_bound_exe_time_ms", critical_upper_bound_exe_time_ms_);
 
-  initial_pose_timeout_sec_ =
-    this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);
+  critical_upper_bound_exe_time_ms_ =
+    this->declare_parameter<int>("critical_upper_bound_exe_time_ms");
 
   initial_pose_timeout_sec_ = this->declare_parameter<double>("initial_pose_timeout_sec");
 
@@ -159,6 +159,11 @@ NDTScanMatcher::NDTScanMatcher()
   }
 
   initial_estimate_particles_num_ = this->declare_parameter<int>("initial_estimate_particles_num");
+
+  estimate_scores_for_degrounded_scan_ = 
+    this->declare_parameter<bool>("estimate_scores_for_degrounded_scan");
+
+  z_margin_for_ground_removal_ = this->declare_parameter<double>("z_margin_for_ground_removal");
 
   rclcpp::CallbackGroup::SharedPtr initial_pose_callback_group;
   initial_pose_callback_group =


### PR DESCRIPTION
## Description

Since there were still default values in the cpp code, which may occur unexpected results, I deleted them so that `ndt_scan_matcher` can get those value only from `ndt_scan_matcher.param.yaml`.
On this operation, parameter `map_frame` is extracted to `ndt_scan_matcher.param.yaml`.
Plus, I updated `README.md` so that it matches `ndt_scan_matcher.param.yaml`.

Related: https://github.com/autowarefoundation/autoware_launch/pull/596

## Tests performed

It is able to build ndt_scan_matcher locally.
It is also confirmed that the [logging_simulator on the tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) works fine.

## Effects on system behavior

This won't directly do something to the system.
It is expected to be less prone to unexpected behavior when parameter definitions are incomplete.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
