### PR TITLE
refactor(processing_time_checker): display in alphabetical order

### DIFF
--- a/planning/planning_debug_tools/scripts/processing_time_checker.py
+++ b/planning/planning_debug_tools/scripts/processing_time_checker.py
@@ -96,7 +96,9 @@ class ProcessingTimeSubscriber(Node):
         print("-" * len(header_str))
 
         # Print each topic's data
-        for topic, data in self.data_map.items():
+        for topic in sorted(self.data_map.keys()):
+            # Fetch the data for the current topic
+            data = self.data_map[topic]
             # Round the data to the third decimal place for display
             data_rounded = round(data, 3)
             # Calculate the number of bars to be displayed (clamped to max_display_time)


### PR DESCRIPTION
## Description

Display processing time in alphabetical order

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/0719b11f-787a-4cc7-805f-8db1f6090689)


## Tests performed

run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
