### PR TITLE
perf(radius_search_2d_outlier_filter_nodelet): replace PCL KdTree for naive algorithm

### DIFF
--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/radius_search_2d_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/radius_search_2d_outlier_filter_nodelet.hpp
@@ -16,14 +16,6 @@
 #define POINTCLOUD_PREPROCESSOR__OUTLIER_FILTER__RADIUS_SEARCH_2D_OUTLIER_FILTER_NODELET_HPP_
 
 #include "pointcloud_preprocessor/filter.hpp"
-
-#include <pcl/common/impl/common.hpp>
-
-#include <pcl/filters/extract_indices.h>
-#include <pcl/filters/radius_outlier_removal.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/search/pcl_search.h>
-
 #include <vector>
 
 namespace pointcloud_preprocessor
@@ -32,15 +24,11 @@ class RadiusSearch2DOutlierFilterComponent : public pointcloud_preprocessor::Fil
 {
 protected:
   virtual void filter(
-    const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output);
+    const PointCloud2ConstPtr & input, PointCloud2 & output);
 
 private:
   double search_radius_;
   size_t min_neighbors_;
-
-  // pcl::RadiusOutlierRemoval<pcl::PCLPointCloud2> radius_outlier_removal_;
-  pcl::search::Search<pcl::PointXY>::Ptr kd_tree_;
-  // pcl::ExtractIndices<pcl::PCLPointCloud2> extract_indices_;
 
   /** \brief Parameter service callback result : needed to be hold */
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/radius_search_2d_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/radius_search_2d_outlier_filter_nodelet.hpp
@@ -16,6 +16,7 @@
 #define POINTCLOUD_PREPROCESSOR__OUTLIER_FILTER__RADIUS_SEARCH_2D_OUTLIER_FILTER_NODELET_HPP_
 
 #include "pointcloud_preprocessor/filter.hpp"
+
 #include <vector>
 
 namespace pointcloud_preprocessor
@@ -23,8 +24,7 @@ namespace pointcloud_preprocessor
 class RadiusSearch2DOutlierFilterComponent : public pointcloud_preprocessor::Filter
 {
 protected:
-  virtual void filter(
-    const PointCloud2ConstPtr & input, PointCloud2 & output);
+  virtual void filter(const PointCloud2ConstPtr & input, PointCloud2 & output);
 
 private:
   double search_radius_;

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/radius_search_2d_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/radius_search_2d_outlier_filter_nodelet.cpp
@@ -39,7 +39,7 @@ void RadiusSearch2DOutlierFilterComponent::filter(
   for (size_t i = 0; i < point_size; i++) {
     for (size_t j = i + 1; j < point_size; j++) {
       size_t square_distance =
-        (input->points[i].x - input->points[j].x) * (input->points[i].x - input->points[j].x) + 
+        (input->points[i].x - input->points[j].x) * (input->points[i].x - input->points[j].x) +
         (input->points[i].y - input->points[j].y) * (input->points[i].y - input->points[j].y);
       if (square_distance <= search_radius_ * search_radius_) {
         neighbors[i]++;


### PR DESCRIPTION
Signed-off-by: veqcc [ryuta.kambe@tier4.jp](mailto:ryuta.kambe@tier4.jp)

### Description
First, I want to ask whether this `radius_search_2d_outlier_filter_nodelet` is still used or will be used in the future?
Since now I'm removing PCL from Autoware as much as possible, and I could not find any program which calls the nodelet.
If it is true, then I will discard this PR and create a new one in which `radius_search_2d_outlier_filter_nodelet` is totally deleted.

Otherwise, I will confirm whether this PR really reduces the latency, memory usage and soft page faults.