### PR TITLE
refactor(localization_error_monitor): rename localization_accuracy

### DIFF
--- a/localization/localization_error_monitor/src/diagnostics.cpp
+++ b/localization/localization_error_monitor/src/diagnostics.cpp
@@ -23,7 +23,7 @@ diagnostic_msgs::msg::DiagnosticStatus checkLocalizationAccuracy(
   diagnostic_msgs::msg::DiagnosticStatus stat;
 
   diagnostic_msgs::msg::KeyValue key_value;
-  key_value.key = "localization_accuracy";
+  key_value.key = "localization_error_ellipse";
   key_value.value = std::to_string(ellipse_size);
   stat.values.push_back(key_value);
 
@@ -47,7 +47,7 @@ diagnostic_msgs::msg::DiagnosticStatus checkLocalizationAccuracyLateralDirection
   diagnostic_msgs::msg::DiagnosticStatus stat;
 
   diagnostic_msgs::msg::KeyValue key_value;
-  key_value.key = "localization_accuracy_lateral_direction";
+  key_value.key = "localization_error_ellipse_lateral_direction";
   key_value.value = std::to_string(ellipse_size);
   stat.values.push_back(key_value);
 

--- a/simulator/fault_injection/config/fault_injection.param.yaml
+++ b/simulator/fault_injection/config/fault_injection.param.yaml
@@ -4,7 +4,7 @@
       vehicle_is_out_of_lane: "lane_departure"
       trajectory_deviation_is_high: "trajectory_deviation"
       localization_matching_score_is_low: "ndt_scan_matcher"
-      localization_accuracy_is_low: "localization_accuracy"
+      localization_accuracy_is_low: "localization_error_ellipse"
       map_version_is_different: "map_version"
       trajectory_is_invalid: "trajectory_point_validation"
       cpu_temperature_is_high: "CPU Temperature"

--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -24,9 +24,9 @@
               contains: ["ndt_scan_matcher"]
               timeout: 1.0
 
-            localization_accuracy:
+            localization_error_ellipse:
               type: diagnostic_aggregator/GenericAnalyzer
-              path: localization_accuracy
+              path: localization_error_ellipse
               contains: ["localization: localization_error_monitor"]
               timeout: 1.0
 

--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -24,7 +24,7 @@
 
         /autoware/localization/node_alive_monitoring: default
         /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
-        /autoware/localization/performance_monitoring/localization_accuracy: default
+        /autoware/localization/performance_monitoring/localization_error_ellipse: default
 
         /autoware/map/node_alive_monitoring: default
 

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -24,7 +24,7 @@
 
         /autoware/localization/node_alive_monitoring: default
         # /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
-        # /autoware/localization/performance_monitoring/localization_accuracy: default
+        # /autoware/localization/performance_monitoring/localization_error_ellipse: default
 
         /autoware/map/node_alive_monitoring: default
 


### PR DESCRIPTION
## Background
This is for the issue https://github.com/autowarefoundation/autoware.universe/issues/3065
This must be merged simultaneously with https://github.com/autowarefoundation/autoware_launch/pull/605 .
## Contents
Rename "localization_accuracy" to localization_error_ellipse

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

It was confirmed that Build is OK.

## Effects on system behavior

Start to display `localization_error_ellipse` instead of `localization_accuracy`. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/