### PR TITLE
refactor(simple_planning_simulator): rework parameters

### DIFF
--- a/simulator/simple_planning_simulator/README.md
+++ b/simulator/simple_planning_simulator/README.md
@@ -40,17 +40,7 @@ The purpose of this simulator is for the integration test of planning and contro
 
 ### Common Parameters
 
-| Name                  | Type   | Description                                                                                                                                | Default value        |
-| :-------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------- | :------------------- |
-| simulated_frame_id    | string | set to the child_frame_id in output tf                                                                                                     | "base_link"          |
-| origin_frame_id       | string | set to the frame_id in output tf                                                                                                           | "odom"               |
-| initialize_source     | string | If "ORIGIN", the initial pose is set at (0,0,0). If "INITIAL_POSE_TOPIC", node will wait until the `input/initialpose` topic is published. | "INITIAL_POSE_TOPIC" |
-| add_measurement_noise | bool   | If true, the Gaussian noise is added to the simulated results.                                                                             | true                 |
-| pos_noise_stddev      | double | Standard deviation for position noise                                                                                                      | 0.01                 |
-| rpy_noise_stddev      | double | Standard deviation for Euler angle noise                                                                                                   | 0.0001               |
-| vel_noise_stddev      | double | Standard deviation for longitudinal velocity noise                                                                                         | 0.0                  |
-| angvel_noise_stddev   | double | Standard deviation for angular velocity noise                                                                                              | 0.0                  |
-| steer_noise_stddev    | double | Standard deviation for steering angle noise                                                                                                | 0.0001               |
+{{ json_to_markdown("simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json") }}
 
 ### Vehicle Model Parameters
 

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -48,9 +48,6 @@ def launch_setup(context, *args, **kwargs):
             vehicle_info_param,
             vehicle_characteristics_param,
             simulator_model_param,
-            {
-                "initial_engage_state": LaunchConfiguration("initial_engage_state"),
-            },
         ],
         remappings=[
             ("input/vector_map", "/map/vector_map"),

--- a/simulator/simple_planning_simulator/param/simple_planning_simulator_default.param.yaml
+++ b/simulator/simple_planning_simulator/param/simple_planning_simulator_default.param.yaml
@@ -4,14 +4,22 @@
     origin_frame_id: "map"
     vehicle_model_type: "DELAY_STEER_ACC_GEARED"
     initialize_source: "INITIAL_POSE_TOPIC"
+    initial_engage_state: True
+    enable_road_slope_simulation: False
     timer_sampling_time_ms: 25
     add_measurement_noise: False
+    pos_noise_stddev: 1e-2
+    vel_noise_stddev: 1e-2
+    rpy_noise_stddev: 1e-4
+    steer_noise_stddev: 1e-4
     vel_lim: 30.0
     vel_rate_lim: 30.0
     steer_lim: 0.6
     steer_rate_lim: 6.28
     acc_time_delay: 0.1
     acc_time_constant: 0.1
+    vel_time_delay: 0.25
+    vel_time_constant: 0.5
     steer_time_delay: 0.1
     steer_time_constant: 0.1
     x_stddev: 0.0001 # x standard deviation for dummy covariance in map coordinate

--- a/simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json
+++ b/simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Parameters for Simple Planning_ Simulator",
+  "title": "Parameters for Simple Planning Simulator Node",
   "type": "object",
   "definitions": {
     "simple_planning_simulator": {
@@ -255,7 +255,8 @@
         "steer_time_delay",
         "steer_time_constant",
         "x_stddev",
-        "y_stddev"
+        "y_stddev",
+        "vehicle_characteristics"
       ]
     }
   },

--- a/simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json
+++ b/simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json
@@ -157,22 +157,77 @@
         "vehicle_characteristics": {
           "type": "object",
           "properties": {
-            "INSERT_PARAMETER_1_NAME": {
-              "type": "INSERT_TYPE",
-              "description": "INSERT_DESCRIPTION",
-              "default": "INSERT_DEFAULT",
-              "INSERT_BOUND_CONDITION(S)": "INSERT_BOUND_VALUE(S)"
+            "cg_to_front_m": {
+              "type": "number",
+              "description": "center of gravity to vehicle front [m]",
+              "default": "1.228",
+              "minimum": 0
             },
-            "INSERT_PARAMETER_N_NAME": {
-              "type": "INSERT_TYPE",
-              "description": "INSERT_DESCRIPTION",
-              "default": "INSERT_DEFAULT",
-              "INSERT_BOUND_CONDITION(S)": "INSERT_BOUND_VALUE(S)"
+            "cg_to_rear_m": {
+              "type": "number",
+              "description": "center of gravity to vehicle rear [m]",
+              "default": "1.5618",
+              "minimum": 0
+            },
+            "front_corner_stiffness": {
+              "type": "number",
+              "description": "stiffness of vehicle front corner",
+              "default": "17000.0",
+              "minimum": 0
+            },
+            "rear_corner_stiffness": {
+              "type": "number",
+              "description": "stiffness of vehicle rear corner",
+              "default": "20000.0",
+              "minimum": 0
+            },
+            "mass_kg": {
+              "type": "number",
+              "description": "vehicle weight [kg]",
+              "default": "1460.0",
+              "minimum": 0
+            },
+            "yaw_inertia_kgm2": {
+              "type": "number",
+              "description": "yaw inertia [kgm2]",
+              "default": "2170.0",
+              "minimum": 0
+            },
+            "width_m": {
+              "type": "number",
+              "description": "vehicle width [m]",
+              "default": "2.0",
+              "minimum": 0
+            },
+            "front_overhang_m": {
+              "type": "number",
+              "description": "front overhang [m]",
+              "default": "0.5",
+              "minimum": 0
+            },
+            "rear_overhang_m": {
+              "type": "number",
+              "description": "rear overhang [m]",
+              "default": "0.5",
+              "minimum": 0
+            },
+            "max_steer_angle": {
+              "type": "number",
+              "description": "max angle of steer [rad]",
+              "default": "0.70"
             }
           },
           "required": [
-            "INSERT_PARAMETER_1_NAME",
-            "INSERT_PARAMETER_N_NAME"
+            "cg_to_front_m",
+            "cg_to_rear_m",
+            "front_corner_stiffness",
+            "rear_corner_stiffness",
+            "mass_kg",
+            "yaw_inertia_kgm2",
+            "width_m",
+            "front_overhang_m",
+            "rear_overhang_m",
+            "max_steer_angle"
           ]
         }
       },

--- a/simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json
+++ b/simulator/simple_planning_simulator/schema/simple_planning_simulator.schema.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Simple Planning_ Simulator",
+  "type": "object",
+  "definitions": {
+    "simple_planning_simulator": {
+      "type": "object",
+      "properties": {
+        "simulated_frame_id": {
+          "type": "string",
+          "description": "set to the child_frame_id in output tf",
+          "default": "base_link"
+        },
+        "origin_frame_id": {
+          "type": "string",
+          "description": "set to the frame_id in output tf",
+          "default": "map"
+        },
+        "vehicle_model_type": {
+          "type": "string",
+          "description": "Vehicle Model Parameters setting.",
+          "default": "DELAY_STEER_ACC_GEARED",
+          "enum": [
+            "IDEAL_STEER_VEL",
+            "IDEAL_STEER_ACC",
+            "IDEAL_STEER_ACC_GEARED",
+            "DELAY_STEER_VEL",
+            "DELAY_STEER_ACC",
+            "DELAY_STEER_ACC_GEARED"
+          ]
+        },
+        "initialize_source": {
+          "type": "string",
+          "description": "If 'ORIGIN', the initial pose is set at (0,0,0). If 'INITIAL_POSE_TOPIC', node will wait until the 'input/initialpose' topic is published.",
+          "default": "INITIAL_POSE_TOPIC",
+          "enum": [
+            "ORIGIN",
+            "INITIAL_POSE_TOPIC"
+          ]
+        },
+        "initial_engage_state": {
+          "type": "boolean",
+          "description": "initial engage state setting",
+          "default": "true"
+        },
+        "enable_road_slope_simulation": {
+          "type": "boolean",
+          "description": "Enable road slope simulation or not.",
+          "default": "false"
+        },
+        "timer_sampling_time_ms": {
+          "type": "integer",
+          "description": "Setting timer for sampling time [ms].",
+          "default": "25",
+          "exclusiveMinimum": 0
+        },
+        "add_measurement_noise": {
+          "type": "boolean",
+          "description": "If true, the Gaussian noise is added to the simulated results.",
+          "default": "false"
+        },
+        "pos_noise_stddev": {
+          "type": "number",
+          "description": "Standard deviation for position noise",
+          "default": "1e-2",
+          "minimum": 0
+        },
+        "vel_noise_stddev": {
+          "type": "number",
+          "description": "Standard deviation for longitudinal velocity noise",
+          "default": "1e-2",
+          "minimum": 0
+        },
+        "rpy_noise_stddev": {
+          "type": "number",
+          "description": "Standard deviation for Euler angle noise",
+          "default": "1e-4",
+          "minimum": 0
+        },
+        "steer_noise_stddev": {
+          "type": "number",
+          "description": "Standard deviation for steering angle noise",
+          "default": "1e-4",
+          "minimum": 0
+        },
+        "vel_lim": {
+          "type": "number",
+          "description": "limit of velocity [m/s]",
+          "default": "30.0",
+          "exclusiveMinimum": 0
+        },
+        "vel_rate_lim": {
+          "type": "number",
+          "description": "limit of velocity change rate [m/ss]",
+          "default": "30.0",
+          "minimum": 0
+        },
+        "steer_lim": {
+          "type": "number",
+          "description": "limit of steering angle [rad]",
+          "default": "0.6"
+        },
+        "steer_rate_lim": {
+          "type": "number",
+          "description": "limit of steering angle change rate [rad/s]",
+          "default": "6.28",
+          "minimum": 0
+        },
+        "acc_time_delay": {
+          "type": "number",
+          "description": "dead time for the acceleration input [s]",
+          "default": "0.1",
+          "minimum": 0
+        },
+        "acc_time_constant": {
+          "type": "number",
+          "description": "time constant of the 1st-order acceleration dynamics [s]",
+          "default": "0.1",
+          "minimum": 0
+        },
+        "vel_time_delay": {
+          "type": "number",
+          "description": "dead time for the velocity input [s]",
+          "default": "0.25",
+          "minimum": 0
+        },
+        "vel_time_constant": {
+          "type": "number",
+          "description": "time constant of the 1st-order velocity dynamics [s]",
+          "default": "0.5",
+          "minimum": 0
+        },
+        "steer_time_delay": {
+          "type": "number",
+          "description": "dead time for the steering input [s]",
+          "default": "0.1",
+          "minimum": 0
+        },
+        "steer_time_constant": {
+          "type": "number",
+          "description": "time constant of the 1st-order steering dynamics [s]",
+          "default": "0.1",
+          "minimum": 0
+        },
+        "x_stddev": {
+          "type": "number",
+          "description": "x standard deviation for dummy covariance in map coordinate",
+          "default": "0.0001",
+          "minimum": 0
+        },
+        "y_stddev": {
+          "type": "number",
+          "description": "y standard deviation for dummy covariance in map coordinate",
+          "default": "0.0001",
+          "minimum": 0
+        },
+        "vehicle_characteristics": {
+          "type": "object",
+          "properties": {
+            "INSERT_PARAMETER_1_NAME": {
+              "type": "INSERT_TYPE",
+              "description": "INSERT_DESCRIPTION",
+              "default": "INSERT_DEFAULT",
+              "INSERT_BOUND_CONDITION(S)": "INSERT_BOUND_VALUE(S)"
+            },
+            "INSERT_PARAMETER_N_NAME": {
+              "type": "INSERT_TYPE",
+              "description": "INSERT_DESCRIPTION",
+              "default": "INSERT_DEFAULT",
+              "INSERT_BOUND_CONDITION(S)": "INSERT_BOUND_VALUE(S)"
+            }
+          },
+          "required": [
+            "INSERT_PARAMETER_1_NAME",
+            "INSERT_PARAMETER_N_NAME"
+          ]
+        }
+      },
+      "required": [
+        "simulated_frame_id",
+        "origin_frame_id",
+        "vehicle_model_type",
+        "initialize_source",
+        "initial_engage_state",
+        "enable_road_slope_simulation",
+        "timer_sampling_time_ms",
+        "add_measurement_noise",
+        "pos_noise_stddev",
+        "vel_noise_stddev",
+        "rpy_noise_stddev",
+        "steer_noise_stddev",
+        "vel_lim",
+        "vel_rate_lim",
+        "steer_lim",
+        "steer_rate_lim",
+        "acc_time_delay",
+        "acc_time_constant",
+        "vel_time_delay",
+        "vel_time_constant",
+        "steer_time_delay",
+        "steer_time_constant",
+        "x_stddev",
+        "y_stddev"
+      ]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/simple_planning_simulator"
+        }
+      },
+      "required": [
+        "ros__parameters"
+      ]
+    }
+  },
+  "required": [
+    "/**"
+  ]
+}

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -98,11 +98,11 @@ namespace simple_planning_simulator
 SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & options)
 : Node("simple_planning_simulator", options), tf_buffer_(get_clock()), tf_listener_(tf_buffer_)
 {
-  simulated_frame_id_ = declare_parameter("simulated_frame_id", "base_link");
-  origin_frame_id_ = declare_parameter("origin_frame_id", "odom");
-  add_measurement_noise_ = declare_parameter("add_measurement_noise", false);
+  simulated_frame_id_ = declare_parameter<std::string>("simulated_frame_id");
+  origin_frame_id_ = declare_parameter<std::string>("origin_frame_id");
+  add_measurement_noise_ = declare_parameter<bool>("add_measurement_noise");
   simulate_motion_ = declare_parameter<bool>("initial_engage_state");
-  enable_road_slope_simulation_ = declare_parameter("enable_road_slope_simulation", false);
+  enable_road_slope_simulation_ = declare_parameter<bool>("enable_road_slope_simulation");
 
   using rclcpp::QoS;
   using std::placeholders::_1;
@@ -165,7 +165,7 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
   set_param_res_ = this->add_on_set_parameters_callback(
     std::bind(&SimplePlanningSimulator::on_parameter, this, _1));
 
-  timer_sampling_time_ms_ = static_cast<uint32_t>(declare_parameter("timer_sampling_time_ms", 25));
+  timer_sampling_time_ms_ = static_cast<uint32_t>(declare_parameter<int>("timer_sampling_time_ms"));
   on_timer_ = rclcpp::create_timer(
     this, get_clock(), std::chrono::milliseconds(timer_sampling_time_ms_),
     std::bind(&SimplePlanningSimulator::on_timer, this));
@@ -180,7 +180,7 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
   initialize_vehicle_model();
 
   // set initialize source
-  const auto initialize_source = declare_parameter("initialize_source", "INITIAL_POSE_TOPIC");
+  const auto initialize_source = declare_parameter<std::string>("initialize_source");
   RCLCPP_INFO(this->get_logger(), "initialize_source : %s", initialize_source.c_str());
   if (initialize_source == "ORIGIN") {
     Pose p;
@@ -195,17 +195,17 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
     std::random_device seed;
     auto & m = measurement_noise_;
     m.rand_engine_ = std::make_shared<std::mt19937>(seed());
-    double pos_noise_stddev = declare_parameter("pos_noise_stddev", 1e-2);
-    double vel_noise_stddev = declare_parameter("vel_noise_stddev", 1e-2);
-    double rpy_noise_stddev = declare_parameter("rpy_noise_stddev", 1e-4);
-    double steer_noise_stddev = declare_parameter("steer_noise_stddev", 1e-4);
+    double pos_noise_stddev = declare_parameter<double>("pos_noise_stddev");
+    double vel_noise_stddev = declare_parameter<double>("vel_noise_stddev");
+    double rpy_noise_stddev = declare_parameter<double>("rpy_noise_stddev");
+    double steer_noise_stddev = declare_parameter<double>("steer_noise_stddev");
     m.pos_dist_ = std::make_shared<std::normal_distribution<>>(0.0, pos_noise_stddev);
     m.vel_dist_ = std::make_shared<std::normal_distribution<>>(0.0, vel_noise_stddev);
     m.rpy_dist_ = std::make_shared<std::normal_distribution<>>(0.0, rpy_noise_stddev);
     m.steer_dist_ = std::make_shared<std::normal_distribution<>>(0.0, steer_noise_stddev);
 
-    x_stddev_ = declare_parameter("x_stddev", 0.0001);
-    y_stddev_ = declare_parameter("y_stddev", 0.0001);
+    x_stddev_ = declare_parameter<double>("x_stddev");
+    y_stddev_ = declare_parameter<double>("y_stddev");
   }
 
   // control mode
@@ -215,20 +215,20 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
 
 void SimplePlanningSimulator::initialize_vehicle_model()
 {
-  const auto vehicle_model_type_str = declare_parameter("vehicle_model_type", "IDEAL_STEER_VEL");
+  const auto vehicle_model_type_str = declare_parameter<std::string>("vehicle_model_type");
 
   RCLCPP_INFO(this->get_logger(), "vehicle_model_type = %s", vehicle_model_type_str.c_str());
 
-  const double vel_lim = declare_parameter("vel_lim", 50.0);
-  const double vel_rate_lim = declare_parameter("vel_rate_lim", 7.0);
-  const double steer_lim = declare_parameter("steer_lim", 1.0);
-  const double steer_rate_lim = declare_parameter("steer_rate_lim", 5.0);
-  const double acc_time_delay = declare_parameter("acc_time_delay", 0.1);
-  const double acc_time_constant = declare_parameter("acc_time_constant", 0.1);
-  const double vel_time_delay = declare_parameter("vel_time_delay", 0.25);
-  const double vel_time_constant = declare_parameter("vel_time_constant", 0.5);
-  const double steer_time_delay = declare_parameter("steer_time_delay", 0.24);
-  const double steer_time_constant = declare_parameter("steer_time_constant", 0.27);
+  const double vel_lim = declare_parameter<double>("vel_lim");
+  const double vel_rate_lim = declare_parameter<double>("vel_rate_lim");
+  const double steer_lim = declare_parameter<double>("steer_lim");
+  const double steer_rate_lim = declare_parameter<double>("steer_rate_lim");
+  const double acc_time_delay = declare_parameter<double>("acc_time_delay");
+  const double acc_time_constant = declare_parameter<double>("acc_time_constant");
+  const double vel_time_delay = declare_parameter<double>("vel_time_delay");
+  const double vel_time_constant = declare_parameter<double>("vel_time_constant");
+  const double steer_time_delay = declare_parameter<double>("steer_time_delay");
+  const double steer_time_constant = declare_parameter<double>("steer_time_constant");
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
   const double wheelbase = vehicle_info.wheel_base_m;
 


### PR DESCRIPTION
## Description
Implement the ROS Node configuration layout described in https://github.com/orgs/autowarefoundation/discussions/3371 for the `simple_planning_simulator` package.

- Remove the default value from the source code in order to ensure all parameter values are passed from the parameter files.
- Create the schema

## Tests performed
Package built and launch locally.
`colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to simple_planning_simulator`

## Effects on system behavior
More reliable and faster parameter configuration file creation.

## Pre-review checklist for the PR author
The PR author **must** check the checkboxes below when creating the PR.
- [x] I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [x] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

## In-review checklist for the PR reviewers
The PR reviewers **must** check the checkboxes below before approval.
- [ ] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author
The PR author **must** check the checkboxes below before merging.
- [x] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
