### PR TITLE
feat(duplicated_node_checker): add duplicated node names to msg

### DIFF
--- a/system/duplicated_node_checker/config/duplicated_node_checker.param.yaml
+++ b/system/duplicated_node_checker/config/duplicated_node_checker.param.yaml
@@ -1,3 +1,4 @@
 /**:
   ros__parameters:
     update_rate: 10.0
+    add_duplicated_node_names_to_msg: false # if true, duplicated node names are added to msg

--- a/system/duplicated_node_checker/include/duplicated_node_checker/duplicated_node_checker_core.hpp
+++ b/system/duplicated_node_checker/include/duplicated_node_checker/duplicated_node_checker_core.hpp
@@ -48,6 +48,7 @@ private:
 
   diagnostic_updater::Updater updater_{this};
   rclcpp::TimerBase::SharedPtr timer_;
+  bool add_duplicated_node_names_to_msg_;
 };
 }  // namespace duplicated_node_checker
 

--- a/system/duplicated_node_checker/src/duplicated_node_checker_core.cpp
+++ b/system/duplicated_node_checker/src/duplicated_node_checker_core.cpp
@@ -28,6 +28,7 @@ DuplicatedNodeChecker::DuplicatedNodeChecker(const rclcpp::NodeOptions & node_op
 : Node("duplicated_node_checker", node_options)
 {
   double update_rate = declare_parameter<double>("update_rate");
+  add_duplicated_node_names_to_msg_ = declare_parameter<bool>("add_duplicated_node_names_to_msg");
   updater_.setHardwareID("duplicated_node_checker");
   updater_.add("duplicated_node_checker", this, &DuplicatedNodeChecker::produceDiagnostics);
 
@@ -63,8 +64,14 @@ void DuplicatedNodeChecker::produceDiagnostics(diagnostic_updater::DiagnosticSta
   std::string msg;
   int level;
   if (identical_names.size() > 0) {
-    msg = "Error";
     level = DiagnosticStatus::ERROR;
+    msg = "Error: Duplicated nodes detected";
+    if (add_duplicated_node_names_to_msg_) {
+      std::set<std::string> unique_identical_names(identical_names.begin(), identical_names.end());
+      for (const auto & name : unique_identical_names) {
+        msg += " " + name;
+      }
+    }
     for (auto name : identical_names) {
       stat.add("Duplicated Node Name", name);
     }

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -40,6 +40,7 @@
         /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/system/duplicated_node_checker: default
         # /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "error", spf_at: "none" }
+        # /autoware/system/duplicated_node_checker: default
 
         /autoware/vehicle/node_alive_monitoring: default
 


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 232b433</samp>

This pull request enhances the `duplicated_node_checker` node to optionally report the names of duplicated nodes in the diagnostic message. It also updates the configuration files and comments for the node and its usage in the `system_error_monitor` node.

---

add flag to show duplicated node names to msg (default false)
the motivation for this is it's necessary to check duplicated node name in the log file sometimes (e.g. running scenario simulator in CI/CD environment)

launcher [PR](https://github.com/autowarefoundation/autoware_launch/pull/651) should be merged first
 

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Run scenario_simulator_v2 in local environment.
I confirmed node name is added to msg when duplicated node is launched shown below.
```
[system_error_monitor-16] [ERROR 1698054734.955753195] [system_error_monitor /autoware/system/duplicated_node_checker/duplicated_node_checker: duplicated_node_checker]: [Single Point Fault]: Error: Duplicated nodes detected /simulation/openscenario_interpreter (logThrottledNamed():54)
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
