### PR TITLE
refactor(side_shift): support new interface

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -49,8 +49,6 @@ public:
   bool isExecutionReady() const override;
   bool isReadyForNextRequest(
     const double & min_request_time_sec, bool override_requests = false) const noexcept;
-  // TODO(someone): remove this, and use base class function
-  [[deprecated]] ModuleStatus updateState() override;
   void updateData() override;
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
@@ -70,32 +68,12 @@ public:
   {
   }
 
-  // TODO(someone): remove this, and use base class function
-  [[deprecated]] BehaviorModuleOutput run() override
-  {
-    updateData();
-
-    if (!isWaitingApproval()) {
-      return plan();
-    }
-
-    // module is waiting approval. Check it.
-    if (isActivated()) {
-      RCLCPP_DEBUG(getLogger(), "Was waiting approval, and now approved. Do plan().");
-      return plan();
-    } else {
-      RCLCPP_DEBUG(getLogger(), "keep waiting approval... Do planCandidate().");
-      return planWaitingApproval();
-    }
-  }
-
 private:
-  bool canTransitSuccessState() override { return false; }
+  bool canTransitSuccessState() override;
 
   bool canTransitFailureState() override { return false; }
 
-  bool canTransitIdleToRunningState() override { return false; }
-  rclcpp::Subscription<LateralOffset>::SharedPtr lateral_offset_subscriber_;
+  bool canTransitIdleToRunningState() override { return true; }
 
   void initVariables();
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -40,8 +40,6 @@ SideShiftModule::SideShiftModule(
   const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map}, parameters_{parameters}
 {
-  // If lateral offset is subscribed, it approves side shift module automatically
-  clearWaitingApproval();
 }
 
 void SideShiftModule::initVariables()
@@ -80,7 +78,7 @@ void SideShiftModule::setParameters(const std::shared_ptr<SideShiftParameters> &
 
 bool SideShiftModule::isExecutionRequested() const
 {
-  if (current_state_ == ModuleStatus::RUNNING) {
+  if (getCurrentStatus() == ModuleStatus::RUNNING) {
     return true;
   }
 
@@ -112,7 +110,7 @@ bool SideShiftModule::isReadyForNextRequest(
   return false;
 }
 
-ModuleStatus SideShiftModule::updateState()
+bool SideShiftModule::canTransitSuccessState()
 {
   // Never return the FAILURE. When the desired offset is zero and the vehicle is in the original
   // drivable area,this module can stop the computation and return SUCCESS.
@@ -150,7 +148,7 @@ ModuleStatus SideShiftModule::updateState()
     no_shifted_plan);
 
   if (no_request && no_shifted_plan && no_offset_diff) {
-    return ModuleStatus::SUCCESS;
+    return true;
   }
 
   const auto & current_lanes = utils::getCurrentLanes(planner_data_);
@@ -169,7 +167,7 @@ ModuleStatus SideShiftModule::updateState()
   } else {
     shift_status_ = SideShiftStatus::AFTER_SHIFT;
   }
-  return ModuleStatus::RUNNING;
+  return false;
 }
 
 void SideShiftModule::updateData()
@@ -184,7 +182,7 @@ void SideShiftModule::updateData()
     }
   }
 
-  if (current_state_ != ModuleStatus::RUNNING && current_state_ != ModuleStatus::IDLE) {
+  if (getCurrentStatus() != ModuleStatus::RUNNING && getCurrentStatus() != ModuleStatus::IDLE) {
     return;
   }
 
@@ -330,8 +328,6 @@ BehaviorModuleOutput SideShiftModule::planWaitingApproval()
   path_reference_ = getPreviousModuleOutput().reference_path;
 
   prev_output_ = shifted_path;
-
-  waitApproval();
 
   return output;
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 943fef0</samp>

Refactored and simplified the `SideShiftModule` class for the behavior path planner. Removed unused functions, used base class functions, and renamed and changed the return type of `updateState` function. Improved the functionality and readability of the side shift module.

<!-- Write a brief description of this PR. -->

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/44889564/fc2fd05c-86f2-4147-8336-784881f6a2a8

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
