### PR TITLE
Feat(tier4_system_rviz_plugin): improve visualization results / logics

### DIFF
--- a/common/tier4_system_rviz_plugin/src/mrm_summary_overlay_display.hpp
+++ b/common/tier4_system_rviz_plugin/src/mrm_summary_overlay_display.hpp
@@ -86,6 +86,8 @@ protected:
   void update(float wall_dt, float ros_dt) override;
   void processMessage(
     const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg_ptr) override;
+  bool checkLocalizationNotInit();
+  bool checkPlanningGoalNotInit();
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
   rviz_common::properties::IntProperty * property_left_;


### PR DESCRIPTION
## Description

The great PR https://github.com/autowarefoundation/autoware.universe/pull/4945 added the visualization functionality for HazardStatus messages, which is important in daily testing. However, there are two problems that make the RVIz plugin not perfect enough for everyday usage.

1. The plugin will print out a large amount of errors before we provide the initial localization and mission planning. 
2. The plugin will keep printing out information when there are no error messages, which occupies quite a part of the window while providing limited information.

In this PR, we 
1. Completly clean up text outputs when there is simply no error received.
2.  Produce different instruction texts when the initial localization or goal is not provided.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

PSim

1. Print out helper text when localization is not initialized. 
![localization_required](https://github.com/tier4/autoware.universe/assets/31618608/a382b14a-984e-4149-8a59-27b1215b7cb3)

2. Print out helper text when goal is not set (after localization is set).
![goal_required](https://github.com/tier4/autoware.universe/assets/31618608/5ecf9de7-fcd3-4806-bd56-19e05fb4ac8f)

3. No text print out when running normally
![cleanedup_when_no_error](https://github.com/tier4/autoware.universe/assets/31618608/2c621538-907d-4877-91b8-86d926b77115)

4. Print out text as the original PR when errors/warnings received.
![onlyDisplay_when_needed](https://github.com/tier4/autoware.universe/assets/31618608/f0a63c16-1851-4c82-921e-5028fe18cfb6)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers


### Code Mechanism
To determine if the initial localization is provided, we look up the list of errors, and find out errors with name ```/autoware/localization/node_alive_monitoring/topic_status/topic_state_monitor_initialpose3d: localization_topic_status``` with key-value pair: ```status: Not Received```.

To determine if the goal is provided, we look up the list of errors, and find out errors with name ```
/autoware/planning/node_alive_monitoring/topic_status/topic_state_monitor_mission_planning_route: planning_topic_status
``` with key-value pair: ```status: Not Received```.

If there are any better ideas to implement this functionality or want to make these into parameters, please follow in the comment section.

### Something Tricky
When the goal is set, it still takes some frames (about 0.2s?) to clean up all the errors due to launching the planning and control module. But I am not sure how to tackle this problem.


### Color and Text
During my personal usage, I would be considering using different colors. But I am not sure how to determine this for a public commit. So I keep the visualization effect the same as the original code.


<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
