### PR TITLE
refactor(topic_state_monitor): add state log message

### DIFF
--- a/system/default_ad_api/src/operation_mode.hpp
+++ b/system/default_ad_api/src/operation_mode.hpp
@@ -20,6 +20,7 @@
 #include <component_interface_utils/status.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -65,7 +66,7 @@ private:
   Cli<system_interface::ChangeOperationMode> cli_mode_;
   Cli<system_interface::ChangeAutowareControl> cli_control_;
 
-  std::vector<bool> module_states_;
+  std::unordered_map<std::string, bool> module_states_;
   std::vector<rclcpp::Subscription<ModeChangeAvailable>::SharedPtr> sub_module_states_;
 
   void on_change_to_stop(

--- a/system/topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -151,6 +151,10 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
     stat.addf("topic", "%s", node_param_.topic.c_str());
   }
 
+  const auto print_warn = [&](const std::string & msg) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 3000, "%s", msg.c_str());
+  };
+
   // Judge level
   int8_t level = DiagnosticStatus::OK;
   if (topic_status == TopicStatus::Ok) {
@@ -159,15 +163,19 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   } else if (topic_status == TopicStatus::NotReceived) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "NotReceived");
+    print_warn(node_param_.topic + " has not received.");
   } else if (topic_status == TopicStatus::WarnRate) {
     level = DiagnosticStatus::WARN;
     stat.add("status", "WarnRate");
+    print_warn(node_param_.topic + " is in warning rate.");
   } else if (topic_status == TopicStatus::ErrorRate) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "ErrorRate");
+    print_warn(node_param_.topic + " is in error rate.");
   } else if (topic_status == TopicStatus::Timeout) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "Timeout");
+    print_warn(node_param_.topic + " is timeout.");
   }
 
   // Add key-value

--- a/system/topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -170,11 +170,11 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   } else if (topic_status == TopicStatus::WarnRate) {
     level = DiagnosticStatus::WARN;
     stat.add("status", "WarnRate");
-    print_warn(node_param_.topic + " topic has dropped to the warning level.");
+    print_warn(node_param_.topic + " topic rate has dropped to the warning level.");
   } else if (topic_status == TopicStatus::ErrorRate) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "ErrorRate");
-    print_warn(node_param_.topic + " topic has dropped to the error level.");
+    print_warn(node_param_.topic + " topic rate has dropped to the error level.");
   } else if (topic_status == TopicStatus::Timeout) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "Timeout");

--- a/system/topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -154,6 +154,9 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   const auto print_warn = [&](const std::string & msg) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 3000, "%s", msg.c_str());
   };
+  const auto print_debug = [&](const std::string & msg) {
+    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), 3000, "%s", msg.c_str());
+  };
 
   // Judge level
   int8_t level = DiagnosticStatus::OK;
@@ -163,19 +166,19 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   } else if (topic_status == TopicStatus::NotReceived) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "NotReceived");
-    print_warn(node_param_.topic + " has not received.");
+    print_debug(node_param_.topic + " has not received.");
   } else if (topic_status == TopicStatus::WarnRate) {
     level = DiagnosticStatus::WARN;
     stat.add("status", "WarnRate");
-    print_warn(node_param_.topic + " is in warning rate.");
+    print_warn(node_param_.topic + " topic has dropped to the warning level.");
   } else if (topic_status == TopicStatus::ErrorRate) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "ErrorRate");
-    print_warn(node_param_.topic + " is in error rate.");
+    print_warn(node_param_.topic + " topic has dropped to the error level.");
   } else if (topic_status == TopicStatus::Timeout) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "Timeout");
-    print_warn(node_param_.topic + " is timeout.");
+    print_warn(node_param_.topic + " topic is timeout.");
   }
 
   // Add key-value


### PR DESCRIPTION
## Description

We frequently receive reports that, for unknown reasons, it is not possible to switch to Auto mode.
I added explicit messages stating "Cannot switch to AUTO" and "The frequency of the topic has dropped" on the terminal.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/1cb84aa8-1258-42f0-9db4-c86258fc7011)


## Tests performed

run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
