### PR TITLE
fix(utils): fix bug in drivable area expansion

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -231,6 +231,15 @@ std::vector<geometry_msgs::msg::Point> calcBound(
   const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
   const bool is_left);
 
+std::vector<lanelet::ConstPoint3d> getBoundWithHatchedRoadMarkings(
+  const std::vector<lanelet::ConstPoint3d> & original_bound,
+  const std::shared_ptr<RouteHandler> & route_handler);
+
+std::vector<lanelet::ConstPoint3d> getBoundWithIntersectionAreas(
+  const std::vector<lanelet::ConstPoint3d> & original_bound,
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::vector<DrivableLanes> & drivable_lanes, const bool is_left);
+
 boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
 std::vector<DrivableLanes> cutOverlappedLanes(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes);


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 895de6a</samp>

Refactored the `calcBound` function in `behavior_path_planner` to use separate functions for expanding the drivable area by hatched road markings and intersection areas. Moved some lambda functions to the header file and changed the point type.

### Before this PR (crashed road bound)

![Screenshot from 2023-10-02 09-53-58](https://github.com/autowarefoundation/autoware.universe/assets/44889564/85dcf4d2-96d1-456a-a13d-88919f2840d6)

### After this PR

**interseciotn_area + hatched_road_marking**

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/32459028-8095-4714-8033-17740a389e78)

**only hatched_road_marking**

![Screenshot from 2023-10-02 18-13-46](https://github.com/autowarefoundation/autoware.universe/assets/44889564/2b84ed9e-8768-4b1e-876b-e50f22de2d43)

**only interseciotn_area**

![Screenshot from 2023-10-02 18-16-32](https://github.com/autowarefoundation/autoware.universe/assets/44889564/381b992e-a020-4d3d-a82d-92a36e6b7f14)

**ignore all additional drivable are polygon**

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/973fe3c0-4034-421e-a1e2-7cb02686d012)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS 1st try](https://evaluation.tier4.jp/evaluation/reports/000ed14f-2eb4-564b-bd43-e8c00ae96ebd?project_id=prd_jt)
- [x] [PASS TIER IV INTERNAL SCENARIOS 2nd try](https://evaluation.tier4.jp/evaluation/reports/c36f65ca-212a-5bb5-8cd5-18e87558972d?project_id=prd_jt)
- [x] [PASS TIER IV INTERNAL SCENARIOS 3rd try](https://evaluation.tier4.jp/evaluation/reports/b58725bf-5dfc-5a07-8668-48fe3b1c2066?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix bug.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
