### PR TITLE
refactor(bpp): make lateral offset smaller for monotonic bounds

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1935,7 +1935,7 @@ void makeBoundLongitudinallyMonotonic(
 
       const auto theta = normalizeRadian(p1_to_p2 - p2_to_p3);
 
-      return (is_points_left && 0 < theta) || (!is_points_left && theta < 0);
+      return (is_points_left && 0 > theta) || (!is_points_left && theta > 0);
     };
 
   // define a function to remove non monotonic point on bound
@@ -1954,7 +1954,7 @@ void makeBoundLongitudinallyMonotonic(
 
       // NOTE: is_bound_left is used instead of is_points_left since orientation of path point is
       // opposite.
-      const double lat_offset = is_bound_left ? 100.0 : -100.0;
+      const double lat_offset = is_bound_left ? 0.1 : -0.1;
 
       const auto p_bound_1 = getPoint(bound_with_pose.at(bound_idx));
       const auto p_bound_2 = getPoint(bound_with_pose.at(bound_idx + 1));
@@ -1962,7 +1962,7 @@ void makeBoundLongitudinallyMonotonic(
       const auto p_bound_offset =
         calcOffsetPose(getPose(bound_with_pose.at(bound_idx)), 0.0, lat_offset, 0.0);
 
-      if (!is_monotonic(p_bound_1, p_bound_2, p_bound_offset.position, is_points_left)) {
+      if (is_monotonic(p_bound_1, p_bound_2, p_bound_offset.position, is_points_left)) {
         bound_idx++;
         continue;
       }


### PR DESCRIPTION
## Description

closes https://github.com/autowarefoundation/autoware.universe/issues/5396

This PR solves the specific issue above however logic in the `makeBoundLongitudinallyMonotonic` needs to be fixed as already addressed with a todo comment.

![Screenshot from 2023-10-24 12-45-15](https://github.com/autowarefoundation/autoware.universe/assets/48479081/78b6592d-33fe-4860-8ba7-dbbd320b8548)


## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/48479081/4692f900-3775-4fc6-94ce-a16836ea70ca

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
