### PR TITLE
fix(intersection): fix infinite loop in tsort

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -605,6 +605,8 @@ mergeLaneletsByTopologicalSort(
     id2lanelet[id] = lanelet;
     ind++;
   }
+  // NOTE: this function aims to traverse the detection lanelet backward from ego side to farthest
+  // side, so if lane B follows lane A on the routing_graph, adj[B][A] = true
   for (const auto & lanelet : lanelets) {
     const auto & followings = routing_graph_ptr->following(lanelet);
     const int dst = lanelet.id();
@@ -628,18 +630,25 @@ mergeLaneletsByTopologicalSort(
     if (!has_no_previous(src)) {
       continue;
     }
+    // So `src` has no previous lanelets
     branches[(ind2id[src])] = std::vector<lanelet::Id>{};
     auto & branch = branches[(ind2id[src])];
     lanelet::Id node_iter = ind2id[src];
+    std::set<lanelet::Id> visited_ids;
     while (true) {
       const auto & destinations = adjacency[(id2ind[node_iter])];
-      // NOTE: assuming detection lanelets have only one previous lanelet
+      // NOTE: assuming detection lanelets have only one "previous"(on the routing_graph) lanelet
       const auto next = std::find(destinations.begin(), destinations.end(), true);
       if (next == destinations.end()) {
         branch.push_back(node_iter);
         break;
       }
+      if (visited_ids.find(node_iter) != visited_ids.end()) {
+        // loop detected
+        break;
+      }
       branch.push_back(node_iter);
+      visited_ids.insert(node_iter);
       node_iter = ind2id[std::distance(destinations.begin(), next)];
     }
   }


### PR DESCRIPTION
## Description

If detection lanelets have a loop, topological sort runs into infinite loops. I fixed this by checking visited nodes.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

with a map that causes loop detection lanelets due to improper RightOfWay setting.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
