### PR TITLE
fix(detected_object_validation): add 3d pointcloud based validator

### DIFF
--- a/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -11,3 +11,5 @@
     min_points_and_distance_ratio:
     #UNKNOWN,  CAR,    TRUCK,     BUS,    TRAILER, MOTORBIKE, BICYCLE,      PEDESTRIAN
       [800.0,  800.0,  800.0,    800.0,   800.0,      800.0,    800.0,         800.0]
+
+    using_2d_validator: false

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/debugger.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/debugger.hpp
@@ -71,15 +71,16 @@ public:
   void addNeighborPointcloud(const pcl::PointCloud<pcl::PointXY>::Ptr & input)
   {
     pcl::PointCloud<pcl::PointXYZ>::Ptr input_xyz = toXYZ(input);
-    for (const auto & point : *input_xyz) {
-      neighbor_pointcloud_->push_back(point);
-    }
+    addNeighborPointcloud(input_xyz);
   }
 
   void addNeighborPointcloud(const pcl::PointCloud<pcl::PointXYZ>::Ptr & input)
   {
-    for (const auto & point : *input) {
-      neighbor_pointcloud_->push_back(point);
+    if (!input->empty()) {
+      neighbor_pointcloud_->reserve(neighbor_pointcloud_->size() + input->size());
+      for (const auto & point : *input) {
+        neighbor_pointcloud_->push_back(point);
+      }
     }
   }
   void addPointcloudWithinPolygon(const pcl::PointCloud<pcl::PointXYZ>::Ptr & input)

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/debugger.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/debugger.hpp
@@ -76,6 +76,12 @@ public:
     }
   }
 
+  void addNeighborPointcloud(const pcl::PointCloud<pcl::PointXYZ>::Ptr & input)
+  {
+    for (const auto & point : *input) {
+      neighbor_pointcloud_->push_back(point);
+    }
+  }
   void addPointcloudWithinPolygon(const pcl::PointCloud<pcl::PointXYZ>::Ptr & input)
   {
     // pcl::PointCloud<pcl::PointXYZ>::Ptr input_xyz = toXYZ(input);

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -35,9 +35,6 @@
 #include <vector>
 namespace obstacle_pointcloud_based_validator
 {
-using Shape = autoware_auto_perception_msgs::msg::Shape;
-using Polygon2d = tier4_autoware_utils::Polygon2d;
-
 struct PointsNumThresholdParam
 {
   std::vector<int64_t> min_points_num;
@@ -70,11 +67,9 @@ private:
   void onObjectsAndObstaclePointCloud(
     const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
-  void cropPointsInsidePolygon(
-    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points, const Polygon2d & poly2d,
-    pcl::PointCloud<pcl::PointXYZ>::Ptr & output_points);
-  size_t getValidationThreshold(
-    const geometry_msgs::msg::Point & transformed_object_position, const uint8_t object_label_id);
+  void on3dObjectsAndObstaclePointCloud(
+    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
   std::optional<size_t> getPointCloudNumWithinPolygon(
     const autoware_auto_perception_msgs::msg::DetectedObject & object,
     const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud);

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -76,7 +76,9 @@ private:
   std::optional<size_t> getPointCloudNumWithinShape(
     const autoware_auto_perception_msgs::msg::DetectedObject & object,
     const pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud);
-  std::optional<float> getMaxRadius(
+  std::optional<float> getMaxRadius2D(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  std::optional<float> getMaxRadius3D(
     const autoware_auto_perception_msgs::msg::DetectedObject & object);
 };
 }  // namespace obstacle_pointcloud_based_validator

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -61,14 +61,21 @@ private:
   PointsNumThresholdParam points_num_threshold_param_;
 
   std::shared_ptr<Debugger> debugger_;
+  bool using_2d_validator_;
 
 private:
   void onObjectsAndObstaclePointCloud(
     const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
+  void on3dObjectsAndObstaclePointCloud(
+    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
   std::optional<size_t> getPointCloudNumWithinPolygon(
     const autoware_auto_perception_msgs::msg::DetectedObject & object,
     const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud);
+  std::optional<size_t> getPointCloudNumWithinShape(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud);
   std::optional<float> getMaxRadius(
     const autoware_auto_perception_msgs::msg::DetectedObject & object);
 };

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -25,8 +25,13 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
+#include <pcl/filters/crop_hull.h>
+#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl/search/kdtree.h>
+#include <pcl/search/pcl_search.h>
+#include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -35,12 +40,88 @@
 #include <vector>
 namespace obstacle_pointcloud_based_validator
 {
+
 struct PointsNumThresholdParam
 {
   std::vector<int64_t> min_points_num;
   std::vector<int64_t> max_points_num;
   std::vector<double> min_points_and_distance_ratio;
 };
+
+class Validator
+{
+private:
+  PointsNumThresholdParam points_num_threshold_param_;
+
+protected:
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_;
+
+public:
+  explicit Validator(PointsNumThresholdParam & points_num_threshold_param);
+  inline pcl::PointCloud<pcl::PointXYZ>::Ptr getDebugPointCloudWithinObject()
+  {
+    return cropped_pointcloud_;
+  }
+
+  virtual bool setKdtreeInputCloud(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud) = 0;
+  virtual bool validate_object(
+    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object) = 0;
+  virtual std::optional<float> getMaxRadius(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object) = 0;
+  size_t getThresholdPointCloud(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  virtual pcl::PointCloud<pcl::PointXYZ>::Ptr getDebugNeighborPointCloud() = 0;
+};
+
+class Validator2D : public Validator
+{
+private:
+  pcl::PointCloud<pcl::PointXY>::Ptr obstacle_pointcloud_;
+  pcl::PointCloud<pcl::PointXY>::Ptr neighbor_pointcloud_;
+  pcl::search::Search<pcl::PointXY>::Ptr kdtree_;
+
+public:
+  explicit Validator2D(PointsNumThresholdParam & points_num_threshold_param);
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr convertToXYZ(
+    const pcl::PointCloud<pcl::PointXY>::Ptr & pointcloud_xy);
+  inline pcl::PointCloud<pcl::PointXYZ>::Ptr getDebugNeighborPointCloud()
+  {
+    return convertToXYZ(neighbor_pointcloud_);
+  }
+
+  bool setKdtreeInputCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_cloud);
+  bool validate_object(
+    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object);
+  std::optional<float> getMaxRadius(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  std::optional<size_t> getPointCloudWithinObject(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const pcl::PointCloud<pcl::PointXY>::Ptr neighbor_pointcloud);
+};
+class Validator3D : public Validator
+{
+private:
+  pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_pointcloud_;
+  pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud_;
+  pcl::search::Search<pcl::PointXYZ>::Ptr kdtree_;
+
+public:
+  explicit Validator3D(PointsNumThresholdParam & points_num_threshold_param);
+  inline pcl::PointCloud<pcl::PointXYZ>::Ptr getDebugNeighborPointCloud()
+  {
+    return neighbor_pointcloud_;
+  }
+  bool setKdtreeInputCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_cloud);
+  bool validate_object(
+    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object);
+  std::optional<float> getMaxRadius(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  std::optional<size_t> getPointCloudWithinObject(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud);
+};
+
 class ObstaclePointCloudBasedValidator : public rclcpp::Node
 {
 public:
@@ -62,24 +143,12 @@ private:
 
   std::shared_ptr<Debugger> debugger_;
   bool using_2d_validator_;
+  std::unique_ptr<Validator> validator_;
 
 private:
   void onObjectsAndObstaclePointCloud(
     const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
-  void on3dObjectsAndObstaclePointCloud(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
-  std::optional<size_t> getPointCloudNumWithinPolygon(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
-    const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud);
-  std::optional<size_t> getPointCloudNumWithinShape(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
-    const pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud);
-  std::optional<float> getMaxRadius2D(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object);
-  std::optional<float> getMaxRadius3D(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object);
 };
 }  // namespace obstacle_pointcloud_based_validator
 

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -35,6 +35,9 @@
 #include <vector>
 namespace obstacle_pointcloud_based_validator
 {
+using Shape = autoware_auto_perception_msgs::msg::Shape;
+using Polygon2d = tier4_autoware_utils::Polygon2d;
+
 struct PointsNumThresholdParam
 {
   std::vector<int64_t> min_points_num;
@@ -67,9 +70,11 @@ private:
   void onObjectsAndObstaclePointCloud(
     const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
-  void on3dObjectsAndObstaclePointCloud(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
+  void cropPointsInsidePolygon(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points, const Polygon2d & poly2d,
+    pcl::PointCloud<pcl::PointXYZ>::Ptr & output_points);
+  size_t getValidationThreshold(
+    const geometry_msgs::msg::Point & transformed_object_position, const uint8_t object_label_id);
   std::optional<size_t> getPointCloudNumWithinPolygon(
     const autoware_auto_perception_msgs::msg::DetectedObject & object,
     const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud);

--- a/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
+++ b/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
@@ -11,5 +11,6 @@
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param name="enable_debugger" value="false"/>
     <param from="$(var obstacle_pointcloud_based_validator_param_path)"/>
+    <param name="using_2d_validator" value="true"/>
   </node>
 </launch>

--- a/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
+++ b/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
@@ -11,6 +11,5 @@
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param name="enable_debugger" value="false"/>
     <param from="$(var obstacle_pointcloud_based_validator_param_path)"/>
-    <param name="using_2d_validator" value="true"/>
   </node>
 </launch>

--- a/perception/detected_object_validation/obstacle-pointcloud-based-validator.md
+++ b/perception/detected_object_validation/obstacle-pointcloud-based-validator.md
@@ -28,6 +28,7 @@ In the debug image above, the red DetectedObject is the validated object. The bl
 
 | Name                            | Type  | Description                                                                                                                                                                |
 | ------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `using_2d_validator`            | bool  | The xy-plane projected (2D) obstacle point clouds will be used for validation                                                                                              |
 | `min_points_num`                | int   | The minimum number of obstacle point clouds in DetectedObjects                                                                                                             |
 | `max_points_num`                | int   | The max number of obstacle point clouds in DetectedObjects                                                                                                                 |
 | `min_points_and_distance_ratio` | float | Threshold value of the number of point clouds per object when the distance from baselink is 1m, because the number of point clouds varies with the distance from baselink. |

--- a/perception/detected_object_validation/package.xml
+++ b/perception/detected_object_validation/package.xml
@@ -6,6 +6,7 @@
   <description>The ROS 2 detected_object_validation package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
+  <maintainer email="dai.nguyen@tier4.jp">badai nguyen</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -71,6 +71,8 @@ inline pcl::PointCloud<pcl::PointXYZ>::Ptr toXYZ(
 namespace obstacle_pointcloud_based_validator
 {
 namespace bg = boost::geometry;
+using Shape = autoware_auto_perception_msgs::msg::Shape;
+using Polygon2d = tier4_autoware_utils::Polygon2d;
 
 ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   const rclcpp::NodeOptions & node_options)
@@ -95,13 +97,96 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   using std::placeholders::_1;
   using std::placeholders::_2;
 
-  sync_.registerCallback(
-    std::bind(&ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud, this, _1, _2));
+  if (using_2d_validator_) {
+    sync_.registerCallback(
+      std::bind(&ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud, this, _1, _2));
+  } else {
+    sync_.registerCallback(
+      std::bind(&ObstaclePointCloudBasedValidator::on3dObjectsAndObstaclePointCloud, this, _1, _2));
+  }
+
   objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS{1});
 
   const bool enable_debugger = declare_parameter<bool>("enable_debugger", false);
   if (enable_debugger) debugger_ = std::make_shared<Debugger>(this);
+}
+void ObstaclePointCloudBasedValidator::on3dObjectsAndObstaclePointCloud(
+  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud)
+{
+  autoware_auto_perception_msgs::msg::DetectedObjects output, removed_objects;
+  output.header = input_objects->header;
+  removed_objects.header = input_objects->header;
+
+  // Transform to pointcloud frame
+  autoware_auto_perception_msgs::msg::DetectedObjects transformed_objects;
+  if (!object_recognition_utils::transformObjects(
+        *input_objects, input_obstacle_pointcloud->header.frame_id, tf_buffer_,
+        transformed_objects)) {
+    return;
+  }
+
+  // Convert to PCL
+  pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(*input_obstacle_pointcloud, *obstacle_pointcloud);
+  if (obstacle_pointcloud->empty()) {
+    return;
+  }
+
+  // Create Kd-tree to search neighbor pointcloud to reduce cost
+  pcl::search::Search<pcl::PointXYZ>::Ptr kdtree =
+    pcl::make_shared<pcl::search::KdTree<pcl::PointXYZ>>(false);
+  kdtree->setInputCloud(obstacle_pointcloud);
+  for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
+    const auto & transformed_object = transformed_objects.objects.at(i);
+    const auto object_label_id = transformed_object.classification.front().label;
+    const auto & object = input_objects->objects.at(i);
+    const auto & transformed_object_position =
+      transformed_object.kinematics.pose_with_covariance.pose.position;
+    const auto search_radius = getMaxRadius3D(transformed_object);
+    if (!search_radius) {
+      output.objects.push_back(object);
+      continue;
+    }
+    // Search neighbor pointcloud to reduce cost
+    pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
+    std::vector<int> indices;
+    std::vector<float> distances;
+    pcl::PointXYZ trans_obj_position_pcl;
+    trans_obj_position_pcl.x = transformed_object_position.x;
+    trans_obj_position_pcl.y = transformed_object_position.y;
+    trans_obj_position_pcl.z = transformed_object_position.z;
+    kdtree->radiusSearch(trans_obj_position_pcl, search_radius.value(), indices, distances);
+    for (const auto & index : indices) {
+      neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
+    }
+
+    if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
+    // Filter object that have few pointcloud in them
+    const auto num = getPointCloudNumWithinShape(transformed_object, neighbor_pointcloud);
+    const auto object_distance =
+      std::hypot(transformed_object_position.x, transformed_object_position.y);
+    size_t min_pointcloud_num = std::clamp(
+      static_cast<size_t>(
+        points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
+          object_distance +
+        0.5f),
+      static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
+      static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
+    if (num) {
+      (min_pointcloud_num <= num.value()) ? output.objects.push_back(object)
+                                          : removed_objects.objects.push_back(object);
+    } else {
+      output.objects.push_back(object);
+    }
+  }
+  objects_pub_->publish(output);
+  if (debugger_) {
+    debugger_->publishRemovedObjects(removed_objects);
+    debugger_->publishNeighborPointcloud(input_obstacle_pointcloud->header);
+    debugger_->publishPointcloudWithinPolygon(input_obstacle_pointcloud->header);
+  }
 }
 void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
@@ -121,102 +206,61 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   }
 
   // Convert to PCL
+  pcl::PointCloud<pcl::PointXY>::Ptr obstacle_pointcloud(new pcl::PointCloud<pcl::PointXY>);
+  pcl::fromROSMsg(*input_obstacle_pointcloud, *obstacle_pointcloud);
+  if (obstacle_pointcloud->empty()) {
+    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5, "cannot receive pointcloud");
+    // objects_pub_->publish(*input_objects);
+    return;
+  }
 
-  if (using_2d_validator_) {
-    pcl::PointCloud<pcl::PointXY>::Ptr obstacle_pointcloud(new pcl::PointCloud<pcl::PointXY>);
-    pcl::fromROSMsg(*input_obstacle_pointcloud, *obstacle_pointcloud);
-    if (obstacle_pointcloud->empty()) {
-      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5, "cannot receive pointcloud");
-      // objects_pub_->publish(*input_objects);
-      return;
+  // Create Kd-tree to search neighbor pointcloud to reduce cost.
+  pcl::search::Search<pcl::PointXY>::Ptr kdtree =
+    pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
+  kdtree->setInputCloud(obstacle_pointcloud);
+
+  for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
+    const auto & transformed_object = transformed_objects.objects.at(i);
+    const auto object_label_id = transformed_object.classification.front().label;
+    const auto & object = input_objects->objects.at(i);
+    const auto & transformed_object_position =
+      transformed_object.kinematics.pose_with_covariance.pose.position;
+    const auto search_radius = getMaxRadius2D(transformed_object);
+    if (!search_radius) {
+      output.objects.push_back(object);
+      continue;
     }
 
-    // Create Kd-tree to search neighbor pointcloud to reduce cost.
-    pcl::search::Search<pcl::PointXY>::Ptr kdtree =
-      pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
-    kdtree->setInputCloud(obstacle_pointcloud);
-
-    for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
-      const auto & transformed_object = transformed_objects.objects.at(i);
-      const auto object_label_id = transformed_object.classification.front().label;
-      const auto & object = input_objects->objects.at(i);
-      const auto & transformed_object_position =
-        transformed_object.kinematics.pose_with_covariance.pose.position;
-      const auto search_radius = getMaxRadius2D(transformed_object);
-      if (!search_radius) {
-        output.objects.push_back(object);
-        continue;
-      }
-
-      // Search neighbor pointcloud to reduce cost.
-      pcl::PointCloud<pcl::PointXY>::Ptr neighbor_pointcloud(new pcl::PointCloud<pcl::PointXY>);
-      std::vector<int> indices;
-      std::vector<float> distances;
-      kdtree->radiusSearch(
-        toPCL(transformed_object_position), search_radius.value(), indices, distances);
-      for (const auto & index : indices) {
-        neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
-      }
-      if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
-
-      // Filter object that have few pointcloud in them.
-      const auto num = getPointCloudNumWithinPolygon(transformed_object, neighbor_pointcloud);
-      auto validation_threshold =
-        getValidationThreshold(transformed_object_position, object_label_id);
-      if (num) {
-        (validation_threshold <= num.value()) ? output.objects.push_back(object)
-                                              : removed_objects.objects.push_back(object);
-      } else {
-        output.objects.push_back(object);
-      }
+    // Search neighbor pointcloud to reduce cost.
+    pcl::PointCloud<pcl::PointXY>::Ptr neighbor_pointcloud(new pcl::PointCloud<pcl::PointXY>);
+    std::vector<int> indices;
+    std::vector<float> distances;
+    kdtree->radiusSearch(
+      toPCL(transformed_object_position), search_radius.value(), indices, distances);
+    for (const auto & index : indices) {
+      neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
     }
-  } else {
-    // Convert to PCL
-    pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::fromROSMsg(*input_obstacle_pointcloud, *obstacle_pointcloud);
-    if (obstacle_pointcloud->empty()) {
-      return;
-    }
+    if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
 
-    // Create Kd-tree to search neighbor pointcloud to reduce cost
-    pcl::search::Search<pcl::PointXYZ>::Ptr kdtree =
-      pcl::make_shared<pcl::search::KdTree<pcl::PointXYZ>>(false);
-    kdtree->setInputCloud(obstacle_pointcloud);
-    for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
-      const auto & transformed_object = transformed_objects.objects.at(i);
-      const auto object_label_id = transformed_object.classification.front().label;
-      const auto & object = input_objects->objects.at(i);
-      const auto & transformed_object_position =
-        transformed_object.kinematics.pose_with_covariance.pose.position;
-      const auto search_radius = getMaxRadius3D(transformed_object);
-      if (!search_radius) {
-        output.objects.push_back(object);
-        continue;
-      }
-      // Search neighbor pointcloud to reduce cost
-      pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
-      std::vector<int> indices;
-      std::vector<float> distances;
-      pcl::PointXYZ trans_obj_position_pcl = pcl::PointXYZ(
-        transformed_object_position.x, transformed_object_position.y,
-        transformed_object_position.z);
-      kdtree->radiusSearch(trans_obj_position_pcl, search_radius.value(), indices, distances);
-      for (const auto & index : indices) {
-        neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
-      }
-      if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
-      // Filter object that have few pointcloud in them
-      const auto num = getPointCloudNumWithinShape(transformed_object, neighbor_pointcloud);
-      auto validation_threshold =
-        getValidationThreshold(transformed_object_position, object_label_id);
-      if (num) {
-        (validation_threshold <= num.value()) ? output.objects.push_back(object)
-                                              : removed_objects.objects.push_back(object);
-      } else {
-        output.objects.push_back(object);
-      }
+    // Filter object that have few pointcloud in them.
+    const auto num = getPointCloudNumWithinPolygon(transformed_object, neighbor_pointcloud);
+    const auto object_distance =
+      std::hypot(transformed_object_position.x, transformed_object_position.y);
+    size_t min_pointcloud_num = std::clamp(
+      static_cast<size_t>(
+        points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
+          object_distance +
+        0.5f),
+      static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
+      static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
+    if (num) {
+      (min_pointcloud_num <= num.value()) ? output.objects.push_back(object)
+                                          : removed_objects.objects.push_back(object);
+    } else {
+      output.objects.push_back(object);
     }
   }
+
   objects_pub_->publish(output);
   if (debugger_) {
     debugger_->publishRemovedObjects(removed_objects);
@@ -228,16 +272,33 @@ std::optional<size_t> ObstaclePointCloudBasedValidator::getPointCloudNumWithinSh
   const autoware_auto_perception_msgs::msg::DetectedObject & object,
   const pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud)
 {
-  Polygon2d poly2d =
-    tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
-  if (bg::is_empty(poly2d)) return std::nullopt;
-
   pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_2d(new pcl::PointCloud<pcl::PointXYZ>);
-  cropPointsInsidePolygon(pointcloud, poly2d, cropped_pointcloud_2d);
+  std::vector<pcl::Vertices> vertices_array;
+  pcl::Vertices vertices;
+
   auto const & object_position = object.kinematics.pose_with_covariance.pose.position;
   auto const object_height = object.shape.dimensions.z;
   auto z_min = object_position.z - object_height / 2.0f;
   auto z_max = object_position.z + object_height / 2.0f;
+
+  Polygon2d poly2d =
+    tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
+  if (bg::is_empty(poly2d)) return std::nullopt;
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr poly3d(new pcl::PointCloud<pcl::PointXYZ>);
+
+  for (size_t i = 0; i < poly2d.outer().size(); ++i) {
+    vertices.vertices.emplace_back(i);
+    vertices_array.emplace_back(vertices);
+    poly3d->emplace_back(poly2d.outer().at(i).x(), poly2d.outer().at(i).y(), 0.0);
+  }
+  pcl::CropHull<pcl::PointXYZ> cropper;
+  cropper.setInputCloud(pointcloud);
+  cropper.setDim(2);
+  cropper.setHullIndices(vertices_array);
+  cropper.setHullCloud(poly3d);
+  cropper.setCropOutside(true);
+  cropper.filter(*cropped_pointcloud_2d);
 
   pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_3d(new pcl::PointCloud<pcl::PointXYZ>);
   cropped_pointcloud_3d->reserve(cropped_pointcloud_2d->size());
@@ -254,36 +315,34 @@ std::optional<size_t> ObstaclePointCloudBasedValidator::getPointCloudNumWithinPo
   const autoware_auto_perception_msgs::msg::DetectedObject & object,
   const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud)
 {
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
+  std::vector<pcl::Vertices> vertices_array;
+  pcl::Vertices vertices;
+
   Polygon2d poly2d =
     tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
   if (bg::is_empty(poly2d)) return std::nullopt;
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
-  cropPointsInsidePolygon(toXYZ(pointcloud), poly2d, cropped_pointcloud);
-  if (debugger_) debugger_->addPointcloudWithinPolygon(cropped_pointcloud);
-  return cropped_pointcloud->size();
-}
-
-void ObstaclePointCloudBasedValidator::cropPointsInsidePolygon(
-  const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points, const Polygon2d & poly2d,
-  pcl::PointCloud<pcl::PointXYZ>::Ptr & output_points)
-{
-  std::vector<pcl::Vertices> vertices_array;
-  pcl::Vertices vertices;
   pcl::PointCloud<pcl::PointXYZ>::Ptr poly3d(new pcl::PointCloud<pcl::PointXYZ>);
+
   for (size_t i = 0; i < poly2d.outer().size(); ++i) {
     vertices.vertices.emplace_back(i);
     vertices_array.emplace_back(vertices);
     poly3d->emplace_back(poly2d.outer().at(i).x(), poly2d.outer().at(i).y(), 0.0);
   }
-  pcl::CropHull<pcl::PointXYZ> cropper;
-  cropper.setInputCloud(input_points);
+
+  pcl::CropHull<pcl::PointXYZ> cropper;  // don't be implemented PointXY by PCL
+  cropper.setInputCloud(toXYZ(pointcloud));
   cropper.setDim(2);
   cropper.setHullIndices(vertices_array);
   cropper.setHullCloud(poly3d);
   cropper.setCropOutside(true);
-  cropper.filter(*output_points);
+  cropper.filter(*cropped_pointcloud);
+
+  if (debugger_) debugger_->addPointcloudWithinPolygon(cropped_pointcloud);
+  return cropped_pointcloud->size();
 }
+
 std::optional<float> ObstaclePointCloudBasedValidator::getMaxRadius2D(
   const autoware_auto_perception_msgs::msg::DetectedObject & object)
 {
@@ -310,21 +369,6 @@ std::optional<float> ObstaclePointCloudBasedValidator::getMaxRadius3D(
   }
   const auto object_height = object.shape.dimensions.z;
   return std::hypot(max_dist_2d.value(), object_height / 2.0);
-}
-
-size_t ObstaclePointCloudBasedValidator::getValidationThreshold(
-  const geometry_msgs::msg::Point & transformed_object_position, const uint8_t object_label_id)
-{
-  const auto object_distance =
-    std::hypot(transformed_object_position.x, transformed_object_position.y);
-  size_t min_pointcloud_num = std::clamp(
-    static_cast<size_t>(
-      points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
-        object_distance +
-      0.5f),
-    static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
-    static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
-  return min_pointcloud_num;
 }
 
 }  // namespace obstacle_pointcloud_based_validator

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -97,6 +97,7 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   using std::placeholders::_1;
   using std::placeholders::_2;
 
+  // TODO(badai-nguyen): change to single bind function
   if (using_2d_validator_) {
     sync_.registerCallback(
       std::bind(&ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud, this, _1, _2));

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -158,8 +158,8 @@ void ObstaclePointCloudBasedValidator::on3dObjectsAndObstaclePointCloud(
     trans_obj_position_pcl.y = transformed_object_position.y;
     trans_obj_position_pcl.z = transformed_object_position.z;
     kdtree->radiusSearch(trans_obj_position_pcl, search_radius.value(), indices, distances);
-    for (const auto & indice : indices) {
-      neighbor_pointcloud->push_back(obstacle_pointcloud->at(indice));
+    for (const auto & index : indices) {
+      neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
     }
 
     if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -19,12 +19,6 @@
 
 #include <boost/geometry.hpp>
 
-#include <pcl/filters/crop_hull.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/search/kdtree.h>
-#include <pcl/search/pcl_search.h>
-#include <pcl_conversions/pcl_conversions.h>
-
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
@@ -35,44 +29,247 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-namespace
-{
-inline pcl::PointXY toPCL(const double x, const double y)
-{
-  pcl::PointXY pcl_point;
-  pcl_point.x = x;
-  pcl_point.y = y;
-  return pcl_point;
-}
-
-inline pcl::PointXY toPCL(const geometry_msgs::msg::Point & point)
-{
-  return toPCL(point.x, point.y);
-}
-
-inline pcl::PointXYZ toXYZ(const pcl::PointXY & point)
-{
-  return pcl::PointXYZ(point.x, point.y, 0.0);
-}
-
-inline pcl::PointCloud<pcl::PointXYZ>::Ptr toXYZ(
-  const pcl::PointCloud<pcl::PointXY>::Ptr & pointcloud)
-{
-  pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_xyz(new pcl::PointCloud<pcl::PointXYZ>);
-  pointcloud_xyz->reserve(pointcloud->size());
-  for (const auto & point : *pointcloud) {
-    pointcloud_xyz->push_back(toXYZ(point));
-  }
-  return pointcloud_xyz;
-}
-
-}  // namespace
-
 namespace obstacle_pointcloud_based_validator
 {
 namespace bg = boost::geometry;
 using Shape = autoware_auto_perception_msgs::msg::Shape;
 using Polygon2d = tier4_autoware_utils::Polygon2d;
+
+Validator::Validator(PointsNumThresholdParam & points_num_threshold_param)
+{
+  points_num_threshold_param_.min_points_num = points_num_threshold_param.min_points_num;
+  points_num_threshold_param_.max_points_num = points_num_threshold_param.max_points_num;
+  points_num_threshold_param_.min_points_and_distance_ratio =
+    points_num_threshold_param.min_points_and_distance_ratio;
+}
+
+size_t Validator::getThresholdPointCloud(
+  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+{
+  const auto object_label_id = object.classification.front().label;
+  const auto object_distance = std::hypot(
+    object.kinematics.pose_with_covariance.pose.position.x,
+    object.kinematics.pose_with_covariance.pose.position.y);
+  size_t threshold_pc = std::clamp(
+    static_cast<size_t>(
+      points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
+        object_distance +
+      0.5f),
+    static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
+    static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
+  return threshold_pc;
+}
+
+Validator2D::Validator2D(PointsNumThresholdParam & points_num_threshold_param)
+: Validator(points_num_threshold_param)
+{
+}
+
+bool Validator2D::setKdtreeInputCloud(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_cloud)
+{
+  obstacle_pointcloud_.reset(new pcl::PointCloud<pcl::PointXY>);
+  pcl::fromROSMsg(*input_cloud, *obstacle_pointcloud_);
+  if (obstacle_pointcloud_->empty()) {
+    return false;
+  }
+
+  kdtree_ = pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
+  kdtree_->setInputCloud(obstacle_pointcloud_);
+
+  return true;
+}
+pcl::PointCloud<pcl::PointXYZ>::Ptr Validator2D::convertToXYZ(
+  const pcl::PointCloud<pcl::PointXY>::Ptr & pointcloud_xy)
+{
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_xyz(new pcl::PointCloud<pcl::PointXYZ>);
+  pointcloud_xyz->reserve(pointcloud_xy->size());
+  for (const auto & point : *pointcloud_xy) {
+    pointcloud_xyz->push_back(pcl::PointXYZ(point.x, point.y, 0.0));
+  }
+  return pointcloud_xyz;
+}
+
+std::optional<size_t> Validator2D::getPointCloudWithinObject(
+  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud)
+{
+  std::vector<pcl::Vertices> vertices_array;
+  pcl::Vertices vertices;
+  Polygon2d poly2d =
+    tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
+  if (bg::is_empty(poly2d)) return std::nullopt;
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr poly3d(new pcl::PointCloud<pcl::PointXYZ>);
+
+  for (size_t i = 0; i < poly2d.outer().size(); ++i) {
+    vertices.vertices.emplace_back(i);
+    vertices_array.emplace_back(vertices);
+    poly3d->emplace_back(poly2d.outer().at(i).x(), poly2d.outer().at(i).y(), 0.0);
+  }
+  cropped_pointcloud_.reset(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::CropHull<pcl::PointXYZ> cropper;  // don't be implemented PointXY by PCL
+  cropper.setInputCloud(convertToXYZ(pointcloud));
+  cropper.setDim(2);
+  cropper.setHullIndices(vertices_array);
+  cropper.setHullCloud(poly3d);
+  cropper.setCropOutside(true);
+  cropper.filter(*cropped_pointcloud_);
+  return cropped_pointcloud_->size();
+}
+
+bool Validator2D::validate_object(
+  const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object)
+{
+  // get neighbor_pointcloud of object
+  neighbor_pointcloud_.reset(new pcl::PointCloud<pcl::PointXY>);
+  std::vector<int> indices;
+  std::vector<float> distances;
+  const auto search_radius = getMaxRadius(transformed_object);
+  if (!search_radius) {
+    return false;
+  }
+  kdtree_->radiusSearch(
+    pcl::PointXY(
+      transformed_object.kinematics.pose_with_covariance.pose.position.x,
+      transformed_object.kinematics.pose_with_covariance.pose.position.y),
+    search_radius.value(), indices, distances);
+  for (const auto & index : indices) {
+    neighbor_pointcloud_->push_back(obstacle_pointcloud_->at(index));
+  }
+  const auto num = getPointCloudWithinObject(transformed_object, neighbor_pointcloud_);
+  if (!num) return true;
+
+  size_t threshold_pointcloud_num = getThresholdPointCloud(transformed_object);
+  if (num.value() > threshold_pointcloud_num) {
+    return true;
+  }
+  return false;  // remove object
+}
+
+std::optional<float> Validator2D::getMaxRadius(
+  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+{
+  if (object.shape.type == Shape::BOUNDING_BOX || object.shape.type == Shape::CYLINDER) {
+    return std::hypot(object.shape.dimensions.x * 0.5f, object.shape.dimensions.y * 0.5f);
+  } else if (object.shape.type == Shape::POLYGON) {
+    float max_dist = 0.0;
+    for (const auto & point : object.shape.footprint.points) {
+      const float dist = std::hypot(point.x, point.y);
+      max_dist = max_dist < dist ? dist : max_dist;
+    }
+    return max_dist;
+  } else {
+    return std::nullopt;
+  }
+}
+
+Validator3D::Validator3D(PointsNumThresholdParam & points_num_threshold_param)
+: Validator(points_num_threshold_param)
+{
+}
+bool Validator3D::setKdtreeInputCloud(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_cloud)
+{
+  obstacle_pointcloud_.reset(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(*input_cloud, *obstacle_pointcloud_);
+  if (obstacle_pointcloud_->empty()) {
+    return false;
+  }
+  // setup kdtree_
+  kdtree_ = pcl::make_shared<pcl::search::KdTree<pcl::PointXYZ>>(false);
+  kdtree_->setInputCloud(obstacle_pointcloud_);
+  return true;
+}
+std::optional<float> Validator3D::getMaxRadius(
+  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+{
+  if (object.shape.type == Shape::BOUNDING_BOX || object.shape.type == Shape::CYLINDER) {
+    auto square_radius = (object.shape.dimensions.x * 0.5f) * (object.shape.dimensions.x * 0.5f) +
+                         (object.shape.dimensions.y * 0.5f) * (object.shape.dimensions.y * 0.5f) +
+                         (object.shape.dimensions.z * 0.5f) * (object.shape.dimensions.z * 0.5f);
+    return std::sqrt(square_radius);
+  } else if (object.shape.type == Shape::POLYGON) {
+    float max_dist = 0.0;
+    for (const auto & point : object.shape.footprint.points) {
+      const float dist = std::hypot(point.x, point.y);
+      max_dist = max_dist < dist ? dist : max_dist;
+    }
+    return std::hypot(max_dist, object.shape.dimensions.z * 0.5f);
+  } else {
+    return std::nullopt;
+  }
+}
+
+std::optional<size_t> Validator3D::getPointCloudWithinObject(
+  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud)
+{
+  std::vector<pcl::Vertices> vertices_array;
+  pcl::Vertices vertices;
+  auto const & object_position = object.kinematics.pose_with_covariance.pose.position;
+  auto const object_height = object.shape.dimensions.x;
+  auto z_min = object_position.z - object_height / 2.0f;
+  auto z_max = object_position.z + object_height / 2.0f;
+  Polygon2d poly2d =
+    tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
+  if (bg::is_empty(poly2d)) return std::nullopt;
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr poly3d(new pcl::PointCloud<pcl::PointXYZ>);
+  for (size_t i = 0; i < poly2d.outer().size(); ++i) {
+    vertices.vertices.emplace_back(i);
+    vertices_array.emplace_back(vertices);
+    poly3d->emplace_back(poly2d.outer().at(i).x(), poly2d.outer().at(i).y(), 0.0);
+  }
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_2d(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::CropHull<pcl::PointXYZ> cropper;
+  cropper.setInputCloud(neighbor_pointcloud);
+  cropper.setDim(2);
+  cropper.setHullIndices(vertices_array);
+  cropper.setHullCloud(poly3d);
+  cropper.setCropOutside(true);
+  cropper.filter(*cropped_pointcloud_2d);
+
+  cropped_pointcloud_.reset(new pcl::PointCloud<pcl::PointXYZ>);
+  cropped_pointcloud_->reserve(cropped_pointcloud_2d->size());
+  for (const auto & point : *cropped_pointcloud_2d) {
+    if (point.z > z_min && point.z < z_max) {
+      cropped_pointcloud_->push_back(point);
+    }
+  }
+  return cropped_pointcloud_->size();
+}
+
+bool Validator3D::validate_object(
+  const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object)
+{
+  neighbor_pointcloud_.reset(new pcl::PointCloud<pcl::PointXYZ>);
+  std::vector<int> indices;
+  std::vector<float> distances;
+  const auto search_radius = getMaxRadius(transformed_object);
+  if (!search_radius) {
+    return false;
+  }
+  kdtree_->radiusSearch(
+    pcl::PointXYZ(
+      transformed_object.kinematics.pose_with_covariance.pose.position.x,
+      transformed_object.kinematics.pose_with_covariance.pose.position.y,
+      transformed_object.kinematics.pose_with_covariance.pose.position.z),
+    search_radius.value(), indices, distances);
+  for (const auto & index : indices) {
+    neighbor_pointcloud_->push_back(obstacle_pointcloud_->at(index));
+  }
+
+  const auto num = getPointCloudWithinObject(transformed_object, neighbor_pointcloud_);
+  if (!num) return true;
+
+  size_t threshold_pointcloud_num = getThresholdPointCloud(transformed_object);
+  if (num.value() > threshold_pointcloud_num) {
+    return true;
+  }
+  return false;  // remove object
+}
 
 ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   const rclcpp::NodeOptions & node_options)
@@ -97,13 +294,12 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   using std::placeholders::_1;
   using std::placeholders::_2;
 
-  // TODO(badai-nguyen): change to single bind function
+  sync_.registerCallback(
+    std::bind(&ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud, this, _1, _2));
   if (using_2d_validator_) {
-    sync_.registerCallback(
-      std::bind(&ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud, this, _1, _2));
+    validator_ = std::make_unique<Validator2D>(points_num_threshold_param_);
   } else {
-    sync_.registerCallback(
-      std::bind(&ObstaclePointCloudBasedValidator::on3dObjectsAndObstaclePointCloud, this, _1, _2));
+    validator_ = std::make_unique<Validator3D>(points_num_threshold_param_);
   }
 
   objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
@@ -111,83 +307,6 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
 
   const bool enable_debugger = declare_parameter<bool>("enable_debugger", false);
   if (enable_debugger) debugger_ = std::make_shared<Debugger>(this);
-}
-void ObstaclePointCloudBasedValidator::on3dObjectsAndObstaclePointCloud(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
-  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud)
-{
-  autoware_auto_perception_msgs::msg::DetectedObjects output, removed_objects;
-  output.header = input_objects->header;
-  removed_objects.header = input_objects->header;
-
-  // Transform to pointcloud frame
-  autoware_auto_perception_msgs::msg::DetectedObjects transformed_objects;
-  if (!object_recognition_utils::transformObjects(
-        *input_objects, input_obstacle_pointcloud->header.frame_id, tf_buffer_,
-        transformed_objects)) {
-    return;
-  }
-
-  // Convert to PCL
-  pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::fromROSMsg(*input_obstacle_pointcloud, *obstacle_pointcloud);
-  if (obstacle_pointcloud->empty()) {
-    return;
-  }
-
-  // Create Kd-tree to search neighbor pointcloud to reduce cost
-  pcl::search::Search<pcl::PointXYZ>::Ptr kdtree =
-    pcl::make_shared<pcl::search::KdTree<pcl::PointXYZ>>(false);
-  kdtree->setInputCloud(obstacle_pointcloud);
-  for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
-    const auto & transformed_object = transformed_objects.objects.at(i);
-    const auto object_label_id = transformed_object.classification.front().label;
-    const auto & object = input_objects->objects.at(i);
-    const auto & transformed_object_position =
-      transformed_object.kinematics.pose_with_covariance.pose.position;
-    const auto search_radius = getMaxRadius3D(transformed_object);
-    if (!search_radius) {
-      output.objects.push_back(object);
-      continue;
-    }
-    // Search neighbor pointcloud to reduce cost
-    pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
-    std::vector<int> indices;
-    std::vector<float> distances;
-    pcl::PointXYZ trans_obj_position_pcl;
-    trans_obj_position_pcl.x = transformed_object_position.x;
-    trans_obj_position_pcl.y = transformed_object_position.y;
-    trans_obj_position_pcl.z = transformed_object_position.z;
-    kdtree->radiusSearch(trans_obj_position_pcl, search_radius.value(), indices, distances);
-    for (const auto & index : indices) {
-      neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
-    }
-
-    if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
-    // Filter object that have few pointcloud in them
-    const auto num = getPointCloudNumWithinShape(transformed_object, neighbor_pointcloud);
-    const auto object_distance =
-      std::hypot(transformed_object_position.x, transformed_object_position.y);
-    size_t min_pointcloud_num = std::clamp(
-      static_cast<size_t>(
-        points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
-          object_distance +
-        0.5f),
-      static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
-      static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
-    if (num) {
-      (min_pointcloud_num <= num.value()) ? output.objects.push_back(object)
-                                          : removed_objects.objects.push_back(object);
-    } else {
-      output.objects.push_back(object);
-    }
-  }
-  objects_pub_->publish(output);
-  if (debugger_) {
-    debugger_->publishRemovedObjects(removed_objects);
-    debugger_->publishNeighborPointcloud(input_obstacle_pointcloud->header);
-    debugger_->publishPointcloudWithinPolygon(input_obstacle_pointcloud->header);
-  }
 }
 void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
@@ -205,60 +324,23 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
     // objects_pub_->publish(*input_objects);
     return;
   }
-
-  // Convert to PCL
-  pcl::PointCloud<pcl::PointXY>::Ptr obstacle_pointcloud(new pcl::PointCloud<pcl::PointXY>);
-  pcl::fromROSMsg(*input_obstacle_pointcloud, *obstacle_pointcloud);
-  if (obstacle_pointcloud->empty()) {
+  if (!validator_->setKdtreeInputCloud(input_obstacle_pointcloud)) {
     RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5, "cannot receive pointcloud");
-    // objects_pub_->publish(*input_objects);
     return;
   }
 
-  // Create Kd-tree to search neighbor pointcloud to reduce cost.
-  pcl::search::Search<pcl::PointXY>::Ptr kdtree =
-    pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
-  kdtree->setInputCloud(obstacle_pointcloud);
-
   for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
     const auto & transformed_object = transformed_objects.objects.at(i);
-    const auto object_label_id = transformed_object.classification.front().label;
     const auto & object = input_objects->objects.at(i);
-    const auto & transformed_object_position =
-      transformed_object.kinematics.pose_with_covariance.pose.position;
-    const auto search_radius = getMaxRadius2D(transformed_object);
-    if (!search_radius) {
+    const auto validated = validator_->validate_object(transformed_object);
+    if (debugger_) {
+      debugger_->addNeighborPointcloud(validator_->getDebugNeighborPointCloud());
+      debugger_->addPointcloudWithinPolygon(validator_->getDebugPointCloudWithinObject());
+    }
+    if (validated) {
       output.objects.push_back(object);
-      continue;
-    }
-
-    // Search neighbor pointcloud to reduce cost.
-    pcl::PointCloud<pcl::PointXY>::Ptr neighbor_pointcloud(new pcl::PointCloud<pcl::PointXY>);
-    std::vector<int> indices;
-    std::vector<float> distances;
-    kdtree->radiusSearch(
-      toPCL(transformed_object_position), search_radius.value(), indices, distances);
-    for (const auto & index : indices) {
-      neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
-    }
-    if (debugger_) debugger_->addNeighborPointcloud(neighbor_pointcloud);
-
-    // Filter object that have few pointcloud in them.
-    const auto num = getPointCloudNumWithinPolygon(transformed_object, neighbor_pointcloud);
-    const auto object_distance =
-      std::hypot(transformed_object_position.x, transformed_object_position.y);
-    size_t min_pointcloud_num = std::clamp(
-      static_cast<size_t>(
-        points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
-          object_distance +
-        0.5f),
-      static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
-      static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
-    if (num) {
-      (min_pointcloud_num <= num.value()) ? output.objects.push_back(object)
-                                          : removed_objects.objects.push_back(object);
     } else {
-      output.objects.push_back(object);
+      removed_objects.objects.push_back(object);
     }
   }
 
@@ -268,108 +350,6 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
     debugger_->publishNeighborPointcloud(input_obstacle_pointcloud->header);
     debugger_->publishPointcloudWithinPolygon(input_obstacle_pointcloud->header);
   }
-}
-std::optional<size_t> ObstaclePointCloudBasedValidator::getPointCloudNumWithinShape(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
-  const pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud)
-{
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_2d(new pcl::PointCloud<pcl::PointXYZ>);
-  std::vector<pcl::Vertices> vertices_array;
-  pcl::Vertices vertices;
-
-  auto const & object_position = object.kinematics.pose_with_covariance.pose.position;
-  auto const object_height = object.shape.dimensions.z;
-  auto z_min = object_position.z - object_height / 2.0f;
-  auto z_max = object_position.z + object_height / 2.0f;
-
-  Polygon2d poly2d =
-    tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
-  if (bg::is_empty(poly2d)) return std::nullopt;
-
-  pcl::PointCloud<pcl::PointXYZ>::Ptr poly3d(new pcl::PointCloud<pcl::PointXYZ>);
-
-  for (size_t i = 0; i < poly2d.outer().size(); ++i) {
-    vertices.vertices.emplace_back(i);
-    vertices_array.emplace_back(vertices);
-    poly3d->emplace_back(poly2d.outer().at(i).x(), poly2d.outer().at(i).y(), 0.0);
-  }
-  pcl::CropHull<pcl::PointXYZ> cropper;
-  cropper.setInputCloud(pointcloud);
-  cropper.setDim(2);
-  cropper.setHullIndices(vertices_array);
-  cropper.setHullCloud(poly3d);
-  cropper.setCropOutside(true);
-  cropper.filter(*cropped_pointcloud_2d);
-
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_3d(new pcl::PointCloud<pcl::PointXYZ>);
-  cropped_pointcloud_3d->reserve(cropped_pointcloud_2d->size());
-  for (const auto & point : *cropped_pointcloud_2d) {
-    if (point.z > z_min && point.z < z_max) {
-      cropped_pointcloud_3d->push_back(point);
-    }
-  }
-  if (debugger_) debugger_->addPointcloudWithinPolygon(cropped_pointcloud_3d);
-  return cropped_pointcloud_3d->size();
-}
-
-std::optional<size_t> ObstaclePointCloudBasedValidator::getPointCloudNumWithinPolygon(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
-  const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud)
-{
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
-  std::vector<pcl::Vertices> vertices_array;
-  pcl::Vertices vertices;
-
-  Polygon2d poly2d =
-    tier4_autoware_utils::toPolygon2d(object.kinematics.pose_with_covariance.pose, object.shape);
-  if (bg::is_empty(poly2d)) return std::nullopt;
-
-  pcl::PointCloud<pcl::PointXYZ>::Ptr poly3d(new pcl::PointCloud<pcl::PointXYZ>);
-
-  for (size_t i = 0; i < poly2d.outer().size(); ++i) {
-    vertices.vertices.emplace_back(i);
-    vertices_array.emplace_back(vertices);
-    poly3d->emplace_back(poly2d.outer().at(i).x(), poly2d.outer().at(i).y(), 0.0);
-  }
-
-  pcl::CropHull<pcl::PointXYZ> cropper;  // don't be implemented PointXY by PCL
-  cropper.setInputCloud(toXYZ(pointcloud));
-  cropper.setDim(2);
-  cropper.setHullIndices(vertices_array);
-  cropper.setHullCloud(poly3d);
-  cropper.setCropOutside(true);
-  cropper.filter(*cropped_pointcloud);
-
-  if (debugger_) debugger_->addPointcloudWithinPolygon(cropped_pointcloud);
-  return cropped_pointcloud->size();
-}
-
-std::optional<float> ObstaclePointCloudBasedValidator::getMaxRadius2D(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
-{
-  if (object.shape.type == Shape::BOUNDING_BOX || object.shape.type == Shape::CYLINDER) {
-    return std::hypot(object.shape.dimensions.x * 0.5f, object.shape.dimensions.y * 0.5f);
-  } else if (object.shape.type == Shape::POLYGON) {
-    float max_dist = 0.0;
-    for (const auto & point : object.shape.footprint.points) {
-      const float dist = std::hypot(point.x, point.y);
-      max_dist = max_dist < dist ? dist : max_dist;
-    }
-    return max_dist;
-  } else {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "unknown shape type");
-    return std::nullopt;
-  }
-}
-std::optional<float> ObstaclePointCloudBasedValidator::getMaxRadius3D(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
-{
-  const auto max_dist_2d = getMaxRadius2D(object);
-  if (!max_dist_2d) {
-    return std::nullopt;
-  }
-  const auto object_height = object.shape.dimensions.z;
-  return std::hypot(max_dist_2d.value(), object_height / 2.0);
 }
 
 }  // namespace obstacle_pointcloud_based_validator


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- Currently obstacle_pointcloud_based_validator projects pointcloud into xy_plane and check the number of points within object footprint. 
- In some cases like the centerpoint misdetects tree bushes as car, then the high position points of the tree migh be included which cause a wrong validation.
- This PR will add an option to validate obstacle pointcloud base on 3d shape of detected objects.


| frequently misdetection case | tree leaves are also projected and treated as validation points|
| -- | --|
|    | yellow: obstacle points, green points: neighbor, pink: within polygon; green bbox: validated object|
|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/0a55f329-e2b6-49cf-a7c3-22979b91ca06) |![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/359e98e4-9fec-4811-8dae-259c9ec92ee3)|


## Related link

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-29267?focusedCommentId=139292)

## Tests performed

Tested by logging_simulator
- green points: neighbor points 
- pink points: points within object shape
- orange bbox: non-validated centerpoint result
![Screenshot from 2023-10-17 10-39-58](https://github.com/autowarefoundation/autoware.universe/assets/94814556/dd1401d7-c272-44e2-8091-ad04413af6f4)

CPU usage comparison: there was not significant change in cpu usage of obstacle-pointcloud-based-validator-node 
| 2d validation | 3d validation | 
| --- | ---|
| ![obstacle-pointcloud-based-validator-node-2d_CPU-Percent](https://github.com/autowarefoundation/autoware.universe/assets/94814556/e218ae01-8a29-452d-bcdc-fe40a666d3a1)| ![obstacle-pointcloud-based-validator-node-3d_CPU-Percent](https://github.com/autowarefoundation/autoware.universe/assets/94814556/f79467b0-a131-4741-a150-a90f79aba2e4)|

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added support for 3D shape-based validation of obstacle point clouds in the `ObstaclePointCloudBasedValidator` class.
- New Feature: Introduced a new method `addNeighborPointcloud` to the `Debugger` class, allowing users to add neighbor point clouds.
- New Feature: Added a parameter to the launch file (`obstacle_pointcloud_based_validator.launch.xml`) to choose between 2D and 3D validation methods.
- Documentation: Updated documentation for the `ObstaclePointCloudBasedValidator` class to reflect the changes and provide usage instructions.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->