### PR TITLE
ci(sync-files): change stale label to type:stale

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -12,6 +12,8 @@
     - source: .github/PULL_REQUEST_TEMPLATE/standard-change.md
     - source: .github/dependabot.yaml
     - source: .github/stale.yml
+      pre-commands: |
+        sd "staleLabel: stale" "staleLabel: type:stale" {source}
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -89,5 +89,5 @@
         sd -- \
         "  - macros" \
         "  - macros:
-               module_name: mkdocs_macros" {source}
+              module_name: mkdocs_macros" {source}
     - source: docs/assets/js/mathjax.js


### PR DESCRIPTION
## Description

Related issue: https://github.com/autowarefoundation/autoware/issues/3955

This PR renames the `stale` label into `type:stale` through the `sync-files` job.

## Tests performed

This PR automates the creation of the following PR:
- https://github.com/autowarefoundation/autoware.universe/pull/5216/files

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
