### PR TITLE
refactor(behavior_path_planner): use updateData()

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -63,6 +63,9 @@ struct PullOutStatus
   bool is_safe_dynamic_objects{false};  // current path is safe against dynamic objects
   bool back_finished{false};  // if backward driving is not required, this is also set to true
                               // todo: rename to clear variable name.
+  bool backward_driving_complete{
+    false};  // after backward driving is complete, this is set to true (warning: this is set to
+             // false at next cycle after backward driving is complete)
   Pose pull_out_start_pose{};
 
   PullOutStatus() {}
@@ -87,12 +90,13 @@ public:
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
   // TODO(someone): remove this, and use base class function
-  [[deprecated]] ModuleStatus updateState() override;
+  [[deprecated]] void updateCurrentState() override;
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;
   void processOnEntry() override;
   void processOnExit() override;
+  void updateData() override;
 
   void setParameters(const std::shared_ptr<StartPlannerParameters> & parameters)
   {

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -96,6 +96,7 @@ void StartPlannerModule::onFreespacePlannerTimer()
 
 BehaviorModuleOutput StartPlannerModule::run()
 {
+  updateData();
   if (!isActivated()) {
     return planWaitingApproval();
   }
@@ -118,6 +119,23 @@ void StartPlannerModule::processOnExit()
   resetPathCandidate();
   resetPathReference();
   debug_marker_.markers.clear();
+}
+
+void StartPlannerModule::updateData()
+{
+  if (isBackwardDrivingComplete()) {
+    updateStatusAfterBackwardDriving();
+  } else {
+    status_.backward_driving_complete = false;
+  }
+
+  const bool has_received_new_route =
+    !planner_data_->prev_route_id ||
+    *planner_data_->prev_route_id != planner_data_->route_handler->getRouteUuid();
+
+  if (has_received_new_route) {
+    status_ = PullOutStatus();
+  }
 }
 
 bool StartPlannerModule::isExecutionRequested() const
@@ -178,9 +196,16 @@ bool StartPlannerModule::isExecutionReady() const
   return true;
 }
 
-ModuleStatus StartPlannerModule::updateState()
+void StartPlannerModule::updateCurrentState()
 {
-  RCLCPP_DEBUG(getLogger(), "START_PLANNER updateState");
+  RCLCPP_DEBUG(getLogger(), "START_PLANNER updateCurrentState");
+
+  const auto print = [this](const auto & from, const auto & to) {
+    RCLCPP_DEBUG(getLogger(), "[start_planner] Transit from %s to %s.", from.data(), to.data());
+  };
+
+  const auto & from = current_state_;
+  // current_state_ = updateState();
 
   if (isActivated() && !isWaitingApproval()) {
     current_state_ = ModuleStatus::RUNNING;
@@ -188,16 +213,15 @@ ModuleStatus StartPlannerModule::updateState()
     current_state_ = ModuleStatus::IDLE;
   }
 
+  // TODO(someone): move to canTransitSuccessState
   if (hasFinishedPullOut()) {
-    return ModuleStatus::SUCCESS;
+    current_state_ = ModuleStatus::SUCCESS;
   }
-
-  if (isBackwardDrivingComplete()) {
-    updateStatusAfterBackwardDriving();
-    return ModuleStatus::SUCCESS;  // for breaking loop
+  // TODO(someone): move to canTransitSuccessState
+  if (status_.backward_driving_complete) {
+    current_state_ = ModuleStatus::SUCCESS;  // for breaking loop
   }
-
-  return current_state_;
+  print(magic_enum::enum_name(from), magic_enum::enum_name(current_state_));
 }
 
 BehaviorModuleOutput StartPlannerModule::plan()
@@ -616,10 +640,6 @@ void StartPlannerModule::updatePullOutStatus()
     !planner_data_->prev_route_id ||
     *planner_data_->prev_route_id != planner_data_->route_handler->getRouteUuid();
 
-  if (has_received_new_route) {
-    status_ = PullOutStatus();
-  }
-
   // save pull out lanes which is generated using current pose before starting pull out
   // (before approval)
   status_.pull_out_lanes = start_planner_utils::getPullOutLanes(
@@ -674,6 +694,7 @@ void StartPlannerModule::updatePullOutStatus()
 void StartPlannerModule::updateStatusAfterBackwardDriving()
 {
   status_.back_finished = true;
+  status_.backward_driving_complete = true;
   // request start_planner approval
   waitApproval();
   // To enable approval of the forward path, the RTC status is removed.


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40f99e0</samp>

Refactored the start planner module to improve readability and modularity. Separated the data and state updating functions, and added a new variable to track the backward driving maneuver. Simplified some logic related to the pull out and backward driving actions.

<!-- Write a brief description of this PR. -->

## Tests performed

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/33558e59-9ec2-5125-9840-3ad0f76172c5?project_id=prd_jt)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
