### PR TITLE
fix(goal_planner): do not generate path candidates before execution

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -146,6 +146,17 @@ void GoalPlannerModule::onTimer()
   if (status_.get_goal_candidates().empty()) {
     return;
   }
+
+  if (!isExecutionRequested()) {
+    return;
+  }
+
+  if (
+    !planner_data_ ||
+    !goal_planner_utils::isAllowedGoalModification(planner_data_->route_handler)) {
+    return;
+  }
+
   const auto goal_candidates = status_.get_goal_candidates();
 
   // generate valid pull over path candidates and calculate closest start pose
@@ -229,6 +240,10 @@ void GoalPlannerModule::onFreespaceParkingTimer()
 
 void GoalPlannerModule::updateData()
 {
+  if (getCurrentStatus() == ModuleStatus::IDLE) {
+    return;
+  }
+
   // Initialize Occupancy Grid Map
   // This operation requires waiting for `planner_data_`, hence it is executed here instead of in
   // the constructor. Ideally, this operation should only need to be performed once.
@@ -990,7 +1005,7 @@ BehaviorModuleOutput GoalPlannerModule::planWaitingApprovalWithGoalModification(
   }
 
   BehaviorModuleOutput out;
-  out.modified_goal = plan().modified_goal;  // update status_
+  out.modified_goal = planWithGoalModification().modified_goal;  // update status_
   out.path = std::make_shared<PathWithLaneId>(generateStopPath());
   out.reference_path = getPreviousModuleOutput().reference_path;
   path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


updateData()  is always called even if before execution is requested.
this starts path generation too. this process in not necessary and may cause bug because too eary.
and fix the long path

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/8909ef1f-3947-44e3-856b-ba97ea2ddaa1)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim.

evaluator_description: fix/pull_over_path_candidate
2023/10/28 https://evaluation.tier4.jp/evaluation/reports/424fc18f-a191-5685-b915-a375c654f96e/?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
