### PR TITLE
feat(pid_longitudinal_controller): transit to STOPPED even if the sign of the ego velocity goes opposite

### DIFF
--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -504,6 +504,8 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
   const bool is_stopped = std::abs(current_vel) < p.stopped_state_entry_vel &&
                           std::abs(current_acc) < p.stopped_state_entry_acc;
+  // Case where the ego slips in the opposite direction of the gear due to e.g. a slope is also
+  // considered as a stop
   const bool is_not_running = [&]() {
     if (control_data.shift == Shift::Forward) {
       if (is_stopped || current_vel < 0.0) {

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -512,10 +512,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         // NOTE: Stopped or moving backward
         return true;
       }
-    }
-    if (is_stopped || 0.0 < current_vel) {
-      // NOTE: Stopped or moving forward
-      return true;
+    } else {
+      if (is_stopped || 0.0 < current_vel) {
+        // NOTE: Stopped or moving forward
+        return true;
+      }
     }
     return false;
   }();

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -501,9 +501,23 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     m_enable_keep_stopped_until_steer_convergence && !lateral_sync_data_.is_steer_converged;
 
   const bool stopping_condition = stop_dist < p.stopping_state_stop_dist;
-  if (
-    std::fabs(current_vel) > p.stopped_state_entry_vel ||
-    std::fabs(current_acc) > p.stopped_state_entry_acc) {
+
+  const bool is_stopped = std::abs(current_vel) < p.stopped_state_entry_vel &&
+                          std::abs(current_acc) < p.stopped_state_entry_acc;
+  const bool is_not_running = [&]() {
+    if (control_data.shift == Shift::Forward) {
+      if (is_stopped || current_vel < 0.0) {
+        // NOTE: Stopped or moving backward
+        return true;
+      }
+    }
+    if (is_stopped || 0.0 < current_vel) {
+      // NOTE: Stopped or moving forward
+      return true;
+    }
+    return false;
+  }();
+  if (!is_not_running) {
     m_last_running_time = std::make_shared<rclcpp::Time>(clock_->now());
   }
   const bool stopped_condition =


### PR DESCRIPTION
## Description

Currently, in the pid_longitudinal_controller, the condition to transit to STOPPED is that the absolute values of the velocity and acceleration are small enough.
However, on the steep ascending slope, if the ego tries to stop by the state transiting to STOPPED but the ego moves backward due to the slope, the state will never transit to STOPPED since the absolute value of the velocity is not small enough.

To deal with this case, the condition to transit to STOPPED is changed as follows
- The absolute values of the velocity and acceleration are small enough, which is the original condition.
- **Or the sign of the velocity is opposite to the expected.**
    - e.g. When the shift is forward but the velocity is negative, the condition to transit to STOPPED is met.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

unit test
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
can stop on the steep slope.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
