### PR TITLE
fix(trajectory_visualizer): fix plotter error

### DIFF
--- a/planning/planning_debug_tools/scripts/trajectory_visualizer.py
+++ b/planning/planning_debug_tools/scripts/trajectory_visualizer.py
@@ -178,15 +178,15 @@ class TrajectoryVisualizer(Node):
 
         # main process
         if PLOT_TYPE == "VEL_ACC_JERK":
+            self.setPlotTrajectory()
             self.ani = animation.FuncAnimation(
                 self.fig, self.plotTrajectory, interval=100, blit=True
             )
-            self.setPlotTrajectory()
         else:
+            self.setPlotTrajectoryVelocity()
             self.ani = animation.FuncAnimation(
                 self.fig, self.plotTrajectoryVelocity, interval=100, blit=True
             )
-            self.setPlotTrajectoryVelocity()
 
         plt.show()
 


### PR DESCRIPTION
## Description

Sometimes `self.im10` is undefined because the animator starts before `setPlotTrajectory` is called.

## Tests performed

Not applicable.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
