### PR TITLE
feat(motion_velocity_smoother): add motion_velocity_smoother's virtual wall such as MRM

### DIFF
--- a/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
+++ b/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
@@ -46,6 +46,7 @@ VelocityLimit getHardestLimit(
     // find hardest max velocity
     if (max_velocity < hardest_max_velocity) {
       hardest_limit.stamp = limit.second.stamp;
+      hardest_limit.sender = limit.first;
       hardest_limit.max_velocity = max_velocity;
       hardest_max_velocity = max_velocity;
     }

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -42,6 +42,7 @@
 #include "tier4_debug_msgs/msg/float32_stamped.hpp"         // temporary
 #include "tier4_planning_msgs/msg/stop_speed_exceeded.hpp"  // temporary
 #include "tier4_planning_msgs/msg/velocity_limit.hpp"       // temporary
+#include "visualization_msgs/msg/marker_array.hpp"
 
 #include <iostream>
 #include <memory>
@@ -63,6 +64,7 @@ using nav_msgs::msg::Odometry;
 using tier4_debug_msgs::msg::Float32Stamped;        // temporary
 using tier4_planning_msgs::msg::StopSpeedExceeded;  // temporary
 using tier4_planning_msgs::msg::VelocityLimit;      // temporary
+using visualization_msgs::msg::MarkerArray;
 
 struct Motion
 {
@@ -80,6 +82,7 @@ public:
 
 private:
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_virtual_wall_;
   rclcpp::Publisher<StopSpeedExceeded>::SharedPtr pub_over_stop_velocity_;
   rclcpp::Subscription<Odometry>::SharedPtr sub_current_odometry_;
   rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr sub_current_acceleration_;
@@ -95,6 +98,7 @@ private:
   double max_velocity_with_deceleration_;         // maximum velocity with deceleration
                                                   // for external velocity limit
   double wheelbase_;                              // wheelbase
+  double base_link2front_;                        // base_link to front
 
   TrajectoryPoints prev_output_;  // previously published trajectory
 
@@ -153,6 +157,7 @@ private:
   {
     double velocity{0.0};  // current external_velocity_limit
     double dist{0.0};      // distance to set external velocity limit
+    std::string sender{""};
   };
   ExternalVelocityLimit
     external_velocity_limit_;  // velocity and distance constraint  of external velocity limit

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -14,6 +14,7 @@
 
 #include "motion_velocity_smoother/motion_velocity_smoother_node.hpp"
 
+#include "motion_utils/marker/marker_helper.hpp"
 #include "motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 #include "motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 #include "motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
@@ -41,6 +42,7 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   // set common params
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
   wheelbase_ = vehicle_info.wheel_base_m;
+  base_link2front_ = vehicle_info.max_longitudinal_offset_m;
   initCommonParam();
   over_stop_velocity_warn_thr_ = declare_parameter<double>("over_stop_velocity_warn_thr");
 
@@ -49,6 +51,7 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
 
   // publishers, subscribers
   pub_trajectory_ = create_publisher<Trajectory>("~/output/trajectory", 1);
+  pub_virtual_wall_ = create_publisher<MarkerArray>("~/virtual_wall", 1);
   pub_velocity_limit_ = create_publisher<VelocityLimit>(
     "~/output/current_velocity_limit_mps", rclcpp::QoS{1}.transient_local());
   pub_dist_to_stopline_ = create_publisher<Float32Stamped>("~/distance_to_stopline", 1);
@@ -328,6 +331,9 @@ void MotionVelocitySmootherNode::calcExternalVelocityLimit()
   if (!external_velocity_limit_ptr_) {
     return;
   }
+
+  // sender
+  external_velocity_limit_.sender = external_velocity_limit_ptr_->sender;
 
   // on the first time, apply directly
   if (prev_output_.empty() || !current_closest_point_from_prev_output_) {
@@ -889,6 +895,12 @@ void MotionVelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & t
   // apply external velocity limit from the inserted point
   trajectory_utils::applyMaximumVelocityLimit(
     *inserted_index, traj.size(), external_velocity_limit_.velocity, traj);
+
+  // create virtual wall
+  const auto virtual_wall_marker = motion_utils::createStopVirtualWallMarker(
+    traj.at(*inserted_index).pose, external_velocity_limit_.sender, this->now(), 0,
+    base_link2front_);
+  pub_virtual_wall_->publish(virtual_wall_marker);
 
   RCLCPP_DEBUG(
     get_logger(), "externalVelocityLimit : limit_vel = %.3f", external_velocity_limit_.velocity);

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -897,10 +897,12 @@ void MotionVelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & t
     *inserted_index, traj.size(), external_velocity_limit_.velocity, traj);
 
   // create virtual wall
-  const auto virtual_wall_marker = motion_utils::createStopVirtualWallMarker(
-    traj.at(*inserted_index).pose, external_velocity_limit_.sender, this->now(), 0,
-    base_link2front_);
-  pub_virtual_wall_->publish(virtual_wall_marker);
+  if (std::abs(external_velocity_limit_.velocity) < 1e-3) {
+    const auto virtual_wall_marker = motion_utils::createStopVirtualWallMarker(
+      traj.at(*inserted_index).pose, external_velocity_limit_.sender, this->now(), 0,
+      base_link2front_);
+    pub_virtual_wall_->publish(virtual_wall_marker);
+  }
 
   RCLCPP_DEBUG(
     get_logger(), "externalVelocityLimit : limit_vel = %.3f", external_velocity_limit_.velocity);


### PR DESCRIPTION
## Description

Currently, when the mrm_confortable_stop_operator requests the motion_velocity_smoother to stop, no virtual wall appears.
For better visualization, this PR adds the virtual wall by motion_velocity_smoother.

This is the case where the ego would leave the lane soon and MRM occurred by lane departure checker.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/89207472-eb38-4615-ac1b-b9e7063f6901)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Added a motion_velocity_smoother's virtual wall
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
