### PR TITLE
ci(sync-files): change stale label to status:stale (#5474)

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -13,7 +13,7 @@
     - source: .github/dependabot.yaml
     - source: .github/stale.yml
       pre-commands: |
-        sd "staleLabel: stale" "staleLabel: type:stale" {source}
+        sd "staleLabel: stale" "staleLabel: status:stale" {source}
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml


### PR DESCRIPTION
## Description

Fixes the label name to match:
- https://github.com/autowarefoundation/autoware/issues/3955

Old PR:
- https://github.com/autowarefoundation/autoware.universe/pull/5474

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
