### PR TITLE
refactor(system_error_monitor): hide error log in no-fault condition

### DIFF
--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -148,6 +148,8 @@ private:
   bool canAutoRecovery() const;
   bool isEmergencyHoldingRequired() const;
 
+  void loggingErrors(const autoware_auto_system_msgs::msg::HazardStatus & diag_array);
+
   std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
 };
 

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -140,17 +140,9 @@ diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Safe Fault]"));
   }
   for (const auto & hazard_diag : hazard_status.diag_latent_fault) {
-    const std::string logger_name = "system_error_monitor " + hazard_diag.name;
-    logThrottledNamed<DebugLevel::WARN>(
-      logger_name, clock, 5000, "[Latent Fault]: " + hazard_diag.message);
-
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Latent Fault]"));
   }
   for (const auto & hazard_diag : hazard_status.diag_single_point_fault) {
-    const std::string logger_name = "system_error_monitor " + hazard_diag.name;
-    logThrottledNamed<DebugLevel::ERROR>(
-      logger_name, clock, 5000, "[Single Point Fault]: " + hazard_diag.message);
-
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Single Point Fault]"));
   }
 
@@ -688,6 +680,9 @@ void AutowareErrorMonitor::publishHazardStatus(
   hazard_status_stamped.stamp = this->now();
   hazard_status_stamped.status = hazard_status;
   pub_hazard_status_->publish(hazard_status_stamped);
+
+  loggingErrors(hazard_status_stamped.status);
+
   pub_diagnostics_err_->publish(
     convertHazardStatusToDiagnosticArray(this->get_clock(), hazard_status_stamped.status));
 }
@@ -702,4 +697,26 @@ bool AutowareErrorMonitor::onClearEmergencyService(
   response->message = "Emergency Holding state was cleared.";
 
   return true;
+}
+
+void AutowareErrorMonitor::loggingErrors(
+  const autoware_auto_system_msgs::msg::HazardStatus & hazard_status)
+{
+  const auto is_in_no_fault_condition = isInNoFaultCondition(*autoware_state_, *current_gate_mode_);
+
+  if (is_in_no_fault_condition) {
+    RCLCPP_DEBUG(get_logger(), "Autoware is in no-fault condition.");
+    return;
+  }
+
+  for (const auto & hazard_diag : hazard_status.diag_latent_fault) {
+    const std::string logger_name = "system_error_monitor " + hazard_diag.name;
+    logThrottledNamed<DebugLevel::WARN>(
+      logger_name, get_clock(), 5000, "[Latent Fault]: " + hazard_diag.message);
+  }
+  for (const auto & hazard_diag : hazard_status.diag_single_point_fault) {
+    const std::string logger_name = "system_error_monitor " + hazard_diag.name;
+    logThrottledNamed<DebugLevel::ERROR>(
+      logger_name, get_clock(), 5000, "[Single Point Fault]: " + hazard_diag.message);
+  }
 }

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -702,9 +702,7 @@ bool AutowareErrorMonitor::onClearEmergencyService(
 void AutowareErrorMonitor::loggingErrors(
   const autoware_auto_system_msgs::msg::HazardStatus & hazard_status)
 {
-  const auto is_in_no_fault_condition = isInNoFaultCondition(*autoware_state_, *current_gate_mode_);
-
-  if (is_in_no_fault_condition) {
+  if (isInNoFaultCondition(*autoware_state_, *current_gate_mode_)) {
     RCLCPP_DEBUG(get_logger(), "Autoware is in no-fault condition.");
     return;
   }


### PR DESCRIPTION
## Description

- Do not print ERROR log in NO-FAULT condition

## Related links

[TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-3887)

## Tests performed

Run psim

## Notes for reviewers

None

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Error logs are not displayed in the initializing state.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
