### PR TITLE
feat(external_cmd_converter): add auto brake hold function

### DIFF
--- a/vehicle/external_cmd_converter/include/external_cmd_converter/node.hpp
+++ b/vehicle/external_cmd_converter/include/external_cmd_converter/node.hpp
@@ -82,6 +82,7 @@ private:
   bool wait_for_first_topic_;
   double control_command_timeout_;
   double emergency_stop_timeout_;
+  bool auto_brake_hold_;
 
   // Diagnostics
   diagnostic_updater::Updater updater_{this};

--- a/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.py
+++ b/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.py
@@ -67,6 +67,11 @@ def generate_launch_description():
             default_value="3.0",
             description="emergency stop timeout for external heartbeat",
         ),
+        DeclareLaunchArgument(
+            "auto_brake_hold",
+            default_value="true",
+            description="hold brake when the ego vehicle is stationary",
+        ),
         # input
         DeclareLaunchArgument(
             "in/external_control_cmd",
@@ -121,6 +126,7 @@ def generate_launch_description():
                     _create_mapping_tuple("wait_for_first_topic"),
                     _create_mapping_tuple("control_command_timeout"),
                     _create_mapping_tuple("emergency_stop_timeout"),
+                    _create_mapping_tuple("auto_brake_hold"),
                 ]
             )
         ],

--- a/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.xml
+++ b/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.xml
@@ -9,6 +9,7 @@
   <arg name="wait_for_first_topic" default="true"/>
   <arg name="control_command_timeout" default="1.0"/>
   <arg name="emergency_stop_timeout" default="3.0"/>
+  <arg name="auto_brake_hold" default="true"/>
 
   <!-- input -->
   <arg name="in/external_control_cmd" default="/external/selected/external_control_cmd"/>
@@ -29,6 +30,7 @@
     <param name="wait_for_first_topic" value="$(var wait_for_first_topic)"/>
     <param name="control_command_timeout" value="$(var control_command_timeout)"/>
     <param name="emergency_stop_timeout" value="$(var emergency_stop_timeout)"/>
+    <param name="auto_brake_hold" value="$(var auto_brake_hold)"/>
     <remap from="in/external_control_cmd" to="$(var in/external_control_cmd)"/>
     <remap from="in/shift_cmd" to="$(var in/shift_cmd)"/>
     <remap from="in/emergency_stop" to="$(var in/emergency_stop)"/>

--- a/vehicle/external_cmd_converter/src/node.cpp
+++ b/vehicle/external_cmd_converter/src/node.cpp
@@ -123,13 +123,6 @@ void ExternalCmdConverterNode::onExternalCmd(const ExternalControlCommand::Const
   const double sign = getShiftVelocitySign(*current_shift_cmd_);
   double ref_acceleration = calculateAcc(*cmd_ptr, std::fabs(*current_velocity_ptr_));
 
-  if (ref_acceleration > 0.0 && sign == 0.0) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
-      "Target acceleration is positive, but the gear is not appropriate. accel: %f, gear: %d",
-      ref_acceleration, current_shift_cmd_->command);
-  }
-
   double ref_velocity = *current_velocity_ptr_ + ref_acceleration * ref_vel_gain_ * sign;
   if (current_shift_cmd_->command == GearCommand::REVERSE) {
     ref_velocity = std::min(0.0, ref_velocity);
@@ -147,6 +140,13 @@ void ExternalCmdConverterNode::onExternalCmd(const ExternalControlCommand::Const
   if (auto_brake_hold_ && std::abs(*current_velocity_ptr_) < stop_velocity_thr) {
     ref_velocity = 0.0;
     ref_acceleration = -1.5;  // TODO(Horibe): parametrize hold brake
+  }
+
+  if (ref_acceleration > 0.0 && sign == 0.0) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "Target acceleration is positive, but the gear is not appropriate. accel: %f, gear: %d",
+      ref_acceleration, current_shift_cmd_->command);
   }
 
   // Publish ControlCommand


### PR DESCRIPTION
## Description

Add an "auto brake hold" function in the external_cmd_converter. 
This feature ensures that the vehicle does not start moving even if the brake is released when it is stopped. The brake hold is released when an acceleration is commanded.

## Related links

None

## Tests performed

- [x] Run psim (but can't test with external control)
- [ ] Integration test with remote control

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

Vehicle keeps being stopped even if brake is released in external control.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
