### PR TITLE
fix(avoidance): fix a bug regarding the nearest search

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -614,9 +614,6 @@ struct DebugData
 
   // debug msg array
   AvoidanceDebugMsgArray avoidance_debug_msg_array;
-
-  Pose prev_idx_pose;
-  Pose orig_idx_pose;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -614,6 +614,9 @@ struct DebugData
 
   // debug msg array
   AvoidanceDebugMsgArray avoidance_debug_msg_array;
+
+  Pose prev_idx_pose;
+  Pose orig_idx_pose;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2025,7 +2025,7 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
     planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
 
   const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
-  const auto prev_ego_idx = motion_utils::findNearestIndex(
+  const auto prev_ego_idx = motion_utils::findNearestSegmentIndex(
     previous_path.points, getPose(original_path.points.at(orig_ego_idx)),
     std::numeric_limits<double>::max(), planner_data_->parameters.ego_nearest_yaw_threshold);
   if (!prev_ego_idx) {

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -43,6 +43,36 @@
 #include <string>
 #include <vector>
 
+#define debug(var)                                                      \
+  do {                                                                  \
+    std::cerr << __func__ << ": " << __LINE__ << ", " << #var << " : "; \
+    view(var);                                                          \
+  } while (0)
+template <typename T>
+void view(T e)
+{
+  std::cerr << e << std::endl;
+}
+template <typename T>
+void view(const std::vector<T> & v)
+{
+  for (const auto & e : v) {
+    std::cerr << e << " ";
+  }
+  std::cerr << std::endl;
+}
+template <typename T>
+void view(const std::vector<std::vector<T>> & vv)
+{
+  for (const auto & v : vv) {
+    view(v);
+  }
+}
+#define line()                                                                         \
+  {                                                                                    \
+    std::cerr << "(" << __FILE__ << ") " << __func__ << ": " << __LINE__ << std::endl; \
+  }
+
 // set as macro so that calling function name will be printed.
 // debug print is heavy. turn on only when debugging.
 #define DEBUG_PRINT(...) \
@@ -2025,23 +2055,36 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
     planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
 
   const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
-  const size_t prev_ego_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+  // const size_t prev_ego_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+  //   previous_path.points, getPose(original_path.points.at(orig_ego_idx)),
+  //   std::numeric_limits<double>::max(), planner_data_->parameters.ego_nearest_yaw_threshold);
+  const auto prev_ego_idx = motion_utils::findNearestSegmentIndex(
     previous_path.points, getPose(original_path.points.at(orig_ego_idx)),
     std::numeric_limits<double>::max(), planner_data_->parameters.ego_nearest_yaw_threshold);
+  if (!prev_ego_idx) {
+    PathWithLaneId null_path{};
+    return null_path;
+  }
+
+  // debug(orig_ego_idx);
+  // debug(*prev_ego_idx);
+  // debug_data_.prev_idx_pose = getPose(previous_path.points.at(*prev_ego_idx));
+  // debug_data_.orig_idx_pose = getPose(original_path.points.at(orig_ego_idx));
 
   size_t clip_idx = 0;
   for (size_t i = 0; i < prev_ego_idx; ++i) {
-    if (backward_length > calcSignedArcLength(previous_path.points, clip_idx, prev_ego_idx)) {
+    if (backward_length > calcSignedArcLength(previous_path.points, clip_idx, *prev_ego_idx)) {
       break;
     }
     clip_idx = i;
   }
+  // debug(clip_idx);
 
   PathWithLaneId extended_path{};
   {
     extended_path.points.insert(
       extended_path.points.end(), previous_path.points.begin() + clip_idx,
-      previous_path.points.begin() + prev_ego_idx);
+      previous_path.points.begin() + *prev_ego_idx);
   }
 
   // overwrite backward path velocity by latest one.
@@ -2730,6 +2773,7 @@ void AvoidanceModule::updateDebugMarker(
   }
 
   const auto & path = data.reference_path;
+  const auto & path_rough = data.reference_path_rough;
 
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
 
@@ -2778,11 +2822,12 @@ void AvoidanceModule::updateDebugMarker(
 
   // shift line pre-process
   {
-    addAvoidLine(debug.step1_registered_shift_line, "step1_registered_shift_line", 0.2, 0.2, 1.0);
-    addAvoidLine(debug.step1_current_shift_line, "step1_current_shift_line", 0.2, 0.4, 0.8, 0.3);
-    addAvoidLine(debug.step1_merged_shift_line, "step1_merged_shift_line", 0.2, 0.6, 0.6, 0.3);
-    addAvoidLine(debug.step1_filled_shift_line, "step1_filled_shift_line", 0.2, 0.8, 0.4, 0.3);
-    addAvoidLine(debug.step1_return_shift_line, "step1_return_shift_line", 0.2, 1.0, 0.2, 0.3);
+    //   addAvoidLine(debug.step1_registered_shift_line, "step1_registered_shift_line", 0.2,
+    //   0.2, 1.0); addAvoidLine(debug.step1_current_shift_line, "step1_current_shift_line", 0.2,
+    //   0.4, 0.8, 0.3); addAvoidLine(debug.step1_merged_shift_line, "step1_merged_shift_line", 0.2,
+    //   0.6, 0.6, 0.3); addAvoidLine(debug.step1_filled_shift_line, "step1_filled_shift_line", 0.2,
+    //   0.8, 0.4, 0.3); addAvoidLine(debug.step1_return_shift_line, "step1_return_shift_line",
+    //   0.2, 1.0, 0.2, 0.3);
   }
 
   // merge process
@@ -2792,9 +2837,9 @@ void AvoidanceModule::updateDebugMarker(
 
   // trimming process
   {
-    addAvoidLine(debug.step3_grad_filtered_1st, "step3_grad_filtered_1st", 0.2, 0.8, 0.0, 0.3);
-    addAvoidLine(debug.step3_grad_filtered_2nd, "step3_grad_filtered_2nd", 0.4, 0.6, 0.0, 0.3);
-    addAvoidLine(debug.step3_grad_filtered_3rd, "step3_grad_filtered_3rd", 0.6, 0.4, 0.0, 0.3);
+    // addAvoidLine(debug.step3_grad_filtered_1st, "step3_grad_filtered_1st", 0.2, 0.8, 0.0, 0.3);
+    // addAvoidLine(debug.step3_grad_filtered_2nd, "step3_grad_filtered_2nd", 0.4, 0.6, 0.0, 0.3);
+    // addAvoidLine(debug.step3_grad_filtered_3rd, "step3_grad_filtered_3rd", 0.6, 0.4, 0.0, 0.3);
   }
 
   // registering process
@@ -2806,16 +2851,16 @@ void AvoidanceModule::updateDebugMarker(
 
   // safety check
   {
-    add(showSafetyCheckInfo(debug.collision_check, "object_debug_info"));
-    add(showPredictedPath(debug.collision_check, "ego_predicted_path"));
-    add(showPolygon(debug.collision_check, "ego_and_target_polygon_relation"));
+    // add(showSafetyCheckInfo(debug.collision_check, "object_debug_info"));
+    // add(showPredictedPath(debug.collision_check, "ego_predicted_path"));
+    // add(showPolygon(debug.collision_check, "ego_and_target_polygon_relation"));
   }
 
   // shift length
   {
-    addShiftLength(debug.pos_shift, "merged_length_pos", 0.0, 0.7, 0.5);
-    addShiftLength(debug.neg_shift, "merged_length_neg", 0.0, 0.5, 0.7);
-    addShiftLength(debug.total_shift, "merged_length_total", 0.99, 0.4, 0.2);
+    // addShiftLength(debug.pos_shift, "merged_length_pos", 0.0, 0.7, 0.5);
+    // addShiftLength(debug.neg_shift, "merged_length_neg", 0.0, 0.5, 0.7);
+    // addShiftLength(debug.total_shift, "merged_length_total", 0.99, 0.4, 0.2);
   }
 
   // shift grad
@@ -2829,11 +2874,14 @@ void AvoidanceModule::updateDebugMarker(
   // misc
   {
     add(createEgoStatusMarkerArray(data, getEgoPose(), "ego_status"));
+    add(createPoseMarkerArray(debug.prev_idx_pose, "hoge", 0, 0.9, 0.0, 0.0));
+    add(createPoseMarkerArray(debug.orig_idx_pose, "hoge", 1, 0.0, 0.0, 0.9));
+    add(createPathMarkerArray(path_rough, "rought_centerline_resampled", 0, 0.9, 0.0, 0.0));
     add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
     add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
     add(createPolygonMarkerArray(debug.detection_area, "detection_area", 0L, 0.16, 1.0, 0.69, 0.1));
-    add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
-    add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
+    // add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
+    // add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
   }
 }
 


### PR DESCRIPTION
## Description
This PR fix a bug regarding the nearest search in the function `extendBackwardLength()`
This function requires two pose which are appropriately near to the current ego pose.
The first one is denoted by `orig_ego_idx` and shown in the figure as the blue arrow, the other one is dented by `prev_ego_idx` and shown in the figure as the red arrow.
The code so far failure to find `prev_ego_idx` appropriately and this PR fix this bug.

![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/efcc5889-30c9-4bfb-9e18-351daba3d287)

This PR is re-opened PR from https://github.com/autowarefoundation/autoware.universe/pull/5574 by the author's mistaken force push

## Tests performed
psim tests and the tier4 internal test were performed in success. 

## Effects on system behavior
This PR enables to the system generates avoidance path appropriately on the curved reference paths 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
