### PR TITLE
fix(start_planner): fix invalid lane id access

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -624,6 +624,9 @@ lanelet::ConstLanelets StartPlannerModule::getPathRoadLanes(const PathWithLaneId
   std::vector<lanelet::Id> lane_ids;
   for (const auto & p : path.points) {
     for (const auto & id : p.lane_ids) {
+      if (id == lanelet::InvalId) {
+        continue;
+      }
       if (route_handler->isShoulderLanelet(lanelet_layer.get(id))) {
         continue;
       }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

add guard for
```
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140508136683072) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140508136683072) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140508136683072, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fca9c042476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fca9c0287f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007fca9c4a2b9e in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007fca9c4ae20c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007fca9c4ae277 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007fca9c4ae4d8 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007fca78476d4b in ?? () from /opt/ros/humble/lib/x86_64-linux-gnu/liblanelet2_core.so.1
#10 0x00007fca33ab534e in behavior_path_planner::StartPlannerModule::getPathRoadLanes (this=<optimized out>, path=...) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:627
#11 0x00007fca33ab579f in behavior_path_planner::StartPlannerModule::generateDrivableLanes (this=0x7fca240ce570, path=...) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:650
#12 0x00007fca33ab7c81 in behavior_path_planner::StartPlannerModule::setDrivableAreaInfo (this=0x7fca240ce570, output=...) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:1227
#13 0x00007fca33ab92aa in behavior_path_planner::StartPlannerModule::generateStopOutput (this=0x7fca240ce570) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:1153
#14 0x00007fca33abd80d in behavior_path_planner::StartPlannerModule::plan (this=0x7fca240ce570) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:240
#15 0x00007fca33abb069 in behavior_path_planner::StartPlannerModule::run (this=0x7fca240ce570) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:103
#16 0x00007fca33976e27 in behavior_path_planner::PlannerManager::run (this=this@entry=0x7fca341a3150, module_ptr=std::shared_ptr<behavior_path_planner::SceneModuleInterface> (use count 1, weak count 1) = {...}, planner_data=std::shared_ptr<behavior_path_planner::PlannerData> (use count 19, weak count 0) = {...}, previous_module_output=...)
    at ../../src/autoware/universe/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp:269
#17 0x00007fca3395d55b in operator()<std::shared_ptr<behavior_path_planner::SceneModuleInterface> > (m=std::shared_ptr<behavior_path_planner::SceneModuleInterface> (use count 1, weak count 1) = {...}, __closure=<synthetic pointer>) at ../../src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:617
#18 std::for_each<__gnu_cxx::__normal_iterator<std::shared_ptr<behavior_path_planner::SceneModuleInterface>*, std::vector<std::shared_ptr<behavior_path_planner::SceneModuleInterface> > >, behavior_path_planner::PlannerManager::runApprovedModules(const std::shared_ptr<behavior_path_planner::PlannerData>&)::<lambda(const auto:128&)> > (__f=...,
    __last=<error reading variable: Cannot access memory at address 0x22d>, __first=std::shared_ptr<behavior_path_planner::SceneModuleInterface> (use count 1, weak count 1) = {get() = 0x7fca240ce570}) at /usr/include/c++/11/bits/stl_algo.h:3820
#19 behavior_path_planner::PlannerManager::runApprovedModules (this=0x7fca341a3150, data=std::shared_ptr<behavior_path_planner::PlannerData> (use count 19, weak count 0) = {...}) at ../../src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:617
#20 0x00007fca33960009 in operator() (__closure=0x7fca999318e0) at ../../src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:90
#21 0x00007fca33960d88 in behavior_path_planner::PlannerManager::run (this=this@entry=0x7fca341a3150, data=std::shared_ptr<behavior_path_planner::PlannerData> (use count 19, weak count 0) = {...}) at ../../src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:55
#22 0x00007fca3399710e in behavior_path_planner::BehaviorPathPlannerNode::run (this=0x7fca34047fc0) at /usr/include/c++/11/bits/shared_ptr_base.h:1295
#23 0x00007fca3399c345 in std::__invoke_impl<void, void (behavior_path_planner::BehaviorPathPlannerNode::*&)(), behavior_path_planner::BehaviorPathPlannerNode*&> (__t=@0x7fca80027950: 0x7fca34047fc0,
    __f=@0x7fca80027940: (void (behavior_path_planner::BehaviorPathPlannerNode::*)(behavior_path_planner::BehaviorPathPlannerNode * const)) 0x7fca33996ce0 <behavior_path_planner::BehaviorPathPlannerNode::run()>) at /usr/include/c++/11/bits/invoke.h:71
#24 std::__invoke<void (behavior_path_planner::BehaviorPathPlannerNode::*&)(), behavior_path_planner::BehaviorPathPlannerNode*&> (__fn=@0x7fca80027940: (void (behavior_path_planner::BehaviorPathPlannerNode::*)(behavior_path_planner::BehaviorPathPlannerNode * const)) 0x7fca33996ce0 <behavior_path_planner::BehaviorPathPlannerNode::run()>) at /usr/include/c++/11/bits/invoke.h:96
#25 std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (__args=..., this=0x7fca80027940) at /usr/include/c++/11/functional:420
#26 std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>::operator()<, void>() (this=0x7fca80027940) at /usr/include/c++/11/functional:503
#27 rclcpp::GenericTimer<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>::execute_callback_delegate<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>() (this=0x7fca80027910)
    at ../../install/rclcpp/include/rclcpp/rclcpp/timer.hpp:244
#28 rclcpp::GenericTimer<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>::execute_callback() (this=0x7fca80027910) at ../../install/rclcpp/include/rclcpp/rclcpp/timer.hpp:230
#29 0x00007fca9c95effe in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) () from /home/kosuke55/pilot-auto/install/rclcpp/lib/librclcpp.so
#30 0x00007fca9c965432 in rclcpp::executors::MultiThreadedExecutor::run(unsigned long) () from /home/kosuke55/pilot-auto/install/rclcpp/lib/librclcpp.so
#31 0x00007fca9c4dc253 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#32 0x00007fca9c094ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#33 0x00007fca9c126a40 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
(gdb) f 10
#10 0x00007fca33ab534e in behavior_path_planner::StartPlannerModule::getPathRoadLanes (this=<optimized out>, path=...) at ../../src/autoware/universe/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp:627
627           if (route_handler->isShoulderLanelet(lanelet_layer.get(id))) {
(gdb) p id
$8 = (const long &) @0x7fca240bf3e0: 0
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
