### PR TITLE
feat(imu_corrector): changed GyroBiasEstimator to use ndt pose instead of twist

### DIFF
--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -58,6 +58,10 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 
 Note that the input pose is assumed to be accurate enough. For example when using NDT, we assume that the NDT is appropriately converged.
 
+Currently, it is possible to use methods other than NDT as a `pose_source` for Autoware, but less accurate methods are not suitable for IMU bias estimation.
+
+In the future, with careful implementation for pose errors, the IMU bias estimated by NDT could potentially be used not only for validation but also for online calibration.
+
 ### Output
 
 | Name                 | Type                                 | Description                   |

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -72,4 +72,3 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 | `gyro_bias_threshold`                 | double | threshold of the bias of the gyroscope [rad/s]                                              |
 | `timer_callback_interval_sec`         | double | seconds about the timer callback function [sec]                                             |
 | `straight_motion_ang_vel_upper_limit` | double | upper limit of yaw angular velocity, beyond which motion is not considered straight [rad/s] |
-| `data_num_threshold`                  | int    | number of data used to calculate bias                                                       |

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -51,10 +51,10 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 
 ### Input
 
-| Name              | Type                                             | Description      |
-| ----------------- | ------------------------------------------------ | ---------------- |
-| `~/input/imu_raw` | `sensor_msgs::msg::Imu`                          | **raw** imu data |
-| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped`  | ndt pose         |
+| Name              | Type                                            | Description      |
+| ----------------- | ----------------------------------------------- | ---------------- |
+| `~/input/imu_raw` | `sensor_msgs::msg::Imu`                         | **raw** imu data |
+| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped` | ndt pose         |
 
 ### Output
 

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -51,10 +51,10 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 
 ### Input
 
-| Name              | Type                                            | Description      |
-| ----------------- | ----------------------------------------------- | ---------------- |
-| `~/input/imu_raw` | `sensor_msgs::msg::Imu`                         | **raw** imu data |
-| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped` | ndt pose         |
+| Name              | Type                                            | Description                                                                                                                               |
+| ----------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/input/imu_raw` | `sensor_msgs::msg::Imu`                         | **raw** imu data                                                                                                                          |
+| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped` | Note that the input pose is assumed to be accurate enough. For example when using NDT, we assume that the NDT is appropriately converged. |
 
 ### Output
 

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -54,7 +54,7 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 | Name              | Type                                             | Description      |
 | ----------------- | ------------------------------------------------ | ---------------- |
 | `~/input/imu_raw` | `sensor_msgs::msg::Imu`                          | **raw** imu data |
-| `~/input/twist`   | `geometry_msgs::msg::TwistWithCovarianceStamped` | vehicle velocity |
+| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped`  | ndt pose         |
 
 ### Output
 
@@ -64,12 +64,12 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 
 ### Parameters
 
-| Name                        | Type   | Description                                                                   |
-| --------------------------- | ------ | ----------------------------------------------------------------------------- |
-| `angular_velocity_offset_x` | double | roll rate offset in imu_link [rad/s]                                          |
-| `angular_velocity_offset_y` | double | pitch rate offset imu_link [rad/s]                                            |
-| `angular_velocity_offset_z` | double | yaw rate offset imu_link [rad/s]                                              |
-| `gyro_bias_threshold`       | double | threshold of the bias of the gyroscope [rad/s]                                |
-| `velocity_threshold`        | double | threshold of the vehicle velocity to determine if the vehicle is stopped[m/s] |
-| `timestamp_threshold`       | double | threshold of the timestamp diff between IMU and twist [s]                     |
-| `data_num_threshold`        | int    | number of data used to calculate bias                                         |
+| Name                                  | Type   | Description                                                                                 |
+| ------------------------------------- | ------ | ------------------------------------------------------------------------------------------- |
+| `angular_velocity_offset_x`           | double | roll rate offset in imu_link [rad/s]                                                        |
+| `angular_velocity_offset_y`           | double | pitch rate offset imu_link [rad/s]                                                          |
+| `angular_velocity_offset_z`           | double | yaw rate offset imu_link [rad/s]                                                            |
+| `gyro_bias_threshold`                 | double | threshold of the bias of the gyroscope [rad/s]                                              |
+| `timer_callback_interval_sec`         | double | seconds about the timer callback function [sec]                                             |
+| `straight_motion_ang_vel_upper_limit` | double | upper limit of yaw angular velocity, beyond which motion is not considered straight [rad/s] |
+| `data_num_threshold`                  | int    | number of data used to calculate bias                                                       |

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -56,6 +56,8 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 | `~/input/imu_raw` | `sensor_msgs::msg::Imu`                         | **raw** imu data |
 | `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped` | ndt pose         |
 
+Note that the input pose is assumed to be accurate enough. For example when using NDT, we assume that the NDT is appropriately converged.
+
 ### Output
 
 | Name                 | Type                                 | Description                   |

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -51,10 +51,10 @@ Note that the node calculates bias from the gyroscope data by averaging the data
 
 ### Input
 
-| Name              | Type                                            | Description                                                                                                                               |
-| ----------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `~/input/imu_raw` | `sensor_msgs::msg::Imu`                         | **raw** imu data                                                                                                                          |
-| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped` | Note that the input pose is assumed to be accurate enough. For example when using NDT, we assume that the NDT is appropriately converged. |
+| Name              | Type                                            | Description      |
+| ----------------- | ----------------------------------------------- | ---------------- |
+| `~/input/imu_raw` | `sensor_msgs::msg::Imu`                         | **raw** imu data |
+| `~/input/pose`    | `geometry_msgs::msg::PoseWithCovarianceStamped` | ndt pose         |
 
 ### Output
 

--- a/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
+++ b/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    gyro_bias_threshold: 0.0050 # [rad/s]
+    gyro_bias_threshold: 0.0015 # [rad/s]
     timer_callback_interval_sec: 0.5 # [sec]
     straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]
     data_num_threshold: 200 # [num]

--- a/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
+++ b/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
@@ -3,4 +3,3 @@
     gyro_bias_threshold: 0.0015 # [rad/s]
     timer_callback_interval_sec: 0.5 # [sec]
     straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]
-    data_num_threshold: 200 # [num]

--- a/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
+++ b/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    gyro_bias_threshold: 0.0015 # [rad/s]
-    velocity_threshold: 0.0 # [m/s]
-    timestamp_threshold: 0.1 # [s]
+    gyro_bias_threshold: 0.0050 # [rad/s]
+    timer_callback_interval_sec: 0.5 # [sec]
+    straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]
     data_num_threshold: 200 # [num]

--- a/sensing/imu_corrector/launch/gyro_bias_estimator.launch.xml
+++ b/sensing/imu_corrector/launch/gyro_bias_estimator.launch.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="input_imu_raw" default="imu_raw"/>
-  <arg name="input_twist" default="twist"/>
+  <arg name="input_pose" default="pose"/>
   <arg name="output_gyro_bias" default="gyro_bias"/>
   <arg name="gyro_bias_estimator_param_file" default="$(find-pkg-share imu_corrector)/config/gyro_bias_estimator.param.yaml"/>
   <arg name="imu_corrector_param_file" default="$(find-pkg-share imu_corrector)/config/imu_corrector.param.yaml"/>
 
   <node pkg="imu_corrector" exec="gyro_bias_estimator" name="gyro_bias_estimator" output="screen">
     <remap from="~/input/imu_raw" to="$(var input_imu_raw)"/>
-    <remap from="~/input/twist" to="$(var input_twist)"/>
+    <remap from="~/input/pose" to="$(var input_pose)"/>
     <remap from="~/output/gyro_bias" to="$(var output_gyro_bias)"/>
     <param from="$(var gyro_bias_estimator_param_file)"/>
     <param from="$(var imu_corrector_param_file)"/>

--- a/sensing/imu_corrector/src/gyro_bias_estimation_module.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimation_module.cpp
@@ -64,11 +64,6 @@ geometry_msgs::msg::Vector3 calculate_error_rpy(
   return error_rpy;
 }
 
-GyroBiasEstimationModule::GyroBiasEstimationModule(const size_t data_num_threshold)
-: data_num_threshold_(data_num_threshold)
-{
-}
-
 /**
  * @brief update gyroscope bias based on a given trajectory data
  */
@@ -102,10 +97,6 @@ void GyroBiasEstimationModule::update_bias(
   gyro_bias.x = error_rpy.x / dt_pose;
   gyro_bias.y = error_rpy.y / dt_pose;
   gyro_bias.z = error_rpy.z / dt_pose;
-  gyro_bias_deque_.push_back(gyro_bias);
-  if (gyro_bias_deque_.size() > data_num_threshold_) {
-    gyro_bias_deque_.pop_front();
-  }
 }
 
 /**
@@ -123,37 +114,6 @@ geometry_msgs::msg::Vector3 GyroBiasEstimationModule::get_bias_base_link() const
   gyro_bias_base.y = gyro_bias_pair_.first.y / gyro_bias_pair_.second.y;
   gyro_bias_base.z = gyro_bias_pair_.first.z / gyro_bias_pair_.second.z;
   return gyro_bias_base;
-}
-
-/**
- * @brief getter function for current standard deviation of estimated bias
- */
-geometry_msgs::msg::Vector3 GyroBiasEstimationModule::get_bias_std() const
-{
-  auto calculate_std_mean_const = [](const std::vector<double> & v, const double mean) {
-    if (v.size() == 0) {
-      return 0.0;
-    }
-
-    double error = 0;
-    for (const double & t : v) {
-      error += pow(t - mean, 2);
-    }
-    return std::sqrt(error / v.size());
-  };
-
-  std::vector<double> stddev_bias_list_x, stddev_bias_list_y, stddev_bias_list_z;
-  for (const auto & e : gyro_bias_deque_) {
-    stddev_bias_list_x.push_back(e.x);
-    stddev_bias_list_y.push_back(e.y);
-    stddev_bias_list_z.push_back(e.z);
-  }
-  geometry_msgs::msg::Vector3 mean = get_bias_base_link();
-  geometry_msgs::msg::Vector3 stddev_bias;
-  stddev_bias.x = calculate_std_mean_const(stddev_bias_list_x, mean.x);
-  stddev_bias.y = calculate_std_mean_const(stddev_bias_list_y, mean.y);
-  stddev_bias.z = calculate_std_mean_const(stddev_bias_list_z, mean.z);
-  return stddev_bias;
 }
 
 }  // namespace imu_corrector

--- a/sensing/imu_corrector/src/gyro_bias_estimation_module.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimation_module.cpp
@@ -14,58 +14,146 @@
 
 #include "gyro_bias_estimation_module.hpp"
 
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
 namespace imu_corrector
 {
-GyroBiasEstimationModule::GyroBiasEstimationModule(
-  const double velocity_threshold, const double timestamp_threshold,
-  const size_t data_num_threshold)
-: velocity_threshold_(velocity_threshold),
-  timestamp_threshold_(timestamp_threshold),
-  data_num_threshold_(data_num_threshold),
-  is_stopped_(false)
+
+/**
+ * @brief perform dead reckoning based on "gyro_list" and return a relative pose (in RPY)
+ */
+geometry_msgs::msg::Vector3 integrate_orientation(
+  const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list,
+  const geometry_msgs::msg::Vector3 & gyro_bias)
+{
+  geometry_msgs::msg::Vector3 d_rpy{};
+  double t_prev = rclcpp::Time(gyro_list.front().header.stamp).seconds();
+  for (std::size_t i = 0; i < gyro_list.size() - 1; ++i) {
+    double t_cur = rclcpp::Time(gyro_list[i + 1].header.stamp).seconds();
+
+    d_rpy.x += (t_cur - t_prev) * (gyro_list[i].vector.x - gyro_bias.x);
+    d_rpy.y += (t_cur - t_prev) * (gyro_list[i].vector.y - gyro_bias.y);
+    d_rpy.z += (t_cur - t_prev) * (gyro_list[i].vector.z - gyro_bias.z);
+
+    t_prev = t_cur;
+  }
+  return d_rpy;
+}
+
+/**
+ * @brief calculate RPY error on dead-reckoning (calculated from "gyro_list") compared to the
+ * ground-truth pose from "pose_list".
+ */
+geometry_msgs::msg::Vector3 calculate_error_rpy(
+  const std::vector<geometry_msgs::msg::PoseStamped> & pose_list,
+  const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list,
+  const geometry_msgs::msg::Vector3 & gyro_bias)
+{
+  const geometry_msgs::msg::Vector3 rpy_0 =
+    tier4_autoware_utils::getRPY(pose_list.front().pose.orientation);
+  const geometry_msgs::msg::Vector3 rpy_1 =
+    tier4_autoware_utils::getRPY(pose_list.back().pose.orientation);
+  const geometry_msgs::msg::Vector3 d_rpy = integrate_orientation(gyro_list, gyro_bias);
+
+  geometry_msgs::msg::Vector3 error_rpy;
+  error_rpy.x = tier4_autoware_utils::normalizeRadian(-rpy_1.x + rpy_0.x + d_rpy.x);
+  error_rpy.y = tier4_autoware_utils::normalizeRadian(-rpy_1.y + rpy_0.y + d_rpy.y);
+  error_rpy.z = tier4_autoware_utils::normalizeRadian(-rpy_1.z + rpy_0.z + d_rpy.z);
+  return error_rpy;
+}
+
+GyroBiasEstimationModule::GyroBiasEstimationModule(const size_t data_num_threshold)
+: data_num_threshold_(data_num_threshold)
 {
 }
 
-void GyroBiasEstimationModule::update_gyro(
-  const double time, const geometry_msgs::msg::Vector3 & gyro)
+/**
+ * @brief update gyroscope bias based on a given trajectory data
+ */
+void GyroBiasEstimationModule::update_bias(
+  const std::vector<geometry_msgs::msg::PoseStamped> & pose_list,
+  const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list)
 {
-  if (time - last_velocity_time_ > timestamp_threshold_) {
-    return;
+  const double dt_pose =
+    (rclcpp::Time(pose_list.back().header.stamp) - rclcpp::Time(pose_list.front().header.stamp))
+      .seconds();
+  const double dt_gyro =
+    (rclcpp::Time(gyro_list.back().header.stamp) - rclcpp::Time(gyro_list.front().header.stamp))
+      .seconds();
+  if (dt_pose == 0 || dt_gyro == 0) {
+    throw std::runtime_error("dt_pose or dt_gyro is zero");
   }
-  if (!is_stopped_) {
-    return;
-  }
-  gyro_buffer_.push_back(gyro);
-  if (gyro_buffer_.size() > data_num_threshold_) {
-    gyro_buffer_.pop_front();
+
+  auto error_rpy = calculate_error_rpy(pose_list, gyro_list, geometry_msgs::msg::Vector3{});
+  error_rpy.x *= dt_pose / dt_gyro;
+  error_rpy.y *= dt_pose / dt_gyro;
+  error_rpy.z *= dt_pose / dt_gyro;
+
+  gyro_bias_pair_.first.x += dt_pose * error_rpy.x;
+  gyro_bias_pair_.first.y += dt_pose * error_rpy.y;
+  gyro_bias_pair_.first.z += dt_pose * error_rpy.z;
+  gyro_bias_pair_.second.x += dt_pose * dt_pose;
+  gyro_bias_pair_.second.y += dt_pose * dt_pose;
+  gyro_bias_pair_.second.z += dt_pose * dt_pose;
+
+  geometry_msgs::msg::Vector3 gyro_bias;
+  gyro_bias.x = error_rpy.x / dt_pose;
+  gyro_bias.y = error_rpy.y / dt_pose;
+  gyro_bias.z = error_rpy.z / dt_pose;
+  gyro_bias_deque_.push_back(gyro_bias);
+  if (gyro_bias_deque_.size() > data_num_threshold_) {
+    gyro_bias_deque_.pop_front();
   }
 }
 
-void GyroBiasEstimationModule::update_velocity(const double time, const double velocity)
+/**
+ * @brief getter function for current estimated bias
+ */
+geometry_msgs::msg::Vector3 GyroBiasEstimationModule::get_bias_base_link() const
 {
-  is_stopped_ = velocity <= velocity_threshold_;
-  last_velocity_time_ = time;
+  geometry_msgs::msg::Vector3 gyro_bias_base;
+  if (
+    gyro_bias_pair_.second.x == 0 || gyro_bias_pair_.second.y == 0 ||
+    gyro_bias_pair_.second.z == 0) {
+    throw std::runtime_error("gyro_bias_pair_.second is zero");
+  }
+  gyro_bias_base.x = gyro_bias_pair_.first.x / gyro_bias_pair_.second.x;
+  gyro_bias_base.y = gyro_bias_pair_.first.y / gyro_bias_pair_.second.y;
+  gyro_bias_base.z = gyro_bias_pair_.first.z / gyro_bias_pair_.second.z;
+  return gyro_bias_base;
 }
 
-geometry_msgs::msg::Vector3 GyroBiasEstimationModule::get_bias() const
+/**
+ * @brief getter function for current standard deviation of estimated bias
+ */
+geometry_msgs::msg::Vector3 GyroBiasEstimationModule::get_bias_std() const
 {
-  if (gyro_buffer_.size() < data_num_threshold_) {
-    throw std::runtime_error("Bias estimation is not yet ready because of insufficient data.");
-  }
+  auto calculate_std_mean_const = [](const std::vector<double> & v, const double mean) {
+    if (v.size() == 0) {
+      return 0.0;
+    }
 
-  geometry_msgs::msg::Vector3 bias;
-  bias.x = 0.0;
-  bias.y = 0.0;
-  bias.z = 0.0;
-  for (const auto & gyro : gyro_buffer_) {
-    bias.x += gyro.x;
-    bias.y += gyro.y;
-    bias.z += gyro.z;
+    double error = 0;
+    for (const double & t : v) {
+      error += pow(t - mean, 2);
+    }
+    return std::sqrt(error / v.size());
+  };
+
+  std::vector<double> stddev_bias_list_x, stddev_bias_list_y, stddev_bias_list_z;
+  for (const auto & e : gyro_bias_deque_) {
+    stddev_bias_list_x.push_back(e.x);
+    stddev_bias_list_y.push_back(e.y);
+    stddev_bias_list_z.push_back(e.z);
   }
-  bias.x /= gyro_buffer_.size();
-  bias.y /= gyro_buffer_.size();
-  bias.z /= gyro_buffer_.size();
-  return bias;
+  geometry_msgs::msg::Vector3 mean = get_bias_base_link();
+  geometry_msgs::msg::Vector3 stddev_bias;
+  stddev_bias.x = calculate_std_mean_const(stddev_bias_list_x, mean.x);
+  stddev_bias.y = calculate_std_mean_const(stddev_bias_list_y, mean.y);
+  stddev_bias.z = calculate_std_mean_const(stddev_bias_list_z, mean.z);
+  return stddev_bias;
 }
 
 }  // namespace imu_corrector

--- a/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
@@ -27,16 +27,13 @@ namespace imu_corrector
 class GyroBiasEstimationModule
 {
 public:
-  explicit GyroBiasEstimationModule(const size_t data_num_threshold);
+  GyroBiasEstimationModule() = default;
   void update_bias(
     const std::vector<geometry_msgs::msg::PoseStamped> & pose_list,
     const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list);
   geometry_msgs::msg::Vector3 get_bias_base_link() const;
-  geometry_msgs::msg::Vector3 get_bias_std() const;
 
 private:
-  const size_t data_num_threshold_;
-  std::deque<geometry_msgs::msg::Vector3> gyro_bias_deque_;
   std::pair<geometry_msgs::msg::Vector3, geometry_msgs::msg::Vector3> gyro_bias_pair_;
 };
 }  // namespace imu_corrector

--- a/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
@@ -20,13 +20,14 @@
 
 #include <deque>
 #include <utility>
+#include <vector>
 
 namespace imu_corrector
 {
 class GyroBiasEstimationModule
 {
 public:
-  GyroBiasEstimationModule(const size_t data_num_threshold);
+  explicit GyroBiasEstimationModule(const size_t data_num_threshold);
   void update_bias(
     const std::vector<geometry_msgs::msg::PoseStamped> & pose_list,
     const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list);

--- a/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
@@ -11,11 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef GYRO_BIAS_ESTIMATION_MODULE_HPP_
-#define GYRO_BIAS_ESTIMATION_MODULE_HPP_
 
-#include <geometry_msgs/msg/vector3.hpp>
+#ifndef IMU_CORRECTOR__GYRO_BIAS_ESTIMATION_MODULE_HPP_
+#define IMU_CORRECTOR__GYRO_BIAS_ESTIMATION_MODULE_HPP_
 
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+
+#include <utility>
 #include <deque>
 
 namespace imu_corrector
@@ -23,22 +26,18 @@ namespace imu_corrector
 class GyroBiasEstimationModule
 {
 public:
-  GyroBiasEstimationModule(
-    const double velocity_threshold, const double timestamp_threshold,
-    const size_t data_num_threshold);
-  geometry_msgs::msg::Vector3 get_bias() const;
-  void update_gyro(const double time, const geometry_msgs::msg::Vector3 & gyro);
-  void update_velocity(const double time, const double velocity);
+  GyroBiasEstimationModule(const size_t data_num_threshold);
+  void update_bias(
+    const std::vector<geometry_msgs::msg::PoseStamped> & pose_list,
+    const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list);
+  geometry_msgs::msg::Vector3 get_bias_base_link() const;
+  geometry_msgs::msg::Vector3 get_bias_std() const;
 
 private:
-  const double velocity_threshold_;
-  const double timestamp_threshold_;
   const size_t data_num_threshold_;
-  bool is_stopped_;
-  std::deque<geometry_msgs::msg::Vector3> gyro_buffer_;
-
-  double last_velocity_time_;
+  std::deque<geometry_msgs::msg::Vector3> gyro_bias_deque_;
+  std::pair<geometry_msgs::msg::Vector3, geometry_msgs::msg::Vector3> gyro_bias_pair_;
 };
 }  // namespace imu_corrector
 
-#endif  // GYRO_BIAS_ESTIMATION_MODULE_HPP_
+#endif  // IMU_CORRECTOR__GYRO_BIAS_ESTIMATION_MODULE_HPP_

--- a/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimation_module.hpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IMU_CORRECTOR__GYRO_BIAS_ESTIMATION_MODULE_HPP_
-#define IMU_CORRECTOR__GYRO_BIAS_ESTIMATION_MODULE_HPP_
+#ifndef GYRO_BIAS_ESTIMATION_MODULE_HPP_
+#define GYRO_BIAS_ESTIMATION_MODULE_HPP_
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 
-#include <utility>
 #include <deque>
+#include <utility>
 
 namespace imu_corrector
 {
@@ -40,4 +40,4 @@ private:
 };
 }  // namespace imu_corrector
 
-#endif  // IMU_CORRECTOR__GYRO_BIAS_ESTIMATION_MODULE_HPP_
+#endif  // GYRO_BIAS_ESTIMATION_MODULE_HPP_

--- a/sensing/imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.cpp
@@ -78,6 +78,16 @@ void GyroBiasEstimator::callback_imu(const Imu::ConstSharedPtr imu_msg_ptr)
   gyro.vector = transform_vector3(imu_msg_ptr->angular_velocity, *tf_imu2base_ptr);
 
   gyro_all_.push_back(gyro);
+
+  // Publish results for debugging
+  if (gyro_bias_ != std::nullopt) {
+    Vector3Stamped gyro_bias_msg;
+
+    gyro_bias_msg.header.stamp = this->now();
+    gyro_bias_msg.vector = gyro_bias_.value();
+
+    gyro_bias_pub_->publish(gyro_bias_msg);
+  }
 }
 
 void GyroBiasEstimator::callback_pose(const PoseWithCovarianceStamped::ConstSharedPtr pose_msg_ptr)

--- a/sensing/imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.cpp
@@ -19,6 +19,8 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <utility>
+
 namespace imu_corrector
 {
 GyroBiasEstimator::GyroBiasEstimator()

--- a/sensing/imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.cpp
@@ -14,6 +14,11 @@
 
 #include "gyro_bias_estimator.hpp"
 
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 namespace imu_corrector
 {
 GyroBiasEstimator::GyroBiasEstimator()
@@ -22,59 +27,138 @@ GyroBiasEstimator::GyroBiasEstimator()
   angular_velocity_offset_x_(declare_parameter<double>("angular_velocity_offset_x")),
   angular_velocity_offset_y_(declare_parameter<double>("angular_velocity_offset_y")),
   angular_velocity_offset_z_(declare_parameter<double>("angular_velocity_offset_z")),
+  timer_callback_interval_sec_(declare_parameter<double>("timer_callback_interval_sec")),
+  straight_motion_ang_vel_upper_limit_(
+    declare_parameter<double>("straight_motion_ang_vel_upper_limit")),
   updater_(this),
   gyro_bias_(std::nullopt)
 {
   updater_.setHardwareID(get_name());
   updater_.add("gyro_bias_validator", this, &GyroBiasEstimator::update_diagnostics);
-
-  const double velocity_threshold = declare_parameter<double>("velocity_threshold");
-  const double timestamp_threshold = declare_parameter<double>("timestamp_threshold");
   const size_t data_num_threshold =
     static_cast<size_t>(declare_parameter<int>("data_num_threshold"));
-  gyro_bias_estimation_module_ = std::make_unique<GyroBiasEstimationModule>(
-    velocity_threshold, timestamp_threshold, data_num_threshold);
+
+  gyro_bias_estimation_module_ = std::make_unique<GyroBiasEstimationModule>(data_num_threshold);
 
   imu_sub_ = create_subscription<Imu>(
     "~/input/imu_raw", rclcpp::SensorDataQoS(),
     [this](const Imu::ConstSharedPtr msg) { callback_imu(msg); });
-  twist_sub_ = create_subscription<TwistWithCovarianceStamped>(
-    "~/input/twist", rclcpp::SensorDataQoS(),
-    [this](const TwistWithCovarianceStamped::ConstSharedPtr msg) { callback_twist(msg); });
-
+  pose_sub_ = create_subscription<PoseWithCovarianceStamped>(
+    "~/input/pose", rclcpp::SensorDataQoS(),
+    [this](const PoseWithCovarianceStamped::ConstSharedPtr msg) { callback_pose(msg); });
   gyro_bias_pub_ = create_publisher<Vector3Stamped>("~/output/gyro_bias", rclcpp::SensorDataQoS());
+
+  auto timer_callback = std::bind(&GyroBiasEstimator::timer_callback, this);
+  auto period_control = std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::duration<double>(timer_callback_interval_sec_));
+  timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
+    this->get_clock(), period_control, std::move(timer_callback),
+    this->get_node_base_interface()->get_context());
+  this->get_node_timers_interface()->add_timer(timer_, nullptr);
+
+  transform_listener_ = std::make_shared<tier4_autoware_utils::TransformListener>(this);
 }
 
 void GyroBiasEstimator::callback_imu(const Imu::ConstSharedPtr imu_msg_ptr)
 {
-  // Update gyro data
-  gyro_bias_estimation_module_->update_gyro(
-    rclcpp::Time(imu_msg_ptr->header.stamp).seconds(), imu_msg_ptr->angular_velocity);
-
-  // Estimate gyro bias
-  try {
-    gyro_bias_ = gyro_bias_estimation_module_->get_bias();
-  } catch (const std::runtime_error & e) {
-    RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *(this->get_clock()), 1000, e.what());
+  imu_frame_ = imu_msg_ptr->header.frame_id;
+  geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
+    transform_listener_->getLatestTransform(imu_frame_, output_frame_);
+  if (!tf_imu2base_ptr) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Please publish TF %s to %s", output_frame_.c_str(),
+      (imu_frame_).c_str());
+    return;
   }
 
-  // Publish results for debugging
-  if (gyro_bias_ != std::nullopt) {
-    Vector3Stamped gyro_bias_msg;
-    gyro_bias_msg.header.stamp = this->now();
-    gyro_bias_msg.vector = gyro_bias_.value();
-    gyro_bias_pub_->publish(gyro_bias_msg);
+  geometry_msgs::msg::Vector3Stamped gyro;
+  gyro.header.stamp = imu_msg_ptr->header.stamp;
+  gyro.vector = transform_vector3(imu_msg_ptr->angular_velocity, *tf_imu2base_ptr);
+
+  gyro_all_.push_back(gyro);
+}
+
+void GyroBiasEstimator::callback_pose(const PoseWithCovarianceStamped::ConstSharedPtr pose_msg_ptr)
+{
+  // push pose_msg to queue
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header = pose_msg_ptr->header;
+  pose.pose = pose_msg_ptr->pose.pose;
+  pose_buf_.push_back(pose);
+}
+
+void GyroBiasEstimator::timer_callback()
+{
+  if (pose_buf_.empty()) {
+    return;
   }
 
-  // Update diagnostics
+  // Copy data
+  const std::vector<geometry_msgs::msg::PoseStamped> pose_buf = pose_buf_;
+  const std::vector<geometry_msgs::msg::Vector3Stamped> gyro_all = gyro_all_;
+  pose_buf_.clear();
+  gyro_all_.clear();
+
+  // Check time
+  const rclcpp::Time t0_rclcpp_time = rclcpp::Time(pose_buf.front().header.stamp);
+  const rclcpp::Time t1_rclcpp_time = rclcpp::Time(pose_buf.back().header.stamp);
+  if (t1_rclcpp_time <= t0_rclcpp_time) {
+    return;
+  }
+
+  // Filter gyro data
+  std::vector<geometry_msgs::msg::Vector3Stamped> gyro_filtered;
+  for (const auto & gyro : gyro_all) {
+    const rclcpp::Time t = rclcpp::Time(gyro.header.stamp);
+    if (t0_rclcpp_time <= t && t < t1_rclcpp_time) {
+      gyro_filtered.push_back(gyro);
+    }
+  }
+
+  // Check gyro data size
+  // Data size must be greater than or equal to 2 since the time difference will be taken later
+  if (gyro_filtered.size() <= 1) {
+    return;
+  }
+
+  // Check if the vehicle is moving straight
+  const geometry_msgs::msg::Vector3 rpy_0 =
+    tier4_autoware_utils::getRPY(pose_buf.front().pose.orientation);
+  const geometry_msgs::msg::Vector3 rpy_1 =
+    tier4_autoware_utils::getRPY(pose_buf.back().pose.orientation);
+  const double yaw_diff = std::abs(tier4_autoware_utils::normalizeRadian(rpy_1.z - rpy_0.z));
+  const double time_diff = (t1_rclcpp_time - t0_rclcpp_time).seconds();
+  const double yaw_vel = yaw_diff / time_diff;
+  const bool is_straight = (yaw_vel < straight_motion_ang_vel_upper_limit_);
+  if (!is_straight) {
+    return;
+  }
+
+  // Calculate gyro bias
+  gyro_bias_estimation_module_->update_bias(pose_buf, gyro_filtered);
+
+  geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_base2imu_ptr =
+    transform_listener_->getLatestTransform(output_frame_, imu_frame_);
+  if (!tf_base2imu_ptr) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Please publish TF %s to %s", imu_frame_.c_str(), output_frame_.c_str());
+    return;
+  }
+  gyro_bias_ =
+    transform_vector3(gyro_bias_estimation_module_->get_bias_base_link(), *tf_base2imu_ptr);
+
   updater_.force_update();
 }
 
-void GyroBiasEstimator::callback_twist(
-  const TwistWithCovarianceStamped::ConstSharedPtr twist_msg_ptr)
+geometry_msgs::msg::Vector3 GyroBiasEstimator::transform_vector3(
+  const geometry_msgs::msg::Vector3 & vec, const geometry_msgs::msg::TransformStamped & transform)
 {
-  gyro_bias_estimation_module_->update_velocity(
-    rclcpp::Time(twist_msg_ptr->header.stamp).seconds(), twist_msg_ptr->twist.twist.linear.x);
+  geometry_msgs::msg::Vector3Stamped vec_stamped;
+  vec_stamped.vector = vec;
+
+  geometry_msgs::msg::Vector3Stamped vec_stamped_transformed;
+  tf2::doTransform(vec_stamped, vec_stamped_transformed, transform);
+  return vec_stamped_transformed.vector;
 }
 
 void GyroBiasEstimator::update_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat)

--- a/sensing/imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.cpp
@@ -37,10 +37,8 @@ GyroBiasEstimator::GyroBiasEstimator()
 {
   updater_.setHardwareID(get_name());
   updater_.add("gyro_bias_validator", this, &GyroBiasEstimator::update_diagnostics);
-  const size_t data_num_threshold =
-    static_cast<size_t>(declare_parameter<int>("data_num_threshold"));
 
-  gyro_bias_estimation_module_ = std::make_unique<GyroBiasEstimationModule>(data_num_threshold);
+  gyro_bias_estimation_module_ = std::make_unique<GyroBiasEstimationModule>();
 
   imu_sub_ = create_subscription<Imu>(
     "~/input/imu_raw", rclcpp::SensorDataQoS(),

--- a/sensing/imu_corrector/src/gyro_bias_estimator.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace imu_corrector
 {

--- a/sensing/imu_corrector/src/gyro_bias_estimator.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.hpp
@@ -77,7 +77,6 @@ private:
 
   std::vector<geometry_msgs::msg::Vector3Stamped> gyro_all_;
   std::vector<geometry_msgs::msg::PoseStamped> pose_buf_;
-
 };
 }  // namespace imu_corrector
 

--- a/sensing/imu_corrector/src/gyro_bias_estimator.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.hpp
@@ -15,11 +15,12 @@
 #define GYRO_BIAS_ESTIMATOR_HPP_
 
 #include "gyro_bias_estimation_module.hpp"
+#include "tier4_autoware_utils/ros/transform_listener.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
@@ -33,7 +34,7 @@ class GyroBiasEstimator : public rclcpp::Node
 {
 private:
   using Imu = sensor_msgs::msg::Imu;
-  using TwistWithCovarianceStamped = geometry_msgs::msg::TwistWithCovarianceStamped;
+  using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Vector3Stamped = geometry_msgs::msg::Vector3Stamped;
   using Vector3 = geometry_msgs::msg::Vector3;
 
@@ -43,12 +44,19 @@ public:
 private:
   void update_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void callback_imu(const Imu::ConstSharedPtr imu_msg_ptr);
-  void callback_twist(const TwistWithCovarianceStamped::ConstSharedPtr twist_msg_ptr);
+  void callback_pose(const PoseWithCovarianceStamped::ConstSharedPtr pose_msg_ptr);
+  void timer_callback();
+
+  static geometry_msgs::msg::Vector3 transform_vector3(
+    const geometry_msgs::msg::Vector3 & vec,
+    const geometry_msgs::msg::TransformStamped & transform);
+
+  const std::string output_frame_ = "base_link";
 
   rclcpp::Subscription<Imu>::SharedPtr imu_sub_;
-  rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr twist_sub_;
-
+  rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr pose_sub_;
   rclcpp::Publisher<Vector3Stamped>::SharedPtr gyro_bias_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
   std::unique_ptr<GyroBiasEstimationModule> gyro_bias_estimation_module_;
 
@@ -56,10 +64,20 @@ private:
   const double angular_velocity_offset_x_;
   const double angular_velocity_offset_y_;
   const double angular_velocity_offset_z_;
+  const double timer_callback_interval_sec_;
+  const double straight_motion_ang_vel_upper_limit_;
 
   diagnostic_updater::Updater updater_;
 
   std::optional<Vector3> gyro_bias_;
+
+  std::shared_ptr<tier4_autoware_utils::TransformListener> transform_listener_;
+
+  std::string imu_frame_;
+
+  std::vector<geometry_msgs::msg::Vector3Stamped> gyro_all_;
+  std::vector<geometry_msgs::msg::PoseStamped> pose_buf_;
+
 };
 }  // namespace imu_corrector
 

--- a/sensing/imu_corrector/test/test_gyro_bias_estimation_module.cpp
+++ b/sensing/imu_corrector/test/test_gyro_bias_estimation_module.cpp
@@ -14,6 +14,8 @@
 
 #include "../src/gyro_bias_estimation_module.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <gtest/gtest.h>
 
 namespace imu_corrector
@@ -21,45 +23,68 @@ namespace imu_corrector
 class GyroBiasEstimationModuleTest : public ::testing::Test
 {
 protected:
-  double velocity_threshold = 1.0;
-  double timestamp_threshold = 5.0;
   size_t data_num_threshold = 10;
-  GyroBiasEstimationModule module =
-    GyroBiasEstimationModule(velocity_threshold, timestamp_threshold, data_num_threshold);
+  GyroBiasEstimationModule module = GyroBiasEstimationModule(data_num_threshold);
 };
 
 TEST_F(GyroBiasEstimationModuleTest, GetBiasEstimationWhenVehicleStopped)
 {
-  geometry_msgs::msg::Vector3 gyro;
-  gyro.x = 0.1;
-  gyro.y = 0.2;
-  gyro.z = 0.3;
+  std::vector<geometry_msgs::msg::PoseStamped> pose_list;
+  std::vector<geometry_msgs::msg::Vector3Stamped> gyro_list;
+  geometry_msgs::msg::PoseStamped pose1;
+  pose1.header.stamp = rclcpp::Time(0);
+  pose1.pose.orientation.w = 1.0;
+  pose_list.push_back(pose1);
+  geometry_msgs::msg::PoseStamped pose2;
+  pose2.header.stamp = rclcpp::Time(1e9);
+  pose2.pose.orientation.w = 1.0;
+  pose_list.push_back(pose2);
+
+  geometry_msgs::msg::Vector3Stamped gyro1;
+  gyro1.header.stamp = rclcpp::Time(0.25 * 1e9);
+  gyro1.vector.x = 0.1;
+  gyro1.vector.y = 0.2;
+  gyro1.vector.z = 0.3;
+  gyro_list.push_back(gyro1);
+  geometry_msgs::msg::Vector3Stamped gyro2;
+  gyro2.header.stamp = rclcpp::Time(0.5 * 1e9);
+  gyro2.vector.x = 0.1;
+  gyro2.vector.y = 0.2;
+  gyro2.vector.z = 0.3;
+  gyro_list.push_back(gyro2);
+
   for (size_t i = 0; i < data_num_threshold + 1; ++i) {
-    module.update_velocity(
-      i * 0.1 * timestamp_threshold, 0.0);  // velocity = 0.0 < 1.0 = velocity_threshold
-    module.update_gyro(i * 0.1 * timestamp_threshold, gyro);
+    module.update_bias(pose_list, gyro_list);
   }
-  ASSERT_NEAR(module.get_bias().x, gyro.x, 0.0001);
-  ASSERT_NEAR(module.get_bias().y, gyro.y, 0.0001);
-  ASSERT_NEAR(module.get_bias().z, gyro.z, 0.0001);
+  const geometry_msgs::msg::Vector3 result = module.get_bias_base_link();
+  ASSERT_DOUBLE_EQ(result.x, 0.1);
+  ASSERT_DOUBLE_EQ(result.y, 0.2);
+  ASSERT_DOUBLE_EQ(result.z, 0.3);
 }
 
 TEST_F(GyroBiasEstimationModuleTest, GetInsufficientDataException)
 {
-  ASSERT_THROW(module.get_bias(), std::runtime_error);
+  ASSERT_THROW(module.get_bias_base_link(), std::runtime_error);
 }
 
 TEST_F(GyroBiasEstimationModuleTest, GetInsufficientDataExceptionWhenVehicleMoving)
 {
-  geometry_msgs::msg::Vector3 gyro;
-  gyro.x = 0.1;
-  gyro.y = 0.2;
-  gyro.z = 0.3;
+  std::vector<geometry_msgs::msg::PoseStamped> pose_list;
+  std::vector<geometry_msgs::msg::Vector3Stamped> gyro_list;
+  geometry_msgs::msg::PoseStamped pose1;
+  pose1.header.stamp = rclcpp::Time(0);
+  pose1.pose.orientation.w = 1.0;
+  pose_list.push_back(pose1);
+
+  geometry_msgs::msg::Vector3Stamped gyro1;
+  gyro1.header.stamp = rclcpp::Time(0);
+  gyro1.vector.x = 0.1;
+  gyro1.vector.y = 0.2;
+  gyro1.vector.z = 0.3;
+  gyro_list.push_back(gyro1);
+
   for (size_t i = 0; i < data_num_threshold + 1; ++i) {
-    module.update_velocity(
-      i * 0.1 * timestamp_threshold, 5.0);  // velocity = 5.0 > 1.0 = velocity_threshold
-    module.update_gyro(i * 0.1 * timestamp_threshold, gyro);
+    ASSERT_THROW(module.update_bias(pose_list, gyro_list), std::runtime_error);
   }
-  ASSERT_THROW(module.get_bias(), std::runtime_error);
 }
 }  // namespace imu_corrector

--- a/sensing/imu_corrector/test/test_gyro_bias_estimation_module.cpp
+++ b/sensing/imu_corrector/test/test_gyro_bias_estimation_module.cpp
@@ -23,8 +23,7 @@ namespace imu_corrector
 class GyroBiasEstimationModuleTest : public ::testing::Test
 {
 protected:
-  size_t data_num_threshold = 10;
-  GyroBiasEstimationModule module = GyroBiasEstimationModule(data_num_threshold);
+  GyroBiasEstimationModule module;
 };
 
 TEST_F(GyroBiasEstimationModuleTest, GetBiasEstimationWhenVehicleStopped)
@@ -53,7 +52,7 @@ TEST_F(GyroBiasEstimationModuleTest, GetBiasEstimationWhenVehicleStopped)
   gyro2.vector.z = 0.3;
   gyro_list.push_back(gyro2);
 
-  for (size_t i = 0; i < data_num_threshold + 1; ++i) {
+  for (size_t i = 0; i < 10; ++i) {
     module.update_bias(pose_list, gyro_list);
   }
   const geometry_msgs::msg::Vector3 result = module.get_bias_base_link();
@@ -83,7 +82,7 @@ TEST_F(GyroBiasEstimationModuleTest, GetInsufficientDataExceptionWhenVehicleMovi
   gyro1.vector.z = 0.3;
   gyro_list.push_back(gyro1);
 
-  for (size_t i = 0; i < data_num_threshold + 1; ++i) {
+  for (size_t i = 0; i < 10; ++i) {
     ASSERT_THROW(module.update_bias(pose_list, gyro_list), std::runtime_error);
   }
 }


### PR DESCRIPTION
## Description

Before : Use `twist` to determine whether ego-vehicle is stopping, and calculate imu bias by comparing it to 0 while it is stopping.

After: Use `ndt pose` to determine whether ego-vehicle is curving, and calculate imu bias by comparing it to ndt pose while it is not curving.

## Related link
* https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/78
* https://github.com/tier4/aip_launcher/pull/180
* https://github.com/RobotecAI/awsim_sensor_kit_launch/pull/10

## Tests performed

It has been confirmed that it works as expected with sample rosbag.

The red dashed line indicates the range extended from the orange line, which is the calibration value, by gyro_bias_threshold.

If it is within the red dashed line range, the IMU bias is considered normal.

<img src="https://github.com/autowarefoundation/autoware.universe/assets/28504069/79c342e2-b046-437e-aa46-3a36b7b3d52b" width="40%">

For TIER IV's internal rosbags, the result of the IMU bias variation detection function for data taken on a day not long after calibration is as follows.

<img src="https://github.com/autowarefoundation/autoware.universe/assets/28504069/7166e5d0-2c27-4453-8f61-b40199613eb5" width="40%">

For data taken on a day when more time has passed since calibration, the result is as follows.

<img src="https://github.com/autowarefoundation/autoware.universe/assets/28504069/89934df5-9500-404f-9832-d9cc657b0e2e" width="40%">

## Effects on system behavior

Improves performance of IMU bias variation detection.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
