### PR TITLE
refactor(rtc_auto_mode_manager): rework parameters

### DIFF
--- a/planning/rtc_auto_mode_manager/schema/rtc_auto_mode_manager.schema.json
+++ b/planning/rtc_auto_mode_manager/schema/rtc_auto_mode_manager.schema.json
@@ -17,10 +17,7 @@
           "default": "['blind_spot', 'crosswalk', 'detection_area', 'intersection', 'no_stopping_area', 'traffic_light', 'lane_change_left', lane_change_right', 'avoidance_left', 'avoidance_right', 'goal_planner', 'start_planner', 'intersection_occlusion']"
         }
       },
-      "required": [
-        "module_list",
-        "default_enable_list"
-      ]
+      "required": ["module_list", "default_enable_list"]
     }
   },
   "properties": {
@@ -31,12 +28,8 @@
           "$ref": "#/definitions/rtc_auto_mode_manager"
         }
       },
-      "required": [
-        "ros__parameters"
-      ]
+      "required": ["ros__parameters"]
     }
   },
-  "required": [
-    "/**"
-  ]
+  "required": ["/**"]
 }

--- a/planning/rtc_auto_mode_manager/schema/rtc_auto_mode_manager.schema.json
+++ b/planning/rtc_auto_mode_manager/schema/rtc_auto_mode_manager.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for RTC Auto Mode Manager",
+  "type": "object",
+  "definitions": {
+    "rtc_auto_mode_manager": {
+      "type": "object",
+      "properties": {
+        "module_list": {
+          "type": "array",
+          "description": "Module names managing in rtc_auto_mode_manager",
+          "default": "['blind_spot', 'crosswalk', 'detection_area', 'intersection', 'no_stopping_area', 'traffic_light', 'lane_change_left', 'lane_change_right', 'avoidance_left', 'avoidance_right', 'goal_planner', 'start_planner', 'intersection_occlusion']"
+        },
+        "default_enable_list": {
+          "type": "array",
+          "description": "Module names enabled auto mode at initialization",
+          "default": "['blind_spot', 'crosswalk', 'detection_area', 'intersection', 'no_stopping_area', 'traffic_light', 'lane_change_left', lane_change_right', 'avoidance_left', 'avoidance_right', 'goal_planner', 'start_planner', 'intersection_occlusion']"
+        }
+      },
+      "required": [
+        "module_list",
+        "default_enable_list"
+      ]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/rtc_auto_mode_manager"
+        }
+      },
+      "required": [
+        "ros__parameters"
+      ]
+    }
+  },
+  "required": [
+    "/**"
+  ]
+}


### PR DESCRIPTION
## Description
Implement the ROS Node configuration layout described in https://github.com/orgs/autowarefoundation/discussions/3371 for the `rtc_auto_mode_manager` package.

- Create the schema

## Tests performed
Package built locally.
`colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to rtc_auto_mode_manager`

## Effects on system behavior
More reliable and faster parameter configuration file creation.

## Pre-review checklist for the PR author
The PR author **must** check the checkboxes below when creating the PR.
- [x] I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [x] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

## In-review checklist for the PR reviewers
The PR reviewers **must** check the checkboxes below before approval.
- [ ] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author
The PR author **must** check the checkboxes below before merging.
- [x] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.