### PR TITLE
chore(obstacle_velocity_limiter): publish processing time as float

### DIFF
--- a/planning/obstacle_velocity_limiter/README.md
+++ b/planning/obstacle_velocity_limiter/README.md
@@ -161,7 +161,7 @@ For example a value of `1` means all trajectory points will be evaluated while a
 | ------------------------------- | ---------------------------------------- | -------------------------------------------------------- |
 | `~/output/trajectory`           | `autoware_auto_planning_msgs/Trajectory` | Trajectory with adjusted velocities                      |
 | `~/output/debug_markers`        | `visualization_msgs/MarkerArray`         | Debug markers (envelopes, obstacle polygons)             |
-| `~/output/runtime_microseconds` | `std_msgs/Int64`                         | Time taken to calculate the trajectory (in microseconds) |
+| `~/output/runtime_microseconds` | `tier4_debug_msgs/Float64`               | Time taken to calculate the trajectory (in microseconds) |
 
 ## Parameters
 

--- a/planning/obstacle_velocity_limiter/include/obstacle_velocity_limiter/obstacle_velocity_limiter_node.hpp
+++ b/planning/obstacle_velocity_limiter/include/obstacle_velocity_limiter/obstacle_velocity_limiter_node.hpp
@@ -29,7 +29,7 @@
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <std_msgs/msg/int64.hpp>
+#include <tier4_debug_msgs/msg/float64_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <boost/optional.hpp>
@@ -56,7 +56,7 @@ private:
     pub_trajectory_;  //!< @brief publisher for output trajectory
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     pub_debug_markers_;  //!< @brief publisher for debug markers
-  rclcpp::Publisher<std_msgs::msg::Int64>::SharedPtr
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_runtime_;  //!< @brief publisher for callback runtime
   rclcpp::Subscription<Trajectory>::SharedPtr
     sub_trajectory_;  //!< @brief subscriber for reference trajectory

--- a/planning/obstacle_velocity_limiter/src/obstacle_velocity_limiter_node.cpp
+++ b/planning/obstacle_velocity_limiter/src/obstacle_velocity_limiter_node.cpp
@@ -68,7 +68,8 @@ ObstacleVelocityLimiterNode::ObstacleVelocityLimiterNode(const rclcpp::NodeOptio
   pub_trajectory_ = create_publisher<Trajectory>("~/output/trajectory", 1);
   pub_debug_markers_ =
     create_publisher<visualization_msgs::msg::MarkerArray>("~/output/debug_markers", 1);
-  pub_runtime_ = create_publisher<std_msgs::msg::Int64>("~/output/runtime_microseconds", 1);
+  pub_runtime_ =
+    create_publisher<tier4_debug_msgs::msg::Float64Stamped>("~/output/runtime_microseconds", 1);
 
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
   vehicle_lateral_offset_ = static_cast<Float>(vehicle_info.max_lateral_offset_m);
@@ -223,7 +224,8 @@ void ObstacleVelocityLimiterNode::onTrajectory(const Trajectory::ConstSharedPtr 
 
   const auto t_end = std::chrono::system_clock::now();
   const auto runtime = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start);
-  pub_runtime_->publish(std_msgs::msg::Int64().set__data(runtime.count()));
+  pub_runtime_->publish(tier4_debug_msgs::msg::Float64Stamped().set__stamp(now()).set__data(
+    static_cast<double>(runtime.count())));
 
   if (pub_debug_markers_->get_subscription_count() > 0) {
     const auto safe_projected_linestrings =


### PR DESCRIPTION
## Description

Use Float64 msg for processing time as other planning modules do.

## Tests performed

run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
