### PR TITLE
build(tracking_object_merger): remove no longer needed nlohmann_json dependency

### DIFF
--- a/perception/tracking_object_merger/CMakeLists.txt
+++ b/perception/tracking_object_merger/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
-find_package(nlohmann_json REQUIRED) # for debug
 
 
 # find dependencies
@@ -36,7 +35,6 @@ ament_auto_add_library(decorative_tracker_merger_node SHARED
 target_link_libraries(decorative_tracker_merger_node
   mu_successive_shortest_path
   Eigen3::Eigen
-  nlohmann_json::nlohmann_json # for debug
 )
 
 rclcpp_components_register_node(decorative_tracker_merger_node

--- a/perception/tracking_object_merger/include/tracking_object_merger/data_association/data_association.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/data_association/data_association.hpp
@@ -19,8 +19,6 @@
 #ifndef TRACKING_OBJECT_MERGER__DATA_ASSOCIATION__DATA_ASSOCIATION_HPP_
 #define TRACKING_OBJECT_MERGER__DATA_ASSOCIATION__DATA_ASSOCIATION_HPP_
 
-// #include <nlohmann/json.hpp>  // for debug json library
-
 #include <list>
 #include <memory>
 #include <unordered_map>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Remove use of `nlohmann_json`, it's no longer used and it being in `CMakeLists.txt` is causing the Debian build fail (see https://github.com/autowarefoundation/autoware-deb-packages/actions/runs/6639929281/job/18039381566?pr=41)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
