### PR TITLE
refactor(motion_velocity_smoother): align processing time topic name

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -79,7 +79,7 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   debug_closest_acc_ = create_publisher<Float32Stamped>("~/closest_acceleration", 1);
   debug_closest_jerk_ = create_publisher<Float32Stamped>("~/closest_jerk", 1);
   debug_closest_max_velocity_ = create_publisher<Float32Stamped>("~/closest_max_velocity", 1);
-  debug_calculation_time_ = create_publisher<Float32Stamped>("~/calculation_time", 1);
+  debug_calculation_time_ = create_publisher<Float32Stamped>("~/debug/processing_time_ms", 1);
   pub_trajectory_raw_ = create_publisher<Trajectory>("~/debug/trajectory_raw", 1);
   pub_trajectory_vel_lim_ =
     create_publisher<Trajectory>("~/debug/trajectory_external_velocity_limited", 1);


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f724cc</samp>

Refactored the motion velocity smoother node to improve performance and readability. Renamed the topic for publishing the processing time to `~/debug/processing_time_ms`.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

```
➜  pilot-auto git:(awf-latest) ✗ ros2 topic echo /planning/scenario_planning/motion_velocity_smoother/debug/processing_time_ms                                                                                                                                                                                                                                                                                                  
stamp:                                                                                                                                                                                                                                                                                                                                                                                                                          
  sec: 1697073393                                                                                                                                                                                                                                                                                                                                                                                                               
  nanosec: 735140327                                                                                    
data: 12.781999588012695                                                                                
---                                                                                                     
stamp:                                                                                                  
  sec: 1697073393                                                                                       
  nanosec: 882572164                                                                                    
data: 10.720999717712402                                                                                
---                                                                                                     
stamp:                                                                                                  
  sec: 1697073393                                                                                       
  nanosec: 931832309                                                                                    
data: 9.756999969482422                
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
