### PR TITLE
fix(lane_change): do not use reference values of polygon outer

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -837,7 +837,8 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     // calc distance from the current ego position
     double max_dist_ego_to_obj = std::numeric_limits<double>::lowest();
     double min_dist_ego_to_obj = std::numeric_limits<double>::max();
-    for (const auto & polygon_p : obj_polygon.outer()) {
+    const auto obj_polygon_outer = obj_polygon.outer();
+    for (const auto & polygon_p : obj_polygon_outer) {
       const auto obj_p = tier4_autoware_utils::createPoint(polygon_p.x(), polygon_p.y(), 0.0);
       const double dist_ego_to_obj = calcSignedArcLength(path.points, current_pose.position, obj_p);
       max_dist_ego_to_obj = std::max(dist_ego_to_obj, max_dist_ego_to_obj);

--- a/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
@@ -51,7 +51,8 @@ bool isTargetObjectFront(
     tier4_autoware_utils::calcOffsetPose(ego_pose, base_to_front, 0.0, 0.0);
 
   // check all edges in the polygon
-  for (const auto & obj_edge : obj_polygon.outer()) {
+  const auto obj_polygon_outer = obj_polygon.outer();
+  for (const auto & obj_edge : obj_polygon_outer) {
     const auto obj_point = tier4_autoware_utils::createPoint(obj_edge.x(), obj_edge.y(), 0.0);
     if (tier4_autoware_utils::calcLongitudinalDeviation(ego_offset_pose, obj_point) > 0.0) {
       return true;
@@ -70,7 +71,8 @@ bool isTargetObjectFront(
     tier4_autoware_utils::calcOffsetPose(ego_pose, base_to_front, 0.0, 0.0).position;
 
   // check all edges in the polygon
-  for (const auto & obj_edge : obj_polygon.outer()) {
+  const auto obj_polygon_outer = obj_polygon.outer();
+  for (const auto & obj_edge : obj_polygon_outer) {
     const auto obj_point = tier4_autoware_utils::createPoint(obj_edge.x(), obj_edge.y(), 0.0);
     if (motion_utils::isTargetPointFront(path.points, ego_point, obj_point)) {
       return true;
@@ -134,7 +136,8 @@ Polygon2d createExtendedPolygon(
   double min_x = std::numeric_limits<double>::max();
   double max_y = std::numeric_limits<double>::lowest();
   double min_y = std::numeric_limits<double>::max();
-  for (const auto & polygon_p : obj_polygon.outer()) {
+  const auto obj_polygon_outer = obj_polygon.outer();
+  for (const auto & polygon_p : obj_polygon_outer) {
     const auto obj_p = tier4_autoware_utils::createPoint(polygon_p.x(), polygon_p.y(), 0.0);
     const auto transformed_p = tier4_autoware_utils::inverseTransformPoint(obj_p, obj_pose);
 


### PR DESCRIPTION
## Description

Do not use reference values of polygon outer.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

planning simulator
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Not applicable.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
