### PR TITLE
fix(simple_planning_simulator): initialize variables

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -171,36 +171,36 @@ private:
   tf2_ros::TransformListener tf_listener_;
 
   /* received & published topics */
-  PoseWithCovarianceStamped::ConstSharedPtr initial_pose_;
-  TwistStamped initial_twist_;
-  VelocityReport current_velocity_;
-  Odometry current_odometry_;
-  SteeringReport current_steer_;
-  AckermannControlCommand current_ackermann_cmd_;
-  AckermannControlCommand current_manual_ackermann_cmd_;
-  GearCommand current_gear_cmd_;
-  GearCommand current_manual_gear_cmd_;
-  TurnIndicatorsCommand::ConstSharedPtr current_turn_indicators_cmd_ptr_;
-  HazardLightsCommand::ConstSharedPtr current_hazard_lights_cmd_ptr_;
-  Trajectory::ConstSharedPtr current_trajectory_ptr_;
-  bool simulate_motion_;  //!< stop vehicle motion simulation if false
-  ControlModeReport current_control_mode_;
-  bool enable_road_slope_simulation_;
+  PoseWithCovarianceStamped::ConstSharedPtr initial_pose_{};
+  TwistStamped initial_twist_{};
+  VelocityReport current_velocity_{};
+  Odometry current_odometry_{};
+  SteeringReport current_steer_{};
+  AckermannControlCommand current_ackermann_cmd_{};
+  AckermannControlCommand current_manual_ackermann_cmd_{};
+  GearCommand current_gear_cmd_{};
+  GearCommand current_manual_gear_cmd_{};
+  TurnIndicatorsCommand::ConstSharedPtr current_turn_indicators_cmd_ptr_{};
+  HazardLightsCommand::ConstSharedPtr current_hazard_lights_cmd_ptr_{};
+  Trajectory::ConstSharedPtr current_trajectory_ptr_{};
+  bool simulate_motion_ = true;  //!< stop vehicle motion simulation if false
+  ControlModeReport current_control_mode_{};
+  bool enable_road_slope_simulation_ = true;
 
   /* frame_id */
-  std::string simulated_frame_id_;  //!< @brief simulated vehicle frame id
-  std::string origin_frame_id_;     //!< @brief map frame_id
+  std::string simulated_frame_id_ = "";  //!< @brief simulated vehicle frame id
+  std::string origin_frame_id_ = "";     //!< @brief map frame_id
 
   /* flags */
-  bool is_initialized_;         //!< @brief flag to check the initial position is set
-  bool add_measurement_noise_;  //!< @brief flag to add measurement noise
+  bool is_initialized_ = false;         //!< @brief flag to check the initial position is set
+  bool add_measurement_noise_ = false;  //!< @brief flag to add measurement noise
 
-  DeltaTime delta_time_;  //!< @brief to calculate delta time
+  DeltaTime delta_time_{};  //!< @brief to calculate delta time
 
-  MeasurementNoiseGenerator measurement_noise_;  //!< @brief for measurement noise
+  MeasurementNoiseGenerator measurement_noise_{};  //!< @brief for measurement noise
 
-  double x_stddev_;  //!< @brief x standard deviation for dummy covariance in map coordinate
-  double y_stddev_;  //!< @brief y standard deviation for dummy covariance in map coordinate
+  double x_stddev_ = 0.0;  //!< @brief x standard deviation for dummy covariance in map coordinate
+  double y_stddev_ = 0.0;  //!< @brief y standard deviation for dummy covariance in map coordinate
 
   /* vehicle model */
   enum class VehicleModelType {


### PR DESCRIPTION
## Description

Initialize simulator variables, otherwise for example `is_initialized_` is not initialized correctly causing unexpected behavior.

In my case, ego pose is published before initialization since `is_initialized_` is initialized with a broken value.

## Tests performed

run psim

## Effects on system behavior

ego pose will not be published before initialization

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
