### PR TITLE
perf(system_monitor): fix program command line reading

### DIFF
--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -92,8 +92,8 @@ protected:
    * @brief get command line from process id
    * @param [in] pid process id
    * @param [out] command output command line
-   * @return true if success to get command line name 
-  */
+   * @return true if success to get command line name
+   */
   bool getCommandLineFromPiD(const std::string & pid, std::string * command);
 
   /**

--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -89,6 +89,14 @@ protected:
   void getHighMemoryProcesses(const std::string & output);
 
   /**
+   * @brief get command line from process id
+   * @param [in] pid process id
+   * @param [out] command output command line
+   * @return true if success to get command line name 
+  */
+  bool getCommandLineFromPiD(const std::string & pid, std::string * command);
+
+  /**
    * @brief get top-rated processes
    * @param [in] tasks list of diagnostics tasks for high load procs
    * @param [in] output top command output

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -419,11 +419,11 @@ bool ProcessMonitor::getCommandLineFromPiD(const std::string & pid, std::string 
   std::string commandLineFilePath = "/proc/" + pid + "/cmdline";
   std::ifstream commandFile(commandLineFilePath);
   if (commandFile.is_open()) {
-      std::getline(commandFile, *command);
-      commandFile.close();
-      return true;
+    std::getline(commandFile, *command);
+    commandFile.close();
+    return true;
   } else {
-      return false;
+    return false;
   }
 }
 
@@ -481,7 +481,7 @@ void ProcessMonitor::getTopratedProcesses(
     bool flag_find_commandline = getCommandLineFromPiD(info.processId, &info.commandName);
 
     if (!flag_find_commandline) {
-      info.commandName = program_name; // if command line is not found, use program name instead
+      info.commandName = program_name;  // if command line is not found, use program name instead
     }
 
     tasks->at(index)->setDiagnosticsStatus(DiagStatus::OK, "OK");

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -414,6 +414,19 @@ void ProcessMonitor::getHighMemoryProcesses(const std::string & output)
   getTopratedProcesses(&memory_tasks_, &p2);
 }
 
+bool ProcessMonitor::getCommandLineFromPiD(const std::string & pid, std::string * command)
+{
+  std::string commandLineFilePath = "/proc/" + pid + "/cmdline";
+  std::ifstream commandFile(commandLineFilePath);
+  if (commandFile.is_open()) {
+      std::getline(commandFile, *command);
+      commandFile.close();
+      return true;
+  } else {
+      return false;
+  }
+}
+
 void ProcessMonitor::getTopratedProcesses(
   std::vector<std::shared_ptr<DiagTask>> * tasks, bp::pipe * p)
 {
@@ -462,7 +475,14 @@ void ProcessMonitor::getTopratedProcesses(
       info.virtualImage >> info.residentSize >> info.sharedMemSize >> info.processStatus >>
       info.cpuUsage >> info.memoryUsage >> info.cpuTime;
 
-    std::getline(stream, info.commandName);
+    std::string program_name;
+    std::getline(stream, program_name);
+
+    bool flag_find_commandline = getCommandLineFromPiD(info.processId, &info.commandName);
+
+    if (!flag_find_commandline) {
+      info.commandName = program_name; // if command line is not found, use program name instead
+    }
 
     tasks->at(index)->setDiagnosticsStatus(DiagStatus::OK, "OK");
     tasks->at(index)->setProcessInformation(info);
@@ -515,7 +535,7 @@ void ProcessMonitor::onTimer()
   std::ostringstream os;
 
   // Get processes
-  bp::child c("top -bcn1 -o %CPU -w 256", bp::std_out > is_out, bp::std_err > is_err);
+  bp::child c("top -bn1 -o %CPU -w 128", bp::std_out > is_out, bp::std_err > is_err);
   c.wait();
 
   if (c.exit_code() != 0) {

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -478,9 +478,9 @@ void ProcessMonitor::getTopratedProcesses(
     std::string program_name;
     std::getline(stream, program_name);
 
-    bool flag_find_commandline = getCommandLineFromPiD(info.processId, &info.commandName);
+    bool flag_find_command_line = getCommandLineFromPiD(info.processId, &info.commandName);
 
-    if (!flag_find_commandline) {
+    if (!flag_find_command_line) {
       info.commandName = program_name;  // if command line is not found, use program name instead
     }
 


### PR DESCRIPTION
## Description

Since the enhancement from https://github.com/autowarefoundation/autoware.universe/pull/4553/, it has been reported that reading the full return of the ```top``` command with hundreds of processes could lead to failure in boost::process::child.

In this PR, we step back the ```top```  reading in boost::process::child to the original version in https://github.com/autowarefoundation/autoware.universe/pull/4553/ which means reading only the program names by default. Then for Top-rated processes, we try to read its command-line name in ```/proc/{PID}/cmdline```. If the reading of a process fails (probably the process ends after the top command), we will only show its program name instead.

<!-- Write a brief description of this PR. -->

## Related links

None.
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

PSim
<!-- Describe how you have tested this PR. -->

![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/fa845f67-f7e3-4171-b3fe-ceb6a7a33fef)

## Notes for reviewers


<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
