### PR TITLE
fix(vehicle_cmd_gate): fix filtering condition

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -555,9 +555,7 @@ AckermannControlCommand VehicleCmdGate::filterControlCommand(const AckermannCont
   // set prev value for both to keep consistency over switching:
   // Actual steer, vel, acc should be considered in manual mode to prevent sudden motion when
   // switching from manual to autonomous
-  const auto in_autonomous =
-    (mode.mode == OperationModeState::AUTONOMOUS && mode.is_autoware_control_enabled);
-  auto prev_values = in_autonomous ? out : current_status_cmd;
+  auto prev_values = mode.is_autoware_control_enabled ? out : current_status_cmd;
 
   if (ego_is_stopped) {
     prev_values.longitudinal = out.longitudinal;


### PR DESCRIPTION
## Description

The original filtering condition in `vehicle_cmd_gate` did not take into account a case where the operation mode is `STOP` and `is_autoware_control_enabled` is true. 

INTERNAL LINK: https://tier4.atlassian.net/browse/RT0-29417
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested with planning simulator that
- With this PR, psim works normally with the sample map
- If `simple_planning_simulator` incorporates acceleration error (e.g. by adding 0.1[m/s/s] offset in `.longitudinal.acceleration` in [this line](https://github.com/autowarefoundation/autoware.universe/blob/c508aa71c19d09f4198e24cd93c39191c9dacca6/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp#L338)), start planning_simulator, runs the vehicle straight, and push `STOP` button to change the operation mode,
  - without this PR, the vehicle sometimes keeps accelerating even if the mode is correctly set
  - with this PR, the vehicle successfully stops when the operation mode is set


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The behavior when switching the operation mode to STOP may improve.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
