### PR TITLE
fix(route_handler): filter out start lanelets wrt start checkpoint orientation

### DIFF
--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -14,6 +14,7 @@
 
 #include "route_handler/route_handler.hpp"
 
+#include <autoware_utils/math/normalization.hpp>
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/route_checker.hpp>
@@ -2127,10 +2128,24 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   double shortest_path_length2d = std::numeric_limits<double>::max();
 
   for (const auto & st_llt : start_lanelets) {
+    // check if the angle difference between start_checkpoint and start lanelet center line
+    // orientation is in yaw_threshold range
+    double yaw_threshold = M_PI / 2.0;
+    bool is_proper_angle = false;
+    {
+      double lanelet_angle = lanelet::utils::getLaneletAngle(st_llt, start_checkpoint.position);
+      double pose_yaw = tf2::getYaw(start_checkpoint.orientation);
+      double angle_diff = std::abs(autoware_utils::normalize_radian(lanelet_angle - pose_yaw));
+
+      if (angle_diff <= std::abs(yaw_threshold)) {
+        is_proper_angle = true;
+      }
+    }
+
     optional_route = routing_graph_ptr_->getRoute(st_llt, goal_lanelet, 0);
-    if (!optional_route) {
+    if (!optional_route || !is_proper_angle) {
       RCLCPP_ERROR_STREAM(
-        logger_, "Failed to find a proper path!"
+        logger_, "Failed to find a proper route!"
                    << std::endl
                    << " - start checkpoint: " << toString(start_checkpoint) << std::endl
                    << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl


### PR DESCRIPTION
## Description

closes https://github.com/autowarefoundation/autoware.universe/issues/5357

_What this PR changes?_
- route_handler filters start_lanelet's to eliminate improper oriented ones wrt start_checkpoint

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/48479081/8bdeacb0-9947-47e2-83b4-29fc4050c571

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
