### PR TITLE
build(trtexec_vendor): fix cmake to find trtexec bin

### DIFF
--- a/common/trtexec_vendor/CMakeLists.txt
+++ b/common/trtexec_vendor/CMakeLists.txt
@@ -28,7 +28,8 @@ if(TENSORRT_VERSION VERSION_LESS 8.2.1)
 endif()
 
 set(TRTEXEC_DEFAULT_BIN /usr/src/tensorrt/bin/trtexec)
-if(NOT EXISTS TRTEXEC_DEFAULT_BIN)
+if(NOT EXISTS ${TRTEXEC_DEFAULT_BIN})
+  message(STATUS "${TRTEXEC_DEFAULT_BIN} not found, download and build from source...")
   include(FetchContent)
   fetchcontent_declare(tensorrt
     GIT_REPOSITORY https://github.com/NVIDIA/TensorRT
@@ -71,6 +72,8 @@ if(NOT EXISTS TRTEXEC_DEFAULT_BIN)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
+else()  
+  message(STATUS "Found trtexec: ${TRTEXEC_DEFAULT_BIN}")
 endif()
 
 if(BUILD_TESTING)

--- a/common/trtexec_vendor/CMakeLists.txt
+++ b/common/trtexec_vendor/CMakeLists.txt
@@ -72,7 +72,7 @@ if(NOT EXISTS ${TRTEXEC_DEFAULT_BIN})
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-else()  
+else()
   message(STATUS "Found trtexec: ${TRTEXEC_DEFAULT_BIN}")
 endif()
 

--- a/common/trtexec_vendor/CMakeLists.txt
+++ b/common/trtexec_vendor/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT EXISTS ${TRTEXEC_DEFAULT_BIN})
   message(STATUS "${TRTEXEC_DEFAULT_BIN} not found, download and build from source...")
   include(FetchContent)
   fetchcontent_declare(tensorrt
-    GIT_REPOSITORY https://github.com/NVIDIA/TensorRT
+    GIT_REPOSITORY https://github.com/NVIDIA/TensorRT.git
     GIT_TAG release/${TENSORRT_VERSION_MAJOR}.${TENSORRT_VERSION_MINOR}
     GIT_SUBMODULES ""
   )


### PR DESCRIPTION
## Description

This pr fixes https://github.com/autowarefoundation/autoware.universe/issues/5453

## Tests performed

cmake build of trtexec_vendor

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
