### PR TITLE
fix(avoidance): fix avoidance return dead point calculation logic for high curverture path

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2902,8 +2902,15 @@ void AvoidanceModule::insertReturnDeadLine(
     return;
   }
 
+  // Consider the difference in path length between the shifted path and original path (the path
+  // that is shifted inward has a shorter distance to the end of the path than the other one.)
+  const auto & to_reference_path_end = data.arclength_from_ego.back();
+  const auto to_shifted_path_end = calcSignedArcLength(
+    shifted_path.path.points, getEgoPosition(), shifted_path.path.points.size() - 1);
+  const auto buffer = std::max(0.0, to_shifted_path_end - to_reference_path_end);
+
   const auto min_return_distance = helper_.getMinAvoidanceDistance(shift_length);
-  const auto to_stop_line = data.to_return_point - min_return_distance;
+  const auto to_stop_line = data.to_return_point - min_return_distance - buffer;
 
   // If we don't need to consider deceleration constraints, insert a deceleration point
   // and return immediately


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84adaf6</samp>

Adjust the stop line distance for the avoidance path in `avoidance_module.cpp`. This prevents the vehicle from overshooting the stop line due to the shifted path curvature.

related ticket: https://tier4.atlassian.net/browse/RT1-4125

---

The avoidance module inserts a stop point in order not to pass through dead line to return original path. The return point is generated on original path, and the stop point is inserted on shifted path.

Therefore, it has to take the difference of distance between inner and outer path distance caused by high curverture into consideration. In this PR, it calculates the difference and set a stop point proper position.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/83ae16ef-977d-4b1f-8152-3028c449bb29)


<!-- Write a brief description of this PR. -->

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/44889564/ec042988-81b2-4d0b-8896-bccaf992b736

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/eb1e878a-d414-5b55-a86d-4bf894367e50?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve avoidance maneuver.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
