### PR TITLE
feat(intersection): suppress pass judge sudden stop

### DIFF
--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -12,6 +12,7 @@
         use_intersection_area: false
         path_interpolation_ds: 0.1 # [m]
         consider_wrong_direction_vehicle: false
+        disable_pass_judge_sudden_stop: false
       stuck_vehicle:
         turn_direction:
           left: true

--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -13,6 +13,7 @@
         path_interpolation_ds: 0.1 # [m]
         consider_wrong_direction_vehicle: false
         disable_pass_judge_sudden_stop: false
+        enable_peeking_pass_judge: false
       stuck_vehicle:
         turn_direction:
           left: true

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -64,6 +64,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<bool>(node, ns + ".common.consider_wrong_direction_vehicle");
   ip.common.disable_pass_judge_sudden_stop =
     getOrDeclareParameter<bool>(node, ns + ".common.disable_pass_judge_sudden_stop");
+  ip.common.enable_peeking_pass_judge =
+    getOrDeclareParameter<bool>(node, ns + ".common.enable_peeking_pass_judge");
 
   ip.stuck_vehicle.turn_direction.left =
     getOrDeclareParameter<bool>(node, ns + ".stuck_vehicle.turn_direction.left");

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -62,6 +62,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".common.path_interpolation_ds");
   ip.common.consider_wrong_direction_vehicle =
     getOrDeclareParameter<bool>(node, ns + ".common.consider_wrong_direction_vehicle");
+  ip.common.disable_pass_judge_sudden_stop =
+    getOrDeclareParameter<bool>(node, ns + ".common.disable_pass_judge_sudden_stop");
 
   ip.stuck_vehicle.turn_direction.left =
     getOrDeclareParameter<bool>(node, ns + ".stuck_vehicle.turn_direction.left");

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -978,7 +978,7 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto intersection_stop_lines_opt = util::generateIntersectionStopLines(
     first_conflicting_area, dummy_first_attention_area, planner_data_, interpolated_path_info,
     planner_param_.stuck_vehicle.use_stuck_stopline, planner_param_.common.stop_line_margin,
-    planner_param.occlusion.enable, peeking_offset, path);
+    planner_param_.occlusion.enable, peeking_offset, path);
   if (!intersection_stop_lines_opt) {
     return IntersectionModule::Indecisive{"failed to generate intersection_stop_lines"};
   }
@@ -1085,7 +1085,9 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
       logger_, "is_over_default_stop_line && !is_over_pass_judge_line && keep_detection");
     // do nothing
   } else if (
-    (was_safe && is_over_default_stop_line && is_over_pass_judge_line && is_go_out_) ||
+    (was_safe &&
+     (is_over_default_stop_line || planner_param_.common.disable_pass_judge_sudden_stop) &&
+     is_over_pass_judge_line && is_go_out_) ||
     is_permanent_go_) {
     // is_go_out_: previous RTC approval
     // activated_: current RTC approval

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -978,7 +978,7 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto intersection_stop_lines_opt = util::generateIntersectionStopLines(
     first_conflicting_area, dummy_first_attention_area, planner_data_, interpolated_path_info,
     planner_param_.stuck_vehicle.use_stuck_stopline, planner_param_.common.stop_line_margin,
-    planner_param_.occlusion.enable, peeking_offset, path);
+    planner_param_.common.enable_peeking_pass_judge, peeking_offset, path);
   if (!intersection_stop_lines_opt) {
     return IntersectionModule::Indecisive{"failed to generate intersection_stop_lines"};
   }

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -978,7 +978,7 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto intersection_stop_lines_opt = util::generateIntersectionStopLines(
     first_conflicting_area, dummy_first_attention_area, planner_data_, interpolated_path_info,
     planner_param_.stuck_vehicle.use_stuck_stopline, planner_param_.common.stop_line_margin,
-    peeking_offset, path);
+    planner_param.occlusion.enable, peeking_offset, path);
   if (!intersection_stop_lines_opt) {
     return IntersectionModule::Indecisive{"failed to generate intersection_stop_lines"};
   }

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -58,6 +58,7 @@ public:
       bool use_intersection_area;
       bool consider_wrong_direction_vehicle;
       bool disable_pass_judge_sudden_stop;
+      bool enable_peeking_pass_judge;
       double path_interpolation_ds;
     } common;
     struct StuckVehicle

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -57,6 +57,7 @@ public:
       double stop_overshoot_margin;  //! overshoot margin for stuck, collision detection
       bool use_intersection_area;
       bool consider_wrong_direction_vehicle;
+      bool disable_pass_judge_sudden_stop;
       double path_interpolation_ds;
     } common;
     struct StuckVehicle

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -269,7 +269,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const lanelet::CompoundPolygon3d & first_detection_area,
   const std::shared_ptr<const PlannerData> & planner_data,
   const InterpolatedPathInfo & interpolated_path_info, const bool use_stuck_stopline,
-  const double stop_line_margin, const double peeking_offset, const bool enable_occlusion,
+  const double stop_line_margin, const bool enable_peeking_pass_judge, const double peeking_offset,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path)
 {
   const auto & path_ip = interpolated_path_info.path;
@@ -419,8 +419,8 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
       intersection_stop_lines_temp.default_stop_line;
   }
   if (
-    enable_occlusion && (intersection_stop_lines_temp.occlusion_peeking_stop_line >
-                         intersection_stop_lines_temp.pass_judge_line)) {
+    enable_peeking_pass_judge && (intersection_stop_lines_temp.occlusion_peeking_stop_line >
+                                  intersection_stop_lines_temp.pass_judge_line)) {
     intersection_stop_lines_temp.pass_judge_line =
       intersection_stop_lines_temp.occlusion_peeking_stop_line;
   }

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -269,7 +269,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const lanelet::CompoundPolygon3d & first_detection_area,
   const std::shared_ptr<const PlannerData> & planner_data,
   const InterpolatedPathInfo & interpolated_path_info, const bool use_stuck_stopline,
-  const double stop_line_margin, const double peeking_offset,
+  const double stop_line_margin, const double peeking_offset, const bool enable_occlusion,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path)
 {
   const auto & path_ip = interpolated_path_info.path;
@@ -419,8 +419,8 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
       intersection_stop_lines_temp.default_stop_line;
   }
   if (
-    intersection_stop_lines_temp.occlusion_peeking_stop_line >
-    intersection_stop_lines_temp.pass_judge_line) {
+    enable_occlusion && (intersection_stop_lines_temp.occlusion_peeking_stop_line >
+                         intersection_stop_lines_temp.pass_judge_line)) {
     intersection_stop_lines_temp.pass_judge_line =
       intersection_stop_lines_temp.occlusion_peeking_stop_line;
   }

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -70,7 +70,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const lanelet::CompoundPolygon3d & first_detection_area,
   const std::shared_ptr<const PlannerData> & planner_data,
   const InterpolatedPathInfo & interpolated_path_info, const bool use_stuck_stopline,
-  const double stop_line_margin, const double peeking_offset, const bool enable_occlusion,
+  const double stop_line_margin, const bool enable_peeking_pass_judge, const double peeking_offset,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path);
 
 std::optional<size_t> getFirstPointInsidePolygon(

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -70,7 +70,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   const lanelet::CompoundPolygon3d & first_detection_area,
   const std::shared_ptr<const PlannerData> & planner_data,
   const InterpolatedPathInfo & interpolated_path_info, const bool use_stuck_stopline,
-  const double stop_line_margin, const double peeking_offset,
+  const double stop_line_margin, const double peeking_offset, const bool enable_occlusion,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path);
 
 std::optional<size_t> getFirstPointInsidePolygon(


### PR DESCRIPTION
## Description

Currently, the sudden stop may occur since the pass judge line is not calculated correctly.
This PR fixes the bug. 
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim
scenario test: https://evaluation.tier4.jp/evaluation/reports/d07e2188-4ff1-550c-83ba-9fa6969141e3?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
No sudden stop by pass judge in intersection

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
