### PR TITLE
fix(lane_change): calculate distance to crosswalk

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -861,13 +861,16 @@ bool NormalLaneChange::hasEnoughLengthToCrosswalk(
   const auto & route_handler = *getRouteHandler();
   const auto overall_graphs_ptr = route_handler.getOverallGraphPtr();
 
+  const double base_link2front = planner_data_->parameters.base_link2front;
   const double dist_to_crosswalk_from_lane_change_start_pose =
     utils::getDistanceToCrosswalk(current_pose, current_lanes, *overall_graphs_ptr) -
-    path.info.length.prepare;
+    base_link2front;
+
   // Check lane changing section includes crosswalk
   if (
-    dist_to_crosswalk_from_lane_change_start_pose > 0.0 &&
-    dist_to_crosswalk_from_lane_change_start_pose < path.info.length.lane_changing) {
+    dist_to_crosswalk_from_lane_change_start_pose > path.info.length.prepare &&
+    dist_to_crosswalk_from_lane_change_start_pose <
+      path.info.length.prepare + path.info.length.lane_changing) {
     return false;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -864,13 +864,12 @@ bool NormalLaneChange::hasEnoughLengthToCrosswalk(
   const double base_link2front = planner_data_->parameters.base_link2front;
   const double dist_to_crosswalk_from_lane_change_start_pose =
     utils::getDistanceToCrosswalk(current_pose, current_lanes, *overall_graphs_ptr) -
-    base_link2front;
+    path.info.length.prepare - base_link2front;
 
   // Check lane changing section includes crosswalk
   if (
-    dist_to_crosswalk_from_lane_change_start_pose > path.info.length.prepare &&
-    dist_to_crosswalk_from_lane_change_start_pose <
-      path.info.length.prepare + path.info.length.lane_changing) {
+    dist_to_crosswalk_from_lane_change_start_pose > 0.0 &&
+    dist_to_crosswalk_from_lane_change_start_pose < path.info.length.lane_changing) {
     return false;
   }
 


### PR DESCRIPTION
## Description

Fixed the distance calculation to the crosswalk implemented by https://github.com/autowarefoundation/autoware.universe/pull/5105
`base_link2front` was not considered.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
