### PR TITLE
feat(obstacle_cruise_planner)!: change logic to secure safe distance margin as polygons distance

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -110,14 +110,17 @@ struct StopObstacle : public TargetObstacleInterface
     const std::string & arg_uuid, const rclcpp::Time & arg_stamp,
     const geometry_msgs::msg::Pose & arg_pose, const Shape & arg_shape,
     const double arg_lon_velocity, const double arg_lat_velocity,
-    const geometry_msgs::msg::Point arg_collision_point)
+    const geometry_msgs::msg::Point arg_collision_point,
+    const double arg_traj_dist_to_stop_point)
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_lon_velocity, arg_lat_velocity),
     shape(arg_shape),
-    collision_point(arg_collision_point)
+    collision_point(arg_collision_point),
+    traj_dist_to_stop_point(arg_traj_dist_to_stop_point)
   {
   }
   Shape shape;
   geometry_msgs::msg::Point collision_point;
+  double traj_dist_to_stop_point;
 };
 
 struct CruiseObstacle : public TargetObstacleInterface

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -110,11 +110,9 @@ struct StopObstacle : public TargetObstacleInterface
     const std::string & arg_uuid, const rclcpp::Time & arg_stamp,
     const geometry_msgs::msg::Pose & arg_pose, const Shape & arg_shape,
     const double arg_lon_velocity, const double arg_lat_velocity,
-    const geometry_msgs::msg::Point arg_collision_point,
     const double arg_traj_dist_to_stop_point)
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_lon_velocity, arg_lat_velocity),
     shape(arg_shape),
-    collision_point(arg_collision_point),
     traj_dist_to_stop_point(arg_traj_dist_to_stop_point)
   {
   }

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -67,6 +67,9 @@ private:
   bool isOutsideCruiseObstacle(const uint8_t label) const;
   bool isCruiseObstacle(const uint8_t label) const;
   bool isSlowDownObstacle(const uint8_t label) const;
+  std::optional<double> calcTrajDistToSecurePolysDist(
+    const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
+    const Obstacle & obstacle) const;
   std::optional<geometry_msgs::msg::Point> createCollisionPointForStopObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle) const;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -94,7 +94,7 @@ private:
 
   void checkConsistency(
     const rclcpp::Time & current_time, const PredictedObjects & predicted_objects,
-    const std::vector<TrajectoryPoint> & traj_points, std::vector<StopObstacle> & stop_obstacles);
+    std::vector<StopObstacle> & stop_obstacles);
   void publishVelocityLimit(
     const std::optional<VelocityLimit> & vel_limit, const std::string & module_name);
   void publishDebugMarker() const;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -102,6 +102,11 @@ public:
     slow_down_debug_multi_array_.stamp = current_time;
     return slow_down_debug_multi_array_;
   }
+  double getSafeDistanceMargin()
+  {
+    return longitudinal_info_.safe_distance_margin;
+  }
+
 
 protected:
   // Parameters

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -107,7 +107,6 @@ public:
     return longitudinal_info_.safe_distance_margin;
   }
 
-
 protected:
   // Parameters
   bool enable_debug_info_{false};

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -37,7 +37,6 @@ PoseWithStamp getCurrentObjectPose(
   const rclcpp::Time & current_time, const bool use_prediction);
 
 std::optional<StopObstacle> getClosestStopObstacle(
-  const std::vector<TrajectoryPoint> & traj_points,
   const std::vector<StopObstacle> & stop_obstacles);
 
 template <class T>

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
+
 namespace
 {
 StopSpeedExceeded createStopSpeedExceededMsg(
@@ -212,18 +213,18 @@ double calcDecelerationVelocityFromDistanceToTarget(
   return current_velocity;
 }
 
-std::vector<TrajectoryPoint> resampleTrajectoryPoints(
-  const std::vector<TrajectoryPoint> & traj_points, const double interval)
-{
-  const auto traj = motion_utils::convertToTrajectory(traj_points);
-  const auto resampled_traj = motion_utils::resampleTrajectory(traj, interval);
-  return motion_utils::convertToTrajectoryPointArray(resampled_traj);
-}
+// std::vector<TrajectoryPoint> resampleTrajectoryPoints(
+//   const std::vector<TrajectoryPoint> & traj_points, const double interval)
+// {
+//   const auto traj = motion_utils::convertToTrajectory(traj_points);
+//   const auto resampled_traj = motion_utils::resampleTrajectory(traj, interval);
+//   return motion_utils::convertToTrajectoryPointArray(resampled_traj);
+// }
 
-tier4_autoware_utils::Point2d convertPoint(const geometry_msgs::msg::Point & p)
-{
-  return tier4_autoware_utils::Point2d{p.x, p.y};
-}
+// tier4_autoware_utils::Point2d convertPoint(const geometry_msgs::msg::Point & p)
+// {
+//   return tier4_autoware_utils::Point2d{p.x, p.y};
+// }
 }  // namespace
 
 std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
@@ -257,8 +258,18 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
     "stop planning");
 
   // Get Closest Stop Obstacle
-  const auto closest_stop_obstacle =
-    obstacle_cruise_utils::getClosestStopObstacle(planner_data.traj_points, stop_obstacles);
+  const auto closest_stop_obstacle = [&]() {
+    std::optional<StopObstacle> candidate_obstacle = std::nullopt;
+    for (const auto & stop_obstacle : stop_obstacles) {
+      if (
+        !candidate_obstacle ||
+        stop_obstacle.traj_dist_to_stop_point < candidate_obstacle->traj_dist_to_stop_point) {
+        candidate_obstacle = stop_obstacle;
+      }
+    }
+    return candidate_obstacle;
+  }();
+
   if (!closest_stop_obstacle) {
     // delete marker
     const auto markers =
@@ -269,113 +280,87 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
     return planner_data.traj_points;
   }
 
-  // Get Closest Obstacle Stop Distance
-  const double closest_obstacle_dist = motion_utils::calcSignedArcLength(
-    planner_data.traj_points, 0, closest_stop_obstacle->collision_point);
-
   const auto ego_segment_idx =
     ego_nearest_param_.findSegmentIndex(planner_data.traj_points, planner_data.ego_pose);
-  const auto negative_dist_to_ego = motion_utils::calcSignedArcLength(
-    planner_data.traj_points, planner_data.ego_pose.position, ego_segment_idx, 0);
-  const double dist_to_ego = -negative_dist_to_ego;
+  double candidate_stop_dist_on_ref_traj =
+    motion_utils::calcSignedArcLength(planner_data.traj_points, 0, ego_segment_idx) +
+    closest_stop_obstacle->traj_dist_to_stop_point;
 
-  const double margin_from_obstacle =
-    calculateMarginFromObstacleOnCurve(planner_data, *closest_stop_obstacle);
+  const auto ref_traj_length = motion_utils::calcSignedArcLength(
+    planner_data.traj_points, 0, planner_data.traj_points.size() - 1);
 
-  // If behavior stop point is ahead of the closest_obstacle_stop point within a certain margin
-  // we set closest_obstacle_stop_distance to closest_behavior_stop_distance
-  const double margin_from_obstacle_considering_behavior_module = [&]() {
-    const size_t nearest_segment_idx =
-      findEgoSegmentIndex(planner_data.traj_points, planner_data.ego_pose);
-    const auto closest_behavior_stop_idx =
-      motion_utils::searchZeroVelocityIndex(planner_data.traj_points, nearest_segment_idx + 1);
+  if (
+    candidate_stop_dist_on_ref_traj + longitudinal_info_.safe_distance_margin >
+    ref_traj_length + longitudinal_info_.terminal_safe_distance_margin) {
+    // Use terminal margin (terminal_safe_distance_margin) for obstacle stop
 
-    if (!closest_behavior_stop_idx) {
-      return margin_from_obstacle;
+    // delete marker
+    const auto markers =
+      motion_utils::createDeletedStopVirtualWallMarker(planner_data.current_time, 0);
+    tier4_autoware_utils::appendMarkerArray(markers, &debug_data_ptr_->stop_wall_marker);
+
+    prev_stop_distance_info_ = std::nullopt;
+    return planner_data.traj_points;
+  }
+
+  const auto closest_behavior_stop_idx =
+    motion_utils::searchZeroVelocityIndex(planner_data.traj_points, ego_segment_idx + 1);
+  if (closest_behavior_stop_idx) {
+    const double closest_behavior_stop_dist_from_ego =
+      motion_utils::calcSignedArcLength(planner_data.traj_points, 0, *closest_behavior_stop_idx);
+    const double stop_dist_diff =
+      closest_behavior_stop_dist_from_ego - candidate_stop_dist_on_ref_traj;
+
+    if (0.0 < stop_dist_diff && stop_dist_diff < longitudinal_info_.safe_distance_margin) {
+      // Use shorter margin (min_behavior_stop_margin) for obstacle stop
+      candidate_stop_dist_on_ref_traj +=
+        longitudinal_info_.safe_distance_margin - min_behavior_stop_margin_;
     }
+  }
 
-    const double closest_behavior_stop_dist_from_ego = motion_utils::calcSignedArcLength(
-      planner_data.traj_points, planner_data.ego_pose.position, nearest_segment_idx,
-      *closest_behavior_stop_idx);
+  // Check feasibility to stop
+  bool will_collide_with_obstacle = false;
+  if (suppress_sudden_obstacle_stop_) {
+    // Calculate feasible stop margin (Check the feasibility)
+    const double feasible_stop_dist =
+      calcMinimumDistanceToStop(
+        planner_data.ego_vel, longitudinal_info_.limit_max_accel,
+        longitudinal_info_.limit_min_accel) +
+      motion_utils::calcSignedArcLength(
+        planner_data.traj_points, 0, planner_data.ego_pose.position);
 
-    if (*closest_behavior_stop_idx == planner_data.traj_points.size() - 1) {
-      // Closest behavior stop point is the end point
-      const double closest_obstacle_stop_dist_from_ego =
-        closest_obstacle_dist - dist_to_ego - longitudinal_info_.terminal_safe_distance_margin -
-        abs_ego_offset;
-      const double stop_dist_diff =
-        closest_behavior_stop_dist_from_ego - closest_obstacle_stop_dist_from_ego;
-      if (stop_dist_diff < margin_from_obstacle) {
-        // Use terminal margin (terminal_safe_distance_margin) for obstacle stop
-        return longitudinal_info_.terminal_safe_distance_margin;
-      }
-    } else {
-      const double closest_obstacle_stop_dist_from_ego =
-        closest_obstacle_dist - dist_to_ego - margin_from_obstacle - abs_ego_offset;
-      const double stop_dist_diff =
-        closest_behavior_stop_dist_from_ego - closest_obstacle_stop_dist_from_ego;
-      if (0.0 < stop_dist_diff && stop_dist_diff < margin_from_obstacle) {
-        // Use shorter margin (min_behavior_stop_margin) for obstacle stop
-        return min_behavior_stop_margin_;
-      }
+    if (candidate_stop_dist_on_ref_traj < feasible_stop_dist) {
+      candidate_stop_dist_on_ref_traj = feasible_stop_dist;
+      will_collide_with_obstacle = true;
     }
-    return margin_from_obstacle;
-  }();
+  }
 
-  const auto [stop_margin_from_obstacle, will_collide_with_obstacle] = [&]() {
-    // Check feasibility to stop
-    if (suppress_sudden_obstacle_stop_) {
-      const double closest_obstacle_stop_dist =
-        closest_obstacle_dist - margin_from_obstacle_considering_behavior_module - abs_ego_offset;
+  // Hold previous stop distance if necessary
+  if (
+    std::abs(planner_data.ego_vel) < longitudinal_info_.hold_stop_velocity_threshold &&
+    prev_stop_distance_info_) {
+    // NOTE: We assume that the current trajectory's front point is ahead of the previous
+    // trajectory's front point.
+    const size_t traj_front_point_prev_seg_idx =
+      motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+        prev_stop_distance_info_->first, planner_data.traj_points.front().pose);
+    const double diff_dist_front_points = motion_utils::calcSignedArcLength(
+      prev_stop_distance_info_->first, 0, planner_data.traj_points.front().pose.position,
+      traj_front_point_prev_seg_idx);
 
-      // Calculate feasible stop margin (Check the feasibility)
-      const double feasible_stop_dist = calcMinimumDistanceToStop(
-                                          planner_data.ego_vel, longitudinal_info_.limit_max_accel,
-                                          longitudinal_info_.limit_min_accel) +
-                                        dist_to_ego;
-
-      if (closest_obstacle_stop_dist < feasible_stop_dist) {
-        const auto feasible_margin_from_obstacle =
-          margin_from_obstacle_considering_behavior_module -
-          (feasible_stop_dist - closest_obstacle_stop_dist);
-        return std::make_pair(feasible_margin_from_obstacle, true);
-      }
-    }
-    return std::make_pair(margin_from_obstacle_considering_behavior_module, false);
-  }();
-
-  // Generate Output Trajectory
-  const double zero_vel_dist = [&]() {
-    const double current_zero_vel_dist =
-      std::max(0.0, closest_obstacle_dist - abs_ego_offset - stop_margin_from_obstacle);
-
-    // Hold previous stop distance if necessary
+    const double prev_zero_vel_dist = prev_stop_distance_info_->second - diff_dist_front_points;
     if (
-      std::abs(planner_data.ego_vel) < longitudinal_info_.hold_stop_velocity_threshold &&
-      prev_stop_distance_info_) {
-      // NOTE: We assume that the current trajectory's front point is ahead of the previous
-      // trajectory's front point.
-      const size_t traj_front_point_prev_seg_idx =
-        motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
-          prev_stop_distance_info_->first, planner_data.traj_points.front().pose);
-      const double diff_dist_front_points = motion_utils::calcSignedArcLength(
-        prev_stop_distance_info_->first, 0, planner_data.traj_points.front().pose.position,
-        traj_front_point_prev_seg_idx);
-
-      const double prev_zero_vel_dist = prev_stop_distance_info_->second - diff_dist_front_points;
-      if (
-        std::abs(prev_zero_vel_dist - current_zero_vel_dist) <
-        longitudinal_info_.hold_stop_distance_threshold) {
-        return prev_zero_vel_dist;
-      }
+      std::abs(prev_zero_vel_dist - candidate_stop_dist_on_ref_traj) <
+      longitudinal_info_.hold_stop_distance_threshold) {
+      candidate_stop_dist_on_ref_traj = prev_zero_vel_dist;
     }
-
-    return current_zero_vel_dist;
-  }();
+  }
 
   // Insert stop point
   auto output_traj_points = planner_data.traj_points;
-  const auto zero_vel_idx = motion_utils::insertStopPoint(0, zero_vel_dist, output_traj_points);
+  // const auto zero_vel_idx = motion_utils::insertStopPoint(0, zero_vel_dist, output_traj_points);
+  const auto zero_vel_idx =
+    motion_utils::insertStopPoint(0, candidate_stop_dist_on_ref_traj, output_traj_points);
   if (zero_vel_idx) {
     // virtual wall marker for stop obstacle
     const auto markers = motion_utils::createStopVirtualWallMarker(
@@ -396,17 +381,19 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
       createStopSpeedExceededMsg(planner_data.current_time, will_collide_with_obstacle);
     stop_speed_exceeded_pub_->publish(stop_speed_exceeded_msg);
 
-    prev_stop_distance_info_ = std::make_pair(output_traj_points, zero_vel_dist);
+    prev_stop_distance_info_ = std::make_pair(output_traj_points, candidate_stop_dist_on_ref_traj);
   }
 
   stop_planning_debug_info_.set(
     StopPlanningDebugInfo::TYPE::STOP_CURRENT_OBSTACLE_DISTANCE,
-    closest_obstacle_dist - abs_ego_offset);  // TODO(murooka)
+    candidate_stop_dist_on_ref_traj -
+      motion_utils::calcSignedArcLength(
+        planner_data.traj_points, 0, planner_data.ego_pose.position));  // TODO(murooka)
   stop_planning_debug_info_.set(
     StopPlanningDebugInfo::TYPE::STOP_CURRENT_OBSTACLE_VELOCITY, closest_stop_obstacle->velocity);
 
-  stop_planning_debug_info_.set(
-    StopPlanningDebugInfo::TYPE::STOP_TARGET_OBSTACLE_DISTANCE, stop_margin_from_obstacle);
+  // stop_planning_debug_info_.set(
+  // StopPlanningDebugInfo::TYPE::STOP_TARGET_OBSTACLE_DISTANCE, stop_margin_from_obstacle);
   stop_planning_debug_info_.set(StopPlanningDebugInfo::TYPE::STOP_TARGET_VELOCITY, 0.0);
   stop_planning_debug_info_.set(StopPlanningDebugInfo::TYPE::STOP_TARGET_ACCELERATION, 0.0);
 
@@ -418,90 +405,90 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
   return output_traj_points;
 }
 
-double PlannerInterface::calculateMarginFromObstacleOnCurve(
-  const PlannerData & planner_data, const StopObstacle & stop_obstacle) const
-{
-  if (!enable_approaching_on_curve_) {
-    return longitudinal_info_.safe_distance_margin;
-  }
+// double PlannerInterface::calculateMarginFromObstacleOnCurve(
+//   const PlannerData & planner_data, const StopObstacle & stop_obstacle) const
+// {
+//   if (!enable_approaching_on_curve_) {
+//     return longitudinal_info_.safe_distance_margin;
+//   }
 
-  const double abs_ego_offset = planner_data.is_driving_forward
-                                  ? std::abs(vehicle_info_.max_longitudinal_offset_m)
-                                  : std::abs(vehicle_info_.min_longitudinal_offset_m);
+//   const double abs_ego_offset = planner_data.is_driving_forward
+//                                   ? std::abs(vehicle_info_.max_longitudinal_offset_m)
+//                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);
 
-  // calculate short trajectory points towards obstacle
-  const size_t obj_segment_idx =
-    motion_utils::findNearestSegmentIndex(planner_data.traj_points, stop_obstacle.collision_point);
-  std::vector<TrajectoryPoint> short_traj_points{planner_data.traj_points.at(obj_segment_idx + 1)};
-  double sum_short_traj_length{0.0};
-  for (int i = obj_segment_idx; 0 <= i; --i) {
-    short_traj_points.push_back(planner_data.traj_points.at(i));
+//   // calculate short trajectory points towards obstacle
+//   const size_t obj_segment_idx =
+//     motion_utils::findNearestSegmentIndex(planner_data.traj_points,
+//     stop_obstacle.collision_point);
+//   std::vector<TrajectoryPoint> short_traj_points{planner_data.traj_points.at(obj_segment_idx +
+//   1)}; double sum_short_traj_length{0.0}; for (int i = obj_segment_idx; 0 <= i; --i) {
+//     short_traj_points.push_back(planner_data.traj_points.at(i));
 
-    if (
-      1 < short_traj_points.size() &&
-      longitudinal_info_.safe_distance_margin + abs_ego_offset < sum_short_traj_length) {
-      break;
-    }
-    sum_short_traj_length += tier4_autoware_utils::calcDistance2d(
-      planner_data.traj_points.at(i), planner_data.traj_points.at(i + 1));
-  }
-  std::reverse(short_traj_points.begin(), short_traj_points.end());
-  if (short_traj_points.size() < 2) {
-    return longitudinal_info_.safe_distance_margin;
-  }
+//     if (
+//       1 < short_traj_points.size() &&
+//       longitudinal_info_.safe_distance_margin + abs_ego_offset < sum_short_traj_length) {
+//       break;
+//     }
+//     sum_short_traj_length += tier4_autoware_utils::calcDistance2d(
+//       planner_data.traj_points.at(i), planner_data.traj_points.at(i + 1));
+//   }
+//   std::reverse(short_traj_points.begin(), short_traj_points.end());
+//   if (short_traj_points.size() < 2) {
+//     return longitudinal_info_.safe_distance_margin;
+//   }
 
-  // calculate collision index between straight line from ego pose and object
-  const auto calculate_distance_from_straight_ego_path =
-    [&](const auto & ego_pose, const auto & object_polygon) {
-      const auto forward_ego_pose = tier4_autoware_utils::calcOffsetPose(
-        ego_pose, longitudinal_info_.safe_distance_margin + 3.0, 0.0, 0.0);
-      const auto ego_straight_segment = tier4_autoware_utils::Segment2d{
-        convertPoint(ego_pose.position), convertPoint(forward_ego_pose.position)};
-      return boost::geometry::distance(ego_straight_segment, object_polygon);
-    };
-  const auto resampled_short_traj_points = resampleTrajectoryPoints(short_traj_points, 0.5);
-  const auto object_polygon =
-    tier4_autoware_utils::toPolygon2d(stop_obstacle.pose, stop_obstacle.shape);
-  const auto collision_idx = [&]() -> std::optional<size_t> {
-    for (size_t i = 0; i < resampled_short_traj_points.size(); ++i) {
-      const double dist_to_obj = calculate_distance_from_straight_ego_path(
-        resampled_short_traj_points.at(i).pose, object_polygon);
-      if (dist_to_obj < vehicle_info_.vehicle_width_m / 2.0) {
-        return i;
-      }
-    }
-    return std::nullopt;
-  }();
-  if (!collision_idx) {
-    return min_safe_distance_margin_on_curve_;
-  }
-  if (*collision_idx == 0) {
-    return longitudinal_info_.safe_distance_margin;
-  }
+//   // calculate collision index between straight line from ego pose and object
+//   const auto calculate_distance_from_straight_ego_path =
+//     [&](const auto & ego_pose, const auto & object_polygon) {
+//       const auto forward_ego_pose = tier4_autoware_utils::calcOffsetPose(
+//         ego_pose, longitudinal_info_.safe_distance_margin + 3.0, 0.0, 0.0);
+//       const auto ego_straight_segment = tier4_autoware_utils::Segment2d{
+//         convertPoint(ego_pose.position), convertPoint(forward_ego_pose.position)};
+//       return boost::geometry::distance(ego_straight_segment, object_polygon);
+//     };
+//   const auto resampled_short_traj_points = resampleTrajectoryPoints(short_traj_points, 0.5);
+//   const auto object_polygon =
+//     tier4_autoware_utils::toPolygon2d(stop_obstacle.pose, stop_obstacle.shape);
+//   const auto collision_idx = [&]() -> std::optional<size_t> {
+//     for (size_t i = 0; i < resampled_short_traj_points.size(); ++i) {
+//       const double dist_to_obj = calculate_distance_from_straight_ego_path(
+//         resampled_short_traj_points.at(i).pose, object_polygon);
+//       if (dist_to_obj < vehicle_info_.vehicle_width_m / 2.0) {
+//         return i;
+//       }
+//     }
+//     return std::nullopt;
+//   }();
+//   if (!collision_idx) {
+//     return min_safe_distance_margin_on_curve_;
+//   }
+//   if (*collision_idx == 0) {
+//     return longitudinal_info_.safe_distance_margin;
+//   }
 
-  // calculate margin from obstacle
-  const double partial_segment_length = [&]() {
-    const double collision_segment_length = tier4_autoware_utils::calcDistance2d(
-      resampled_short_traj_points.at(*collision_idx - 1),
-      resampled_short_traj_points.at(*collision_idx));
-    const double prev_dist = calculate_distance_from_straight_ego_path(
-      resampled_short_traj_points.at(*collision_idx - 1).pose, object_polygon);
-    const double next_dist = calculate_distance_from_straight_ego_path(
-      resampled_short_traj_points.at(*collision_idx).pose, object_polygon);
-    return (next_dist - vehicle_info_.vehicle_width_m / 2.0) / (next_dist - prev_dist) *
-           collision_segment_length;
-  }();
+//   // calculate margin from obstacle
+//   const double partial_segment_length = [&]() {
+//     const double collision_segment_length = tier4_autoware_utils::calcDistance2d(
+//       resampled_short_traj_points.at(*collision_idx - 1),
+//       resampled_short_traj_points.at(*collision_idx));
+//     const double prev_dist = calculate_distance_from_straight_ego_path(
+//       resampled_short_traj_points.at(*collision_idx - 1).pose, object_polygon);
+//     const double next_dist = calculate_distance_from_straight_ego_path(
+//       resampled_short_traj_points.at(*collision_idx).pose, object_polygon);
+//     return (next_dist - vehicle_info_.vehicle_width_m / 2.0) / (next_dist - prev_dist) *
+//            collision_segment_length;
+//   }();
 
-  const double short_margin_from_obstacle =
-    partial_segment_length +
-    motion_utils::calcSignedArcLength(
-      resampled_short_traj_points, *collision_idx, stop_obstacle.collision_point) -
-    abs_ego_offset + additional_safe_distance_margin_on_curve_;
+//   const double short_margin_from_obstacle =
+//     partial_segment_length +
+//     motion_utils::calcSignedArcLength(
+//       resampled_short_traj_points, *collision_idx, stop_obstacle.collision_point) -
+//     abs_ego_offset + additional_safe_distance_margin_on_curve_;
 
-  return std::min(
-    longitudinal_info_.safe_distance_margin,
-    std::max(min_safe_distance_margin_on_curve_, short_margin_from_obstacle));
-}
+//   return std::min(
+//     longitudinal_info_.safe_distance_margin,
+//     std::max(min_safe_distance_margin_on_curve_, short_margin_from_obstacle));
+// }
 
 double PlannerInterface::calcDistanceToCollisionPoint(
   const PlannerData & planner_data, const geometry_msgs::msg::Point & collision_point)

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -98,6 +98,7 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> getCollisionIndex(
 
   return std::nullopt;
 }
+
 }  // namespace
 
 namespace polygon_utils
@@ -127,10 +128,9 @@ Polygon2d createOneStepPolygon(
   }
 
   bg::correct(polygon);
-
   Polygon2d hull_polygon;
   bg::convex_hull(polygon, hull_polygon);
-
+  bg::correct(hull_polygon);
   return hull_polygon;
 }
 

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -98,7 +98,6 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> getCollisionIndex(
 
   return std::nullopt;
 }
-
 }  // namespace
 
 namespace polygon_utils
@@ -130,7 +129,6 @@ Polygon2d createOneStepPolygon(
   bg::correct(polygon);
   Polygon2d hull_polygon;
   bg::convex_hull(polygon, hull_polygon);
-  bg::correct(hull_polygon);
   return hull_polygon;
 }
 

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -95,24 +95,16 @@ PoseWithStamp getCurrentObjectPose(
   return PoseWithStamp{obj_base_time, *interpolated_pose};
 }
 
-std::optional<StopObstacle> getClosestStopObstacle(
-  const std::vector<TrajectoryPoint> & traj_points,
-  const std::vector<StopObstacle> & stop_obstacles)
+std::optional<StopObstacle> getClosestStopObstacle(const std::vector<StopObstacle> & stop_obstacles)
 {
-  if (stop_obstacles.empty()) {
-    return std::nullopt;
-  }
-
-  std::optional<StopObstacle> closest_stop_obstacle = std::nullopt;
-  double dist_to_closest_stop_obstacle = std::numeric_limits<double>::max();
+  std::optional<StopObstacle> candidate_obstacle = std::nullopt;
   for (const auto & stop_obstacle : stop_obstacles) {
-    const double dist_to_stop_obstacle =
-      motion_utils::calcSignedArcLength(traj_points, 0, stop_obstacle.collision_point);
-    if (dist_to_stop_obstacle < dist_to_closest_stop_obstacle) {
-      dist_to_closest_stop_obstacle = dist_to_stop_obstacle;
-      closest_stop_obstacle = stop_obstacle;
+    if (
+      !candidate_obstacle ||
+      stop_obstacle.traj_dist_to_stop_point < candidate_obstacle->traj_dist_to_stop_point) {
+      candidate_obstacle = stop_obstacle;
     }
   }
-  return closest_stop_obstacle;
+  return candidate_obstacle;
 }
 }  // namespace obstacle_cruise_utils


### PR DESCRIPTION
## Description


BEFORE:
The current implementation calculate the stop point by the closest collision point.
This cause inappropriate behavior for looped trajectories.
![image-20231020-104158](https://github.com/autowarefoundation/autoware.universe/assets/141538661/a1ecafe2-3438-403b-a886-2bb50674f993)


AFTER:
The stop point is calculation relies on the distance between the polygons
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/7f07f039-6654-4607-b858-2323ffad2f66)
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/15db0da2-1860-4a94-97a0-a07ddde5796e)
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/a3d34625-f382-482d-8002-985ae2b802d7)

The followings are achieved by this PR, 
- Proper handling of collision in extended trajectory is achieved (It is the main motivation of this PR).
- The stop point modification around the goal point is now working properly.
- This PR contains the similar feature to https://github.com/autowarefoundation/autoware.universe/pull/4952, and therefore approaching on curve is now provided as default setting.
- `goal_extension_length` and `goal_extension_interval` may be no longer used and `safe_distance_margin` and `decimate_trajectory_step_length` are used instead.

## Related links
No launch file changes.

## Tests performed
psim test and tier4 internal tests was performed.
Implemented logic works well.
Calculation time seems to increase somewhat but may not be doubled.

https://evaluation.tier4.jp/evaluation/reports/9843ed0c-3a29-54c2-9ded-8522350900ac?project_id=prd_jt

## Notes for reviewers
While no longer used parameters remain, I will remove these parameters after this PR has been agreed upon.

## Interface changes
No interface changes.

## Effects on system behavior
The minor bugs mentioned above have been fixed.
The slow down planning and the cruise planning may not changed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
