### PR TITLE
feat(drivable_area_expansion): faster lines distance calculation

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -52,18 +52,21 @@ Point convert_to_geometry_point(const Point2d & point)
 double calculate_point_segment_distance(
   const Point2d & p1, const Point2d & p2_first, const Point2d & p2_second)
 {
-  // NOTE: use 3 dimension to use the cross operation.
-  Eigen::Vector3d p(p1.x(), p1.y(), 0.0);
-  Eigen::Vector3d a(p2_first.x(), p2_first.y(), 0.0);
-  Eigen::Vector3d b(p2_second.x(), p2_second.y(), 0.0);
+  Eigen::Vector2d first_to_target(p1.x() - p2_first.x(), p1.y() - p2_first.y());
+  Eigen::Vector2d second_to_target(p1.x() - p2_second.x(), p1.y() - p2_second.y());
+  Eigen::Vector2d first_to_second(p2_second.x() - p2_first.x(), p2_second.y() - p2_first.y());
 
-  if ((p - a).dot(b - a) < 0) {
-    return (p - a).norm();
+  if (first_to_target.dot(first_to_second) < 0) {
+    return first_to_target.norm();
   }
-  if ((p - b).dot(a - b) < 0) {
-    return (p - b).norm();
+  if (second_to_target.dot(-first_to_second) < 0) {
+    return second_to_target.norm();
   }
-  return ((b - a).cross(p - a)).norm() / (b - a).norm();
+
+  Eigen::Vector2d p2_nearest =
+    Eigen::Vector2d{p2_first.x(), p2_first.y()} +
+    first_to_second * first_to_target.dot(first_to_second) / std::pow(first_to_second.norm(), 2);
+  return (p1 - p2_nearest).norm();
 }
 
 double calculate_segments_distance(


### PR DESCRIPTION
## Description

According to https://v1.shunsuke.me/ja/algorithm/geometry/line_point_distance/, this PR implements a function to calculate the distance between two lines (two sets of segments) without using boost::geometry to make it faster.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

unit test, psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
