### PR TITLE
refactor(localization_packages): remove unused <depend> in packages.xml files

### DIFF
--- a/localization/ekf_localizer/package.xml
+++ b/localization/ekf_localizer/package.xml
@@ -24,8 +24,6 @@
   <depend>kalman_filter</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/localization/gyro_odometer/package.xml
+++ b/localization/gyro_odometer/package.xml
@@ -15,10 +15,8 @@
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
 
   <exec_depend>rclcpp</exec_depend>

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml
@@ -14,10 +14,8 @@
   <depend>aruco</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
   <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/localization/landmark_based_localizer/landmark_tf_caster/package.xml
+++ b/localization/landmark_based_localizer/landmark_tf_caster/package.xml
@@ -12,9 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
-  <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/localization/localization_error_monitor/package.xml
+++ b/localization/localization_error_monitor/package.xml
@@ -13,10 +13,10 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
+  <buildtool_depend>eigen</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
-  <depend>eigen</depend>
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/localization/yabloc/yabloc_common/package.xml
+++ b/localization/yabloc/yabloc_common/package.xml
@@ -13,22 +13,16 @@
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_extension</depend>
-  <depend>lanelet2_io</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>pcl_conversions</depend>
-  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
-  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>signal_processing</depend>
   <depend>sophus</depend>
   <depend>std_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>ublox_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/yabloc/yabloc_image_processing/package.xml
+++ b/localization/yabloc/yabloc_image_processing/package.xml
@@ -12,14 +12,10 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>cv_bridge</depend>
-  <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
-  <depend>sophus</depend>
   <depend>std_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>visualization_msgs</depend>
   <depend>yabloc_common</depend>

--- a/localization/yabloc/yabloc_particle_filter/package.xml
+++ b/localization/yabloc/yabloc_particle_filter/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>sophus</depend>
@@ -22,7 +21,6 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tf2_sensor_msgs</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>visualization_msgs</depend>
   <depend>yabloc_common</depend>

--- a/localization/yabloc/yabloc_pose_initializer/package.xml
+++ b/localization/yabloc/yabloc_pose_initializer/package.xml
@@ -15,11 +15,7 @@
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
-  <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>tf2</depend>
   <depend>tier4_localization_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>yabloc_common</depend>


### PR DESCRIPTION
## Description
This PR derived from https://github.com/autowarefoundation/autoware.universe/pull/3606


result of unused.sh (https://github.com/autowarefoundation/autoware/issues/3468)

```
--- Checking src/universe/autoware.universe/localization/ekf_localizer/package.xml ---
sensor_msgs seems not to be used
std_msgs seems not to be used

--- Checking src/universe/autoware.universe/localization/pose_initializer/package.xml ---

--- Checking src/universe/autoware.universe/localization/pose2twist/package.xml ---

--- Checking src/universe/autoware.universe/localization/yabloc/yabloc_particle_filter/package.xml ---
libgoogle-glog-dev seems not to be used
tf2_sensor_msgs seems not to be used

--- Checking src/universe/autoware.universe/localization/yabloc/yabloc_monitor/package.xml ---

--- Checking src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/package.xml ---
rclpy seems not to be used
std_msgs seems not to be used
std_srvs seems not to be used
tf2 seems not to be used

--- Checking src/universe/autoware.universe/localization/yabloc/yabloc_common/package.xml ---
geographiclib seems not to be used
lanelet2_io seems not to be used
libgoogle-glog-dev seems not to be used
rcl_interfaces seems not to be used
rclcpp_components seems not to be used
ublox_msgs seems not to be used

--- Checking src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/package.xml ---
nav_msgs seems not to be used
sophus seems not to be used
tf2 seems not to be used
tf2_ros seems not to be used

--- Checking src/universe/autoware.universe/localization/localization_error_monitor/package.xml ---
eigen should be rather be marked as <buildtool_depend>, not <depend>

--- Checking src/universe/autoware.universe/localization/gyro_odometer/package.xml ---
std_msgs seems not to be used
tf2_ros seems not to be used

--- Checking src/universe/autoware.universe/localization/landmark_based_localizer/landmark_tf_caster/package.xml ---
geometry_msgs seems not to be used
libopencv-dev seems not to be used

--- Checking src/universe/autoware.universe/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml ---
geometry_msgs seems not to be used
sensor_msgs seems not to be used

--- Checking src/universe/autoware.universe/localization/stop_filter/package.xml ---

--- Checking src/universe/autoware.universe/localization/twist2accel/package.xml ---

--- Checking src/universe/autoware.universe/localization/ndt_scan_matcher/package.xml ---

```
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
