### PR TITLE
refactor(safety_check): support lambda function in target filtering logic

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp
@@ -117,14 +117,16 @@ void filterObjectsByClass(
  * lanelet.
  */
 std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanelets(
-  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
+  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets,
+  const std::function<bool(const PredictedObject, const lanelet::ConstLanelet)> & condition);
 
 /**
  * @brief Separate the objects into two part based on whether the object is within lanelet.
  * @return Objects pair. first objects are in the lanelet, and second others are out of lanelet.
  */
 std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
-  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
+  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets,
+  const std::function<bool(const PredictedObject, const lanelet::ConstLanelet)> & condition);
 
 /**
  * @brief Get the predicted path from an object.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -336,6 +336,8 @@ std::optional<double> getSignedDistanceFromBoundary(
 
 // misc
 
+Polygon2d toPolygon2d(const lanelet::ConstLanelet & lanelet);
+
 std::vector<Polygon2d> getTargetLaneletPolygons(
   const lanelet::ConstLanelets & lanelets, const Pose & pose, const double check_length,
   const std::string & target_type);

--- a/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
@@ -266,13 +266,18 @@ void GoalSearcher::countObjectsToAvoid(
 
 void GoalSearcher::update(GoalCandidates & goal_candidates) const
 {
+  const auto condition = [](const PredictedObject & object, const lanelet::ConstLanelet & lanelet) {
+    const auto object_polygon = tier4_autoware_utils::toPolygon2d(object);
+    const auto lanelet_polygon = utils::toPolygon2d(lanelet);
+    return !boost::geometry::disjoint(lanelet_polygon, object_polygon);
+  };
   const auto stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     *(planner_data_->dynamic_object), parameters_.th_moving_object_velocity);
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *(planner_data_->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
     parameters_.forward_goal_search_length);
   const auto [pull_over_lane_stop_objects, others] =
-    utils::path_safety_checker::separateObjectsByLanelets(stop_objects, pull_over_lanes);
+    utils::path_safety_checker::separateObjectsByLanelets(stop_objects, pull_over_lanes, condition);
 
   if (parameters_.prioritize_goals_before_objects) {
     countObjectsToAvoid(goal_candidates, pull_over_lane_stop_objects);

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/utils/path_utils.hpp"
 #include "behavior_path_planner/utils/start_planner/util.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
+#include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 
@@ -62,10 +63,15 @@ boost::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, con
 
   // collision check with stop objects in pull out lanes
   const auto arc_path = planner_.getArcPath();
+  const auto condition = [](const PredictedObject & object, const lanelet::ConstLanelet & lanelet) {
+    const auto object_polygon = tier4_autoware_utils::toPolygon2d(object);
+    const auto lanelet_polygon = utils::toPolygon2d(lanelet);
+    return !boost::geometry::disjoint(lanelet_polygon, object_polygon);
+  };
   const auto & stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     *(planner_data_->dynamic_object), parameters_.th_moving_object_velocity);
   const auto [pull_out_lane_stop_objects, others] =
-    utils::path_safety_checker::separateObjectsByLanelets(stop_objects, pull_out_lanes);
+    utils::path_safety_checker::separateObjectsByLanelets(stop_objects, pull_out_lanes, condition);
 
   if (utils::checkCollisionBetweenPathFootprintsAndObjects(
         vehicle_footprint_, arc_path, pull_out_lane_stop_objects,

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -20,6 +20,7 @@
 #include "behavior_path_planner/utils/start_planner/util.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
 #include "motion_utils/trajectory/path_with_lane_id.hpp"
+#include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 
@@ -64,8 +65,14 @@ boost::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const P
   }
 
   // extract stop objects in pull out lane for collision check
+  const auto condition = [](const PredictedObject & object, const lanelet::ConstLanelet & lanelet) {
+    const auto object_polygon = tier4_autoware_utils::toPolygon2d(object);
+    const auto lanelet_polygon = utils::toPolygon2d(lanelet);
+    return !boost::geometry::disjoint(lanelet_polygon, object_polygon);
+  };
   const auto [pull_out_lane_objects, others] =
-    utils::path_safety_checker::separateObjectsByLanelets(*dynamic_objects, pull_out_lanes);
+    utils::path_safety_checker::separateObjectsByLanelets(
+      *dynamic_objects, pull_out_lanes, condition);
   const auto pull_out_lane_stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     pull_out_lane_objects, parameters_.th_moving_object_velocity);
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2675,6 +2675,19 @@ double getArcLengthToTargetLanelet(
     std::min(arc_front.length - arc_pose.length, arc_back.length - arc_pose.length), 0.0);
 }
 
+Polygon2d toPolygon2d(const lanelet::ConstLanelet & lanelet)
+{
+  Polygon2d polygon;
+  for (const auto & p : lanelet.polygon2d().basicPolygon()) {
+    polygon.outer().emplace_back(p.x(), p.y());
+  }
+  polygon.outer().push_back(polygon.outer().front());
+
+  return tier4_autoware_utils::isClockwise(polygon)
+           ? polygon
+           : tier4_autoware_utils::inverseClockwise(polygon);
+}
+
 std::vector<Polygon2d> getTargetLaneletPolygons(
   const lanelet::PolygonLayer & map_polygons, lanelet::ConstLanelets & lanelets, const Pose & pose,
   const double check_length, const std::string & target_type)


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc4d64f</samp>

This pull request enhances the behavior path planner by adding polygon utilities and custom filtering functions for predicted objects by lanelets. These changes improve the logic and performance of the goal planner, the avoidance by lane change, the start planner, and the path safety checker modules. The pull request also refactors some existing functions and adds a new function `toPolygon2d` to convert lanelets to polygons.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/ffcf6426-9b3d-5acc-aa4b-2a90e6d9d6bc?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
