### PR TITLE
refactor(perception_rviz_plugin): apply thread pool to manage detached thread

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -52,7 +52,7 @@ public:
       std::unique_lock<std::mutex> lock(queue_mutex);
       should_terminate = true;
     }
-    mutex_condition.notify_all();
+    condition.notify_all();
     for (std::thread & active_thread : threads) {
       active_thread.join();
     }
@@ -66,9 +66,9 @@ private:
   {
     {
       std::unique_lock<std::mutex> lock(queue_mutex);
-      jobs.push(job);
+      jobs.push(std::move(job));
     }
-    mutex_condition.notify_one();
+    condition.notify_one();
   }
 
   boost::uuids::uuid to_boost_uuid(const unique_identifier_msgs::msg::UUID & uuid_msg)
@@ -137,7 +137,6 @@ private:
 
   bool should_terminate{false};
   std::mutex queue_mutex;
-  std::condition_variable mutex_condition;
   std::vector<std::thread> threads;
   std::queue<std::function<void()>> jobs;
 

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -58,8 +58,6 @@ public:
     }
     threads.clear();
 
-    ObjectPolygonDisplayBase<autoware_auto_perception_msgs::msg::PredictedObjects>::
-      ~ObjectPolygonDisplayBase<autoware_auto_perception_msgs::msg::PredictedObjects>();
   }
 
 private:

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -62,7 +62,7 @@ public:
 private:
   void processMessage(PredictedObjects::ConstSharedPtr msg) override;
 
-  void queueJob(std::function<void()>  job)
+  void queueJob(std::function<void()> job)
   {
     {
       std::unique_lock<std::mutex> lock(queue_mutex);

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -63,7 +63,7 @@ public:
 private:
   void processMessage(PredictedObjects::ConstSharedPtr msg) override;
 
-  void queueJob(std::function<void()> & job)
+  void queueJob(std::function<void()>  job)
   {
     {
       std::unique_lock<std::mutex> lock(queue_mutex);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -38,7 +38,7 @@ void PredictedObjectsDisplay::workerThread()
     std::function<void()> job;
     {
       std::unique_lock<std::mutex> lock(queue_mutex);
-      mutex_condition.wait(lock, [this] { return !jobs.empty() || should_terminate; });
+      condition.wait(lock, [this] { return !jobs.empty() || should_terminate; });
       if (should_terminate) {
         return;
       }

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -25,7 +25,7 @@ namespace object_detection
 {
 PredictedObjectsDisplay::PredictedObjectsDisplay() : ObjectPolygonDisplayBase("tracks")
 {
-  max_num_threads = 1;            // hard code the number of threads to be created
+  max_num_threads = 1;  // hard code the number of threads to be created
 
   for (int ii = 0; ii < max_num_threads; ++ii) {
     threads.emplace_back(std::thread(&PredictedObjectsDisplay::workerThread, this));

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -25,27 +25,44 @@ namespace object_detection
 {
 PredictedObjectsDisplay::PredictedObjectsDisplay() : ObjectPolygonDisplayBase("tracks")
 {
-  std::thread worker(&PredictedObjectsDisplay::workerThread, this);
-  worker.detach();
+  max_num_threads = 1;            // hard code the number of threads to be created
+
+  for (int ii = 0; ii < max_num_threads; ++ii) {
+    threads.emplace_back(std::thread(&PredictedObjectsDisplay::workerThread, this));
+  }
 }
 
 void PredictedObjectsDisplay::workerThread()
-{
+{  // A standard working thread that waiting for jobs
   while (true) {
-    std::unique_lock<std::mutex> lock(mutex);
-    condition.wait(lock, [this] { return this->msg; });
-
-    auto tmp_msg = this->msg;
-    this->msg.reset();
-
-    lock.unlock();
-
-    auto tmp_markers = createMarkers(tmp_msg);
-    lock.lock();
-    markers = tmp_markers;
-
-    consumed = true;
+    std::function<void()> job;
+    {
+      std::unique_lock<std::mutex> lock(queue_mutex);
+      mutex_condition.wait(lock, [this] { return !jobs.empty() || should_terminate; });
+      if (should_terminate) {
+        return;
+      }
+      job = jobs.front();
+      jobs.pop();
+    }
+    job();
   }
+}
+
+void PredictedObjectsDisplay::messageProcessorThreadJob()
+{
+  // Receiving
+  std::unique_lock<std::mutex> lock(mutex);
+  auto tmp_msg = this->msg;
+  this->msg.reset();
+  lock.unlock();
+
+  auto tmp_markers = createMarkers(tmp_msg);
+
+  lock.lock();
+  markers = tmp_markers;
+
+  consumed = true;
 }
 
 std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay::createMarkers(
@@ -188,7 +205,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
   std::unique_lock<std::mutex> lock(mutex);
 
   this->msg = msg;
-  condition.notify_one();
+  std::function<void()> f = std::bind(&PredictedObjectsDisplay::messageProcessorThreadJob, this);
+  queueJob(f);
 }
 
 void PredictedObjectsDisplay::update(float wall_dt, float ros_dt)

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -205,8 +205,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
   std::unique_lock<std::mutex> lock(mutex);
 
   this->msg = msg;
-  std::function<void()> f = std::bind(&PredictedObjectsDisplay::messageProcessorThreadJob, this);
-  queueJob(f);
+  queueJob(std::bind(&PredictedObjectsDisplay::messageProcessorThreadJob, this));
 }
 
 void PredictedObjectsDisplay::update(float wall_dt, float ros_dt)


### PR DESCRIPTION
## Description

The detached thread leads to memory leaks. In this PR, we propose to adopt the design of a thread pool to manage the life cycles of long-living threads.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/4847

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

LSim

Before PR:　https://drive.google.com/file/d/1OzgCEWhhepYm1PbKY0ogy4z6MXJC5i50/view?usp=drive_link
after PR: https://drive.google.com/file/d/1WN9DCvgnPr--Lw1S8F4WvshYvlxrMXPp/view?usp=drive_link

## Notes for reviewers

https://github.com/autowarefoundation/autoware.universe/pull/4847

This PR discusses the threading usage in this plugin. After a detailed review there, we determined to pick out the thread pool codes to fix the memory leak problem, which is a higher priority. The code also enables the probability of using more threads in the future.

## Interface changes

NA

## Effects on system behavior

This PR should minimize memory leaks in this plugin.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: The `PredictedObjectsDisplay` class in the `autoware_auto_perception_rviz_plugin` has been modified to introduce a thread pool design for managing long-living threads. This improves thread management and fixes memory leaks.
- New Feature: A new private member variable `max_num_threads` has been added to specify the maximum number of threads in the thread pool, allowing users to control the concurrency level.
- Bug Fix: The destructor of the `PredictedObjectsDisplay` class has been updated to properly handle the termination of threads and clear the thread pool, preventing potential resource leaks.
- Performance: The code now creates multiple threads based on the value of `max_num_threads`, improving the processing speed of jobs in the thread pool.
- Documentation: The changes aim to improve the overall documentation and understanding of the `PredictedObjectsDisplay` class and its thread management.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->