### PR TITLE
fix(tier4_autoware_utils): fix `-Werror=float-conversion`

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -261,7 +261,7 @@ inline void setOrientation(const geometry_msgs::msg::Quaternion & orientation, T
 }
 
 template <class T>
-void setLongitudinalVelocity([[maybe_unused]] const double velocity, [[maybe_unused]] T & p)
+void setLongitudinalVelocity([[maybe_unused]] const float velocity, [[maybe_unused]] T & p)
 {
   static_assert(sizeof(T) == 0, "Only specializations of getLongitudinalVelocity can be used.");
   throw std::logic_error("Only specializations of getLongitudinalVelocity can be used.");
@@ -269,21 +269,21 @@ void setLongitudinalVelocity([[maybe_unused]] const double velocity, [[maybe_unu
 
 template <>
 inline void setLongitudinalVelocity(
-  const double velocity, autoware_auto_planning_msgs::msg::TrajectoryPoint & p)
+  const float velocity, autoware_auto_planning_msgs::msg::TrajectoryPoint & p)
 {
   p.longitudinal_velocity_mps = velocity;
 }
 
 template <>
 inline void setLongitudinalVelocity(
-  const double velocity, autoware_auto_planning_msgs::msg::PathPoint & p)
+  const float velocity, autoware_auto_planning_msgs::msg::PathPoint & p)
 {
   p.longitudinal_velocity_mps = velocity;
 }
 
 template <>
 inline void setLongitudinalVelocity(
-  const double velocity, autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+  const float velocity, autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
 {
   p.point.longitudinal_velocity_mps = velocity;
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a19ef0</samp>

Changed velocity type from `double` to `float` in `setLongitudinalVelocity` function and its specializations in `geometry.hpp`. This improves consistency and performance with message types.

```
In file included from /home/satoshi/pilot-auto/install/object_recognition_utils/include/object_recognition_utils/predicted_path_utils.hpp:18,
                 from /home/satoshi/pilot-auto/install/object_recognition_utils/include/object_recognition_utils/object_recognition_utils.hpp:22,
                 from /home/satoshi/pilot-auto/src/autoware/universe/perception/tracking_object_merger/src/data_association/data_association.cpp:17:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp: In function ‘void tier4_autoware_utils::setLongitudinalVelocity(double, T&) [with T = autoware_auto_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> >]’:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:274:33: error: conversion from ‘double’ to ‘autoware_auto_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> >::_longitudinal_velocity_mps_type’ {aka ‘float’} may change value [-Werror=float-conversion]
  274 |   p.longitudinal_velocity_mps = velocity;
      |                                 ^~~~~~~~
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp: In function ‘void tier4_autoware_utils::setLongitudinalVelocity(double, T&) [with T = autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >]’:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:281:33: error: conversion from ‘double’ to ‘autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >::_longitudinal_velocity_mps_type’ {aka ‘float’} may change value [-Werror=float-conversion]
  281 |   p.longitudinal_velocity_mps = velocity;
      |                                 ^~~~~~~~
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp: In function ‘void tier4_autoware_utils::setLongitudinalVelocity(double, T&) [with T = autoware_auto_planning_msgs::msg::PathPointWithLaneId_<std::allocator<void> >]’:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:288:39: error: conversion from ‘double’ to ‘autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >::_longitudinal_velocity_mps_type’ {aka ‘float’} may change value [-Werror=float-conversion]
  288 |   p.point.longitudinal_velocity_mps = velocity;
      |                                       ^~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/decorative_tracker_merger_node.dir/build.make:76: CMakeFiles/decorative_tracker_merger_node.dir/src/data_association/data_association.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
In file included from /home/satoshi/pilot-auto/install/object_recognition_utils/include/object_recognition_utils/predicted_path_utils.hpp:18,
                 from /home/satoshi/pilot-auto/install/object_recognition_utils/include/object_recognition_utils/object_recognition_utils.hpp:22,
                 from /home/satoshi/pilot-auto/src/autoware/universe/perception/tracking_object_merger/src/decorative_tracker_merger.cpp:17:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp: In function ‘void tier4_autoware_utils::setLongitudinalVelocity(double, T&) [with T = autoware_auto_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> >]’:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:274:33: error: conversion from ‘double’ to ‘autoware_auto_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> >::_longitudinal_velocity_mps_type’ {aka ‘float’} may change value [-Werror=float-conversion]
  274 |   p.longitudinal_velocity_mps = velocity;
      |                                 ^~~~~~~~
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp: In function ‘void tier4_autoware_utils::setLongitudinalVelocity(double, T&) [with T = autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >]’:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:281:33: error: conversion from ‘double’ to ‘autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >::_longitudinal_velocity_mps_type’ {aka ‘float’} may change value [-Werror=float-conversion]
  281 |   p.longitudinal_velocity_mps = velocity;
      |                                 ^~~~~~~~
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp: In function ‘void tier4_autoware_utils::setLongitudinalVelocity(double, T&) [with T = autoware_auto_planning_msgs::msg::PathPointWithLaneId_<std::allocator<void> >]’:
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:288:39: error: conversion from ‘double’ to ‘autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >::_longitudinal_velocity_mps_type’ {aka ‘float’} may change value [-Werror=float-conversion]
  288 |   p.point.longitudinal_velocity_mps = velocity;
      |                                       ^~~~~~~~

```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
