### PR TITLE
fix(motion_utils): fix build error

### DIFF
--- a/common/motion_utils/include/motion_utils/vehicle/vehicle_state_checker.hpp
+++ b/common/motion_utils/include/motion_utils/vehicle/vehicle_state_checker.hpp
@@ -55,11 +55,11 @@ public:
 
 protected:
   rclcpp::Subscription<Odometry>::SharedPtr sub_odom_;
-  Odometry::SharedPtr odometry_ptr_;
+  Odometry::ConstSharedPtr odometry_ptr_;
 
 private:
   static constexpr double velocity_buffer_time_sec = 10.0;
-  void onOdom(const Odometry::SharedPtr msg);
+  void onOdom(const Odometry::ConstSharedPtr msg);
 };
 
 class VehicleArrivalChecker : public VehicleStopChecker
@@ -74,9 +74,9 @@ private:
 
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
 
-  Trajectory::SharedPtr trajectory_ptr_;
+  Trajectory::ConstSharedPtr trajectory_ptr_;
 
-  void onTrajectory(const Trajectory::SharedPtr msg);
+  void onTrajectory(const Trajectory::ConstSharedPtr msg);
 };
 }  // namespace motion_utils
 

--- a/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
@@ -88,7 +88,7 @@ VehicleStopChecker::VehicleStopChecker(rclcpp::Node * node)
     std::bind(&VehicleStopChecker::onOdom, this, _1));
 }
 
-void VehicleStopChecker::onOdom(const Odometry::SharedPtr msg)
+void VehicleStopChecker::onOdom(const Odometry::ConstSharedPtr msg)
 {
   odometry_ptr_ = msg;
 
@@ -128,7 +128,7 @@ bool VehicleArrivalChecker::isVehicleStoppedAtStopPoint(const double stop_durati
          th_arrived_distance_m;
 }
 
-void VehicleArrivalChecker::onTrajectory(const Trajectory::SharedPtr msg)
+void VehicleArrivalChecker::onTrajectory(const Trajectory::ConstSharedPtr msg)
 {
   trajectory_ptr_ = msg;
 }


### PR DESCRIPTION
## Description

Fix following build error

```
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp: In instantiation of ‘rclcpp::AnySubscriptionCallback<MessageT, AllocatorT> rclcpp::AnySubscriptionCallback<MessageT, AllocatorT>::set(CallbackT) [with CallbackT = std::_Bind<void (motion_utils::VehicleStopChecker::*(motion_utils::VehicleStopChecker*, std::_Placeholder<1>))(std::shared_ptr<nav_msgs::msg::Odometry_<std::allocator<void> > >)>; MessageT = nav_msgs::msg::Odometry_<std::allocator<void> >; AllocatorT = std::allocator<void>]’:
/opt/ros/humble/include/rclcpp/rclcpp/subscription_factory.hpp:94:32:   required from ‘rclcpp::SubscriptionFactory rclcpp::create_subscription_factory(CallbackT&&, const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&, typename MessageMemoryStrategyT::SharedPtr, std::shared_ptr<rclcpp::topic_statistics::SubscriptionTopicStatistics<ROSMessageType> >) [with MessageT = nav_msgs::msg::Odometry_<std::allocator<void> >; CallbackT = std::_Bind<void (motion_utils::VehicleStopChecker::*(motion_utils::VehicleStopChecker*, std::_Placeholder<1>))(std::shared_ptr<nav_msgs::msg::Odometry_<std::allocator<void> > >)>; AllocatorT = std::allocator<void>; SubscriptionT = rclcpp::Subscription<nav_msgs::msg::Odometry_<std::allocator<void> > >; MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> >; ROSMessageType = nav_msgs::msg::Odometry_<std::allocator<void> >; typename MessageMemoryStrategyT::SharedPtr = std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> > >]’
/opt/ros/humble/include/rclcpp/rclcpp/create_subscription.hpp:122:63:   required from ‘std::shared_ptr<ROSMessageT> rclcpp::detail::create_subscription(NodeParametersT&, NodeTopicsT&, const string&, const rclcpp::QoS&, CallbackT&&, const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&, typename MessageMemoryStrategyT::SharedPtr) [with MessageT = nav_msgs::msg::Odometry_<std::allocator<void> >; CallbackT = std::_Bind<void (motion_utils::VehicleStopChecker::*(motion_utils::VehicleStopChecker*, std::_Placeholder<1>))(std::shared_ptr<nav_msgs::msg::Odometry_<std::allocator<void> > >)>; AllocatorT = std::allocator<void>; SubscriptionT = rclcpp::Subscription<nav_msgs::msg::Odometry_<std::allocator<void> > >; MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> >; NodeParametersT = rclcpp::Node; NodeTopicsT = rclcpp::Node; ROSMessageType = nav_msgs::msg::Odometry_<std::allocator<void> >; std::string = std::__cxx11::basic_string<char>; typename MessageMemoryStrategyT::SharedPtr = std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> > >]’
/opt/ros/humble/include/rclcpp/rclcpp/create_subscription.hpp:191:76:   required from ‘std::shared_ptr<ROSMessageT> rclcpp::create_subscription(NodeT&, const string&, const rclcpp::QoS&, CallbackT&&, const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&, typename MessageMemoryStrategyT::SharedPtr) [with MessageT = nav_msgs::msg::Odometry_<std::allocator<void> >; CallbackT = std::_Bind<void (motion_utils::VehicleStopChecker::*(motion_utils::VehicleStopChecker*, std::_Placeholder<1>))(std::shared_ptr<nav_msgs::msg::Odometry_<std::allocator<void> > >)>; AllocatorT = std::allocator<void>; SubscriptionT = rclcpp::Subscription<nav_msgs::msg::Odometry_<std::allocator<void> > >; MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> >; NodeT = rclcpp::Node; std::string = std::__cxx11::basic_string<char>; typename MessageMemoryStrategyT::SharedPtr = std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> > >]’
/opt/ros/humble/include/rclcpp/rclcpp/node_impl.hpp:99:47:   required from ‘std::shared_ptr<ROSMessageT> rclcpp::Node::create_subscription(const string&, const rclcpp::QoS&, CallbackT&&, const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&, typename MessageMemoryStrategyT::SharedPtr) [with MessageT = nav_msgs::msg::Odometry_<std::allocator<void> >; CallbackT = std::_Bind<void (motion_utils::VehicleStopChecker::*(motion_utils::VehicleStopChecker*, std::_Placeholder<1>))(std::shared_ptr<nav_msgs::msg::Odometry_<std::allocator<void> > >)>; AllocatorT = std::allocator<void>; SubscriptionT = rclcpp::Subscription<nav_msgs::msg::Odometry_<std::allocator<void> > >; MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> >; std::string = std::__cxx11::basic_string<char>; typename MessageMemoryStrategyT::SharedPtr = std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<nav_msgs::msg::Odometry_<std::allocator<void> >, std::allocator<void> > >]’
/home/planning-control-test/pilot-auto.release-0.15.0/src/autoware/universe/common/motion_utils/src/vehicle/vehicle_state_checker.cpp:86:50:   required from here
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:391:21: error: ‘void rclcpp::AnySubscriptionCallback<MessageT, AllocatorT>::set_deprecated(std::function<void(std::shared_ptr<_Yp>)>) [with SetT = nav_msgs::msg::Odometry_<std::allocator<void> >; MessageT = nav_msgs::msg::Odometry_<std::allocator<void> >; AllocatorT = std::allocator<void>]’ is deprecated: use 'void(std::shared_ptr<const MessageT>)' instead [-Werror=deprecated-declarations]
  391 |       set_deprecated(static_cast<typename scbth::callback_type>(callback));
      |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:408:3: note: declared here
  408 |   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
      |   ^~~~~~~~~~~~~~
```
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
