### PR TITLE
fix(detected_object_validation): change the points_num of the validator to be set class by class

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -314,6 +314,7 @@
       <arg name="input/detected_objects" value="$(var lidar_detection_model)/roi_fusion/objects"/>
       <arg name="input/obstacle_pointcloud" value="$(var validator/input/obstacle_pointcloud)"/>
       <arg name="output/objects" value="$(var lidar_detection_model)/validation/objects"/>
+      <arg name="obstacle_pointcloud_based_validator_param_path" value="$(var object_recognition_detection_obstacle_pointcloud_based_validator_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -341,6 +341,7 @@
       <arg name="input/detected_objects" value="$(var lidar_detection_model)/roi_fusion/objects"/>
       <arg name="input/obstacle_pointcloud" value="$(var validator/input/obstacle_pointcloud)"/>
       <arg name="output/objects" value="$(var lidar_detection_model)/validation/objects"/>
+      <arg name="obstacle_pointcloud_based_validator_param_path" value="$(var object_recognition_detection_obstacle_pointcloud_based_validator_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -115,6 +115,7 @@
       <arg name="input/detected_objects" value="$(var lidar_detection_model)/objects"/>
       <arg name="input/obstacle_pointcloud" value="$(var validator/input/obstacle_pointcloud)"/>
       <arg name="output/objects" value="$(var lidar_detection_model)/validation/objects"/>
+      <arg name="obstacle_pointcloud_based_validator_param_path" value="$(var object_recognition_detection_obstacle_pointcloud_based_validator_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -17,6 +17,7 @@
   <arg name="object_recognition_tracking_radar_object_tracker_tracking_setting_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
+  <arg name="object_recognition_detection_obstacle_pointcloud_based_validator_param_path"/>
   <arg name="occupancy_grid_map_method"/>
   <arg name="occupancy_grid_map_param_path"/>
   <arg name="occupancy_grid_map_updater"/>

--- a/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -1,13 +1,13 @@
 /**:
   ros__parameters:
     min_points_num:
-    # CAR     TRUCK BUS  BICYCLE   PEDESTRIAN
-      [10,     10,  10,    10,         10]
+    #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
+      [10,     10,  10,    10,         10,10,    10,         10]
 
     max_points_num:
-    # CAR     TRUCK BUS  BICYCLE   PEDESTRIAN
-      [100,     100,  100,    10,         10]
+    #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
+      [10,     100,  100,    100,         100,10,    10,         10]
 
     min_points_and_distance_ratio:
-    # CAR     TRUCK     BUS     BICYCLE   PEDESTRIAN
-      [800.0,     880.0,     800.0,    800.0,         800.0]
+    #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
+      [800.0,     880.0,     800.0,    800.0,         800.0, 800.0,    800.0,         800.0]

--- a/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -1,0 +1,13 @@
+/**:
+  ros__parameters:
+    min_points_num:
+    # CAR     TRUCK BUS  BICYCLE   PEDESTRIAN
+      [10,     10,  10,    10,         10]
+
+    max_points_num:
+    # CAR     TRUCK BUS  BICYCLE   PEDESTRIAN
+      [100,     100,  100,    10,         10]
+
+    min_points_and_distance_ratio:
+    # CAR     TRUCK     BUS     BICYCLE   PEDESTRIAN
+      [800.0,     880.0,     800.0,    800.0,         800.0]

--- a/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -2,12 +2,12 @@
   ros__parameters:
     min_points_num:
     #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
-      [10,     10,  10,    10,         10,10,    10,         10]
+      [10,     10,  10,    10,     10,     10,      10,         10]
 
     max_points_num:
     #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
-      [10,     100,  100,    100,         100,10,    10,         10]
+      [10,     10,  10,    10,     10,     10,      10,         10]
 
     min_points_and_distance_ratio:
-    #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
-      [800.0,     880.0,     800.0,    800.0,         800.0, 800.0,    800.0,         800.0]
+    #UNKNOWN,  CAR,    TRUCK,     BUS,    TRAILER, MOTORBIKE, BICYCLE,      PEDESTRIAN
+      [800.0,  800.0,  800.0,    800.0,   800.0,      800.0,    800.0,         800.0]

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -37,9 +37,9 @@ namespace obstacle_pointcloud_based_validator
 {
 struct PointsNumThresholdParam
 {
-  size_t min_points_num;
-  size_t max_points_num;
-  float min_points_and_distance_ratio;
+  std::map<uint8_t, int64_t> min_points_num;
+  std::map<uint8_t, int64_t> max_points_num;
+  std::map<uint8_t, double> min_points_and_distance_ratio;
 };
 class ObstaclePointCloudBasedValidator : public rclcpp::Node
 {

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -30,16 +30,16 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-#include <map>
 #include <memory>
 #include <optional>
+#include <vector>
 namespace obstacle_pointcloud_based_validator
 {
 struct PointsNumThresholdParam
 {
-  std::map<uint8_t, int64_t> min_points_num;
-  std::map<uint8_t, int64_t> max_points_num;
-  std::map<uint8_t, double> min_points_and_distance_ratio;
+  std::vector<int64_t> min_points_num;
+  std::vector<int64_t> max_points_num;
+  std::vector<double> min_points_and_distance_ratio;
 };
 class ObstaclePointCloudBasedValidator : public rclcpp::Node
 {

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -30,9 +30,9 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <map>
 #include <memory>
 #include <optional>
-
 namespace obstacle_pointcloud_based_validator
 {
 struct PointsNumThresholdParam

--- a/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
+++ b/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
@@ -3,11 +3,13 @@
   <arg name="input/detected_objects" default="/perception/object_recognition/detection/objects"/>
   <arg name="input/obstacle_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/validation/obstacle_pointcloud_based/objects"/>
+  <arg name="obstacle_pointcloud_based_validator_param_path" default="$(find-pkg-share detected_object_validation)/config/obstacle_pointcloud_based_validator.param.yaml"/>
 
   <node pkg="detected_object_validation" exec="obstacle_pointcloud_based_validator_node" name="obstacle_pointcloud_based_validator_node" output="screen">
     <remap from="~/input/detected_objects" to="$(var input/detected_objects)"/>
     <remap from="~/input/obstacle_pointcloud" to="$(var input/obstacle_pointcloud)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param name="enable_debugger" value="false"/>
+    <param from="$(var obstacle_pointcloud_based_validator_param_path)"/>
   </node>
 </launch>

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -169,7 +169,7 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
     if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
 
     // Filter object that have few pointcloud in them.
-    // TODO change from polygon to bounding box
+    // TODO(badai-nguyen) add 3d validator option
     const auto num = getPointCloudNumWithinPolygon(transformed_object, neighbor_pointcloud);
     const auto object_distance =
       std::hypot(transformed_object_position.x, transformed_object_position.y);

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -37,17 +37,6 @@
 
 namespace
 {
-template <typename T>
-inline std::map<uint8_t, T> convertListToMap(const std::vector<T> & input_vector)
-{
-  std::map<uint8_t, T> output_map;
-  uint8_t label = 0;
-  for (const T & v : input_vector) {
-    output_map.insert(std::make_pair(label, v));
-    label++;
-  }
-  return output_map;
-}
 inline pcl::PointXY toPCL(const double x, const double y)
 {
   pcl::PointXY pcl_point;
@@ -104,11 +93,11 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
     "~/output/objects", rclcpp::QoS{1});
 
   points_num_threshold_param_.min_points_num =
-    convertListToMap(declare_parameter<std::vector<int64_t>>("min_points_num"));
+    declare_parameter<std::vector<int64_t>>("min_points_num");
   points_num_threshold_param_.max_points_num =
-    convertListToMap(declare_parameter<std::vector<int64_t>>("max_points_num"));
+    declare_parameter<std::vector<int64_t>>("max_points_num");
   points_num_threshold_param_.min_points_and_distance_ratio =
-    convertListToMap(declare_parameter<std::vector<double>>("min_points_and_distance_ratio"));
+    declare_parameter<std::vector<double>>("min_points_and_distance_ratio");
 
   const bool enable_debugger = declare_parameter<bool>("enable_debugger", false);
   if (enable_debugger) debugger_ = std::make_shared<Debugger>(this);


### PR DESCRIPTION
## Description

This PR add threshold pointcloud number for each class in `obstacle_pointcloud_based_validator` to reduce FP of less pointcloud vehicle which is detected by DNN(Centerpoint) model.

## Related link

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-29267?focusedCommentId=139292)

## Tests performed
Tested by logging_simulator and internal rosbag.
Green: Centerpoint result 
Yellow: Validator result 
Blue: Predicted result
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/2dbdaa4c-411e-4703-9ca5-7489a507789b)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
