### PR TITLE
fix(avoidance): add condition to block yield maneuver

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -195,6 +195,8 @@
       # For yield maneuver
       yield:
         yield_velocity: 2.78                            # [m/s]
+        condition:
+          yaw_deviation: 0.087                          # [rad] (default: 5.0deg)
 
       # For stop maneuver
       stop:

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -193,8 +193,9 @@ struct AvoidanceParameters
   size_t hysteresis_factor_safe_count;
   double hysteresis_factor_expand_rate{0.0};
 
-  // keep target velocity in yield maneuver
+  // for yield maneuver
   double yield_velocity{0.0};
+  double yield_condition_yaw_deviation{0.087};
 
   // maximum stop distance
   double stop_max_distance{0.0};

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -418,6 +418,15 @@ bool AvoidanceModule::canYieldManeuver(const AvoidancePlanningData & data) const
 {
   // transit yield maneuver only when the avoidance maneuver is not initiated.
   if (helper_.isShifted()) {
+    RCLCPP_DEBUG(getLogger(), "lateral deviation is bigger than threshold.");
+    return false;
+  }
+
+  const auto idx = planner_data_->findEgoIndex(data.reference_path.points);
+  const auto closest_pose = getPose(data.reference_path.points.at(idx));
+  const auto ego_yaw_deviation = tier4_autoware_utils::calcYawDeviation(getEgoPose(), closest_pose);
+  if (std::abs(ego_yaw_deviation) > parameters_->yield_condition_yaw_deviation) {
+    RCLCPP_DEBUG(getLogger(), "yaw deviation is bigger than threshold.");
     return false;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -230,6 +230,8 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   {
     std::string ns = "avoidance.yield.";
     p.yield_velocity = getOrDeclareParameter<double>(*node, ns + "yield_velocity");
+    p.yield_condition_yaw_deviation =
+      getOrDeclareParameter<double>(*node, ns + "condition.yaw_deviation");
   }
 
   // stop


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7058eec</samp>

This pull request adds a new condition for the yield maneuver in the `behavior_path_planner` package. The condition checks the yaw deviation between the ego vehicle and the reference path and prevents the yield maneuver if the deviation is too large. The condition is configurable through the `condition.yaw_deviation` parameter in the `avoidance.param.yaml` file.

related ticket: https://tier4.atlassian.net/browse/RT0-29637
related PR: https://github.com/autowarefoundation/autoware_launch/pull/664

https://github.com/autowarefoundation/autoware.universe/assets/44889564/fba5fd3e-cf91-4d6f-8319-54f3fc2a0861

---

In order to prevent from sudden path change after avoidance approval, I added yaw deviation threshold, other than lateral deviation.

### Before this PR

Sudden steering will happen even when the vehicle head direction is facing the direction of the avoidance path.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/e1b3eedc-8975-491e-b1cf-a26190cd5ded

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

### Psim

https://github.com/autowarefoundation/autoware.universe/assets/44889564/20fa556e-a2b7-4ed0-8e29-08a2ce7d0f0b

### Reproducer + Rosbag

https://github.com/autowarefoundation/autoware.universe/assets/44889564/130ae6bc-66ab-4de9-8edb-c88bd6896e4b

### Evaluator

- [x] [PASS TIER IV INTERNALS SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/0eb738b7-e51c-57d2-8e73-b4133abaf072?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
