### PR TITLE
feat(localization): enable logging_level_configure

### DIFF
--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -1,6 +1,30 @@
 # logger_config.yaml
 
 # ============================================================
+# localization
+# ============================================================
+
+ndt_scan_matcher:
+  - node_name: /localization/pose_estimator/ndt_scan_matcher
+    logger_name: localization.pose_estimator.ndt_scan_matcher
+
+gyro_odometer:
+  - node_name: /localization/twist_estimator/gyro_odometer
+    logger_name: localization.twist_estimator.gyro_odometer
+
+pose_initializer:
+  - node_name: /localization/util/pose_initializer_node
+    logger_name: localization.util.pose_initializer_node
+
+ekf_localizer:
+  - node_name: /localization/pose_twist_fusion_filter/ekf_localizer
+    logger_name: localization.pose_twist_fusion_filter.ekf_localizer
+
+localization_error_monitor:
+  - node_name: /localization/localization_error_monitor
+    logger_name: localization.localization_error_monitor
+
+# ============================================================
 # planning
 # ============================================================
 

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -23,8 +23,8 @@
 #include <kalman_filter/time_delay_kalman_filter.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
-#include <tier4_autoware_utils/system/stop_watch.hpp>
 #include <tier4_autoware_utils/ros/logger_level_configure.hpp>
+#include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -24,6 +24,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
+#include <tier4_autoware_utils/ros/logger_level_configure.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
@@ -143,6 +144,9 @@ private:
   rclcpp::TimerBase::SharedPtr timer_tf_;
   //!< @brief tf broadcaster
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_br_;
+
+  //!< @brief logger configure module
+  std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
 
   //!< @brief  extended kalman filter instance.
   TimeDelayKalmanFilter ekf_;

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -104,6 +104,8 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
   tf_br_ = std::make_shared<tf2_ros::TransformBroadcaster>(
     std::shared_ptr<rclcpp::Node>(this, [](auto) {}));
 
+  logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
+
   initEKF();
 
   z_filter_.set_proc_dev(1.0);

--- a/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
+++ b/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
@@ -17,6 +17,7 @@
 
 #include "tier4_autoware_utils/ros/msg_covariance.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
+#include "tier4_autoware_utils/ros/logger_level_configure.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -63,6 +64,7 @@ private:
     twist_with_covariance_pub_;
 
   std::shared_ptr<tier4_autoware_utils::TransformListener> transform_listener_;
+  std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
 
   std::string output_frame_;
   double message_timeout_sec_;

--- a/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
+++ b/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
@@ -15,9 +15,9 @@
 #ifndef GYRO_ODOMETER__GYRO_ODOMETER_CORE_HPP_
 #define GYRO_ODOMETER__GYRO_ODOMETER_CORE_HPP_
 
+#include "tier4_autoware_utils/ros/logger_level_configure.hpp"
 #include "tier4_autoware_utils/ros/msg_covariance.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
-#include "tier4_autoware_utils/ros/logger_level_configure.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/localization/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/gyro_odometer/src/gyro_odometer_core.cpp
@@ -108,6 +108,7 @@ GyroOdometer::GyroOdometer(const rclcpp::NodeOptions & options)
   imu_arrived_(false)
 {
   transform_listener_ = std::make_shared<tier4_autoware_utils::TransformListener>(this);
+  logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
 
   vehicle_twist_sub_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
     "vehicle/twist_with_covariance", rclcpp::QoS{100},

--- a/localization/localization_error_monitor/include/localization_error_monitor/node.hpp
+++ b/localization/localization_error_monitor/include/localization_error_monitor/node.hpp
@@ -23,6 +23,8 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <memory>
+
 struct Ellipse
 {
   double long_radius;

--- a/localization/localization_error_monitor/include/localization_error_monitor/node.hpp
+++ b/localization/localization_error_monitor/include/localization_error_monitor/node.hpp
@@ -17,6 +17,7 @@
 
 #include <Eigen/Dense>
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/logger_level_configure.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -39,6 +40,9 @@ private:
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diag_pub_;
 
   rclcpp::TimerBase::SharedPtr timer_;
+
+  std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
+
   double scale_;
   double error_ellipse_size_;
   double warn_ellipse_size_;

--- a/localization/localization_error_monitor/package.xml
+++ b/localization/localization_error_monitor/package.xml
@@ -20,6 +20,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>tier4_autoware_utils</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/localization/localization_error_monitor/src/node.cpp
+++ b/localization/localization_error_monitor/src/node.cpp
@@ -53,6 +53,8 @@ LocalizationErrorMonitor::LocalizationErrorMonitor() : Node("localization_error_
     this->create_publisher<visualization_msgs::msg::Marker>("debug/ellipse_marker", durable_qos);
 
   diag_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
+
+  logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
 }
 
 visualization_msgs::msg::Marker LocalizationErrorMonitor::createEllipseMarker(

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -22,6 +22,7 @@
 #include "ndt_scan_matcher/map_update_module.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/logger_level_configure.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -29,7 +30,6 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/set_bool.hpp>
-#include <tier4_autoware_utils/ros/logger_level_configure.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
 #include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -29,6 +29,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/set_bool.hpp>
+#include <tier4_autoware_utils/ros/logger_level_configure.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
 #include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>
@@ -204,6 +205,7 @@ private:
   std::shared_ptr<Tf2ListenerModule> tf2_listener_module_;
   std::unique_ptr<MapModule> map_module_;
   std::unique_ptr<MapUpdateModule> map_update_module_;
+  std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
 
   // cspell: ignore degrounded
   bool estimate_scores_for_degrounded_scan_;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -246,6 +246,8 @@ NDTScanMatcher::NDTScanMatcher()
   } else {
     map_module_ = std::make_unique<MapModule>(this, &ndt_ptr_mtx_, ndt_ptr_, main_callback_group);
   }
+
+  logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
 }
 
 void NDTScanMatcher::timer_diagnostic()

--- a/localization/pose_initializer/package.xml
+++ b/localization/pose_initializer/package.xml
@@ -21,6 +21,7 @@
   <depend>motion_utils</depend>
   <depend>rclcpp</depend>
   <depend>std_srvs</depend>
+  <depend>tier4_autoware_utils</depend>
   <depend>tier4_localization_msgs</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>

--- a/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp
@@ -54,6 +54,7 @@ PoseInitializer::PoseInitializer() : Node("pose_initializer")
     stop_check_duration_ = declare_parameter<double>("stop_check_duration");
     stop_check_ = std::make_unique<StopCheckModule>(this, stop_check_duration_ + 1.0);
   }
+  logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
 
   change_state(State::Message::UNINITIALIZED);
 }

--- a/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp
+++ b/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp
@@ -18,6 +18,7 @@
 #include <component_interface_specs/localization.hpp>
 #include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/logger_level_configure.hpp>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
@@ -55,6 +56,7 @@ private:
   std::unique_ptr<StopCheckModule> stop_check_;
   std::unique_ptr<EkfLocalizationTriggerModule> ekf_localization_trigger_;
   std::unique_ptr<NdtLocalizationTriggerModule> ndt_localization_trigger_;
+  std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
   double stop_check_duration_;
   void change_state(State::Message::_state_type state);
   void on_initialize(


### PR DESCRIPTION
## Description

Enable logging_level_configure for localization.
Note that I only enable it for ndt_scan_matcher pipeline and not for YabLoc and other localization methods for now.

Related: https://github.com/autowarefoundation/autoware.universe/pull/5131
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Confirmed that, through the RViz plugin, the logging level can be configured runtime.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
