### PR TITLE
feat(radar_tracks_msgs_converter): add an error message and prevent the node from crashing.

### DIFF
--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -244,6 +244,10 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
       std::atan2(compensated_velocity.y, compensated_velocity.x));
 
     geometry_msgs::msg::PoseStamped transformed_pose_stamped{};
+    if (transform_ == nullptr){
+      RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "getTransform failed. radar output will be empty.");
+      return tracked_objects;
+    }
     tf2::doTransform(radar_pose_stamped, transformed_pose_stamped, *transform_);
     kinematics.pose_with_covariance.pose = transformed_pose_stamped.pose;
     kinematics.pose_with_covariance.pose.orientation =

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -244,8 +244,9 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
       std::atan2(compensated_velocity.y, compensated_velocity.x));
 
     geometry_msgs::msg::PoseStamped transformed_pose_stamped{};
-    if (transform_ == nullptr){
-      RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "getTransform failed. radar output will be empty.");
+    if (transform_ == nullptr) {
+      RCLCPP_ERROR_THROTTLE(
+        get_logger(), *get_clock(), 5000, "getTransform failed. radar output will be empty.");
       return tracked_objects;
     }
     tf2::doTransform(radar_pose_stamped, transformed_pose_stamped, *transform_);


### PR DESCRIPTION
## Description
Add null check for `transform_` in `radar_tracks_msgs_converter_node.cpp`. 
This prevents node crashes when the radar transformation is unavailable.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested with logging_simulator.launch

## Effects on system behavior

No effects.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
