### PR TITLE
feat(logger_level_reconfigure_plugin): use node interface and some cosmetic updates

### DIFF
--- a/common/tier4_logging_level_configure_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_logging_level_configure_rviz_plugin/CMakeLists.txt
@@ -24,4 +24,5 @@ pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.
 ament_auto_package(
   INSTALL_TO_SHARE
   plugins
+  config
 )

--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -5,55 +5,55 @@
 # ============================================================
 
 behavior_path_planner:
-  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"
-    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner"
-  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+    logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner
+  - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+    logger_name: tier4_autoware_utils
 
 behavior_path_planner_avoidance:
-  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"
-    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance"
+  - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+    logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance
 
 behavior_velocity_planner:
-  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"
-    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner"
-  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
+    logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner
+  - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
+    logger_name: tier4_autoware_utils
 
 behavior_velocity_planner_intersection:
-  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"
-    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection"
+  - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
+    logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection
 
 motion_obstacle_avoidance:
-  - node_name: "/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner"
-    logger_name: "planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner"
-  - node_name: "/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
+    logger_name: planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner
+  - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
+    logger_name: tier4_autoware_utils
 
 motion_velocity_smoother:
-  - node_name: "/planning/scenario_planning/motion_velocity_smoother"
-    logger_name: "planning.scenario_planning.motion_velocity_smoother"
-  - node_name: "/planning/scenario_planning/motion_velocity_smoother"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /planning/scenario_planning/motion_velocity_smoother
+    logger_name: planning.scenario_planning.motion_velocity_smoother
+  - node_name: /planning/scenario_planning/motion_velocity_smoother
+    logger_name: tier4_autoware_utils
 
 # ============================================================
 # control
 # ============================================================
 
 lateral_controller:
-  - node_name: "/control/trajectory_follower/controller_node_exe"
-    logger_name: "control.trajectory_follower.controller_node_exe.lateral_controller"
-  - node_name: "/control/trajectory_follower/controller_node_exe"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /control/trajectory_follower/controller_node_exe
+    logger_name: control.trajectory_follower.controller_node_exe.lateral_controller
+  - node_name: /control/trajectory_follower/controller_node_exe
+    logger_name: tier4_autoware_utils
 
 longitudinal_controller:
-  - node_name: "/control/trajectory_follower/controller_node_exe"
-    logger_name: "control.trajectory_follower.controller_node_exe.longitudinal_controller"
-  - node_name: "/control/trajectory_follower/controller_node_exe"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /control/trajectory_follower/controller_node_exe
+    logger_name: control.trajectory_follower.controller_node_exe.longitudinal_controller
+  - node_name: /control/trajectory_follower/controller_node_exe
+    logger_name: tier4_autoware_utils
 
 vehicle_cmd_gate:
-  - node_name: "/control/vehicle_cmd_gate"
-    logger_name: "control.vehicle_cmd_gate"
-  - node_name: "/control/vehicle_cmd_gate"
-    logger_name: "tier4_autoware_utils"
+  - node_name: /control/vehicle_cmd_gate
+    logger_name: control.vehicle_cmd_gate
+  - node_name: /control/vehicle_cmd_gate
+    logger_name: tier4_autoware_utils

--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -1,0 +1,59 @@
+# logger_config.yaml
+
+# ============================================================
+# planning
+# ============================================================
+
+behavior_path_planner:
+  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"
+    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner"
+  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"
+    logger_name: "tier4_autoware_utils"
+
+behavior_path_planner_avoidance:
+  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"
+    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance"
+
+behavior_velocity_planner:
+  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"
+    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner"
+  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"
+    logger_name: "tier4_autoware_utils"
+
+behavior_velocity_planner_intersection:
+  - node_name: "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"
+    logger_name: "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection"
+
+motion_obstacle_avoidance:
+  - node_name: "/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner"
+    logger_name: "planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner"
+  - node_name: "/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner"
+    logger_name: "tier4_autoware_utils"
+
+motion_velocity_smoother:
+  - node_name: "/planning/scenario_planning/motion_velocity_smoother"
+    logger_name: "planning.scenario_planning.motion_velocity_smoother"
+  - node_name: "/planning/scenario_planning/motion_velocity_smoother"
+    logger_name: "tier4_autoware_utils"
+
+# ============================================================
+# control
+# ============================================================
+
+lateral_controller:
+  - node_name: "/control/trajectory_follower/controller_node_exe"
+    logger_name: "control.trajectory_follower.controller_node_exe.lateral_controller"
+  - node_name: "/control/trajectory_follower/controller_node_exe"
+    logger_name: "tier4_autoware_utils"
+
+longitudinal_controller:
+  - node_name: "/control/trajectory_follower/controller_node_exe"
+    logger_name: "control.trajectory_follower.controller_node_exe.longitudinal_controller"
+  - node_name: "/control/trajectory_follower/controller_node_exe"
+    logger_name: "tier4_autoware_utils"
+
+vehicle_cmd_gate:
+  - node_name: "/control/vehicle_cmd_gate"
+    logger_name: "control.vehicle_cmd_gate"
+  - node_name: "/control/vehicle_cmd_gate"
+    logger_name: "tier4_autoware_utils"

--- a/common/tier4_logging_level_configure_rviz_plugin/include/tier4_logging_level_configure_rviz_plugin/logging_level_configure.hpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/include/tier4_logging_level_configure_rviz_plugin/logging_level_configure.hpp
@@ -48,20 +48,19 @@ private:
   QMap<QString, QButtonGroup *> buttonGroups_;
   rclcpp::Node::SharedPtr raw_node_;
 
-  // logger_node_map_[target_name] = {container_name, logger_name}
-  std::map<QString, std::vector<std::pair<QString, QString>>> logger_node_map_;
+  // node_logger_map_[button_name] = {node_name, logger_name}
+  std::map<QString, std::vector<std::pair<QString, QString>>> node_logger_map_;
 
-  // client_map_[container_name] = service_client
+  // client_map_[node_name] = service_client
   std::unordered_map<QString, rclcpp::Client<logging_demo::srv::ConfigLogger>::SharedPtr>
     client_map_;
 
-  // button_map_[target_name][logging_level] = Q_button_pointer
+  // button_map_[button_name][logging_level] = Q_button_pointer
   std::unordered_map<QString, std::unordered_map<QString, QPushButton *>> button_map_;
 
-  QStringList getContainerList();
+  QStringList getNodeList();
   int getMaxModuleNameWidth(QLabel * containerLabel);
   void setLoggerNodeMap();
-  void attachLoggingComponent();
 
 private Q_SLOTS:
   void onButtonClick(QPushButton * button, const QString & name, const QString & level);

--- a/common/tier4_logging_level_configure_rviz_plugin/include/tier4_logging_level_configure_rviz_plugin/logging_level_configure.hpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/include/tier4_logging_level_configure_rviz_plugin/logging_level_configure.hpp
@@ -64,7 +64,8 @@ private:
 
 private Q_SLOTS:
   void onButtonClick(QPushButton * button, const QString & name, const QString & level);
-  void updateButtonColors(const QString & target_module_name, QPushButton * active_button);
+  void updateButtonColors(
+    const QString & target_module_name, QPushButton * active_button, const QString & level);
   void changeLogLevel(const QString & container, const QString & level);
 };
 

--- a/common/tier4_logging_level_configure_rviz_plugin/package.xml
+++ b/common/tier4_logging_level_configure_rviz_plugin/package.xml
@@ -15,6 +15,7 @@
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
+  <depend>libyaml-cpp-dev</depend>
   <depend>logging_demo</depend>
   <depend>qtbase5-dev</depend>
   <depend>rclcpp</depend>

--- a/common/tier4_logging_level_configure_rviz_plugin/package.xml
+++ b/common/tier4_logging_level_configure_rviz_plugin/package.xml
@@ -15,13 +15,13 @@
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
-  <depend>libyaml-cpp-dev</depend>
   <depend>logging_demo</depend>
   <depend>qtbase5-dev</depend>
   <depend>rclcpp</depend>
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
   <depend>rviz_rendering</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
@@ -30,36 +30,6 @@ LoggingLevelConfigureRvizPlugin::LoggingLevelConfigureRvizPlugin(QWidget * paren
 {
 }
 
-// Calculate the maximum width among all target_module_name.
-int LoggingLevelConfigureRvizPlugin::getMaxModuleNameWidth(QLabel * label)
-{
-  int max_width = 0;
-  QFontMetrics metrics(label->font());
-  for (const auto & item : node_logger_map_) {
-    const auto & target_module_name = item.first;
-    int width = metrics.horizontalAdvance(target_module_name);
-    if (width > max_width) {
-      max_width = width;
-    }
-  }
-  return max_width;
-}
-
-// create node list in node_logger_map_ without
-QStringList LoggingLevelConfigureRvizPlugin::getNodeList()
-{
-  QStringList nodes;
-  for (const auto & item : node_logger_map_) {
-    const auto & node_logger_vec = item.second;
-    for (const auto & node_logger_pair : node_logger_vec) {
-      if (!nodes.contains(node_logger_pair.first)) {
-        nodes.append(node_logger_pair.first);
-      }
-    }
-  }
-  return nodes;
-}
-
 void LoggingLevelConfigureRvizPlugin::onInitialize()
 {
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
@@ -122,6 +92,36 @@ void LoggingLevelConfigureRvizPlugin::onInitialize()
       node.toStdString() + "/config_logger");
     client_map_[node] = client;
   }
+}
+
+// Calculate the maximum width among all target_module_name.
+int LoggingLevelConfigureRvizPlugin::getMaxModuleNameWidth(QLabel * label)
+{
+  int max_width = 0;
+  QFontMetrics metrics(label->font());
+  for (const auto & item : node_logger_map_) {
+    const auto & target_module_name = item.first;
+    int width = metrics.horizontalAdvance(target_module_name);
+    if (width > max_width) {
+      max_width = width;
+    }
+  }
+  return max_width;
+}
+
+// create node list in node_logger_map_ without
+QStringList LoggingLevelConfigureRvizPlugin::getNodeList()
+{
+  QStringList nodes;
+  for (const auto & item : node_logger_map_) {
+    const auto & node_logger_vec = item.second;
+    for (const auto & node_logger_pair : node_logger_vec) {
+      if (!nodes.contains(node_logger_pair.first)) {
+        nodes.append(node_logger_pair.first);
+      }
+    }
+  }
+  return nodes;
 }
 
 // Modify the signature of the onButtonClick function:

--- a/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "yaml-cpp/yaml.h"
+
 #include <QLabel>
 #include <rviz_common/display_context.hpp>
 #include <tier4_logging_level_configure_rviz_plugin/logging_level_configure.hpp>
@@ -164,78 +166,20 @@ void LoggingLevelConfigureRvizPlugin::load(const rviz_common::Config & config)
 
 void LoggingLevelConfigureRvizPlugin::setLoggerNodeMap()
 {
-  // ===============================================================================================
-  // ====================================== Planning ===============================================
-  // ===============================================================================================
+  const auto filename =
+    "/home/horibe/workspace/pilot-auto.latest/src/autoware/universe/common/"
+    "tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml";
+  YAML::Node config = YAML::LoadFile(filename);
 
-  QString behavior_path_planner =
-    "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner";
-  QString behavior_velocity_planner =
-    "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner";
-
-  // behavior_path_planner (all)
-  node_logger_map_["behavior_path_planner"] = {
-    {behavior_path_planner,
-     "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner"},
-    {behavior_path_planner, "tier4_autoware_utils"}};
-
-  // behavior_path_planner: avoidance
-  node_logger_map_["behavior_path_planner: avoidance"] = {
-    {behavior_path_planner,
-     "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner."
-     "avoidance"}};
-
-  // behavior_velocity_planner (all)
-  node_logger_map_["behavior_velocity_planner"] = {
-    {behavior_velocity_planner,
-     "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner"},
-    {behavior_velocity_planner, "tier4_autoware_utils"}};
-
-  // behavior_velocity_planner: intersection
-  node_logger_map_["behavior_velocity_planner: intersection"] = {
-    {behavior_velocity_planner,
-     "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner."
-     "intersection"}};
-
-  // obstacle_avoidance_planner
-  QString motion_avoidance =
-    "/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner";
-  node_logger_map_["motion: obstacle_avoidance"] = {
-    {motion_avoidance,
-     "planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner"},
-    {motion_avoidance, "tier4_autoware_utils"}};
-
-  // motion_velocity_smoother
-  QString velocity_smoother = "/planning/scenario_planning/motion_velocity_smoother";
-  node_logger_map_["motion: velocity_smoother"] = {
-    {velocity_smoother, "planning.scenario_planning.motion_velocity_smoother"},
-    {velocity_smoother, "tier4_autoware_utils"}};
-
-  // ===============================================================================================
-  // ======================================= Control ===============================================
-  // ===============================================================================================
-
-  QString trajectory_follower = "/control/trajectory_follower/controller_node_exe";
-
-  // lateral_controller
-  node_logger_map_["lateral_controller"] = {
-    {trajectory_follower, "control.trajectory_follower.controller_node_exe.lateral_controller"},
-    {trajectory_follower, "tier4_autoware_utils"},
-  };
-
-  // longitudinal_controller
-  node_logger_map_["longitudinal_controller"] = {
-    {trajectory_follower,
-     "control.trajectory_follower.controller_node_exe.longitudinal_controller"},
-    {trajectory_follower, "tier4_autoware_utils"},
-  };
-
-  // vehicle_cmd_gate
-  QString vehicle_cmd_gate = "/control/vehicle_cmd_gate";
-  node_logger_map_["vehicle_cmd_gate"] = {
-    {vehicle_cmd_gate, "control.vehicle_cmd_gate"},
-    {vehicle_cmd_gate, "tier4_autoware_utils"},
-  };
+  for (YAML::const_iterator it = config.begin(); it != config.end(); ++it) {
+    const auto key = QString::fromStdString(it->first.as<std::string>());
+    const YAML::Node values = it->second;
+    for (size_t i = 0; i < values.size(); i++) {
+      const auto node_name = QString::fromStdString(values[i]["node_name"].as<std::string>());
+      const auto logger_name = QString::fromStdString(values[i]["logger_name"].as<std::string>());
+      node_logger_map_[key].push_back({node_name, logger_name});
+    }
+  }
 }
 
 }  // namespace rviz_plugin

--- a/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
@@ -101,7 +101,7 @@ int LoggingLevelConfigureRvizPlugin::getMaxModuleNameWidth(QLabel * label)
   QFontMetrics metrics(label->font());
   for (const auto & item : node_logger_map_) {
     const auto & target_module_name = item.first;
-    int width = metrics.horizontalAdvance(target_module_name);
+    const int width = metrics.horizontalAdvance(target_module_name);
     if (width > max_width) {
       max_width = width;
     }

--- a/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
@@ -65,7 +65,7 @@ void LoggingLevelConfigureRvizPlugin::onInitialize()
       });
     }
     // Set the "INFO" button as checked by default and change its color.
-    updateButtonColors(target_node_name, button_map_[target_node_name]["INFO"]);
+    updateButtonColors(target_node_name, button_map_[target_node_name]["INFO"], "INFO");
 
     buttonGroups_[target_node_name] = group;
     layout->addLayout(hLayout);
@@ -148,27 +148,35 @@ void LoggingLevelConfigureRvizPlugin::onButtonClick(
     }
 
     updateButtonColors(
-      target_module_name, button);  // Modify updateButtonColors to accept QPushButton only.
+      target_module_name, button, level);  // Modify updateButtonColors to accept QPushButton only.
   }
 }
 
 void LoggingLevelConfigureRvizPlugin::updateButtonColors(
-  const QString & target_module_name, QPushButton * active_button)
+  const QString & target_module_name, QPushButton * active_button, const QString & level)
 {
-  const QString LIGHT_GREEN = "rgb(181, 255, 20)";
-  const QString LIGHT_GRAY = "rgb(211, 211, 211)";
+  std::unordered_map<QString, QString> colorMap = {
+    {"DEBUG", "rgb(181, 255, 20)"}, /* green */
+    {"INFO", "rgb(200, 255, 255)"}, /* light blue */
+    {"WARN", "rgb(255, 255, 0)"},   /* yellow */
+    {"ERROR", "rgb(255, 0, 0)"},    /* red */
+    {"FATAL", "rgb(139, 0, 0)"},    /* dark red */
+    {"OFF", "rgb(211, 211, 211)"}   /* gray */
+  };
+
   const QString LIGHT_GRAY_TEXT = "rgb(180, 180, 180)";
+
+  const QString color = colorMap.count(level) ? colorMap[level] : colorMap["OFF"];
 
   for (const auto & button : button_map_[target_module_name]) {
     if (button.second == active_button) {
-      button.second->setStyleSheet("background-color: " + LIGHT_GREEN + "; color: black");
+      button.second->setStyleSheet("background-color: " + color + "; color: black");
     } else {
       button.second->setStyleSheet(
-        "background-color: " + LIGHT_GRAY + "; color: " + LIGHT_GRAY_TEXT);
+        "background-color: " + colorMap["OFF"] + "; color: " + LIGHT_GRAY_TEXT);
     }
   }
 }
-
 void LoggingLevelConfigureRvizPlugin::save(rviz_common::Config config) const
 {
   Panel::save(config);

--- a/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
@@ -101,10 +101,7 @@ int LoggingLevelConfigureRvizPlugin::getMaxModuleNameWidth(QLabel * label)
   QFontMetrics metrics(label->font());
   for (const auto & item : node_logger_map_) {
     const auto & target_module_name = item.first;
-    const int width = metrics.horizontalAdvance(target_module_name);
-    if (width > max_width) {
-      max_width = width;
-    }
+    max_width = std::max(metrics.horizontalAdvance(target_module_name), max_width);
   }
   return max_width;
 }

--- a/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
+++ b/common/tier4_logging_level_configure_rviz_plugin/src/logging_level_configure.cpp
@@ -15,6 +15,7 @@
 #include "yaml-cpp/yaml.h"
 
 #include <QLabel>
+#include <QScrollArea>
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rviz_common/display_context.hpp>
 #include <tier4_logging_level_configure_rviz_plugin/logging_level_configure.hpp>
@@ -100,7 +101,19 @@ void LoggingLevelConfigureRvizPlugin::onInitialize()
     layout->addLayout(hLayout);
   }
 
-  setLayout(layout);
+  // Create a QWidget to hold the layout.
+  QWidget * containerWidget = new QWidget;
+  containerWidget->setLayout(layout);
+
+  // Create a QScrollArea to make the layout scrollable.
+  QScrollArea * scrollArea = new QScrollArea;
+  scrollArea->setWidget(containerWidget);
+  scrollArea->setWidgetResizable(true);
+
+  // Set the QScrollArea as the layout of the main widget.
+  QVBoxLayout * mainLayout = new QVBoxLayout;
+  mainLayout->addWidget(scrollArea);
+  setLayout(mainLayout);
 
   // set up service clients
   const auto & nodes = getNodeList();


### PR DESCRIPTION
## Description

Update logger level reconfigure plugin.

- Use node interface following https://github.com/autowarefoundation/autoware.universe/pull/5146
- Move hard-corded configuration into yaml file
- Make the panel scrollable
- Change the button color based on the logger level

Special thanks to Chat-GPT. This revision is mostly done by his implementation.

https://github.com/autowarefoundation/autoware.universe/assets/21360593/7613845c-7d72-4222-accb-650b679aedc1


## Related links

None

## Tests performed

run psim

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
