### PR TITLE
feat(imu_corrector): changed input topic of GyroBiasEstimator from ndt_pose to ekf_odom

### DIFF
--- a/sensing/imu_corrector/launch/gyro_bias_estimator.launch.xml
+++ b/sensing/imu_corrector/launch/gyro_bias_estimator.launch.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="input_imu_raw" default="imu_raw"/>
-  <arg name="input_pose" default="pose"/>
+  <arg name="input_odom" default="odom"/>
   <arg name="output_gyro_bias" default="gyro_bias"/>
   <arg name="gyro_bias_estimator_param_file" default="$(find-pkg-share imu_corrector)/config/gyro_bias_estimator.param.yaml"/>
   <arg name="imu_corrector_param_file" default="$(find-pkg-share imu_corrector)/config/imu_corrector.param.yaml"/>
 
   <node pkg="imu_corrector" exec="gyro_bias_estimator" name="gyro_bias_estimator" output="screen">
     <remap from="~/input/imu_raw" to="$(var input_imu_raw)"/>
-    <remap from="~/input/pose" to="$(var input_pose)"/>
+    <remap from="~/input/odom" to="$(var input_odom)"/>
     <remap from="~/output/gyro_bias" to="$(var output_gyro_bias)"/>
     <param from="$(var gyro_bias_estimator_param_file)"/>
     <param from="$(var imu_corrector_param_file)"/>

--- a/sensing/imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.cpp
@@ -43,9 +43,9 @@ GyroBiasEstimator::GyroBiasEstimator()
   imu_sub_ = create_subscription<Imu>(
     "~/input/imu_raw", rclcpp::SensorDataQoS(),
     [this](const Imu::ConstSharedPtr msg) { callback_imu(msg); });
-  pose_sub_ = create_subscription<PoseWithCovarianceStamped>(
-    "~/input/pose", rclcpp::SensorDataQoS(),
-    [this](const PoseWithCovarianceStamped::ConstSharedPtr msg) { callback_pose(msg); });
+  odom_sub_ = create_subscription<Odometry>(
+    "~/input/odom", rclcpp::SensorDataQoS(),
+    [this](const Odometry::ConstSharedPtr msg) { callback_odom(msg); });
   gyro_bias_pub_ = create_publisher<Vector3Stamped>("~/output/gyro_bias", rclcpp::SensorDataQoS());
 
   auto timer_callback = std::bind(&GyroBiasEstimator::timer_callback, this);
@@ -88,12 +88,11 @@ void GyroBiasEstimator::callback_imu(const Imu::ConstSharedPtr imu_msg_ptr)
   }
 }
 
-void GyroBiasEstimator::callback_pose(const PoseWithCovarianceStamped::ConstSharedPtr pose_msg_ptr)
+void GyroBiasEstimator::callback_odom(const Odometry::ConstSharedPtr odom_msg_ptr)
 {
-  // push pose_msg to queue
   geometry_msgs::msg::PoseStamped pose;
-  pose.header = pose_msg_ptr->header;
-  pose.pose = pose_msg_ptr->pose.pose;
+  pose.header = odom_msg_ptr->header;
+  pose.pose = odom_msg_ptr->pose.pose;
   pose_buf_.push_back(pose);
 }
 

--- a/sensing/imu_corrector/src/gyro_bias_estimator.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.hpp
@@ -22,6 +22,7 @@
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
 #include <memory>
@@ -38,6 +39,7 @@ private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Vector3Stamped = geometry_msgs::msg::Vector3Stamped;
   using Vector3 = geometry_msgs::msg::Vector3;
+  using Odometry = nav_msgs::msg::Odometry;
 
 public:
   GyroBiasEstimator();
@@ -45,7 +47,7 @@ public:
 private:
   void update_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void callback_imu(const Imu::ConstSharedPtr imu_msg_ptr);
-  void callback_pose(const PoseWithCovarianceStamped::ConstSharedPtr pose_msg_ptr);
+  void callback_odom(const Odometry::ConstSharedPtr odom_msg_ptr);
   void timer_callback();
 
   static geometry_msgs::msg::Vector3 transform_vector3(
@@ -55,7 +57,7 @@ private:
   const std::string output_frame_ = "base_link";
 
   rclcpp::Subscription<Imu>::SharedPtr imu_sub_;
-  rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr pose_sub_;
+  rclcpp::Subscription<Odometry>::SharedPtr odom_sub_;
   rclcpp::Publisher<Vector3Stamped>::SharedPtr gyro_bias_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 


### PR DESCRIPTION
## Description

Change the input topic used by GyroBiasEstimator from `/localization/pose_estimator/pose_with_covariance` to `/localization/kinematic_state`.

This change comes from the idea that `/localization/kinematic_state` is a more formal pose output from the localization module.

It should be noted that EKF is dependent on the IMU, so the EKF itself will be slightly affected when the IMU bias is not fully compensated.

However, if NDT is used as the pose_estimator, experiments have shown that the effect is small.

## Related link
* https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/79
* https://github.com/tier4/aip_launcher/pull/183
* https://github.com/RobotecAI/awsim_sensor_kit_launch/pull/11

## Tests performed

In sample rosbag

|Before(ndt_pose)|After(ekf_odom)|
|:---------------------:|:--------------------:|
|![estimated_gyro_bias_before_sample](https://github.com/autowarefoundation/autoware.universe/assets/28504069/7065684c-b898-441d-90f8-b683e39024e6)|![estimated_gyro_bias_after_sample](https://github.com/autowarefoundation/autoware.universe/assets/28504069/d3021ff2-5a47-47e5-90ae-7faf0df20794)|

In internal rosbag

The experiment was conducted using the IMU bias calibrated in September.

|Month|Before(ndt_pose)|After(ekf_odom)|
|:-------:|:---------------------:|:--------------------:|
|2023/06|![estimated_gyro_bias_before_ndt_06](https://github.com/autowarefoundation/autoware.universe/assets/28504069/c8492d29-2ff0-44e3-8d57-8fee08fbb403)|![estimated_gyro_bias_before_ekf_06](https://github.com/autowarefoundation/autoware.universe/assets/28504069/1a7da6e0-fd67-4f4c-8245-119fbb605abb)|
|2023/09|![estimated_gyro_bias_09_before](https://github.com/autowarefoundation/autoware.universe/assets/28504069/f7fea37b-f092-4d52-b573-db7622af180d)|![estimated_gyro_bias_09_ekf](https://github.com/autowarefoundation/autoware.universe/assets/28504069/e50b77a8-a83b-4652-b4fe-dad697ae7f27)|

The change from NDT to EKF has little effect on the results.

The module can detect a change in yaw bias from June to September.

## Effects on system behavior

The output values to diagnostics are only slightly changed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
