### PR TITLE
refactor(behavior_path_planner): separate processing time function

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -243,6 +243,11 @@ public:
   void print() const;
 
   /**
+   * @brief publish processing time of each module.
+   */
+  void publishProcessingTime() const;
+
+  /**
    * @brief visit each module and get debug information.
    */
   std::shared_ptr<SceneModuleVisitor> getDebugMsg();

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -579,6 +579,7 @@ void BehaviorPathPlannerNode::run()
   lk_pd.unlock();  // release planner_data_
 
   planner_manager_->print();
+  planner_manager_->publishProcessingTime();
   planner_manager_->publishMarker();
   planner_manager_->publishVirtualWall();
   lk_manager.unlock();  // release planner_manager_

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -886,11 +886,17 @@ void PlannerManager::print() const
     string_stream << std::right << "[" << std::setw(max_string_num + 1) << std::left << t.first
                   << ":" << std::setw(4) << std::right << t.second << "ms]\n"
                   << std::setw(21);
-    std::string name = std::string("processing_time/") + t.first;
-    debug_publisher_ptr_->publish<DebugDoubleMsg>(name, t.second);
   }
 
   RCLCPP_INFO_STREAM(logger_, string_stream.str());
+}
+
+void PlannerManager::publishProcessingTime() const
+{
+  for (const auto & t : processing_time_) {
+    std::string name = std::string("processing_time/") + t.first;
+    debug_publisher_ptr_->publish<DebugDoubleMsg>(name, t.second);
+  }
 }
 
 std::shared_ptr<SceneModuleVisitor> PlannerManager::getDebugMsg()


### PR DESCRIPTION
## Description

Separate processing time publish function and call it every time.

```
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/avoidance: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/avoidance_by_lane_change: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/goal_planner: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/lane_change_left: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/lane_change_right: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/side_shift: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/start_planner: tier4_debug_msgs/msg/Float64Stamped
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/total_time: tier4_debug_msgs/msg/Float64Stamped
```

## Tests performed

run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
