### PR TITLE
feat(intersection): find stop line from footprint intersection with areas

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -877,7 +877,8 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
     util::getTrafficPrioritizedLevel(assigned_lanelet, planner_data_->traffic_light_id_map);
   const bool is_prioritized =
     traffic_prioritized_level == util::TrafficPrioritizedLevel::FULLY_PRIORITIZED;
-  intersection_lanelets.update(is_prioritized, interpolated_path_info);
+  const auto footprint = planner_data_->vehicle_info_.createFootprint(0.0, 0.0);
+  intersection_lanelets.update(is_prioritized, interpolated_path_info, footprint);
 
   // this is abnormal
   const auto & conflicting_lanelets = intersection_lanelets.conflicting();

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -94,8 +94,10 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
       planner_param_.attention_area_length, planner_param_.occlusion_attention_area_length,
       planner_param_.consider_wrong_direction_vehicle);
   }
-  intersection_lanelets_.value().update(false, interpolated_path_info);
-  const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area();
+  auto & intersection_lanelets = intersection_lanelets_.value();
+  const auto local_footprint = planner_data_->vehicle_info_.createFootprint(0.0, 0.0);
+  intersection_lanelets.update(false, interpolated_path_info, local_footprint);
+  const auto & first_conflicting_area = intersection_lanelets.first_conflicting_area();
   if (!first_conflicting_area) {
     return false;
   }

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -220,6 +220,50 @@ static std::optional<size_t> getStopLineIndexFromMap(
   return stop_idx_ip_opt.get();
 }
 
+static std::optional<size_t> getFirstPointInsidePolygonByFootprint(
+  const lanelet::CompoundPolygon3d & polygon, const InterpolatedPathInfo & interpolated_path_info,
+  const tier4_autoware_utils::LinearRing2d & footprint)
+{
+  const auto & path_ip = interpolated_path_info.path;
+  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval.value();
+
+  const auto area_2d = lanelet::utils::to2D(polygon).basicPolygon();
+  for (auto i = lane_start; i <= lane_end; ++i) {
+    const auto & base_pose = path_ip.points.at(i).point.pose;
+    const auto path_footprint = tier4_autoware_utils::transformVector(
+      footprint, tier4_autoware_utils::pose2transform(base_pose));
+    if (bg::intersects(path_footprint, area_2d)) {
+      return std::make_optional<size_t>(i);
+    }
+  }
+  return std::nullopt;
+}
+
+static std::optional<std::pair<size_t, const lanelet::CompoundPolygon3d &>>
+getFirstPointInsidePolygonsByFootprint(
+  const std::vector<lanelet::CompoundPolygon3d> & polygons,
+  const InterpolatedPathInfo & interpolated_path_info,
+  const tier4_autoware_utils::LinearRing2d & footprint)
+{
+  const auto & path_ip = interpolated_path_info.path;
+  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval.value();
+
+  for (size_t i = lane_start; i <= lane_end; ++i) {
+    const auto & pose = path_ip.points.at(i).point.pose;
+    const auto path_footprint =
+      tier4_autoware_utils::transformVector(footprint, tier4_autoware_utils::pose2transform(pose));
+    for (const auto & polygon : polygons) {
+      const auto area_2d = lanelet::utils::to2D(polygon).basicPolygon();
+      const bool is_in_polygon = bg::intersects(area_2d, path_footprint);
+      if (is_in_polygon) {
+        return std::make_optional<std::pair<size_t, const lanelet::CompoundPolygon3d &>>(
+          i, polygon);
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const lanelet::CompoundPolygon3d & first_conflicting_area,
   const lanelet::CompoundPolygon3d & first_detection_area,
@@ -236,6 +280,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const int base2front_idx_dist =
     std::ceil(planner_data->vehicle_info_.max_longitudinal_offset_m / ds);
 
+  /*
   // find the index of the first point that intersects with detection_areas
   const auto first_inside_detection_idx_ip_opt =
     getFirstPointInsidePolygon(path_ip, lane_interval_ip, first_detection_area);
@@ -244,21 +289,13 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
     return std::nullopt;
   }
   const auto first_inside_detection_ip = first_inside_detection_idx_ip_opt.value();
+  */
   // find the index of the first point whose vehicle footprint on it intersects with detection_area
-  std::optional<size_t> first_footprint_inside_detection_ip_opt = std::nullopt;
   const auto local_footprint = planner_data->vehicle_info_.createFootprint(0.0, 0.0);
-  const auto area_2d = lanelet::utils::to2D(first_detection_area).basicPolygon();
-  for (size_t i = std::get<0>(lane_interval_ip); i <= std::get<1>(lane_interval_ip); ++i) {
-    const auto & base_pose = path_ip.points.at(i).point.pose;
-    const auto path_footprint = tier4_autoware_utils::transformVector(
-      local_footprint, tier4_autoware_utils::pose2transform(base_pose));
-    if (bg::intersects(path_footprint, area_2d)) {
-      first_footprint_inside_detection_ip_opt = i;
-      break;
-    }
-  }
+  std::optional<size_t> first_footprint_inside_detection_ip_opt =
+    getFirstPointInsidePolygonByFootprint(
+      first_detection_area, interpolated_path_info, local_footprint);
   if (!first_footprint_inside_detection_ip_opt) {
-    RCLCPP_INFO(rclcpp::get_logger("temp"), "no footprint detection intersection");
     return std::nullopt;
   }
   const auto first_footprint_inside_detection_ip = first_footprint_inside_detection_ip_opt.value();
@@ -296,7 +333,8 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
     const auto & base_pose0 = path_ip.points.at(default_stop_line_ip).point.pose;
     const auto path_footprint0 = tier4_autoware_utils::transformVector(
       local_footprint, tier4_autoware_utils::pose2transform(base_pose0));
-    if (bg::intersects(path_footprint0, area_2d)) {
+    if (bg::intersects(
+          path_footprint0, lanelet::utils::to2D(first_detection_area).basicPolygon())) {
       occlusion_peeking_line_valid = false;
     }
   }
@@ -317,8 +355,8 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const double delay_response_time = planner_data->delay_response_time;
   const double braking_dist = planning_utils::calcJudgeLineDistWithJerkLimit(
     velocity, acceleration, max_stop_acceleration, max_stop_jerk, delay_response_time);
-  int pass_judge_ip_int = static_cast<int>(first_inside_detection_ip) - base2front_idx_dist -
-                          std::ceil(braking_dist / ds);
+  int pass_judge_ip_int =
+    static_cast<int>(first_footprint_inside_detection_ip) - std::ceil(braking_dist / ds);
   const auto pass_judge_line_ip = static_cast<size_t>(
     std::clamp<int>(pass_judge_ip_int, 0, static_cast<int>(path_ip.points.size()) - 1));
 
@@ -328,18 +366,18 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   if (use_stuck_stopline) {
     // NOTE: when ego vehicle is approaching detection area and already passed
     // first_conflicting_area, this could be null.
-    const auto stuck_stop_line_idx_ip_opt =
-      getFirstPointInsidePolygon(path_ip, lane_interval_ip, first_conflicting_area);
+    const auto stuck_stop_line_idx_ip_opt = getFirstPointInsidePolygonByFootprint(
+      first_conflicting_area, interpolated_path_info, local_footprint);
     if (!stuck_stop_line_idx_ip_opt) {
       stuck_stop_line_valid = false;
       stuck_stop_line_ip_int = 0;
     } else {
-      stuck_stop_line_ip_int = stuck_stop_line_idx_ip_opt.value();
+      stuck_stop_line_ip_int = stuck_stop_line_idx_ip_opt.value() - stop_line_margin_idx_dist;
     }
   } else {
-    stuck_stop_line_ip_int = std::get<0>(lane_interval_ip);
+    stuck_stop_line_ip_int =
+      std::get<0>(lane_interval_ip) - (stop_line_margin_idx_dist + base2front_idx_dist);
   }
-  stuck_stop_line_ip_int -= (stop_line_margin_idx_dist + base2front_idx_dist);
   if (stuck_stop_line_ip_int < 0) {
     stuck_stop_line_valid = false;
   }
@@ -1250,21 +1288,22 @@ double calcDistanceUntilIntersectionLanelet(
 }
 
 void IntersectionLanelets::update(
-  const bool is_prioritized, const InterpolatedPathInfo & interpolated_path_info)
+  const bool is_prioritized, const InterpolatedPathInfo & interpolated_path_info,
+  const tier4_autoware_utils::LinearRing2d & footprint)
 {
   is_prioritized_ = is_prioritized;
   // find the first conflicting/detection area polygon intersecting the path
-  const auto & path = interpolated_path_info.path;
-  const auto & lane_interval = interpolated_path_info.lane_id_interval.value();
-  {
-    auto first = getFirstPointInsidePolygons(path, lane_interval, conflicting_area_);
-    if (first && !first_conflicting_area_) {
+  if (!first_conflicting_area_) {
+    auto first =
+      getFirstPointInsidePolygonsByFootprint(conflicting_area_, interpolated_path_info, footprint);
+    if (first) {
       first_conflicting_area_ = first.value().second;
     }
   }
-  {
-    auto first = getFirstPointInsidePolygons(path, lane_interval, attention_area_);
-    if (first && !first_attention_area_) {
+  if (!first_attention_area_) {
+    auto first =
+      getFirstPointInsidePolygonsByFootprint(attention_area_, interpolated_path_info, footprint);
+    if (first) {
       first_attention_area_ = first.value().second;
     }
   }

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -15,6 +15,8 @@
 #ifndef UTIL_TYPE_HPP_
 #define UTIL_TYPE_HPP_
 
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -67,7 +69,9 @@ struct InterpolatedPathInfo
 struct IntersectionLanelets
 {
 public:
-  void update(const bool is_prioritized, const InterpolatedPathInfo & interpolated_path_info);
+  void update(
+    const bool is_prioritized, const InterpolatedPathInfo & interpolated_path_info,
+    const tier4_autoware_utils::LinearRing2d & footprint);
   const lanelet::ConstLanelets & attention() const
   {
     return is_prioritized_ ? attention_non_preceding_ : attention_;


### PR DESCRIPTION
## Description

For precise stop line position calculation, find the first intersection point of vehicle footprint with the detection area instead of the position of PathPoint.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Psim

https://github.com/autowarefoundation/autoware.universe/assets/28677420/a7893b55-874f-44e8-a632-cd813f60dac0

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
