### PR TITLE
fix(crosswalk_traffic_light_estimator): change the shape of pedestrian light to CIRCLE

### DIFF
--- a/perception/crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/crosswalk_traffic_light_estimator/src/node.cpp
@@ -231,6 +231,7 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
     TrafficSignal output_traffic_signal;
     TrafficSignalElement output_traffic_signal_element;
     output_traffic_signal_element.color = color;
+    output_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
     output_traffic_signal_element.confidence = 1.0;
     output_traffic_signal.elements.push_back(output_traffic_signal_element);
     output_traffic_signal.traffic_signal_id = tl_reg_elem->id();


### PR DESCRIPTION
## Description

Since the shape of the pedestrian lights should be CIRCLE, I changed it from UNKNOWN to CIRCLE.

## Tests performed

I confirmed this works with rosbag.


The output of `/perception/traffic_light_recognition/fusion/traffic_signals`
```
stamp:
  sec: 1695706515
  nanosec: 196955648
signals:
- traffic_signal_id: 1019
  elements:
  - color: 1
    shape: 1
    status: 0
    confidence: 0.9999982118606567
- traffic_signal_id: 1022
  elements:
  - color: 1
    shape: 1
    status: 0
    confidence: 0.9999982118606567
```

The output of `/perception/traffic_light_recognition/fusion/traffic_signals`
ID 1026 and 1027 are the pedesrian lights, and their shape is 1 (CIRCLE).
```
---
stamp:
  sec: 1695706515
  nanosec: 196955648
signals:
- traffic_signal_id: 1019
  elements:
  - color: 1
    shape: 1
    status: 0
    confidence: 0.9999982118606567
- traffic_signal_id: 1022
  elements:
  - color: 1
    shape: 1
    status: 0
    confidence: 0.9999982118606567
- traffic_signal_id: 1027
  elements:
  - color: 0
    shape: 1
    status: 0
    confidence: 1.0
- traffic_signal_id: 1026
  elements:
  - color: 0
    shape: 1
    status: 0
    confidence: 1.0
- traffic_signal_id: 1027
  elements:
  - color: 0
    shape: 1
    status: 0
    confidence: 1.0
---
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
