### PR TITLE
fix(simple_planning_simulator): set ego pitch to 0 if road slope is not simulated

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -326,9 +326,9 @@ void SimplePlanningSimulator::on_timer()
   }
 
   // calculate longitudinal acceleration by slope
-  const double ego_pitch_angle = calculate_ego_pitch();
-  const double acc_by_slope =
-    enable_road_slope_simulation_ ? -9.81 * std::sin(ego_pitch_angle) : 0.0;
+  constexpr double gravity_acceleration = -9.81;
+  const double ego_pitch_angle = enable_road_slope_simulation_ ? calculate_ego_pitch() : 0.0;
+  const double acc_by_slope = gravity_acceleration * std::sin(ego_pitch_angle);
 
   // update vehicle dynamics
   {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 684bffd</samp>

Refactor `simple_planning_simulator_core.cpp` to skip ego pitch calculation when road slope simulation is off and use a constant for gravity. This improves performance and accuracy of the simple planning simulator.

## Tests performed
I found the bug when using the planning simulator on a specific lanelet map that happened to have inclination (I did not know about the inclination). The result was that the controller output would give negative acceleration and the vehicle would not move after planning a path even when road slope simulation is off . The video shows the bug and the image the control output: 



https://github.com/autowarefoundation/autoware.universe/assets/25967964/a46e06de-95f2-478e-bc67-2ee2a73d3a75



![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/d726bdc7-df37-4db2-bc22-3e5e13f74c9f)

I saved the specific starting pose of the vehicle and replayed the planning simulator after applying the fix on this PR and the problem was solved: the vehicle could move after planning. The acceleration is no longer negative either.


https://github.com/autowarefoundation/autoware.universe/assets/25967964/55f420fb-371a-4064-b310-3f4d96dfa0e1


## Effects on system behavior

When performing simulations, the simulation calculates the acceleration caused by the vehicle's pitch angle, even if the enable_road_slope_simulation_  parameter is set to false which is an unexpected behavior. With this fix, the acceleration caused by pitch will be zero when enable_road_slope_simulation_  is false. So, in those cases, the acceleration given by the controller will change. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
