### PR TITLE
perf(motion_utils): faster removeOverlapPoints and calcLateralOffset functions

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -21,7 +21,6 @@
 #include "tier4_autoware_utils/system/backtrace.hpp"
 
 #include <Eigen/Geometry>
-#include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_point.hpp>
 #include <autoware_auto_planning_msgs/msg/path_point_with_lane_id.hpp>
@@ -623,16 +622,11 @@ calcLateralOffset<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
  * @param throw_exception flag to enable/disable exception throwing
  * @return length (unsigned)
  */
-static auto rm_overlaps_durations_us = 0;
-static auto other_duration_us = 0;
 template <class T>
 double calcLateralOffset(
   const T & points, const geometry_msgs::msg::Point & p_target, const bool throw_exception = false)
 {
-  tier4_autoware_utils::StopWatch<std::chrono::microseconds> stopwatch;
   const auto overlap_removed_points = removeOverlapPoints(points, 0);
-  rm_overlaps_durations_us += stopwatch.toc();
-  stopwatch.tic("other");
 
   if (throw_exception) {
     validateNonEmpty(overlap_removed_points);
@@ -656,9 +650,7 @@ double calcLateralOffset(
   }
 
   const size_t seg_idx = findNearestSegmentIndex(overlap_removed_points, p_target);
-  const auto result = calcLateralOffset(points, p_target, seg_idx, throw_exception);
-  other_duration_us += stopwatch.toc("other");
-  return result;
+  return calcLateralOffset(points, p_target, seg_idx, throw_exception);
 }
 
 extern template double calcLateralOffset<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -21,6 +21,7 @@
 #include "tier4_autoware_utils/system/backtrace.hpp"
 
 #include <Eigen/Geometry>
+#include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_point.hpp>
 #include <autoware_auto_planning_msgs/msg/path_point_with_lane_id.hpp>
@@ -621,11 +622,16 @@ calcLateralOffset<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
  * @param throw_exception flag to enable/disable exception throwing
  * @return length (unsigned)
  */
+static auto rm_overlaps_durations_us = 0;
+static auto other_duration_us = 0;
 template <class T>
 double calcLateralOffset(
   const T & points, const geometry_msgs::msg::Point & p_target, const bool throw_exception = false)
 {
+  tier4_autoware_utils::StopWatch<std::chrono::microseconds> stopwatch;
   const auto overlap_removed_points = removeOverlapPoints(points, 0);
+  rm_overlaps_durations_us += stopwatch.toc();
+  stopwatch.tic("other");
 
   if (throw_exception) {
     validateNonEmpty(overlap_removed_points);
@@ -649,7 +655,9 @@ double calcLateralOffset(
   }
 
   const size_t seg_idx = findNearestSegmentIndex(overlap_removed_points, p_target);
-  return calcLateralOffset(points, p_target, seg_idx, throw_exception);
+  const auto result = calcLateralOffset(points, p_target, seg_idx, throw_exception);
+  other_duration_us += stopwatch.toc("other");
+  return result;
 }
 
 extern template double calcLateralOffset<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -169,6 +169,7 @@ T removeOverlapPoints(const T & points, const size_t start_idx = 0)
   }
 
   T dst;
+  dst.reserve(points.size());
 
   for (size_t i = 0; i <= start_idx; ++i) {
     dst.push_back(points.at(i));

--- a/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -12,19 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "motion_utils/trajectory/tmp_conversion.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
-#include "tier4_autoware_utils/geometry/boost_geometry.hpp"
-#include "tier4_autoware_utils/math/unit_conversion.hpp"
 
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-port.h>
 #include <lanelet2_core/geometry/LineString.h>
 #include <tf2/LinearMath/Quaternion.h>
 
-#include <limits>
 #include <random>
-#include <vector>
 
 namespace
 {

--- a/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -80,8 +80,6 @@ TEST(trajectory_benchmark, DISABLED_calcLateralOffset)
     const auto point = createPoint(uniform_dist(e1), uniform_dist(e1), 0.0);
     calcLateralOffset(traj.points, point);
   }
-  std::cerr << "rm overlaps: " << motion_utils::rm_overlaps_durations_us << "us\n";
-  std::cerr << "other: " << motion_utils::other_duration_us << "us\n";
 }
 
 TEST(trajectory_benchmark, DISABLED_calcLateralOffsetLanelet)

--- a/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -1,0 +1,84 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "motion_utils/trajectory/tmp_conversion.hpp"
+#include "motion_utils/trajectory/trajectory.hpp"
+#include "tier4_autoware_utils/geometry/boost_geometry.hpp"
+#include "tier4_autoware_utils/math/unit_conversion.hpp"
+
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace
+{
+using autoware_auto_planning_msgs::msg::Trajectory;
+using tier4_autoware_utils::createPoint;
+using tier4_autoware_utils::createQuaternionFromRPY;
+
+constexpr double epsilon = 1e-6;
+
+geometry_msgs::msg::Pose createPose(
+  double x, double y, double z, double roll, double pitch, double yaw)
+{
+  geometry_msgs::msg::Pose p;
+  p.position = createPoint(x, y, z);
+  p.orientation = createQuaternionFromRPY(roll, pitch, yaw);
+  return p;
+}
+
+template <class T>
+T generateTestTrajectory(
+  const size_t num_points, const double point_interval, const double vel = 0.0,
+  const double init_theta = 0.0, const double delta_theta = 0.0)
+{
+  using Point = typename T::_points_type::value_type;
+
+  T traj;
+  for (size_t i = 0; i < num_points; ++i) {
+    const double theta = init_theta + i * delta_theta;
+    const double x = i * point_interval * std::cos(theta);
+    const double y = i * point_interval * std::sin(theta);
+
+    Point p;
+    p.pose = createPose(x, y, 0.0, 0.0, 0.0, theta);
+    p.longitudinal_velocity_mps = vel;
+    traj.points.push_back(p);
+  }
+
+  return traj;
+}
+}  // namespace
+
+TEST(trajectory_benchmark, DISABLED_calcLateralOffset)
+{
+  std::random_device r;
+  std::default_random_engine e1(r());
+  std::uniform_real_distribution<double> uniform_dist(0.0, 1000.0);
+
+  using motion_utils::calcLateralOffset;
+
+  const auto traj = generateTestTrajectory<Trajectory>(1000, 1.0, 0.0, 0.0, 0.1);
+  constexpr auto nb_iteration = 10000;
+  for (auto i = 0; i < nb_iteration; ++i) {
+    const auto point = createPoint(uniform_dist(e1), uniform_dist(e1), 0.0);
+    calcLateralOffset(traj.points, point);
+  }
+  std::cerr << "rm overlaps: " << motion_utils::rm_overlaps_durations_us << "us\n";
+  std::cerr << "other: " << motion_utils::other_duration_us << "us\n";
+}

--- a/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-port.h>
-#include <lanelet2_core/geometry/LineString.h>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <random>
@@ -74,23 +73,5 @@ TEST(trajectory_benchmark, DISABLED_calcLateralOffset)
   for (auto i = 0; i < nb_iteration; ++i) {
     const auto point = createPoint(uniform_dist(e1), uniform_dist(e1), 0.0);
     calcLateralOffset(traj.points, point);
-  }
-}
-
-TEST(trajectory_benchmark, DISABLED_calcLateralOffsetLanelet)
-{
-  std::random_device r;
-  std::default_random_engine e1(r());
-  std::uniform_real_distribution<double> uniform_dist(0.0, 1000.0);
-
-  using motion_utils::calcLateralOffset;
-
-  const auto traj = generateTestTrajectory<Trajectory>(1000, 1.0, 0.0, 0.0, 0.1);
-  constexpr auto nb_iteration = 10000;
-  lanelet::BasicLineString2d path_ls;
-  for (const auto & p : traj.points) path_ls.emplace_back(p.pose.position.x, p.pose.position.y);
-  for (auto i = 0; i < nb_iteration; ++i) {
-    const auto point = lanelet::BasicPoint2d{uniform_dist(e1), uniform_dist(e1)};
-    lanelet::geometry::toArcCoordinates(path_ls, point);
   }
 }

--- a/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-port.h>
+#include <lanelet2_core/geometry/LineString.h>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <limits>
@@ -81,4 +82,22 @@ TEST(trajectory_benchmark, DISABLED_calcLateralOffset)
   }
   std::cerr << "rm overlaps: " << motion_utils::rm_overlaps_durations_us << "us\n";
   std::cerr << "other: " << motion_utils::other_duration_us << "us\n";
+}
+
+TEST(trajectory_benchmark, DISABLED_calcLateralOffsetLanelet)
+{
+  std::random_device r;
+  std::default_random_engine e1(r());
+  std::uniform_real_distribution<double> uniform_dist(0.0, 1000.0);
+
+  using motion_utils::calcLateralOffset;
+
+  const auto traj = generateTestTrajectory<Trajectory>(1000, 1.0, 0.0, 0.0, 0.1);
+  constexpr auto nb_iteration = 10000;
+  lanelet::BasicLineString2d path_ls;
+  for (const auto & p : traj.points) path_ls.emplace_back(p.pose.position.x, p.pose.position.y);
+  for (auto i = 0; i < nb_iteration; ++i) {
+    const auto point = lanelet::BasicPoint2d{uniform_dist(e1), uniform_dist(e1)};
+    lanelet::geometry::toArcCoordinates(path_ls, point);
+  }
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Make the `removeOverlapPoints` and `calcLateralOffset` functions faster, simply by calling `reserve` on the vector created in `removeOverlapPoints`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Benchmark test (disabled by default) was added. It calls the function 10000 times on a trajectory with 1000 points.
- Without the fix: ~250ms.
- After the fix: ~80ms.

To test on you local machine:
```
./build/motion_utils/test_motion_utils --gtest_filter=trajectory_benchmark.\* --gtest_also_run_disabled_tests
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
