### PR TITLE
fix(detection_by_tracker): add ignore option for each label

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -195,6 +195,7 @@
   <group if="$(var use_detection_by_tracker)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share detection_by_tracker)/launch/detection_by_tracker.launch.xml"/>
+    <arg name="detection_by_tracker_param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
   </group>
 
   <!-- CenterPoint -->

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -220,6 +220,7 @@
   <group if="$(var use_detection_by_tracker)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share detection_by_tracker)/launch/detection_by_tracker.launch.xml"/>
+    <arg name="detection_by_tracker_param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
   </group>
 
   <!-- CenterPoint -->

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -73,6 +73,7 @@
       <arg name="use_roi_based_cluster" value="$(var use_roi_based_cluster)"/>
       <arg name="input/radar" value="$(var input/radar)"/>
       <arg name="radar_lanelet_filtering_range_param" value="$(var radar_lanelet_filtering_range_param)"/>
+      <arg name="detection_by_tracker_param_path" value="$(var detection_by_tracker_param_path)"/>
     </include>
   </group>
 
@@ -104,6 +105,7 @@
       <arg name="container_name" value="$(var container_name)"/>
       <arg name="use_low_height_cropbox" value="$(var use_low_height_cropbox)"/>
       <arg name="use_roi_based_cluster" value="$(var use_roi_based_cluster)"/>
+      <arg name="detection_by_tracker_param_path" value="$(var detection_by_tracker_param_path)"/>
     </include>
   </group>
 
@@ -133,6 +135,7 @@
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
       <arg name="container_name" value="$(var container_name)"/>
       <arg name="use_low_height_cropbox" value="$(var use_low_height_cropbox)"/>
+      <arg name="detection_by_tracker_param_path" value="$(var detection_by_tracker_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -61,6 +61,7 @@
   <group if="$(var use_detection_by_tracker)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share detection_by_tracker)/launch/detection_by_tracker.launch.xml"/>
+    <arg name="detection_by_tracker_param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
   </group>
 
   <!-- CenterPoint -->

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -18,6 +18,7 @@
   <arg name="obstacle_segmentation_ground_segmentation_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
   <arg name="object_recognition_detection_obstacle_pointcloud_based_validator_param_path"/>
+  <arg name="object_recognition_detection_detection_by_tracker_param"/>
   <arg name="occupancy_grid_map_method"/>
   <arg name="occupancy_grid_map_param_path"/>
   <arg name="occupancy_grid_map_updater"/>
@@ -174,6 +175,7 @@
           <arg name="outlier_param_path" value="$(var object_recognition_detection_outlier_param_path)"/>
           <arg name="voxel_grid_based_euclidean_param_path" value="$(var object_recognition_detection_voxel_grid_based_euclidean_cluster_param_path)"/>
           <arg name="radar_lanelet_filtering_range_param" value="$(var object_recognition_detection_radar_lanelet_filtering_range_param)"/>
+          <arg name="detection_by_tracker_param_path" value="$(var object_recognition_detection_detection_by_tracker_param)"/>
           <arg name="use_pointcloud_map" value="$(var use_pointcloud_map)"/>
           <arg name="use_low_height_cropbox" value="$(var use_low_height_cropbox)"/>
           <arg name="use_object_filter" value="$(var use_object_filter)"/>

--- a/perception/detection_by_tracker/CMakeLists.txt
+++ b/perception/detection_by_tracker/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(
 # Generate exe file
 set(DETECTION_BY_TRACKER_SRC
   src/detection_by_tracker_core.cpp
+  src/utils.cpp
 )
 
 ament_auto_add_library(detection_by_tracker_node SHARED
@@ -45,4 +46,5 @@ rclcpp_components_register_node(detection_by_tracker_node
 
 ament_auto_package(INSTALL_TO_SHARE
   launch
+  config
 )

--- a/perception/detection_by_tracker/config/detection_by_tracker.param.yaml
+++ b/perception/detection_by_tracker/config/detection_by_tracker.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    tracker_ignore_label:
+      UNKNOWN : true
+      CAR : false
+      TRUCK : false
+      BUS : false
+      TRAILER : false
+      MOTORCYCLE : false
+      BICYCLE : false
+      PEDESTRIAN : false

--- a/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
@@ -39,6 +39,8 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
+#include "utils/utils.hpp"
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -46,7 +48,6 @@
 #include <map>
 #include <memory>
 #include <vector>
-
 class TrackerHandler
 {
 private:
@@ -81,7 +82,7 @@ private:
   std::map<uint8_t, int> max_search_distance_for_merger_;
   std::map<uint8_t, int> max_search_distance_for_divider_;
 
-  bool ignore_unknown_tracker_;
+  utils::TrackerIgnoreLabel tracker_ignore_;
 
   void setMaxSearchRange();
 

--- a/perception/detection_by_tracker/include/utils/utils.hpp
+++ b/perception/detection_by_tracker/include/utils/utils.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS__UTILS_HPP_
+#define UTILS__UTILS_HPP_
+
+#include <cstdint>
+
+namespace utils
+{
+struct TrackerIgnoreLabel
+{
+  bool UNKNOWN;
+  bool CAR;
+  bool TRUCK;
+  bool BUS;
+  bool TRAILER;
+  bool MOTORCYCLE;
+  bool BICYCLE;
+  bool PEDESTRIAN;
+  bool isIgnore(const uint8_t label) const;
+};  // struct TrackerIgnoreLabel
+}  // namespace utils
+
+#endif  // UTILS__UTILS_HPP_

--- a/perception/detection_by_tracker/launch/detection_by_tracker.launch.xml
+++ b/perception/detection_by_tracker/launch/detection_by_tracker.launch.xml
@@ -3,10 +3,11 @@
   <arg name="input/tracked_objects" default="/perception/object_recognition/tracking/objects"/>
   <arg name="input/initial_objects" default="/perception/object_recognition/detection/clustering/objects_with_feature"/>
   <arg name="output" default="objects"/>
-
+  <arg name="param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
   <node pkg="detection_by_tracker" exec="detection_by_tracker" name="detection_by_tracker_node" output="screen">
     <remap from="~/input/tracked_objects" to="$(var input/tracked_objects)"/>
     <remap from="~/input/initial_objects" to="$(var input/initial_objects)"/>
     <remap from="~/output" to="$(var output)"/>
+    <param from="$(var param_path)"/>
   </node>
 </launch>

--- a/perception/detection_by_tracker/launch/detection_by_tracker.launch.xml
+++ b/perception/detection_by_tracker/launch/detection_by_tracker.launch.xml
@@ -3,11 +3,11 @@
   <arg name="input/tracked_objects" default="/perception/object_recognition/tracking/objects"/>
   <arg name="input/initial_objects" default="/perception/object_recognition/detection/clustering/objects_with_feature"/>
   <arg name="output" default="objects"/>
-  <arg name="param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
+  <arg name="detection_by_tracker_param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
   <node pkg="detection_by_tracker" exec="detection_by_tracker" name="detection_by_tracker_node" output="screen">
     <remap from="~/input/tracked_objects" to="$(var input/tracked_objects)"/>
     <remap from="~/input/initial_objects" to="$(var input/initial_objects)"/>
     <remap from="~/output" to="$(var output)"/>
-    <param from="$(var param_path)"/>
+    <param from="$(var detection_by_tracker_param_path)"/>
   </node>
 </launch>

--- a/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
@@ -160,7 +160,15 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
   objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
     "~/output", rclcpp::QoS{1});
 
-  ignore_unknown_tracker_ = declare_parameter<bool>("ignore_unknown_tracker", true);
+  // Set parameters
+  tracker_ignore_.UNKNOWN = declare_parameter<bool>("tracker_ignore_label.UNKNOWN");
+  tracker_ignore_.CAR = declare_parameter<bool>("tracker_ignore_label.CAR");
+  tracker_ignore_.TRUCK = declare_parameter<bool>("tracker_ignore_label.TRUCK");
+  tracker_ignore_.BUS = declare_parameter<bool>("tracker_ignore_label.BUS");
+  tracker_ignore_.TRAILER = declare_parameter<bool>("tracker_ignore_label.TRAILER");
+  tracker_ignore_.MOTORCYCLE = declare_parameter<bool>("tracker_ignore_label.MOTORCYCLE");
+  tracker_ignore_.BICYCLE = declare_parameter<bool>("tracker_ignore_label.BICYCLE");
+  tracker_ignore_.PEDESTRIAN = declare_parameter<bool>("tracker_ignore_label.PEDESTRIAN");
 
   // set maximum search setting for merger/divider
   setMaxSearchRange();
@@ -259,7 +267,7 @@ void DetectionByTracker::divideUnderSegmentedObjects(
 
   for (const auto & tracked_object : tracked_objects.objects) {
     const auto & label = tracked_object.classification.front().label;
-    if (ignore_unknown_tracker_ && (label == Label::UNKNOWN)) continue;
+    if (tracker_ignore_.isIgnore(label)) continue;
 
     // change search range according to label type
     const float max_search_range = max_search_distance_for_divider_[label];
@@ -395,7 +403,7 @@ void DetectionByTracker::mergeOverSegmentedObjects(
 
   for (const auto & tracked_object : tracked_objects.objects) {
     const auto & label = tracked_object.classification.front().label;
-    if (ignore_unknown_tracker_ && (label == Label::UNKNOWN)) continue;
+    if (tracker_ignore_.isIgnore(label)) continue;
 
     // change search range according to label type
     const float max_search_range = max_search_distance_for_merger_[label];

--- a/perception/detection_by_tracker/src/utils.cpp
+++ b/perception/detection_by_tracker/src/utils.cpp
@@ -1,0 +1,30 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils/utils.hpp"
+
+#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+
+namespace utils
+{
+using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+
+bool TrackerIgnoreLabel::isIgnore(const uint8_t label) const
+{
+  return (label == Label::UNKNOWN && UNKNOWN) || (label == Label::CAR && CAR) ||
+         (label == Label::TRUCK && TRUCK) || (label == Label::BUS && BUS) ||
+         (label == Label::TRAILER && TRAILER) || (label == Label::MOTORCYCLE && MOTORCYCLE) ||
+         (label == Label::BICYCLE && BICYCLE) || (label == Label::PEDESTRIAN && PEDESTRIAN);
+}
+}  // namespace utils


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR to add ignore option for other labels than UNKNOWN as current. This will allow user to flexibly select which class to be detected by tracker. 
This should be merged together with https://github.com/autowarefoundation/autoware_launch/pull/676 which keep setting as currently so the result should be unchange after PR merged.
## Related link 
[TIER IV INTERNAL LINK](https://star4.slack.com/archives/CRUE57C30/p1698906610256539?thread_ts=1698905091.001629&cid=CRUE57C30)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
