### PR TITLE
fix(autoware_auto_geometry): intersect point templated type

### DIFF
--- a/common/autoware_auto_geometry/include/autoware_auto_geometry/intersection.hpp
+++ b/common/autoware_auto_geometry/include/autoware_auto_geometry/intersection.hpp
@@ -63,7 +63,8 @@ using LineType = std::pair<PointType, PointType>;
 /// \param[in] end End iterator of the list of points
 /// \return The list of faces
 template <typename Iter>
-std::vector<LineType<typename std::iterator_traits<Iter>::value_type>> get_sorted_face_list(const Iter start, const Iter end)
+std::vector<LineType<typename std::iterator_traits<Iter>::value_type>> get_sorted_face_list(
+  const Iter start, const Iter end)
 {
   using PointType = typename std::iterator_traits<Iter>::value_type;
   using Line = LineType<PointType>;


### PR DESCRIPTION
## Description
According to intersect docs:
```
/// \tparam Iter Iterator over point-types that must have point adapters
//      defined or have float members x and y
```
Every Point Type having x,y fields defined is supported by this function, however due to specialized Point type in a few places this is not true.
This PR fixes this, allowing to use there different PointTypes.


## Tests performed

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
