### PR TITLE
fix(obstacle_cruise_planner): fix coordinate transformation bag

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -100,14 +100,15 @@ std::pair<double, double> projectObstacleVelocityToTrajectory(
   const std::vector<TrajectoryPoint> & traj_points, const Obstacle & obstacle)
 {
   const size_t object_idx = motion_utils::findNearestIndex(traj_points, obstacle.pose.position);
-
-  const double object_vel_norm = std::hypot(obstacle.twist.linear.x, obstacle.twist.linear.y);
-  const double object_vel_yaw = std::atan2(obstacle.twist.linear.y, obstacle.twist.linear.x);
   const double traj_yaw = tf2::getYaw(traj_points.at(object_idx).pose.orientation);
 
-  return std::make_pair(
-    object_vel_norm * std::cos(object_vel_yaw - traj_yaw),
-    object_vel_norm * std::sin(object_vel_yaw - traj_yaw));
+  const double obstacle_yaw = tf2::getYaw(obstacle.pose.orientation);
+
+  const Eigen::Rotation2Dd R_ego_to_obstacle(obstacle_yaw - traj_yaw);
+  const Eigen::Vector2d obstacle_velocity(obstacle.twist.linear.x, obstacle.twist.linear.y);
+  const auto projected_velocity = R_ego_to_obstacle * obstacle_velocity;
+
+  return std::make_pair(projected_velocity[0], projected_velocity[1]);
 }
 
 double calcObstacleMaxLength(const Shape & shape)

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -106,7 +106,7 @@ std::pair<double, double> projectObstacleVelocityToTrajectory(
 
   const Eigen::Rotation2Dd R_ego_to_obstacle(obstacle_yaw - traj_yaw);
   const Eigen::Vector2d obstacle_velocity(obstacle.twist.linear.x, obstacle.twist.linear.y);
-  const auto projected_velocity = R_ego_to_obstacle * obstacle_velocity;
+  const Eigen::Vector2d projected_velocity = R_ego_to_obstacle * obstacle_velocity;
 
   return std::make_pair(projected_velocity[0], projected_velocity[1]);
 }


### PR DESCRIPTION
## Description

fix coordinate transformation. linear.x denotes longtidional velocity, not the x velocity in the world coordinate

## Tests performed

The value of projection speed are confirmed.
Tier 4 internal tests ware also performed in well

![Screenshot from 2023-10-02 12-19-50](https://github.com/autowarefoundation/autoware.universe/assets/141538661/b2588f8f-c1e8-404f-b7cc-b431a3b96cee)



## Effects on system behavior
Obstacle cruise planner become to deal with the against vehicles as stop or slow down objects


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
