### PR TITLE
fix(lane_change): current lane obj treated as target lane obj

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -683,6 +683,16 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     lanelet::utils::getLateralDistanceToClosestLanelet(current_lanes, current_pose);
   std::vector<std::optional<lanelet::BasicPolygon2d>> target_backward_polygons;
   for (const auto & target_backward_lane : target_backward_lanes) {
+    // Check to see is target_backward_lane is in current_lanes
+    // Without this check, current lane object might be treated as target lane object
+    const auto is_current_lane = [&](const lanelet::ConstLanelet & current_lane) {
+      return current_lane.id() == target_backward_lane.id();
+    };
+
+    if (std::any_of(current_lanes.begin(), current_lanes.end(), is_current_lane)) {
+      continue;
+    }
+
     lanelet::ConstLanelets lanelet{target_backward_lane};
     auto lane_polygon =
       utils::lane_change::createPolygon(lanelet, 0.0, std::numeric_limits<double>::max());


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aef3324</samp>

Fix a bug in `normal.cpp` that could cause incorrect lane change behavior. Add a check to see if the target backward lane is in the current lanes of the ego vehicle.


![image1](https://github.com/autowarefoundation/autoware.universe/assets/93502286/372e0b2e-193a-402b-a265-f197a1279e54)

Since target object filter is prioritized, the object in current lane may be classified as target lane object, and we wouldn't want this behavior.

#### Before PR

Current lanes object is misclassified as target lane object (blue cube == target lane object)

![Screenshot from 2023-10-03 22-05-26](https://github.com/autowarefoundation/autoware.universe/assets/93502286/904c056c-b44a-4a13-b292-9066b32d2b4a)

#### After PR

Current lanes object is treated correctly.

![Screenshot from 2023-10-03 22-20-41](https://github.com/autowarefoundation/autoware.universe/assets/93502286/f856f176-2bcb-4a99-83fd-2a0a94f693d9)

## Tests performed

Not applicable.


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
