### PR TITLE
ci(pr-labeler): update the labeler.yaml to mark ci and documentation as "type:"

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,4 +1,4 @@
-"component:ci":
+"type:ci":
   - .github/**/*
   - "*.json"
   - "*.yaml"
@@ -6,7 +6,7 @@
   - .clang-format
   - .gitignore
   - .prettierignore
-"component:documentation":
+"type:documentation":
   - docs/**/*
   - "**/*.md"
   - "**/*.rst"


### PR DESCRIPTION
## Description

Modifies labels:
- `component:ci` -> `type:ci`
- `component:documentation` -> `type:documentation`

Related issue:
- https://github.com/autowarefoundation/autoware/issues/3955

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
