### PR TITLE
fix(crosswalk): check all elements in traffic signal

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -962,8 +962,10 @@ bool CrosswalkModule::isRedSignalForPedestrians() const
       continue;
     }
 
-    if (lights.front().color == TrafficSignalElement::RED) {
-      return true;
+    for (const auto & element : lights) {
+      if (
+        element.color == TrafficSignalElement::RED && element.shape == TrafficSignalElement::CIRCLE)
+        return true;
     }
   }
 


### PR DESCRIPTION
## Description

- If there are multiple elements in traffic signal, crosswalk module may fail to find the RED signal in the current implementation.
I fixed it to check all elements in the signal.
- Check the shape of the signal because the shape of pedestrian lights is CIRCLE in Autoware.

Related ticket:
[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT0-29271)


NOTE: 
This PR should be merged with https://github.com/autowarefoundation/autoware.universe/pull/5168

## Tests performed

CI:
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/72baadd6-1a96-56f0-af13-29c60ae56139?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
