### PR TITLE
refactor(behavior_path_planner): align processing time topic name

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -35,7 +35,7 @@ PlannerManager::PlannerManager(rclcpp::Node & node, const bool verbose)
   verbose_{verbose}
 {
   processing_time_.emplace("total_time", 0.0);
-  debug_publisher_ptr_ = std::make_unique<DebugPublisher>(&node, "behavior_planner_manager/debug");
+  debug_publisher_ptr_ = std::make_unique<DebugPublisher>(&node, "~/debug");
 }
 
 BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & data)
@@ -894,7 +894,7 @@ void PlannerManager::print() const
 void PlannerManager::publishProcessingTime() const
 {
   for (const auto & t : processing_time_) {
-    std::string name = std::string("processing_time/") + t.first;
+    std::string name = t.first + std::string("/processing_time_ms");
     debug_publisher_ptr_->publish<DebugDoubleMsg>(name, t.second);
   }
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d48d1f2</samp>

Update topic and metrics names in `planner_manager.cpp` to follow conventions. This enhances the behavior path planner node's compatibility and usability with ROS 2 and Autoware.


before

```
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/avoidance
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/avoidance_by_lane_change
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/goal_planner
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/lane_change_left
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/lane_change_right
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/side_shift
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/start_planner
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planner_manager/debug/processing_time/total_time
```

after

```
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance_by_lane_change/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/goal_planner/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_left/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_right/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/side_shift/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/start_planner/processing_time_ms
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/total_time/processing_time_ms
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
