### PR TITLE
feat(map_based_prediciton): use orientation reliability in prediction

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -710,10 +710,7 @@ void replaceObjectYawWithLaneletsYaw(
   tf2::Matrix3x3(original_quaternion).getRPY(roll, pitch, yaw);
   tf2::Quaternion filtered_quaternion;
   filtered_quaternion.setRPY(roll, pitch, mean_yaw_angle);
-  pose_with_cov.pose.orientation.x = filtered_quaternion.x();
-  pose_with_cov.pose.orientation.y = filtered_quaternion.y();
-  pose_with_cov.pose.orientation.z = filtered_quaternion.z();
-  pose_with_cov.pose.orientation.w = filtered_quaternion.w();
+  pose_with_cov.pose.orientation = tf2::toMsg(filtered_quaternion);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- This PR aims to prevent predict path bending by unreliable object yaw estimation such as with radar sensor
- New logic uses `object.kinematics.orientation_availability` to find unreliable yaw input
- Unstable object's yaw is replaced by mean yaw angle of current_lanelets only in the path generation process


See the sample output: 
- Conventional process will generate extremely bent path due to the large lateral velocity
- With this PR, we can get appropriate path because the path generator assumes the object yaw is equal to lane yaw.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/dbc26e99-bf6c-447a-ba88-db3aa426d2b8)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested with Psim.

This is related radar_far_away_perception project. See related [PR](https://github.com/autowarefoundation/autoware_launch/pull/658).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a function `replaceObjectYawWithLaneletsYaw` in the `map_based_prediction_node.cpp` file to improve path prediction accuracy by replacing the yaw angle of objects with the mean yaw angle of the lanelets they are on.
- Bug Fix: Modified the `objectsCallback` function in the `map_based_prediction_node.cpp` file to call `replaceObjectYawWithLaneletsYaw` before generating predicted paths, preventing path bending caused by unreliable object yaw estimation.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->