### PR TITLE
fix(system_monitor): output command line

### DIFF
--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -94,7 +94,7 @@ protected:
    * @param [out] command output command line
    * @return true if success to get command line name
    */
-  bool getCommandLineFromPiD(const std::string & pid, std::string * command);
+  bool getCommandLineFromPiD(const std::string & pid, std::string & command);
 
   /**
    * @brief get top-rated processes

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -414,14 +414,18 @@ void ProcessMonitor::getHighMemoryProcesses(const std::string & output)
   getTopratedProcesses(&memory_tasks_, &p2);
 }
 
-bool ProcessMonitor::getCommandLineFromPiD(const std::string & pid, std::string * command)
+bool ProcessMonitor::getCommandLineFromPiD(const std::string & pid, std::string & command)
 {
   std::string commandLineFilePath = "/proc/" + pid + "/cmdline";
-  std::ifstream commandFile(commandLineFilePath);
+  std::ifstream commandFile(commandLineFilePath, std::ios::in | std::ios::binary);
+
   if (commandFile.is_open()) {
-    std::getline(commandFile, *command);
+    std::vector<uint8_t> buffer;
+    std::copy(std::istream_iterator<uint8_t>(commandFile), std::istream_iterator<uint8_t>(), std::back_inserter(buffer));
     commandFile.close();
-    return true;
+    std::replace(buffer.begin(), buffer.end(), '\0', ' ');  // 0x00 is used as delimiter in /cmdline instead of 0x20 (space)
+    command = std::string(buffer.begin(), buffer.end());
+    return (buffer.size() > 0) ? true : false;  // cmdline is empty if it is kernel process
   } else {
     return false;
   }
@@ -478,7 +482,7 @@ void ProcessMonitor::getTopratedProcesses(
     std::string program_name;
     std::getline(stream, program_name);
 
-    bool flag_find_command_line = getCommandLineFromPiD(info.processId, &info.commandName);
+    bool flag_find_command_line = getCommandLineFromPiD(info.processId, info.commandName);
 
     if (!flag_find_command_line) {
       info.commandName = program_name;  // if command line is not found, use program name instead

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -421,9 +421,13 @@ bool ProcessMonitor::getCommandLineFromPiD(const std::string & pid, std::string 
 
   if (commandFile.is_open()) {
     std::vector<uint8_t> buffer;
-    std::copy(std::istream_iterator<uint8_t>(commandFile), std::istream_iterator<uint8_t>(), std::back_inserter(buffer));
+    std::copy(
+      std::istream_iterator<uint8_t>(commandFile), std::istream_iterator<uint8_t>(),
+      std::back_inserter(buffer));
     commandFile.close();
-    std::replace(buffer.begin(), buffer.end(), '\0', ' ');  // 0x00 is used as delimiter in /cmdline instead of 0x20 (space)
+    std::replace(
+      buffer.begin(), buffer.end(), '\0',
+      ' ');  // 0x00 is used as delimiter in /cmdline instead of 0x20 (space)
     command = std::string(buffer.begin(), buffer.end());
     return (buffer.size() > 0) ? true : false;  // cmdline is empty if it is kernel process
   } else {


### PR DESCRIPTION
## Description

- Background
  - #4553 modified process_monitor to output full command string instead of just a command name. However, it doesn't work with some environment and #5191 fixed the issue. However, the current process_monitor still have some issues.
- Issue
  - a. Current process_monitor only outputs a command path (details like parameters are not displayed)
  - b. Displayed command name becomes blank when the process is kernel process
- How this PR fixes the issues
  - For issue a, the cause is that `NUL` (`0x00`) is used as deliminator in `/proc/{PID}/cmdline` instead of `SPACE` (`0x20`). Code in #4553 reads cmdline into string, but when `NUL` appears, it finishes reading and only the first part (command path) is stored. This PR reads cmdline into buffer, then replace `NUL` to `SPACE` and casts it to string
   - For issue b, the cause is that `/proc/{PID}/cmdline` for kernel process is empty. So, when the read cmdline is empty, this PR uses the result of top command

## Related links

[TIER IV INTERNAL LINK TO JIRA](https://tier4.atlassian.net/browse/RT0-29259?filter=11500)

## Tests performed

1. Run Autoware.
2. Run rqt_runtime_monitor.

`ros2 run rqt_runtime_monitor rqt_runtime_monitor`

3. Verify a more detailed COMMAND string is provided.

### Original result

↓ComponentContainer (only command path is displayed)

![Screenshot from 2023-10-27 17-26-09](https://github.com/autowarefoundation/autoware.universe/assets/105265012/75fe58cc-8f97-4bc6-9653-1e1dc1445bcb)

↓Kernel Process (COMMAND is empty)

![Screenshot from 2023-10-27 17-25-57](https://github.com/autowarefoundation/autoware.universe/assets/105265012/9659ad3f-b3c8-4e3d-a28d-2d94113e9fbe)

### Result with this PR

↓ComponentContainer

![Screenshot from 2023-10-27 17-32-34](https://github.com/autowarefoundation/autoware.universe/assets/105265012/7b5e2053-12aa-4082-a7b0-d84453f7a083)

↓Kernel Process

![Screenshot from 2023-10-27 17-32-01](https://github.com/autowarefoundation/autoware.universe/assets/105265012/16c62d2c-0e37-4ba9-b497-65b9d40758dd)



## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.