### PR TITLE
ci(build-and-test-differential): remove sync for the build-and-test-differential workflows

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -42,20 +42,6 @@
                   - \"\"
                   - -cuda
                 include:" {source}
-    - source: .github/workflows/build-and-test-differential.yaml
-      pre-commands: |
-        sd "container: ros:(\w+)" "container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest" {source}
-
-        sd -s 'container: ${{ matrix.container }}' 'container: ${{ matrix.container }}${{ matrix.container-suffix }}' {source}
-        sd -- \
-        "       include:" \
-        "       container-suffix:
-                  - \"\"
-                  - -cuda
-                include:" {source}
-
-        sd "^    container: ghcr.io/autowarefoundation/autoware-universe:(\w+)-latest\$" \
-            "    container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest-cuda" {source}
     - source: .github/workflows/build-and-test-differential-self-hosted.yaml
       pre-commands: |
         sd "container: ros:(\w+)" "container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest" {source}


### PR DESCRIPTION
## Description

Directly related sync job:
- https://github.com/autowarefoundation/autoware.universe/pull/4372

### Proposal

To me, with the latest changes introduced by us, the sync job has grown way too much in complexity to be easily understood by anyone.
I think it is time to cut off the sync job at least for the `build-and-test-differential.yaml` workflow.

At least until we find a better way to sync this job. Or maybe once we make the containers smaller, we can remove the self hosted option too.

### Function of this sync job

It syncs from:
- https://github.com/autowarefoundation/autoware_common/blob/main/.github/workflows/build-and-test-differential.yaml
to:
- https://github.com/autowarefoundation/autoware.universe/blob/main/.github/workflows/build-and-test-differential.yaml

But while syncing, it makes some brittle changes to the original file as instructed in the sync job file:
- https://github.com/autowarefoundation/autoware.universe/blob/main/.github/sync-files.yaml#L45-L58

#### ChatGPT analysis of the current sync job

According to ChatGPT analysis, the rename operations can be summarized as follows:

The `pre-commands` in the second YAML file are using `sd` (substitute) command, which is a tool used for substituting or replacing strings in files, somewhat similar to `sed` command in Unix.

1. **First Command:**
   ```yaml
   sd "container: ros:(\w+)" "container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest" {source}
   ```
   It substitutes all occurrences of `container: ros:<any_word_character>` with `container: ghcr.io/autowarefoundation/autoware-universe:<any_word_character>-latest`. 
   Here `<any_word_character>` is captured by `(\w+)` and replaced by `\$1`. 
   This change is applied to the `{source}`, referring to `.github/workflows/build-and-test-differential.yaml`.

2. **Second Command:**
   ```yaml
   sd -s 'container: ${{ matrix.container }}' 'container: ${{ matrix.container }}${{ matrix.container-suffix }}' {source}
   ```
   It substitutes the first occurrence of `container: ${{ matrix.container }}` with `container: ${{ matrix.container }}${{ matrix.container-suffix }}` in `{source}`, adding a potential suffix to the container matrix.

3. **Third Command:**
   ```yaml
   sd -- \
   "       include:" \
   "       container-suffix:
             - \"\"
             - -cuda
           include:" {source}
   ```
   This substitutes `"include:"` with a block that introduces a new matrix variable `container-suffix` with two values, an empty string, and `-cuda`, followed by the original `include:`. 
   This likely enables running the workflow with and without CUDA support by appending the suffix to the container name.

4. **Fourth Command:**
   ```yaml
   sd "^    container: ghcr.io/autowarefoundation/autoware-universe:(\w+)-latest\$" \
       "    container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest-cuda" {source}
   ```
   It substitutes all occurrences of `container: ghcr.io/autowarefoundation/autoware-universe:<any_word_character>-latest` at the beginning of a line with `container: ghcr.io/autowarefoundation/autoware-universe:<any_word_character>-latest-cuda`, 
   effectively appending `-cuda` to the end of the container names.

##### In Summary:
These `pre-commands` are modifying the `build-and-test-differential.yaml` workflow's container names and introducing a new matrix variable, 
likely to adjust the environment in which the jobs are run, 
possibly to add support for CUDA and to use specific container images from `ghcr.io/autowarefoundation/autoware-universe`.


### History of the sync job

Here is a brief history of the `build-and-test-differential` sync job in the Universe repository:

1. The initial file was added to the sync job
   - https://github.com/autowarefoundation/autoware.universe/pull/356
2. Some post-commands are added to rename the containers
   - https://github.com/autowarefoundation/autoware.universe/pull/956
3. More rename operations are added to also have cuda containers too
   - https://github.com/autowarefoundation/autoware.universe/pull/968
4. build_depends repos rename operations added
   - https://github.com/autowarefoundation/autoware.universe/pull/983
5. pre-commands are renamed to post-commands and dest changed to src
   - https://github.com/autowarefoundation/autoware.universe/pull/1182
6. added no-cuda build with more complicated rename operations
   - https://github.com/autowarefoundation/autoware.universe/pull/1307
7. galactic replaced with a variable
   - https://github.com/autowarefoundation/autoware.universe/pull/1514
8. no-cuda test was disabled
   - https://github.com/autowarefoundation/autoware.universe/pull/1669
9. galactic ci was removed
   - https://github.com/autowarefoundation/autoware.universe/pull/2408
10. "no-cuda test was disabled" was reverted
   - https://github.com/autowarefoundation/autoware.universe/pull/2410


And the manual changes made by me and @mitsudome-r :
- https://github.com/autowarefoundation/autoware.universe/pull/4364
- https://github.com/autowarefoundation/autoware.universe/pull/4368

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
