### PR TITLE
feat(behavior_velocity_planner): intersection module considers merge_from_private module's output

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -297,6 +297,7 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
   mp.stop_duration_sec = getOrDeclareParameter<double>(node, ns + ".stop_duration_sec");
   mp.attention_area_length =
     getOrDeclareParameter<double>(node, "intersection.common.attention_area_length");
+  mp.stop_line_margin = getOrDeclareParameter<double>(node, ns + ".stop_line_margin");
   mp.path_interpolation_ds =
     getOrDeclareParameter<double>(node, "intersection.common.path_interpolation_ds");
   mp.stop_distance_threshold = getOrDeclareParameter<double>(node, ns + ".stop_distance_threshold");

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -296,10 +296,9 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
   auto & mp = merge_from_private_area_param_;
   mp.stop_duration_sec = getOrDeclareParameter<double>(node, ns + ".stop_duration_sec");
   mp.attention_area_length =
-    node.get_parameter("intersection.common.attention_area_length").as_double();
-  mp.stop_line_margin = getOrDeclareParameter<double>(node, ns + ".stop_line_margin");
+    getOrDeclareParameter<double>(node, "intersection.common.attention_area_length");
   mp.path_interpolation_ds =
-    node.get_parameter("intersection.common.path_interpolation_ds").as_double();
+    getOrDeclareParameter<double>(node, "intersection.common.path_interpolation_ds");
   mp.stop_distance_threshold = getOrDeclareParameter<double>(node, ns + ".stop_distance_threshold");
 }
 

--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -10,7 +10,7 @@
     is_publish_debug_path: false # publish all debug path with lane id in each module
 
     # NOTE: The following order is the same as the order to launch modules.
-    #       Chaning the order may change its behavior.
+    #       Changing the order may change its behavior.
     launch_modules:
       - behavior_velocity_planner::CrosswalkModulePlugin
       - behavior_velocity_planner::WalkwayModulePlugin

--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -8,12 +8,15 @@
     system_delay: 0.5
     delay_response_time: 0.5
     is_publish_debug_path: false # publish all debug path with lane id in each module
+
+    # NOTE: The following order is the same as the order to launch modules.
+    #       Chaning the order may change its behavior.
     launch_modules:
       - behavior_velocity_planner::CrosswalkModulePlugin
       - behavior_velocity_planner::WalkwayModulePlugin
       - behavior_velocity_planner::TrafficLightModulePlugin
-      - behavior_velocity_planner::IntersectionModulePlugin      # Intersection module should be before merge from private to declare intersection parameters.
       - behavior_velocity_planner::MergeFromPrivateModulePlugin
+      - behavior_velocity_planner::IntersectionModulePlugin       # Intersection module considers the stop point in the input path including the result of above modules.
       - behavior_velocity_planner::BlindSpotModulePlugin
       - behavior_velocity_planner::DetectionAreaModulePlugin
       # behavior_velocity_planner::VirtualTrafficLightModulePlugin


### PR DESCRIPTION
## Description

By the following PR, the intersection module considers the stop point in the input path for collision checking.
https://github.com/autowarefoundation/autoware.universe/pull/5156

By moving the merge_from_private before the intersection, the intersection module can consider the merge_from_private's output as well.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Intersection module's collision checking with the result of merge_from_private module.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
