### PR TITLE
fix(crosswalk): fix duplicated launching

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.cpp
@@ -127,6 +127,13 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
 void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
 {
   const auto rh = planner_data_->route_handler_;
+  if (!opt_use_regulatory_element_) {
+    opt_use_regulatory_element_ = checkRegulatoryElementExistence(rh->getLaneletMapPtr());
+    std::ostringstream string_stream;
+    string_stream << "use crosswalk regulatory element: ";
+    string_stream << std::boolalpha << *opt_use_regulatory_element_;
+    RCLCPP_INFO_STREAM(logger_, string_stream.str());
+  }
 
   const auto launch = [this, &path](const auto id, const auto & use_regulatory_element) {
     if (isModuleRegistered(id)) {
@@ -143,18 +150,21 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
     updateRTCStatus(getUUID(id), true, std::numeric_limits<double>::lowest(), path.header.stamp);
   };
 
-  const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
-    path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
+  if (*opt_use_regulatory_element_) {
+    const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
+      path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  for (const auto & crosswalk : crosswalk_leg_elem_map) {
-    launch(crosswalk.first->id(), true);
-  }
+    for (const auto & crosswalk : crosswalk_leg_elem_map) {
+      launch(crosswalk.first->id(), true);
+    }
+  } else {
+    const auto crosswalk_lanelets = getCrosswalksOnPath(
+      planner_data_->current_odometry->pose, path, rh->getLaneletMapPtr(),
+      rh->getOverallGraphPtr());
 
-  const auto crosswalk_lanelets = getCrosswalksOnPath(
-    planner_data_->current_odometry->pose, path, rh->getLaneletMapPtr(), rh->getOverallGraphPtr());
-
-  for (const auto & crosswalk : crosswalk_lanelets) {
-    launch(crosswalk.id(), false);
+    for (const auto & crosswalk : crosswalk_lanelets) {
+      launch(crosswalk.id(), false);
+    }
   }
 }
 

--- a/planning/behavior_velocity_crosswalk_module/src/manager.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.hpp
@@ -51,6 +51,8 @@ private:
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const PathWithLaneId & path) override;
+
+  std::optional<bool> opt_use_regulatory_element_{std::nullopt};
 };
 
 class CrosswalkModulePlugin : public PluginWrapper<CrosswalkModuleManager>

--- a/planning/behavior_velocity_walkway_module/src/manager.cpp
+++ b/planning/behavior_velocity_walkway_module/src/manager.cpp
@@ -64,13 +64,6 @@ void WalkwayModuleManager::launchNewModules(const PathWithLaneId & path)
       lanelet.id(), lanelet_map_ptr, p, use_regulatory_element, logger, clock_));
   };
 
-  const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
-    path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
-
-  for (const auto & crosswalk : crosswalk_leg_elem_map) {
-    launch(crosswalk.first->crosswalkLanelet(), true);
-  }
-
   const auto crosswalk_lanelets = getCrosswalksOnPath(
     planner_data_->current_odometry->pose, path, rh->getLaneletMapPtr(), rh->getOverallGraphPtr());
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 809a78b</samp>

This pull request improves the crosswalk detection and handling logic in the `behavior_velocity_crosswalk_module` and `behavior_velocity_walkway_module`. It adds an option to use the crosswalk regulatory element or the lanelet geometry, and removes redundant code that launches duplicate crosswalk modules.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
