### PR TITLE
feat(ekf_localizer): add yaw bias monitoring and diagnostics

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/diagnostics.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/diagnostics.hpp
@@ -33,6 +33,8 @@ diagnostic_msgs::msg::DiagnosticStatus checkMeasurementDelayGate(
 diagnostic_msgs::msg::DiagnosticStatus checkMeasurementMahalanobisGate(
   const std::string & measurement_type, const bool is_passed_mahalanobis_gate,
   const double mahalanobis_distance, const double mahalanobis_distance_threshold);
+diagnostic_msgs::msg::DiagnosticStatus checkDianosticYawBias(
+  const std::string & measurement_type, const double yaw_bias, const double yaw_bias_threshold);
 
 diagnostic_msgs::msg::DiagnosticStatus mergeDiagnosticStatus(
   const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & stat_array);

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -289,8 +289,8 @@ private:
    */
   void simpleEstimateYawBias(
     const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
-    const geometry_msgs::msg::TwistWithCovarianceStamped & twist,
-    double & yaw_bias, double & obs_variance);
+    const geometry_msgs::msg::TwistWithCovarianceStamped & twist, double & yaw_bias,
+    double & obs_variance);
 
   /**
    * @brief initialize simple1DFilter

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -153,6 +153,7 @@ private:
   Simple1DFilter z_filter_;
   Simple1DFilter roll_filter_;
   Simple1DFilter pitch_filter_;
+  Simple1DFilter diagnostic_yaw_bias_filter_;
 
   const HyperParameters params_;
 
@@ -196,6 +197,7 @@ private:
   geometry_msgs::msg::TwistStamped current_ekf_twist_;  //!< @brief current estimated twist
   std::array<double, 36ul> current_pose_covariance_;
   std::array<double, 36ul> current_twist_covariance_;
+  geometry_msgs::msg::PoseWithCovarianceStamped previous_ndt_pose_;  //!< @brief previous ndt pose
 
   /**
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time
@@ -281,6 +283,14 @@ private:
    */
   void updateSimple1DFilters(
     const geometry_msgs::msg::PoseWithCovarianceStamped & pose, const size_t smoothing_step);
+
+  /**
+   * @brief estimate yaw bias
+   */
+  void simpleEstimateYawBias(
+    const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
+    const geometry_msgs::msg::TwistWithCovarianceStamped & twist,
+    double & yaw_bias, double & obs_variance);
 
   /**
    * @brief initialize simple1DFilter

--- a/localization/ekf_localizer/src/diagnostics.cpp
+++ b/localization/ekf_localizer/src/diagnostics.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <vector>
+#include <math.h>
 
 diagnostic_msgs::msg::DiagnosticStatus checkProcessActivated(const bool is_activated)
 {
@@ -138,6 +139,30 @@ diagnostic_msgs::msg::DiagnosticStatus checkMeasurementMahalanobisGate(
 
   return stat;
 }
+
+diagnostic_msgs::msg::DiagnosticStatus checkDianosticYawBias(
+  const std::string & measurement_type, const double yaw_bias, const double yaw_bias_threshold)
+{
+  diagnostic_msgs::msg::DiagnosticStatus stat;
+
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = measurement_type + "yaw_bias";
+  key_value.value = std::to_string(yaw_bias);
+  stat.values.push_back(key_value);
+  key_value.key = measurement_type + "yaw_bias_threshold";
+  key_value.value = std::to_string(yaw_bias_threshold);
+  stat.values.push_back(key_value);
+
+  stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  stat.message = "OK";
+  if (std::abs(yaw_bias) > yaw_bias_threshold) {
+    stat.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    stat.message = "[WARN] estimated yaw bias of " + measurement_type + " is large";
+  }
+
+  return stat;
+}
+
 
 // The highest level within the stat_array will be reflected in the merged_stat.
 // When all stat_array entries are 'OK,' the message of merged_stat will be "OK"

--- a/localization/ekf_localizer/src/diagnostics.cpp
+++ b/localization/ekf_localizer/src/diagnostics.cpp
@@ -16,9 +16,10 @@
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
+#include <math.h>
+
 #include <string>
 #include <vector>
-#include <math.h>
 
 diagnostic_msgs::msg::DiagnosticStatus checkProcessActivated(const bool is_activated)
 {
@@ -162,7 +163,6 @@ diagnostic_msgs::msg::DiagnosticStatus checkDianosticYawBias(
 
   return stat;
 }
-
 
 // The highest level within the stat_array will be reflected in the merged_stat.
 // When all stat_array entries are 'OK,' the message of merged_stat will be "OK"

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -33,8 +33,8 @@
 #include <tier4_autoware_utils/ros/msg_covariance.hpp>
 
 #include <fmt/core.h>
-
 #include <math.h>
+
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -678,8 +678,8 @@ void EKFLocalizer::publishDiagnostics()
     diag_status_array.push_back(checkMeasurementMahalanobisGate(
       "pose", pose_is_passed_mahalanobis_gate_, pose_mahalanobis_distance_,
       params_.pose_gate_dist));
-    diag_status_array.push_back(checkDianosticYawBias(
-      "pose", diagnostic_yaw_bias_filter_.get_x(), 0.1));
+    diag_status_array.push_back(
+      checkDianosticYawBias("pose", diagnostic_yaw_bias_filter_.get_x(), 0.1));
 
     diag_status_array.push_back(checkMeasurementUpdated(
       "twist", twist_no_update_count_, params_.twist_no_update_count_threshold_warn,
@@ -720,7 +720,7 @@ void EKFLocalizer::updateSimple1DFilters(
   roll_filter_.update(rpy.x, roll_dev, pose.header.stamp);
   pitch_filter_.update(rpy.y, pitch_dev, pose.header.stamp);
 
-  if (twist_queue_.size() > 0){
+  if (twist_queue_.size() > 0) {
     auto twist = twist_queue_.back();
     double yaw_bias, obs_variance;
     simpleEstimateYawBias(pose, *twist, yaw_bias, obs_variance);
@@ -729,32 +729,32 @@ void EKFLocalizer::updateSimple1DFilters(
   }
 }
 
-void EKFLocalizer::simpleEstimateYawBias(const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
-    const geometry_msgs::msg::TwistWithCovarianceStamped & twist,
-    double & yaw_bias, double & obs_variance)
+void EKFLocalizer::simpleEstimateYawBias(
+  const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
+  const geometry_msgs::msg::TwistWithCovarianceStamped & twist, double & yaw_bias,
+  double & obs_variance)
 {
   double dx = pose.pose.pose.position.x - previous_ndt_pose_.pose.pose.position.x;
   double dy = pose.pose.pose.position.y - previous_ndt_pose_.pose.pose.position.y;
-  double distance = std::sqrt(dx*dx + dy*dy);
+  double distance = std::sqrt(dx * dx + dy * dy);
   double estimated_yaw = std::atan2(dy, dx);
   double measured_yaw = std::atan2(pose.pose.pose.orientation.z, pose.pose.pose.orientation.w);
 
   yaw_bias = measured_yaw - estimated_yaw;
 
-  while (yaw_bias > M_PI/2) {
+  while (yaw_bias > M_PI / 2) {
     yaw_bias -= M_PI;
   }
-  while (yaw_bias < -M_PI/2) {
+  while (yaw_bias < -M_PI / 2) {
     yaw_bias += M_PI;
-  } // normalize to -pi/2 ~ pi/2
+  }  // normalize to -pi/2 ~ pi/2
 
   double speed = std::abs(twist.twist.twist.linear.x);
   double rotation_speed = std::abs(twist.twist.twist.angular.z);
 
-  if ( (speed > 2) && (rotation_speed < 0.01) && (distance < 10)) {
-     obs_variance = 0.1;
-  }
-  else {
+  if ((speed > 2) && (rotation_speed < 0.01) && (distance < 10)) {
+    obs_variance = 0.1;
+  } else {
     obs_variance = 999;
   }
 }
@@ -770,13 +770,14 @@ void EKFLocalizer::initSimple1DFilters(const geometry_msgs::msg::PoseWithCovaria
   double z_dev = pose.pose.covariance[COV_IDX::Z_Z];
   double roll_dev = pose.pose.covariance[COV_IDX::ROLL_ROLL];
   double pitch_dev = pose.pose.covariance[COV_IDX::PITCH_PITCH];
-  double diagnostic_yaw_dev_init = 1e9; // make no assumption for the 
+  double diagnostic_yaw_dev_init = 1e9;  // make no assumption for the
 
   z_filter_.init(z, z_dev, pose.header.stamp);
   roll_filter_.init(rpy.x, roll_dev, pose.header.stamp);
   pitch_filter_.init(rpy.y, pitch_dev, pose.header.stamp);
-  diagnostic_yaw_bias_filter_.init(diagnostic_yaw_bias_init, diagnostic_yaw_dev_init, pose.header.stamp);
-  
+  diagnostic_yaw_bias_filter_.init(
+    diagnostic_yaw_bias_init, diagnostic_yaw_dev_init, pose.header.stamp);
+
   // Record this as the previous pose
   previous_ndt_pose_ = pose;
 }

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -34,6 +34,7 @@
 
 #include <fmt/core.h>
 
+#include <math.h>
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -109,6 +110,7 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
   z_filter_.set_proc_dev(1.0);
   roll_filter_.set_proc_dev(0.01);
   pitch_filter_.set_proc_dev(0.01);
+  diagnostic_yaw_bias_filter_.set_proc_dev(0.0001);
 
   /* debug */
   pub_debug_ = create_publisher<tier4_debug_msgs::msg::Float64MultiArrayStamped>("debug", 1);
@@ -676,6 +678,8 @@ void EKFLocalizer::publishDiagnostics()
     diag_status_array.push_back(checkMeasurementMahalanobisGate(
       "pose", pose_is_passed_mahalanobis_gate_, pose_mahalanobis_distance_,
       params_.pose_gate_dist));
+    diag_status_array.push_back(checkDianosticYawBias(
+      "pose", diagnostic_yaw_bias_filter_.get_x(), 0.1));
 
     diag_status_array.push_back(checkMeasurementUpdated(
       "twist", twist_no_update_count_, params_.twist_no_update_count_threshold_warn,
@@ -715,11 +719,50 @@ void EKFLocalizer::updateSimple1DFilters(
   z_filter_.update(z, z_dev, pose.header.stamp);
   roll_filter_.update(rpy.x, roll_dev, pose.header.stamp);
   pitch_filter_.update(rpy.y, pitch_dev, pose.header.stamp);
+
+  if (twist_queue_.size() > 0){
+    auto twist = twist_queue_.back();
+    double yaw_bias, obs_variance;
+    simpleEstimateYawBias(pose, *twist, yaw_bias, obs_variance);
+    diagnostic_yaw_bias_filter_.update(yaw_bias, obs_variance, pose.header.stamp);
+    previous_ndt_pose_ = pose;
+  }
+}
+
+void EKFLocalizer::simpleEstimateYawBias(const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
+    const geometry_msgs::msg::TwistWithCovarianceStamped & twist,
+    double & yaw_bias, double & obs_variance)
+{
+  double dx = pose.pose.pose.position.x - previous_ndt_pose_.pose.pose.position.x;
+  double dy = pose.pose.pose.position.y - previous_ndt_pose_.pose.pose.position.y;
+  double distance = std::sqrt(dx*dx + dy*dy);
+  double estimated_yaw = std::atan2(dy, dx);
+  double measured_yaw = std::atan2(pose.pose.pose.orientation.z, pose.pose.pose.orientation.w);
+
+  yaw_bias = measured_yaw - estimated_yaw;
+
+  while (yaw_bias > M_PI/2) {
+    yaw_bias -= M_PI;
+  }
+  while (yaw_bias < -M_PI/2) {
+    yaw_bias += M_PI;
+  } // normalize to -pi/2 ~ pi/2
+
+  double speed = std::abs(twist.twist.twist.linear.x);
+  double rotation_speed = std::abs(twist.twist.twist.angular.z);
+
+  if ( (speed > 2) && (rotation_speed < 0.01) && (distance < 10)) {
+     obs_variance = 0.1;
+  }
+  else {
+    obs_variance = 999;
+  }
 }
 
 void EKFLocalizer::initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose)
 {
   double z = pose.pose.pose.position.z;
+  double diagnostic_yaw_bias_init = 0.0;
 
   const auto rpy = tier4_autoware_utils::getRPY(pose.pose.pose.orientation);
 
@@ -727,10 +770,15 @@ void EKFLocalizer::initSimple1DFilters(const geometry_msgs::msg::PoseWithCovaria
   double z_dev = pose.pose.covariance[COV_IDX::Z_Z];
   double roll_dev = pose.pose.covariance[COV_IDX::ROLL_ROLL];
   double pitch_dev = pose.pose.covariance[COV_IDX::PITCH_PITCH];
+  double diagnostic_yaw_dev_init = 1e9; // make no assumption for the 
 
   z_filter_.init(z, z_dev, pose.header.stamp);
   roll_filter_.init(rpy.x, roll_dev, pose.header.stamp);
   pitch_filter_.init(rpy.y, pitch_dev, pose.header.stamp);
+  diagnostic_yaw_bias_filter_.init(diagnostic_yaw_bias_init, diagnostic_yaw_dev_init, pose.header.stamp);
+  
+  // Record this as the previous pose
+  previous_ndt_pose_ = pose;
 }
 
 /**


### PR DESCRIPTION

## Description

This is a draft PR as an enhancement of the ekf localization package.  

While online calibration with a simple kinematic model inside EKF sometimes could lead to performance degradation, we suggest using a simple filter to estimate the yaw bias between LiDAR and the base link. The result is not directly used to update the output, but as diagnostics/warning information for the system, implying potential calibration errors.

We follow EKF to use a kinematic model and only assign low observation variance when the car is moving steadily to the front.

The code is expected to modify nothing of localization output to the main control system.

## Related links

A small test on a short ROS bag using a simple python script is done in [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~6061477cafe465006afac8aa/pages/2920055763/Yaw+Bias+Monitoring), demonstrating the principle of the filter we used.


## Tests performed

**WIP WIP WIP WIP WIP WIP WIP**

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
