### PR TITLE
fix(intersection): reduce path lanelet points

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -159,6 +159,10 @@ double calcDistanceUntilIntersectionLanelet(
   const lanelet::ConstLanelet & assigned_lanelet,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx);
 
+lanelet::ConstLanelet generatePathLanelet(
+  const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width,
+  const double interval);
+
 std::optional<PathLanelets> generatePathLanelets(
   const lanelet::ConstLanelets & lanelets_on_path,
   const util::InterpolatedPathInfo & interpolated_path_info, const std::set<int> & associative_ids,

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/util.hpp
@@ -100,8 +100,6 @@ geometry_msgs::msg::Pose getAheadPose(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path);
 Polygon2d generatePathPolygon(
   const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width);
-lanelet::ConstLanelet generatePathLanelet(
-  const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width);
 double calcJudgeLineDistWithAccLimit(
   const double velocity, const double max_stop_acceleration, const double delay_response_time);
 

--- a/planning/behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner_common/src/utilization/util.cpp
@@ -356,32 +356,6 @@ Polygon2d generatePathPolygon(
   return ego_area;
 }
 
-lanelet::ConstLanelet generatePathLanelet(
-  const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width)
-{
-  lanelet::Points3d lefts;
-  for (size_t i = start_idx; i <= end_idx; ++i) {
-    const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
-    const double x = path.points.at(i).point.pose.position.x + width / 2 * std::sin(yaw);
-    const double y = path.points.at(i).point.pose.position.y - width / 2 * std::cos(yaw);
-    const lanelet::Point3d p(lanelet::InvalId, x, y, path.points.at(i).point.pose.position.z);
-    lefts.emplace_back(p);
-  }
-  lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, lefts);
-
-  lanelet::Points3d rights;
-  for (size_t i = start_idx; i <= end_idx; ++i) {
-    const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
-    const double x = path.points.at(i).point.pose.position.x - width / 2 * std::sin(yaw);
-    const double y = path.points.at(i).point.pose.position.y + width / 2 * std::cos(yaw);
-    const lanelet::Point3d p(lanelet::InvalId, x, y, path.points.at(i).point.pose.position.z);
-    rights.emplace_back(p);
-  }
-  lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, rights);
-
-  return lanelet::Lanelet(lanelet::InvalId, left, right);
-}
-
 double calcJudgeLineDistWithAccLimit(
   const double velocity, const double max_stop_acceleration, const double delay_response_time)
 {


### PR DESCRIPTION
## Description

Reduce the number of points of each `path_lanelet` to reduce computation cost

## Related links

https://tier4.atlassian.net/browse/RT1-4169

## Tests performed

The result of `ros2 topic echo /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection/processing_time_ms` reduced from 800 to 10.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
