### PR TITLE
fix(route_handler): fix getting next lane logic to prevent from unexpected path cut

### DIFF
--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -855,12 +855,11 @@ bool RouteHandler::getNextLaneletWithinRoute(
     return false;
   }
 
-  lanelet::ConstLanelet start_lanelet;
-  const bool flag_check = getClosestLaneletWithinRoute(route_ptr_->start_pose, &start_lanelet);
+  const auto start_lane_id = route_ptr_->segments.front().preferred_primitive.id;
 
   const auto following_lanelets = routing_graph_ptr_->following(lanelet);
   for (const auto & llt : following_lanelets) {
-    if (!(flag_check && start_lanelet.id() == llt.id()) && exists(route_lanelets_, llt)) {
+    if (start_lane_id != llt.id() && exists(route_lanelets_, llt)) {
       *next_lanelet = llt;
       return true;
     }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcf62b6</samp>

Refactor `route_handler.cpp` to use new lanelet2 routing API. Simplify `getNextLaneletWithinRoute` by using start lane id instead of closest lanelet.

---

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/2697

SInce the `start_pose` in route handler is **NOT** always on first preferred lane, sometimes unexpected path cut happens by following process. In this PR, I fix implement the feature which was implemented in #2697 in another way to prevent it.

```c++
  lanelet::ConstLanelet start_lanelet;
  const bool flag_check = getClosestLaneletWithinRoute(route_ptr_->start_pose, &start_lanelet);

  const auto following_lanelets = routing_graph_ptr_->following(lanelet);
  for (const auto & llt : following_lanelets) {
    if (!(flag_check && start_lanelet.id() == llt.id()) && exists(route_lanelets_, llt)) {
      *next_lanelet = llt;
      return true;
    }
```

:arrow_down: `start_pose` position when the unexpected path cut happened.
![Screenshot from 2023-10-19 07-53-39](https://github.com/autowarefoundation/autoware.universe/assets/44889564/875946b4-7697-4489-b0b1-3d0efa15ff85)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/38e64556-2bbc-4653-b1ab-1596fd092c7c)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

Lsim + rosbag: the output path (`~/path_with_lane_id`) reaches the goal pose properly.

![Screenshot from 2023-10-19 16-10-51](https://github.com/autowarefoundation/autoware.universe/assets/44889564/d5022dec-f6aa-4ea3-a42f-d26343b992ce)

<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/b225a8cf-9a3e-5d4b-b5c7-fa905cbe5f81?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
