### PR TITLE
perf(ndt_scan_matcher): changed default `initial_estimate_particles_num` to 200

### DIFF
--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -41,7 +41,7 @@
     converged_param_nearest_voxel_transformation_likelihood: 2.3
 
     # The number of particles to estimate initial pose
-    initial_estimate_particles_num: 100
+    initial_estimate_particles_num: 200
 
     # Tolerance of timestamp difference between current time and sensor pointcloud. [sec]
     lidar_topic_timeout_sec: 1.0


### PR DESCRIPTION
## Description

In this pull request, I propose to change the default value of `initial_estimate_particles_num`, mainly because the initial pose estimation at AWSIM Nishi-Shinjuku fails about 10% of the time.

## Related link

https://github.com/autowarefoundation/autoware_launch/pull/618

## Evaluation
Performed 1000 initial position estimations and recorded TP scores.

#### `initial_estimate_particles_num` = 100

![launch_histogram_100particles](https://github.com/autowarefoundation/autoware.universe/assets/28504069/704f0765-ed65-43cc-bef0-fcab63edde22)

mean_score: 5.171 ± 1.488

mean_elapsed_time: 0.537 ± 0.036 [sec]

#### `initial_estimate_particles_num` = 200

![launch_histogram_200particles](https://github.com/autowarefoundation/autoware.universe/assets/28504069/828e7323-901b-4bf9-916c-1965a433d38b)

mean_score: 5.938 ± 0.911

mean_elapsed_time: 1.073 ± 0.043 [sec]

The TP score improves, but processing time is approximately doubled.

## Tests performed

Tested by

1. logging simulator about the [sample rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).
2. AWSIM

## Effects on system behavior

Improves the performance of initial position estimation, but it takes more time in default parameters.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
