### PR TITLE
perf(drivable area expansion): use faster lateral offset and nearest line calculations

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,6 +24,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -70,9 +71,10 @@ def launch_setup(context, *args, **kwargs):
         name="glog_component",
     )
 
-    behavior_path_planner_component = ComposableNode(
+    behavior_path_planner_component = Node(
         package="behavior_path_planner",
-        plugin="behavior_path_planner::BehaviorPathPlannerNode",
+        # plugin="behavior_path_planner::BehaviorPathPlannerNode",
+        executable="behavior_path_planner",
         name="behavior_path_planner",
         namespace="",
         remappings=[
@@ -119,7 +121,8 @@ def launch_setup(context, *args, **kwargs):
                 ),
             },
         ],
-        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        prefix="konsole -e gdb -ex run --args",
     )
 
     # smoother param
@@ -211,7 +214,6 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
-            behavior_path_planner_component,
             behavior_velocity_planner_component,
             glog_component,
         ],
@@ -261,6 +263,7 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
+            behavior_path_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,7 +24,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -71,10 +70,9 @@ def launch_setup(context, *args, **kwargs):
         name="glog_component",
     )
 
-    behavior_path_planner_component = Node(
+    behavior_path_planner_component = ComposableNode(
         package="behavior_path_planner",
-        # plugin="behavior_path_planner::BehaviorPathPlannerNode",
-        executable="behavior_path_planner",
+        plugin="behavior_path_planner::BehaviorPathPlannerNode",
         name="behavior_path_planner",
         namespace="",
         remappings=[
@@ -121,8 +119,7 @@ def launch_setup(context, *args, **kwargs):
                 ),
             },
         ],
-        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
-        prefix="konsole -e gdb -ex run --args",
+        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     # smoother param
@@ -214,6 +211,7 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
+            behavior_path_planner_component,
             behavior_velocity_planner_component,
             glog_component,
         ],
@@ -263,7 +261,6 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
-            behavior_path_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
@@ -68,14 +68,13 @@ void apply_bound_change_rate_limit(
 /// @brief calculate the maximum distance by which a bound can be expanded
 /// @param [in] path_poses input path
 /// @param [in] bound bound points
-/// @param [in] uncrossable_lines lines that limit the bound expansion
+/// @param [in] uncrossable_segments segments that limit the bound expansion, indexed in a Rtree
 /// @param [in] uncrossable_polygons polygons that limit the bound expansion
 /// @param [in] params parameters with the buffer distance to keep with lines,
 /// and the static maximum expansion distance
 std::vector<double> calculate_maximum_distance(
   const std::vector<Pose> & path_poses, const std::vector<Point> bound,
-  const std::vector<LineString2d> & uncrossable_lines,
-  const std::vector<Polygon2d> & uncrossable_polygons,
+  const SegmentRtree & uncrossable_lines, const std::vector<Polygon2d> & uncrossable_polygons,
   const DrivableAreaExpansionParameters & params);
 
 /// @brief expand a bound by the given lateral distances away from the path

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/map_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/map_utils.hpp
@@ -25,12 +25,12 @@
 
 namespace drivable_area_expansion
 {
-/// @brief Extract uncrossable linestrings from the lanelet map that are in range of ego
+/// @brief Extract uncrossable segments from the lanelet map that are in range of ego
 /// @param[in] lanelet_map lanelet map
 /// @param[in] ego_point point of the current ego position
 /// @param[in] params parameters with linestring types that cannot be crossed and maximum range
-/// @return the uncrossable linestrings
-MultiLineString2d extract_uncrossable_lines(
+/// @return the uncrossable segments stored in a rtree
+SegmentRtree extract_uncrossable_segments(
   const lanelet::LaneletMap & lanelet_map, const Point & ego_point,
   const DrivableAreaExpansionParameters & params);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/types.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/types.hpp
@@ -22,6 +22,8 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
 
+#include <boost/geometry/index/rtree.hpp>
+
 namespace drivable_area_expansion
 {
 using autoware_auto_perception_msgs::msg::PredictedObjects;
@@ -38,6 +40,8 @@ using tier4_autoware_utils::MultiPolygon2d;
 using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 using tier4_autoware_utils::Segment2d;
+
+typedef boost::geometry::index::rtree<Segment2d, boost::geometry::index::rstar<16>> SegmentRtree;
 
 struct PointDistance
 {

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -31,6 +31,15 @@
 
 #include <limits>
 
+// for writing the svg file
+#include <fstream>
+#include <iostream>
+// for the geometry types
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+// for the svg mapper
+#include <boost/geometry/io/svg/svg_mapper.hpp>
+#include <boost/geometry/io/svg/write.hpp>
+
 namespace drivable_area_expansion
 {
 
@@ -259,6 +268,10 @@ void expand_drivable_area(
   PathWithLaneId & path,
   const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data)
 {
+  // Declare a stream and an SVG mapper
+  std::ofstream svg("/home/mclement/Pictures/dyn_da.svg");  // /!\ CHANGE PATH
+  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> mapper(svg, 400, 400);
+
   // skip if no bounds or not enough points to calculate path curvature
   if (path.points.size() < 3 || path.left_bound.empty() || path.right_bound.empty()) return;
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
@@ -280,6 +293,17 @@ void expand_drivable_area(
     path, path_poses, curvatures, planner_data->self_odometry->pose.pose.position, params);
   const auto crop_ms = stop_watch.toc("crop");
 
+  for (const auto & p : path_poses) mapper.add(convert_point(p.position));
+  LineString2d left_ls;
+  for (const auto & p : path.left_bound) left_ls.push_back(convert_point(p));
+  LineString2d right_ls;
+  for (const auto & p : path.right_bound) right_ls.push_back(convert_point(p));
+  mapper.add(left_ls);
+  mapper.add(right_ls);
+  for (const auto & p : path_poses)
+    mapper.map(convert_point(p.position), "fill-opacity:0.3;fill:red;stroke:red;stroke-width:2");
+  mapper.map(left_ls, "fill-opacity:0.3;fill:black;stroke:black;stroke-width:1");
+  mapper.map(right_ls, "fill-opacity:0.3;fill:black;stroke:black;stroke-width:1");
   stop_watch.tic("curvatures_expansion");
   // Only add curvatures for the new points. Curvatures of reused path points are not updated.
   const auto new_curvatures =

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -201,8 +201,7 @@ void apply_bound_change_rate_limit(
 
 std::vector<double> calculate_maximum_distance(
   const std::vector<Pose> & path_poses, const std::vector<Point> bound,
-  const std::vector<LineString2d> & uncrossable_lines,
-  const std::vector<Polygon2d> & uncrossable_polygons,
+  const SegmentRtree & uncrossable_segments, const std::vector<Polygon2d> & uncrossable_polygons,
   const DrivableAreaExpansionParameters & params)
 {
   // TODO(Maxime): improve performances (dont use bg::distance ? use rtree ?)
@@ -212,9 +211,13 @@ std::vector<double> calculate_maximum_distance(
   for (const auto & p : bound) bound_ls.push_back(convert_point(p));
   for (const auto & p : path_poses) path_ls.push_back(convert_point(p.position));
   for (auto i = 0UL; i + 1 < bound_ls.size(); ++i) {
-    const LineString2d segment_ls = {bound_ls[i], bound_ls[i + 1]};
-    for (const auto & uncrossable_line : uncrossable_lines) {
-      const auto bound_to_line_dist = boost::geometry::distance(segment_ls, uncrossable_line);
+    const Segment2d segment_ls = {bound_ls[i], bound_ls[i + 1]};
+    std::vector<Segment2d> query_result;
+    boost::geometry::index::query(
+      uncrossable_segments, boost::geometry::index::nearest(segment_ls, 1),
+      std::back_inserter(query_result));
+    if (!query_result.empty()) {
+      const auto bound_to_line_dist = boost::geometry::distance(segment_ls, query_result.front());
       const auto dist_limit = std::max(0.0, bound_to_line_dist - params.avoid_linestring_dist);
       maximum_distances[i] = std::min(maximum_distances[i], dist_limit);
       maximum_distances[i + 1] = std::min(maximum_distances[i + 1], dist_limit);
@@ -300,7 +303,7 @@ void expand_drivable_area(
   // crop first/last non deviating path_poses
   const auto & params = planner_data->drivable_area_expansion_parameters;
   const auto & route_handler = *planner_data->route_handler;
-  const auto uncrossable_lines = extract_uncrossable_lines(
+  const auto uncrossable_segments = extract_uncrossable_segments(
     *route_handler.getLaneletMapPtr(), planner_data->self_odometry->pose.pose.position, params);
   const auto uncrossable_polygons = create_object_footprints(*planner_data->dynamic_object, params);
   const auto preprocessing_ms = stop_watch.toc("preprocessing");
@@ -339,9 +342,9 @@ void expand_drivable_area(
 
   stop_watch.tic("max_dist");
   const auto max_left_expansions = calculate_maximum_distance(
-    path_poses, path.left_bound, uncrossable_lines, uncrossable_polygons, params);
+    path_poses, path.left_bound, uncrossable_segments, uncrossable_polygons, params);
   const auto max_right_expansions = calculate_maximum_distance(
-    path_poses, path.right_bound, uncrossable_lines, uncrossable_polygons, params);
+    path_poses, path.right_bound, uncrossable_segments, uncrossable_polygons, params);
   for (auto i = 0LU; i < left_expansions.size(); ++i)
     left_expansions[i] = std::min(left_expansions[i], max_left_expansions[i]);
   for (auto i = 0LU; i < right_expansions.size(); ++i)

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -64,9 +64,11 @@ LateralOffsetSearchResult calcLateralOffset(
 {
   LateralOffsetSearchResult result;
   for (auto idx = start_index; idx + 1 < points.size(); ++idx) {
-    const auto offset = motion_utils::calcLateralOffset(points, target, idx);
-    if (offset < result.lateral_offset) {
-      result.lateral_offset = offset;
+    const auto projection = point_to_segment_projection(
+      convert_point(target), convert_point(points[idx].point.pose.position),
+      convert_point(points[idx + 1].point.pose.position));
+    if (std::abs(projection.distance) < result.lateral_offset) {
+      result.lateral_offset = std::abs(projection.distance);
       result.segment_idx = idx;
     }
   }

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -51,7 +51,27 @@ Point2d convert_point(const Point & p)
   return Point2d{p.x, p.y};
 }
 
+struct LateralOffsetSearchResult
+{
+  double lateral_offset = std::numeric_limits<double>::max();
+  size_t segment_idx = 0LU;
+};
+
 }  // namespace
+
+LateralOffsetSearchResult calcLateralOffset(
+  const std::vector<PathPointWithLaneId> & points, const Point & target, const size_t start_index)
+{
+  LateralOffsetSearchResult result;
+  for (auto idx = start_index; idx + 1 < points.size(); ++idx) {
+    const auto offset = motion_utils::calcLateralOffset(points, target, idx);
+    if (offset < result.lateral_offset) {
+      result.lateral_offset = offset;
+      result.segment_idx = idx;
+    }
+  }
+  return result;
+}
 
 void reuse_previous_poses(
   const PathWithLaneId & path, std::vector<Pose> & prev_poses,
@@ -70,11 +90,11 @@ void reuse_previous_poses(
     const auto deviation =
       motion_utils::calcLateralOffset(prev_poses, path.points.front().point.pose.position);
     if (first_idx && deviation < params.max_reuse_deviation) {
+      LateralOffsetSearchResult prev_search_result;
       for (auto idx = *first_idx; idx < prev_poses.size(); ++idx) {
-        if (
-          motion_utils::calcLateralOffset(path.points, prev_poses[idx].position) >
-          params.max_reuse_deviation)
-          break;
+        prev_search_result =
+          calcLateralOffset(path.points, prev_poses[idx].position, prev_search_result.segment_idx);
+        if (prev_search_result.lateral_offset > params.max_reuse_deviation) break;
         cropped_poses.push_back(prev_poses[idx]);
         cropped_curvatures.push_back(prev_curvatures[idx]);
       }

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -202,9 +202,9 @@ void apply_bound_change_rate_limit(
 std::vector<double> calculate_maximum_distance(
   const std::vector<Pose> & path_poses, const std::vector<Point> bound,
   const SegmentRtree & uncrossable_segments, const std::vector<Polygon2d> & uncrossable_polygons,
-  const DrivableAreaExpansionParameters & params)
+  const DrivableAreaExpansionParameters & params,
+  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> & mapper)
 {
-  // TODO(Maxime): improve performances (dont use bg::distance ? use rtree ?)
   std::vector<double> maximum_distances(bound.size(), std::numeric_limits<double>::max());
   LineString2d path_ls;
   LineString2d bound_ls;
@@ -217,6 +217,12 @@ std::vector<double> calculate_maximum_distance(
       uncrossable_segments, boost::geometry::index::nearest(segment_ls, 1),
       std::back_inserter(query_result));
     if (!query_result.empty()) {
+      {
+        Point2d p1, p2;
+        boost::geometry::centroid(segment_ls, p1);
+        boost::geometry::centroid(query_result.front(), p1);
+        mapper.map(Segment2d{p1, p2}, "fill-opacity:0.3;fill:red;stroke:red;stroke-width:1");
+      }
       const auto bound_to_line_dist = boost::geometry::distance(segment_ls, query_result.front());
       const auto dist_limit = std::max(0.0, bound_to_line_dist - params.avoid_linestring_dist);
       maximum_distances[i] = std::min(maximum_distances[i], dist_limit);
@@ -323,10 +329,13 @@ void expand_drivable_area(
   for (const auto & p : path.right_bound) right_ls.push_back(convert_point(p));
   mapper.add(left_ls);
   mapper.add(right_ls);
+  for (const auto & s : uncrossable_segments) mapper.add(s);
   for (const auto & p : path_poses)
-    mapper.map(convert_point(p.position), "fill-opacity:0.3;fill:red;stroke:red;stroke-width:2");
+    mapper.map(convert_point(p.position), "fill-opacity:0.3;fill:red;stroke:red;stroke-width:2", 2);
   mapper.map(left_ls, "fill-opacity:0.3;fill:black;stroke:black;stroke-width:1");
   mapper.map(right_ls, "fill-opacity:0.3;fill:black;stroke:black;stroke-width:1");
+  for (const auto & s : uncrossable_segments)
+    mapper.map(s, "opacity:0.5;fill:black;stroke:black;stroke-width:1");
   stop_watch.tic("curvatures_expansion");
   // Only add curvatures for the new points. Curvatures of reused path points are not updated.
   const auto new_curvatures =
@@ -342,9 +351,9 @@ void expand_drivable_area(
 
   stop_watch.tic("max_dist");
   const auto max_left_expansions = calculate_maximum_distance(
-    path_poses, path.left_bound, uncrossable_segments, uncrossable_polygons, params);
+    path_poses, path.left_bound, uncrossable_segments, uncrossable_polygons, params, mapper);
   const auto max_right_expansions = calculate_maximum_distance(
-    path_poses, path.right_bound, uncrossable_segments, uncrossable_polygons, params);
+    path_poses, path.right_bound, uncrossable_segments, uncrossable_polygons, params, mapper);
   for (auto i = 0LU; i < left_expansions.size(); ++i)
     left_expansions[i] = std::min(left_expansions[i], max_left_expansions[i]);
   for (auto i = 0LU; i < right_expansions.size(); ++i)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR improves the performance of the two heaviest function of the dynamic drivable area expansion feature.

## Tests performed
Psim
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
The runtime of the `behavior_path_planner` should be greatly reduced when using the dynamic drivable area expansion.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
