### PR TITLE
fix(goal_planner): visualize stop wall

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
@@ -104,6 +104,8 @@ PathWithLaneId calcCenterLinePath(
   const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
 
 PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
+
+boost::optional<Pose> getFirstStopPoseFromPath(const PathWithLaneId & path);
 }  // namespace behavior_path_planner::utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__PATH_UTILS_HPP_

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -761,6 +761,7 @@ void GoalPlannerModule::setStopPath(BehaviorModuleOutput & output)
   } else {
     // not_safe -> not_safe: use previous stop path
     output.path = status_.get_prev_stop_path();
+    stop_pose_ = utils::getFirstStopPoseFromPath(*output.path);
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 5000, "Not found safe pull_over path, use previous stop path");
   }
@@ -790,6 +791,7 @@ void GoalPlannerModule::setStopPathFromCurrentPath(BehaviorModuleOutput & output
   } else {
     // not_safe safe(no feasible stop path found) -> not_safe: use previous stop path
     output.path = status_.get_prev_stop_path_after_approval();
+    stop_pose_ = utils::getFirstStopPoseFromPath(*output.path);
     RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "Collision detected, use previous stop path");
   }
   output.reference_path = getPreviousModuleOutput().reference_path;

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -580,4 +580,13 @@ PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & 
   return filtered_path;
 }
 
+boost::optional<Pose> getFirstStopPoseFromPath(const PathWithLaneId & path)
+{
+  for (const auto & p : path.points) {
+    if (std::abs(p.point.longitudinal_velocity_mps) < 0.01) {
+      return p.point.pose;
+    }
+  }
+  return boost::none;
+}
 }  // namespace behavior_path_planner::utils


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`stop_pose_` is removed in manager every loop, so need to set every loop.


after

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/cce92fab-b7fd-48b7-ba23-ad92cd79f6c5)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
