### PR TITLE
refactor(behavior_path_planner): remove last_approved_pose_ from start_planner

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -139,7 +139,6 @@ private:
 
   std::unique_ptr<rclcpp::Time> last_route_received_time_;
   std::unique_ptr<rclcpp::Time> last_pull_out_start_update_time_;
-  std::unique_ptr<Pose> last_approved_pose_;
 
   // generate freespace pull out paths in a separate thread
   std::unique_ptr<PullOutPlannerBase> freespace_planner_;

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -215,8 +215,6 @@ BehaviorModuleOutput StartPlannerModule::plan()
     clearWaitingApproval();
     resetPathCandidate();
     resetPathReference();
-    // save current_pose when approved for start_point of turn_signal for backward driving
-    last_approved_pose_ = std::make_unique<Pose>(planner_data_->self_odometry->pose.pose);
   }
 
   BehaviorModuleOutput output;
@@ -886,7 +884,7 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo() const
   // turn on hazard light when backward driving
   if (!status_.back_finished) {
     turn_signal.hazard_signal.command = HazardLightsCommand::ENABLE;
-    const auto back_start_pose = isWaitingApproval() ? current_pose : *last_approved_pose_;
+    const auto back_start_pose = planner_data_->route_handler->getOriginalStartPose();
     turn_signal.desired_start_point = back_start_pose;
     turn_signal.required_start_point = back_start_pose;
     // pull_out start_pose is same to backward driving end_pose


### PR DESCRIPTION
## Description

`last_approved_pose_` is the pose before start driving backward. 
It replace with `original_start_pose_` and update of `last_approved_pose_` is not necessary.  

<!-- Write a brief description of this PR. -->

## Tests performed

output of 
```
ros2 topic echo /planning/hazard_lights_cmd
```
shows hazard lights on

![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/3bb24ff3-30e6-46b7-b630-18a33648b4a4)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
