### PR TITLE
fix(raw_vehicle_cmd_converter): return false if table is empty

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
@@ -85,6 +85,10 @@ bool CSVLoader::validateMap(const Map & map, const bool is_col_decent)
 
 bool CSVLoader::validateData(const Table & table, const std::string & csv_path)
 {
+  if (table.empty()) {
+    std::cerr << "The table is empty." << std::endl;
+    return false;
+  }
   if (table[0].size() < 2) {
     std::cerr << "Cannot read " << csv_path.c_str() << " CSV file should have at least 2 column"
               << std::endl;


### PR DESCRIPTION
## Description

This is a small bug-fix.

Related issue:
- https://github.com/autowarefoundation/autoware.universe/issues/5311

Related bug report: https://pastebin.com/rxvatCWh

This aims to resolve the first one.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
