### PR TITLE
feat(ekf_localizer, system_error_monitor): system_error_monitor handles ekf diags

### DIFF
--- a/localization/ekf_localizer/config/ekf_localizer.param.yaml
+++ b/localization/ekf_localizer/config/ekf_localizer.param.yaml
@@ -24,9 +24,9 @@
 
     # for diagnostics
     pose_no_update_count_threshold_warn: 50
-    pose_no_update_count_threshold_error: 250
+    pose_no_update_count_threshold_error: 100
     twist_no_update_count_threshold_warn: 50
-    twist_no_update_count_threshold_error: 250
+    twist_no_update_count_threshold_error: 100
 
     # for velocity measurement limitation (Set 0.0 if you want to ignore)
     threshold_observable_velocity_mps: 0.0 # [m/s]

--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -29,3 +29,13 @@
               path: localization_accuracy
               contains: ["localization: localization_error_monitor"]
               timeout: 1.0
+
+            # This diagnostic should ideally be avoided in terms of Fault Tree Analysis (FTA) compatibility.
+            # However, we may need this since the localization accuracy is still not reliable enough and may produce 
+            # false positives. Thus, NOTE that this diagnostic should be removed in the future when the localization accuracy 
+            # is reliable enough.
+            sensor_fusion_status:
+              type: diagnostic_aggregator/GenericAnalyzer
+              path: sensor_fusion_status
+              contains: ["localization: ekf_localizer"]
+              timeout: 1.0

--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -31,8 +31,8 @@
               timeout: 1.0
 
             # This diagnostic should ideally be avoided in terms of Fault Tree Analysis (FTA) compatibility.
-            # However, we may need this since the localization accuracy is still not reliable enough and may produce 
-            # false positives. Thus, NOTE that this diagnostic should be removed in the future when the localization accuracy 
+            # However, we may need this since the localization accuracy is still not reliable enough and may produce
+            # false positives. Thus, NOTE that this diagnostic should be removed in the future when the localization accuracy
             # is reliable enough.
             sensor_fusion_status:
               type: diagnostic_aggregator/GenericAnalyzer


### PR DESCRIPTION
## Description

Although current emergency handling system for localization solely relies on `localization_accuracy`, the criteria may not be accurate enough given that the covariances of NDT, IMU, and wheel odometry are still under development (e.g. the covariance estimation of NDT is still ongoing, and currently we use a static value that is empirically derived). One alternative criteria that we can use (at least temporarily) is to monitor if the valid NDT results have been published recently. In current Autoware implementation, we can monitor this by checking `no_update_count` in `ekf_localizer`. That being said, **I want to make Autoware Universe ready for using the EKF output for emergency handling**. 

Here are the changes that I would like to propose:
- Add EKF diag monitoring in `diagnostic_aggregator`
- Change default parameter of `no_update_count`, since current value (250, which corresponds to 5[sec] with 50Hz EKF) is too large.
- Use the EKF diag for system_error_monitor (only for safe fault by default, see autoware_launch PR)
<!-- Write a brief description of this PR. -->

Note that this PR itself ONLY affects the safe fault and not for single fault or latent fault which are directly connected to the minimum risk maneuver (MRM). The decision whether to really use this for MRM should depend on each reference designs.

Note that we also need to merge https://github.com/autowarefoundation/autoware_launch/pull/674

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No effect expected on current Autoware, since the diagnostic result of EKF is not used in MRM.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
