### PR TITLE
feat(time_synchronizer): organize twist input

### DIFF
--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
@@ -68,7 +68,6 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
@@ -71,6 +71,8 @@
 #include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
@@ -127,10 +129,13 @@ private:
   /** \brief A vector of subscriber. */
   std::vector<rclcpp::Subscription<PointCloud2>::SharedPtr> filters_;
 
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr sub_twist_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr sub_twist_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
 
   rclcpp::TimerBase::SharedPtr timer_;
   diagnostic_updater::Updater updater_{this};
+
+  const std::string input_twist_topic_type_;
 
   /** \brief Output TF frame the concatenated points should be transformed to. */
   std::string output_frame_;
@@ -168,7 +173,8 @@ private:
   void cloud_callback(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_ptr,
     const std::string & topic_name);
-  void twist_callback(const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr input);
+  void twist_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr input);
+  void odom_callback(const nav_msgs::msg::Odometry::ConstSharedPtr input);
   void timer_callback();
 
   void checkSyncStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);

--- a/sensing/pointcloud_preprocessor/launch/preprocessor.launch.py
+++ b/sensing/pointcloud_preprocessor/launch/preprocessor.launch.py
@@ -58,7 +58,10 @@ def launch_setup(context, *args, **kwargs):
             package=pkg,
             plugin="pointcloud_preprocessor::PointCloudDataSynchronizerComponent",
             name="synchronizer_filter",
-            remappings=[("output", "points_raw/concatenated")],
+            remappings=[
+                ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
+                ("output", "points_raw/concatenated")
+            ],
             parameters=[
                 {
                     "input_topics": LaunchConfiguration("input_points_raw_list"),

--- a/sensing/pointcloud_preprocessor/launch/preprocessor.launch.py
+++ b/sensing/pointcloud_preprocessor/launch/preprocessor.launch.py
@@ -60,7 +60,7 @@ def launch_setup(context, *args, **kwargs):
             name="synchronizer_filter",
             remappings=[
                 ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
-                ("output", "points_raw/concatenated")
+                ("output", "points_raw/concatenated"),
             ],
             parameters=[
                 {

--- a/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
@@ -41,7 +41,8 @@ namespace pointcloud_preprocessor
 {
 PointCloudDataSynchronizerComponent::PointCloudDataSynchronizerComponent(
   const rclcpp::NodeOptions & node_options)
-: Node("point_cloud_time_synchronizer_component", node_options)
+: Node("point_cloud_time_synchronizer_component", node_options),
+  input_twist_topic_type_(declare_parameter<std::string>("input_twist_topic_type", "twist"))
 {
   // initialize debug tool
   {
@@ -129,10 +130,23 @@ PointCloudDataSynchronizerComponent::PointCloudDataSynchronizerComponent(
     }
 
     // Subscribe to the twist
-    auto twist_cb =
-      std::bind(&PointCloudDataSynchronizerComponent::twist_callback, this, std::placeholders::_1);
-    sub_twist_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
-      "/vehicle/status/velocity_status", rclcpp::QoS{100}, twist_cb);
+    if (input_twist_topic_type_ == "twist") {
+      auto twist_cb = std::bind(
+        &PointCloudDataSynchronizerComponent::twist_callback, this,
+        std::placeholders::_1);
+      sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+        "~/input/twist", rclcpp::QoS{100}, twist_cb);
+    } else if (input_twist_topic_type_ == "odom") {
+      auto odom_cb = std::bind(
+        &PointCloudDataSynchronizerComponent::odom_callback, this,
+        std::placeholders::_1);
+      sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
+        "~/input/odom", rclcpp::QoS{100}, odom_cb);
+    } else {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "input_twist_topic_type is invalid: " << input_twist_topic_type_);
+      throw std::runtime_error("input_twist_topic_type is invalid: " + input_twist_topic_type_);
+    }
   }
 
   // Transformed Raw PointCloud2 Publisher
@@ -474,7 +488,7 @@ void PointCloudDataSynchronizerComponent::timer_callback()
 }
 
 void PointCloudDataSynchronizerComponent::twist_callback(
-  const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr input)
+  const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr input)
 {
   // if rosbag restart, clear buffer
   if (!twist_ptr_queue_.empty()) {
@@ -495,9 +509,33 @@ void PointCloudDataSynchronizerComponent::twist_callback(
 
   auto twist_ptr = std::make_shared<geometry_msgs::msg::TwistStamped>();
   twist_ptr->header.stamp = input->header.stamp;
-  twist_ptr->twist.linear.x = input->longitudinal_velocity;
-  twist_ptr->twist.linear.y = input->lateral_velocity;
-  twist_ptr->twist.angular.z = input->heading_rate;
+  twist_ptr->twist = input->twist.twist;
+  twist_ptr_queue_.push_back(twist_ptr);
+}
+
+void PointCloudDataSynchronizerComponent::odom_callback(
+  const nav_msgs::msg::Odometry::ConstSharedPtr input)
+{
+  // if rosbag restart, clear buffer
+  if (!twist_ptr_queue_.empty()) {
+    if (rclcpp::Time(twist_ptr_queue_.front()->header.stamp) > rclcpp::Time(input->header.stamp)) {
+      twist_ptr_queue_.clear();
+    }
+  }
+
+  // pop old data
+  while (!twist_ptr_queue_.empty()) {
+    if (
+      rclcpp::Time(twist_ptr_queue_.front()->header.stamp) + rclcpp::Duration::from_seconds(1.0) >
+      rclcpp::Time(input->header.stamp)) {
+      break;
+    }
+    twist_ptr_queue_.pop_front();
+  }
+
+  auto twist_ptr = std::make_shared<geometry_msgs::msg::TwistStamped>();
+  twist_ptr->header.stamp = input->header.stamp;
+  twist_ptr->twist = input->twist.twist;
   twist_ptr_queue_.push_back(twist_ptr);
 }
 

--- a/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
@@ -132,14 +132,12 @@ PointCloudDataSynchronizerComponent::PointCloudDataSynchronizerComponent(
     // Subscribe to the twist
     if (input_twist_topic_type_ == "twist") {
       auto twist_cb = std::bind(
-        &PointCloudDataSynchronizerComponent::twist_callback, this,
-        std::placeholders::_1);
+        &PointCloudDataSynchronizerComponent::twist_callback, this, std::placeholders::_1);
       sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
         "~/input/twist", rclcpp::QoS{100}, twist_cb);
     } else if (input_twist_topic_type_ == "odom") {
-      auto odom_cb = std::bind(
-        &PointCloudDataSynchronizerComponent::odom_callback, this,
-        std::placeholders::_1);
+      auto odom_cb =
+        std::bind(&PointCloudDataSynchronizerComponent::odom_callback, this, std::placeholders::_1);
       sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
         "~/input/odom", rclcpp::QoS{100}, odom_cb);
     } else {


### PR DESCRIPTION
## Description

Organize twist input of time_synchronizer as well as concatenate_filter
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The node will subscribe to /sensing/vehicle_velocity_converter/twist_with_covariance from now on. But we see no practical effects on the system behavior given that the node is not used yet in the system as far as we know.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
