### PR TITLE
fix(planning_validator): not publish diag before data is ready

### DIFF
--- a/planning/planning_validator/include/planning_validator/planning_validator.hpp
+++ b/planning/planning_validator/include/planning_validator/planning_validator.hpp
@@ -109,7 +109,7 @@ private:
   int diag_error_count_threshold_ = 0;
   bool display_on_terminal_ = true;
 
-  Updater diag_updater_{this};
+  std::shared_ptr<Updater> diag_updater_ = nullptr;
 
   PlanningValidatorStatus validation_status_;
   ValidationParams validation_params_;  // for thresholds


### PR DESCRIPTION
## Description

Setup diagnostic updater after all data is ready. Otherwise, the /diagnostic is published with ERROR state before it is ready.

Before
- diag is published with ERROR state before the required data is received

After
- diag is NOT published before the required data is received

## Related links

None

## Tests performed

Run psim

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

See Description

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
