### PR TITLE
feat(lane_change): keep distance against avoidable stationary objects

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -205,10 +205,9 @@ void NormalLaneChange::insertStopPoint(
   const auto target_objects = getTargetObjects(status_.current_lanes, status_.target_lanes);
   const bool is_in_terminal_section = lanelet::utils::isInLanelet(getEgoPose(), lanelets.back()) ||
                                       distance_to_terminal < lane_change_buffer;
-  const double stationary_obj_velocity_threshold = 0.3;
   const bool has_blocking_target_lane_obj = std::any_of(
     target_objects.target_lane.begin(), target_objects.target_lane.end(), [&](const auto & o) {
-      if (o.initial_twist.twist.linear.x > stationary_obj_velocity_threshold) {
+      if (o.initial_twist.twist.linear.x > lane_change_parameters_->stop_velocity_threshold) {
         return false;
       }
       const double distance_to_target_lane_obj = utils::getSignedDistance(
@@ -227,7 +226,8 @@ void NormalLaneChange::insertStopPoint(
 
       for (const auto & object : target_objects.current_lane) {
         // check if stationary
-        if (std::abs(object.initial_twist.twist.linear.x) > stationary_obj_velocity_threshold) {
+        const auto obj_v = std::abs(object.initial_twist.twist.linear.x);
+        if (obj_v > lane_change_parameters_->stop_velocity_threshold) {
           continue;
         }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -232,15 +232,12 @@ void NormalLaneChange::insertStopPoint(
         }
 
         // calculate distance from path front to the stationary object polygon on the ego lane.
-        for (const auto & polygon_p :
-             tier4_autoware_utils::toPolygon2d(object.initial_pose.pose, object.shape).outer()) {
-          auto p = object.initial_pose.pose;
+        const auto polygon =
+          tier4_autoware_utils::toPolygon2d(object.initial_pose.pose, object.shape).outer();
+        auto p = object.initial_pose.pose;
+        for (const auto & polygon_p : polygon) {
           p.position =
             tier4_autoware_utils::createPoint(polygon_p.x(), polygon_p.y(), p.position.z);
-          if (p.position.x < 0.01 || p.position.y < 0.01) {
-            // todo(kosuke55): inverseClockwise make polygon have invalid value, so skip it.
-            continue;
-          }
           const double current_distance_to_obj =
             utils::getSignedDistance(path.points.front().point.pose, p, lanelets);
           // ignore backward object


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


1) 
- ego is in terminal current lanes
- stationary object is in current lanes

-> keep distance against the object 

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/d9591c21-728c-4625-8c0a-a3b20926c7eb)

2) 
- ego is in terminal current lanes

-> keep lane change buffer to the terminal

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/97e0147b-67b3-458b-92d2-994a50ae99b1)

3) 
- ego is NOT in terminal current lanes
- stationaly object is target lane

-> keep distance against the object 

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/c2b00b03-e170-4bce-8841-39bd51f8e7de)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/da8600b8-20fd-4c53-b3c5-ffb9f39f5d96)

4)

- ego is NOT in terminal current lanes

-> keep lane change buffer to the terminal

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/89eb49bc-6579-4b94-9903-3f0191dc6b97)



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
