### PR TITLE
fix(detected_object_validation): consider shoulder lanelet in object lanelet filter

### DIFF
--- a/perception/detected_object_validation/include/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_filter/object_lanelet_filter.hpp
@@ -51,6 +51,7 @@ private:
 
   lanelet::LaneletMapPtr lanelet_map_ptr_;
   lanelet::ConstLanelets road_lanelets_;
+  lanelet::ConstLanelets shoulder_lanelets_;
   std::string lanelet_frame_id_;
 
   tf2_ros::Buffer tf_buffer_;

--- a/perception/detected_object_validation/src/object_lanelet_filter.cpp
+++ b/perception/detected_object_validation/src/object_lanelet_filter.cpp
@@ -62,6 +62,7 @@ void ObjectLaneletFilterNode::mapCallback(
   lanelet::utils::conversion::fromBinMsg(*map_msg, lanelet_map_ptr_);
   const lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
   road_lanelets_ = lanelet::utils::query::roadLanelets(all_lanelets);
+  shoulder_lanelets_ = lanelet::utils::query::shoulderLanelets(all_lanelets);
 }
 
 void ObjectLaneletFilterNode::objectCallback(
@@ -87,7 +88,8 @@ void ObjectLaneletFilterNode::objectCallback(
   // calculate convex hull
   const auto convex_hull = getConvexHull(transformed_objects);
   // get intersected lanelets
-  lanelet::ConstLanelets intersected_lanelets = getIntersectedLanelets(convex_hull, road_lanelets_);
+  lanelet::ConstLanelets intersected_road_lanelets = getIntersectedLanelets(convex_hull, road_lanelets_);
+  lanelet::ConstLanelets intersected_shoulder_lanelets = getIntersectedLanelets(convex_hull, shoulder_lanelets_);
 
   int index = 0;
   for (const auto & object : transformed_objects.objects) {
@@ -101,7 +103,10 @@ void ObjectLaneletFilterNode::objectCallback(
         polygon.outer().emplace_back(point_transformed.x, point_transformed.y);
       }
       polygon.outer().push_back(polygon.outer().front());
-      if (isPolygonOverlapLanelets(polygon, intersected_lanelets)) {
+      if (isPolygonOverlapLanelets(polygon, intersected_road_lanelets)) {
+        output_object_msg.objects.emplace_back(input_msg->objects.at(index));
+      }
+      else if (isPolygonOverlapLanelets(polygon, intersected_shoulder_lanelets)) {
         output_object_msg.objects.emplace_back(input_msg->objects.at(index));
       }
     } else {

--- a/perception/detected_object_validation/src/object_lanelet_filter.cpp
+++ b/perception/detected_object_validation/src/object_lanelet_filter.cpp
@@ -88,8 +88,10 @@ void ObjectLaneletFilterNode::objectCallback(
   // calculate convex hull
   const auto convex_hull = getConvexHull(transformed_objects);
   // get intersected lanelets
-  lanelet::ConstLanelets intersected_road_lanelets = getIntersectedLanelets(convex_hull, road_lanelets_);
-  lanelet::ConstLanelets intersected_shoulder_lanelets = getIntersectedLanelets(convex_hull, shoulder_lanelets_);
+  lanelet::ConstLanelets intersected_road_lanelets =
+    getIntersectedLanelets(convex_hull, road_lanelets_);
+  lanelet::ConstLanelets intersected_shoulder_lanelets =
+    getIntersectedLanelets(convex_hull, shoulder_lanelets_);
 
   int index = 0;
   for (const auto & object : transformed_objects.objects) {
@@ -105,8 +107,7 @@ void ObjectLaneletFilterNode::objectCallback(
       polygon.outer().push_back(polygon.outer().front());
       if (isPolygonOverlapLanelets(polygon, intersected_road_lanelets)) {
         output_object_msg.objects.emplace_back(input_msg->objects.at(index));
-      }
-      else if (isPolygonOverlapLanelets(polygon, intersected_shoulder_lanelets)) {
+      } else if (isPolygonOverlapLanelets(polygon, intersected_shoulder_lanelets)) {
         output_object_msg.objects.emplace_back(input_msg->objects.at(index));
       }
     } else {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Current object lanelet filter only considers the "road" lanelet. 
This PR takes into account the "shoulder" lanelet where objects are filtered.
This idea is based on the current shoulder lane parking design, which considers objects in or accross the shoulder lanes.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
This PR can address the [Internal ticket](https://tier4.atlassian.net/browse/RT1-4092).

## Tests performed

<!-- Describe how you have tested this PR. -->

### Before

The objects in or across the shoulder lanelet **are filtered** after object_lanelet_filter node.
The unknown objects in the picture shows `/perception/object_recognition/detection/objects`

![image](https://github.com/autowarefoundation/autoware.universe/assets/42209144/3ff780d5-7313-4d36-ae5c-8546385fb986)

[Filtered in or across the shoulder lanelet movie](https://github.com/autowarefoundation/autoware.universe/assets/42209144/2e6adfc6-270f-44fe-8bc3-622da0db1a30)

### After

The objects in or across the shoulder lanelet **are not filtered** after object_lanelet_filter node.

![image](https://github.com/autowarefoundation/autoware.universe/assets/42209144/56acf8ce-8da0-480c-b1a8-85c7faa549f7)

[Not filtered in or across the shoulder lanelet movie](https://github.com/autowarefoundation/autoware.universe/assets/42209144/711758a5-08a3-4234-92c2-1867c10cf269)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
No 

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
No

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
This PR enables objects on the shoulder lanelet will be intentionally filtered.
If this is the case, **the latent unknown objects will appear on the road shoulder** which bother the road shoulder parking.
This suggests that we might need to seperate the road filter and shoulder filter in the future.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
