### PR TITLE
fix(image_projection_based_fusion): add arg data_path, update model_path

### DIFF
--- a/perception/image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
@@ -18,8 +18,9 @@
   <arg name="input/camera_info7" default="/camera_info7"/>
   <arg name="input/pointcloud" default="/sensing/lidar/top/rectified/pointcloud"/>
   <arg name="output/objects" default="objects"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="pointpainting" description="options: `pointpainting`"/>
-  <arg name="model_path" default="$(find-pkg-share image_projection_based_fusion)/data"/>
+  <arg name="model_path" default="$(var data_path)/image_projection_based_fusion"/>
   <arg name="model_param_path" default="$(find-pkg-share image_projection_based_fusion)/config/$(var model_name).param.yaml"/>
   <arg name="class_remapper_param_path" default="$(find-pkg-share lidar_centerpoint)/config/detection_class_remapper.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share image_projection_based_fusion)/config/roi_sync.param.yaml"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Belongs to [Standardize a strategy for packages with downloaded artifacts](https://github.com/orgs/autowarefoundation/discussions/3649)
As https://github.com/autowarefoundation/autoware/pull/3375 was merged to Autoware.universe. It is possible to use artifacts downloaded there.
https://github.com/autowarefoundation/autoware.universe/pull/4904 was merged and old path to model file is outdated. 

This PR introduces new launch argument data_path in the form:
`<arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>`
It updates model_path arg as well.
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
