### PR TITLE
fix(lane_change): stop point activated too early

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -1288,13 +1288,13 @@ bool NormalLaneChange::getLaneChangePaths(
           lane_changing_length, forward_path_length, resample_interval, is_goal_in_route,
           next_lane_change_buffer);
 
-        lane_change_info.shift_line = utils::lane_change::getLaneChangingShiftLine(
-          prepare_segment, target_segment, target_lane_reference_path, shift_length);
-
         if (target_lane_reference_path.points.empty()) {
           debug_print("Reject: target_lane_reference_path is empty!!");
           continue;
         }
+
+        lane_change_info.shift_line = utils::lane_change::getLaneChangingShiftLine(
+          prepare_segment, target_segment, target_lane_reference_path, shift_length);
 
         const auto candidate_path = utils::lane_change::constructCandidatePath(
           lane_change_info, prepare_segment, target_segment, target_lane_reference_path,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -220,7 +220,19 @@ void NormalLaneChange::insertStopPoint(
   const double stop_point_buffer = getCommonParam().backward_length_buffer_for_end_of_lane;
   const auto target_objects = getTargetObjects(status_.current_lanes, status_.target_lanes);
   double stopping_distance = distance_to_terminal - lane_change_buffer - stop_point_buffer;
+  const auto lc_start_point = lanelet::utils::conversion::toLaneletPoint(
+    status_.lane_change_path.info.lane_changing_start.position);
 
+  const auto target_neighbor_preferred_lane_poly_2d =
+    utils::lane_change::getTargetNeighborLanesPolygon(*route_handler, status_.current_lanes, type_);
+  const auto is_valid_start_point = boost::geometry::covered_by(
+    lanelet::traits::to2D(lc_start_point), target_neighbor_preferred_lane_poly_2d);
+  if (!is_valid_start_point) {
+    const auto stop_point = utils::insertStopPoint(stopping_distance, path);
+    setStopPose(stop_point.point.pose);
+
+    return;
+  }
   // calculate minimum distance from path front to the stationary object on the ego lane.
   const auto distance_to_ego_lane_obj = [&]() -> double {
     double distance_to_obj = distance_to_terminal;
@@ -640,7 +652,8 @@ double NormalLaneChange::calcMaximumLaneChangeLength(
   const auto shift_intervals =
     getRouteHandler()->getLateralIntervalsToPreferredLane(current_terminal_lanelet);
   return utils::lane_change::calcMaximumLaneChangeLength(
-    getEgoVelocity(), getCommonParam(), shift_intervals, max_acc);
+    std::max(getCommonParam().minimum_lane_changing_velocity, getEgoVelocity()), getCommonParam(),
+    shift_intervals, max_acc);
 }
 
 std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
@@ -1242,6 +1255,20 @@ bool NormalLaneChange::getLaneChangePaths(
           boost::geometry::covered_by(lc_start_point, target_neighbor_preferred_lane_poly_2d) ||
           boost::geometry::covered_by(lc_start_point, target_lane_poly_2d);
 
+        LaneChangeInfo lane_change_info;
+        lane_change_info.longitudinal_acceleration =
+          LaneChangePhaseInfo{longitudinal_acc_on_prepare, longitudinal_acc_on_lane_changing};
+        lane_change_info.duration = LaneChangePhaseInfo{prepare_duration, lane_changing_time};
+        lane_change_info.velocity =
+          LaneChangePhaseInfo{prepare_velocity, initial_lane_changing_velocity};
+        lane_change_info.length = LaneChangePhaseInfo{prepare_length, lane_changing_length};
+        lane_change_info.current_lanes = current_lanes;
+        lane_change_info.target_lanes = target_lanes;
+        lane_change_info.lane_changing_start = prepare_segment.points.back().point.pose;
+        lane_change_info.lane_changing_end = target_segment.points.front().point.pose;
+        lane_change_info.lateral_acceleration = lateral_acc;
+        lane_change_info.terminal_lane_changing_velocity = terminal_lane_changing_velocity;
+
         if (!is_valid_start_point) {
           debug_print(
             "Reject: lane changing points are not inside of the target preferred lanes or its "
@@ -1256,26 +1283,13 @@ bool NormalLaneChange::getLaneChangePaths(
           lane_changing_length, forward_path_length, resample_interval, is_goal_in_route,
           next_lane_change_buffer);
 
+        lane_change_info.shift_line = utils::lane_change::getLaneChangingShiftLine(
+          prepare_segment, target_segment, target_lane_reference_path, shift_length);
+
         if (target_lane_reference_path.points.empty()) {
           debug_print("Reject: target_lane_reference_path is empty!!");
           continue;
         }
-
-        LaneChangeInfo lane_change_info;
-        lane_change_info.longitudinal_acceleration =
-          LaneChangePhaseInfo{longitudinal_acc_on_prepare, longitudinal_acc_on_lane_changing};
-        lane_change_info.duration = LaneChangePhaseInfo{prepare_duration, lane_changing_time};
-        lane_change_info.velocity =
-          LaneChangePhaseInfo{prepare_velocity, initial_lane_changing_velocity};
-        lane_change_info.length = LaneChangePhaseInfo{prepare_length, lane_changing_length};
-        lane_change_info.current_lanes = current_lanes;
-        lane_change_info.target_lanes = target_lanes;
-        lane_change_info.lane_changing_start = prepare_segment.points.back().point.pose;
-        lane_change_info.lane_changing_end = target_segment.points.front().point.pose;
-        lane_change_info.shift_line = utils::lane_change::getLaneChangingShiftLine(
-          prepare_segment, target_segment, target_lane_reference_path, shift_length);
-        lane_change_info.lateral_acceleration = lateral_acc;
-        lane_change_info.terminal_lane_changing_velocity = terminal_lane_changing_velocity;
 
         const auto candidate_path = utils::lane_change::constructCandidatePath(
           lane_change_info, prepare_segment, target_segment, target_lane_reference_path,


### PR DESCRIPTION
## Description

![image](https://github.com/autowarefoundation/autoware.universe/assets/93502286/1906ecc8-28c7-45d2-88e4-a9528a0f2ee0)

Lane change module checks for preferred lane within `forward_lane_length` (for the sake of example, 300 m) from ego vehicle's current position. When preferred lane is found, lane change module will be activated. Then lane change path is computed and if the actual lane changeable lanes is far away, no lane change path will be  generated.

<p align="center">
<img src="https://github.com/autowarefoundation/autoware.universe/assets/93502286/c7d28ea8-e44a-4a3e-93f8-7253780f4910" width="450">
</p>

However, despite no valid path, `insertStopPose` for `stuck` detection will still be activated and the lane change stop wall appear, despite the actual lane change start point is still far away.

<p align="center">
<img src="https://github.com/autowarefoundation/autoware.universe/assets/93502286/e9be78aa-971c-4447-8157-82f6cf9aede3" width="450">
</p>

### THIS PR

When generate for lane change path validity, the lane change start poses are computed and saved in the `status_.lane_Change_path.lane_change_info`. In this PR, the lane change start pose is reuse in the `insertStopPoint` to check the path validity, and  if the path is not valid, the `stuck` detection is not triggered.

<p align="center">
<img src="https://github.com/autowarefoundation/autoware.universe/assets/93502286/b20daac6-a882-404a-9803-fee8b688aee3" width="450">
</p>


## Related links

None

## Tests performed

[1666/1667](https://evaluation.tier4.jp/evaluation/reports/c051fcfd-71f9-5fa8-b3db-960d5e88b5e8?project_id=prd_jt)

## Notes for reviewers

None

## Interface changes

None
## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
