### PR TITLE
feat(ekf_localizer): add diagnostic_yaw_bias_filter in EKF

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/diagnostics.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/diagnostics.hpp
@@ -33,6 +33,8 @@ diagnostic_msgs::msg::DiagnosticStatus checkMeasurementDelayGate(
 diagnostic_msgs::msg::DiagnosticStatus checkMeasurementMahalanobisGate(
   const std::string & measurement_type, const bool is_passed_mahalanobis_gate,
   const double mahalanobis_distance, const double mahalanobis_distance_threshold);
+diagnostic_msgs::msg::DiagnosticStatus checkDianosticYawBias(
+  const std::string & measurement_type, const double yaw_bias, const double yaw_bias_threshold);
 
 diagnostic_msgs::msg::DiagnosticStatus mergeDiagnosticStatus(
   const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & stat_array);

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -152,6 +152,7 @@ private:
   Simple1DFilter z_filter_;
   Simple1DFilter roll_filter_;
   Simple1DFilter pitch_filter_;
+  Simple1DFilter diagnostic_yaw_bias_filter_;
 
   const HyperParameters params_;
 
@@ -171,6 +172,7 @@ private:
 
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
+  geometry_msgs::msg::PoseWithCovarianceStamped previous_ndt_pose_;  //!< @brief previous ndt pose
 
   /**
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time
@@ -227,6 +229,14 @@ private:
    */
   void updateSimple1DFilters(
     const geometry_msgs::msg::PoseWithCovarianceStamped & pose, const size_t smoothing_step);
+
+  /**
+   * @brief estimate yaw bias
+   */
+  void simpleEstimateYawBias(
+    const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
+    const geometry_msgs::msg::TwistWithCovarianceStamped & twist, double & yaw_bias,
+    double & obs_variance);
 
   /**
    * @brief initialize simple1DFilter

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -15,12 +15,12 @@
 #ifndef EKF_LOCALIZER__EKF_LOCALIZER_HPP_
 #define EKF_LOCALIZER__EKF_LOCALIZER_HPP_
 
-#include "ekf_localizer/simple_filter_base.hpp"
-#include "ekf_localizer/yaw_bias_monitor.hpp"
 #include "ekf_localizer/aged_object_queue.hpp"
 #include "ekf_localizer/ekf_module.hpp"
 #include "ekf_localizer/hyper_parameters.hpp"
+#include "ekf_localizer/simple_filter_base.hpp"
 #include "ekf_localizer/warning.hpp"
+#include "ekf_localizer/yaw_bias_monitor.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
@@ -50,7 +50,6 @@
 #include <queue>
 #include <string>
 #include <vector>
-
 
 class EKFLocalizer : public rclcpp::Node
 {

--- a/localization/ekf_localizer/include/ekf_localizer/simple_filter_base.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/simple_filter_base.hpp
@@ -1,0 +1,73 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EKF_LOCALIZER__SIMPLE_FILTER_BASE_HPP_
+#define EKF_LOCALIZER__SIMPLE_FILTER_BASE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+
+
+class Simple1DFilter
+{
+public:
+  Simple1DFilter()
+  {
+    initialized_ = false;
+    x_ = 0;
+    dev_ = 1e9;
+    proc_dev_x_c_ = 0.0;
+    return;
+  };
+  void init(const double init_obs, const double obs_dev, const rclcpp::Time time)
+  {
+    x_ = init_obs;
+    dev_ = obs_dev;
+    latest_time_ = time;
+    initialized_ = true;
+    return;
+  };
+  void update(const double obs, const double obs_dev, const rclcpp::Time time)
+  {
+    if (!initialized_) {
+      init(obs, obs_dev, time);
+      return;
+    }
+
+    // Prediction step (current stddev_)
+    double dt = (time - latest_time_).seconds();
+    double proc_dev_x_d = proc_dev_x_c_ * dt * dt;
+    dev_ = dev_ + proc_dev_x_d;
+
+    // Update step
+    double kalman_gain = dev_ / (dev_ + obs_dev);
+    x_ = x_ + kalman_gain * (obs - x_);
+    dev_ = (1 - kalman_gain) * dev_;
+
+    latest_time_ = time;
+    return;
+  };
+  void set_proc_dev(const double proc_dev) { proc_dev_x_c_ = proc_dev; }
+  double get_x() const { return x_; }
+
+private:
+  bool initialized_;
+  double x_;
+  double dev_;
+  double proc_dev_x_c_;
+  rclcpp::Time latest_time_;
+};
+
+#endif  // EKF_LOCALIZER__SIMPLE_FILTER_BASE_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/simple_filter_base.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/simple_filter_base.hpp
@@ -19,7 +19,6 @@
 
 #include <string>
 
-
 class Simple1DFilter
 {
 public:

--- a/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
@@ -30,11 +30,13 @@ class YawBiasEstimator : public Simple1DFilter
 public:
   YawBiasEstimator()
   : Simple1DFilter(),
-    time_lower_limit(0.03),
-    speed_lower_limit(2),
-    rotation_speed_upper_limit(0.01),
-    distance_upper_limit(10),
-    distance_lower_limit(0.1){};
+    time_lower_limit_(0.03),
+    speed_lower_limit_(2),
+    rotation_speed_upper_limit_(0.01),
+    distance_upper_limit_(10),
+    distance_lower_limit_(0.1)
+  {
+  }
 
   void update(const geometry_msgs::msg::PoseWithCovarianceStamped & pose, double obs_variance = 0.1)
   {
@@ -43,7 +45,7 @@ public:
     double time_diff = pose_time_diff.seconds();
 
     std::cout << "1DKF: time_diff: " << time_diff << std::endl;
-    if (time_diff < time_lower_limit) {
+    if (time_diff < time_lower_limit_) {
       return;
     }
 
@@ -65,8 +67,8 @@ public:
 
     previous_ndt_pose_ = pose;
     if (
-      (speed < speed_lower_limit) || (rotation_speed > rotation_speed_upper_limit) ||
-      (distance > distance_upper_limit) || (distance < distance_lower_limit)) {
+      (speed < speed_lower_limit_) || (rotation_speed > rotation_speed_upper_limit_) ||
+      (distance > distance_upper_limit_) || (distance < distance_lower_limit_)) {
       return;  // ignore when speed is low or rotation speed is high
     }
     Simple1DFilter::update(yaw_bias, obs_variance, pose.header.stamp);
@@ -74,11 +76,11 @@ public:
 
 private:
   geometry_msgs::msg::PoseWithCovarianceStamped previous_ndt_pose_;
-  double time_lower_limit;
-  double speed_lower_limit;
-  double rotation_speed_upper_limit;
-  double distance_upper_limit;
-  double distance_lower_limit;
+  const double time_lower_limit_;
+  const double speed_lower_limit_;
+  const double rotation_speed_upper_limit_;
+  const double distance_upper_limit_;
+  const double distance_lower_limit_;
 
   double normalize_angle_diff(double angle_difference)
   {

--- a/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
@@ -26,13 +26,12 @@
 class YawBiasEstimator : public Simple1DFilter
 {
 public:
-    YawBiasEstimator(): 
-      Simple1DFilter(),
-      speed_lower_limit(2),
-      rotation_speed_upper_limit(0.01),
-      distance_upper_limit(10),
-      distance_lower_limit(0.1)
-    {};
+  YawBiasEstimator()
+  : Simple1DFilter(),
+    speed_lower_limit(2),
+    rotation_speed_upper_limit(0.01),
+    distance_upper_limit(10),
+    distance_lower_limit(0.1){};
 
   void update(
     const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
@@ -57,10 +56,9 @@ public:
     double speed = std::abs(twist.twist.twist.linear.x);
     double rotation_speed = std::abs(twist.twist.twist.angular.z);
     previous_ndt_pose_ = pose;
-    if ((speed < speed_lower_limit) ||
-        (rotation_speed > rotation_speed_upper_limit) ||
-        (distance > distance_upper_limit) ||
-        (distance < distance_lower_limit)) {
+    if (
+      (speed < speed_lower_limit) || (rotation_speed > rotation_speed_upper_limit) ||
+      (distance > distance_upper_limit) || (distance < distance_lower_limit)) {
       return;  // ignore when speed is low or rotation speed is high
     }
     Simple1DFilter::update(yaw_bias, obs_variance, pose.header.stamp);

--- a/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
@@ -1,0 +1,62 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EKF_LOCALIZER__YAW_BIAS_ESTIMATOR_HPP_
+#define EKF_LOCALIZER__YAW_BIAS_ESTIMATOR_HPP_
+
+#include "ekf_localizer/simple_filter_base.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+
+class YawBiasEstimator: public Simple1DFilter
+{
+public:
+    void update(const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
+                const geometry_msgs::msg::TwistWithCovarianceStamped & twist,
+                double obs_variance = 0.1)
+    {
+        double dx = pose.pose.pose.position.x - previous_ndt_pose_.pose.pose.position.x;
+        double dy = pose.pose.pose.position.y - previous_ndt_pose_.pose.pose.position.y;
+        double distance = std::sqrt(dx * dx + dy * dy);
+        double estimated_yaw = std::atan2(dy, dx);
+        double measured_yaw = std::atan2(pose.pose.pose.orientation.z, pose.pose.pose.orientation.w) * 2;
+
+        double yaw_bias = measured_yaw - estimated_yaw;
+
+        while (yaw_bias > M_PI / 2) {
+            yaw_bias -= M_PI;
+        }
+        while (yaw_bias < -M_PI / 2) {
+            yaw_bias += M_PI;
+        }  // normalize to -pi/2 ~ pi/2
+
+        double speed = std::abs(twist.twist.twist.linear.x);
+        double rotation_speed = std::abs(twist.twist.twist.angular.z);
+        previous_ndt_pose_ = pose;
+        if ((speed < 2) || (rotation_speed > 0.01) || (distance > 10) || (distance < 0.1)) {
+            return; // ignore when speed is low or rotation speed is high
+        }
+        Simple1DFilter::update(yaw_bias, obs_variance, pose.header.stamp);
+    }
+
+private:
+  rclcpp::Node * node_;
+    geometry_msgs::msg::PoseWithCovarianceStamped previous_ndt_pose_;
+};
+
+#endif  // EKF_LOCALIZER__YAW_BIAS_ESTIMATOR_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
@@ -17,10 +17,12 @@
 
 #include "ekf_localizer/simple_filter_base.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
-#include <rclcpp/rclcpp.hpp>
+
 #include <string>
 
 class YawBiasEstimator : public Simple1DFilter
@@ -34,10 +36,10 @@ public:
     distance_upper_limit(10),
     distance_lower_limit(0.1){};
 
-  void update(
-    const geometry_msgs::msg::PoseWithCovarianceStamped & pose, double obs_variance = 0.1)
+  void update(const geometry_msgs::msg::PoseWithCovarianceStamped & pose, double obs_variance = 0.1)
   {
-    auto pose_time_diff = rclcpp::Time(pose.header.stamp) - rclcpp::Time(previous_ndt_pose_.header.stamp);
+    auto pose_time_diff =
+      rclcpp::Time(pose.header.stamp) - rclcpp::Time(previous_ndt_pose_.header.stamp);
     double time_diff = pose_time_diff.seconds();
 
     std::cout << "1DKF: time_diff: " << time_diff << std::endl;
@@ -78,7 +80,8 @@ private:
   double distance_upper_limit;
   double distance_lower_limit;
 
-  double normalize_angle_diff(double angle_difference){
+  double normalize_angle_diff(double angle_difference)
+  {
     while (angle_difference > M_PI) {
       angle_difference -= 2 * M_PI;
     }

--- a/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
@@ -17,8 +17,6 @@
 
 #include "ekf_localizer/simple_filter_base.hpp"
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -58,7 +56,6 @@ public:
   }
 
 private:
-  rclcpp::Node * node_;
   geometry_msgs::msg::PoseWithCovarianceStamped previous_ndt_pose_;
 };
 

--- a/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/yaw_bias_monitor.hpp
@@ -26,6 +26,14 @@
 class YawBiasEstimator : public Simple1DFilter
 {
 public:
+    YawBiasEstimator(): 
+      Simple1DFilter(),
+      speed_lower_limit(2),
+      rotation_speed_upper_limit(0.01),
+      distance_upper_limit(10),
+      distance_lower_limit(0.1)
+    {};
+
   void update(
     const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist, double obs_variance = 0.1)
@@ -49,7 +57,10 @@ public:
     double speed = std::abs(twist.twist.twist.linear.x);
     double rotation_speed = std::abs(twist.twist.twist.angular.z);
     previous_ndt_pose_ = pose;
-    if ((speed < 2) || (rotation_speed > 0.01) || (distance > 10) || (distance < 0.1)) {
+    if ((speed < speed_lower_limit) ||
+        (rotation_speed > rotation_speed_upper_limit) ||
+        (distance > distance_upper_limit) ||
+        (distance < distance_lower_limit)) {
       return;  // ignore when speed is low or rotation speed is high
     }
     Simple1DFilter::update(yaw_bias, obs_variance, pose.header.stamp);
@@ -57,6 +68,10 @@ public:
 
 private:
   geometry_msgs::msg::PoseWithCovarianceStamped previous_ndt_pose_;
+  double speed_lower_limit;
+  double rotation_speed_upper_limit;
+  double distance_upper_limit;
+  double distance_lower_limit;
 };
 
 #endif  // EKF_LOCALIZER__YAW_BIAS_MONITOR_HPP_

--- a/localization/ekf_localizer/src/diagnostics.cpp
+++ b/localization/ekf_localizer/src/diagnostics.cpp
@@ -155,8 +155,8 @@ diagnostic_msgs::msg::DiagnosticStatus checkDianosticYawBias(
   stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   stat.message = "OK";
   if (std::abs(yaw_bias) > yaw_bias_threshold) {
-    stat.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    stat.message = "[WARN] estimated yaw bias of " + measurement_type + " is large";
+    stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    stat.message = "[ERROR] estimated yaw bias of " + measurement_type + " is large";
   }
 
   return stat;

--- a/localization/ekf_localizer/src/diagnostics.cpp
+++ b/localization/ekf_localizer/src/diagnostics.cpp
@@ -139,6 +139,29 @@ diagnostic_msgs::msg::DiagnosticStatus checkMeasurementMahalanobisGate(
   return stat;
 }
 
+diagnostic_msgs::msg::DiagnosticStatus checkDianosticYawBias(
+  const std::string & measurement_type, const double yaw_bias, const double yaw_bias_threshold)
+{
+  diagnostic_msgs::msg::DiagnosticStatus stat;
+
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = measurement_type + "yaw_bias";
+  key_value.value = std::to_string(yaw_bias);
+  stat.values.push_back(key_value);
+  key_value.key = measurement_type + "yaw_bias_threshold";
+  key_value.value = std::to_string(yaw_bias_threshold);
+  stat.values.push_back(key_value);
+
+  stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  stat.message = "OK";
+  if (std::abs(yaw_bias) > yaw_bias_threshold) {
+    stat.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    stat.message = "[WARN] estimated yaw bias of " + measurement_type + " is large";
+  }
+
+  return stat;
+}
+
 // The highest level within the stat_array will be reflected in the merged_stat.
 // When all stat_array entries are 'OK,' the message of merged_stat will be "OK"
 diagnostic_msgs::msg::DiagnosticStatus mergeDiagnosticStatus(

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -489,7 +489,7 @@ void EKFLocalizer::initSimple1DFilters(const geometry_msgs::msg::PoseWithCovaria
   double z_dev = pose.pose.covariance[COV_IDX::Z_Z];
   double roll_dev = pose.pose.covariance[COV_IDX::ROLL_ROLL];
   double pitch_dev = pose.pose.covariance[COV_IDX::PITCH_PITCH];
-  double diagnostic_yaw_dev_init = 1e9;  // make no assumption for the
+  double diagnostic_yaw_dev_init = 1e9;  // make no assumption for the prior
 
   z_filter_.init(z, z_dev, pose.header.stamp);
   roll_filter_.init(rpy.x, roll_dev, pose.header.stamp);

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -441,7 +441,9 @@ void EKFLocalizer::updateSimple1DFilters(
       diagnostic_yaw_bias_filter_.update(yaw_bias, obs_variance, pose.header.stamp);
     }
     previous_ndt_pose_ = pose;
-    DEBUG_INFO(get_logger(), "[1DEKF] yaw_bias = %f; [1DEKF] filtered_yaw_bias = %f", yaw_bias, diagnostic_yaw_bias_filter_.get_x());
+    DEBUG_INFO(
+      get_logger(), "[1DEKF] yaw_bias = %f; [1DEKF] filtered_yaw_bias = %f", yaw_bias,
+      diagnostic_yaw_bias_filter_.get_x());
   }
 }
 
@@ -468,8 +470,10 @@ void EKFLocalizer::simpleEstimateYawBias(
   double speed = std::abs(twist.twist.twist.linear.x);
   double rotation_speed = std::abs(twist.twist.twist.angular.z);
 
-  DEBUG_INFO(get_logger(), "[1DEKF] dx = %f, dy = %f, yaw0 = %f, yaw1 = %f; speed = %f; rotation_speed = %f; ",
-                   dx, dy, estimated_yaw, measured_yaw, speed, rotation_speed);
+  DEBUG_INFO(
+    get_logger(),
+    "[1DEKF] dx = %f, dy = %f, yaw0 = %f, yaw1 = %f; speed = %f; rotation_speed = %f; ", dx, dy,
+    estimated_yaw, measured_yaw, speed, rotation_speed);
 
   if ((speed > 2) && (rotation_speed < 0.01) && (distance < 10) && (distance > 0.1)) {
     obs_variance = 0.1;

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -432,11 +432,8 @@ void EKFLocalizer::updateSimple1DFilters(
   z_filter_.update(z, z_dev, pose.header.stamp);
   roll_filter_.update(rpy.x, roll_dev, pose.header.stamp);
   pitch_filter_.update(rpy.y, pitch_dev, pose.header.stamp);
-  if (twist_queue_.size() > 0) {
-    auto twist = twist_queue_.back();
-    diagnostic_yaw_bias_filter_.update(pose, *twist, 0.1);
-    DEBUG_INFO(get_logger(), "[1DKF] filtered_yaw_bias = %f", diagnostic_yaw_bias_filter_.get_x());
-  }
+  diagnostic_yaw_bias_filter_.update(pose, 0.1);
+  DEBUG_INFO(get_logger(), "[1DKF] filtered_yaw_bias = %f", diagnostic_yaw_bias_filter_.get_x());
 }
 
 void EKFLocalizer::initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose)

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -435,7 +435,7 @@ void EKFLocalizer::updateSimple1DFilters(
   if (twist_queue_.size() > 0) {
     auto twist = twist_queue_.back();
     diagnostic_yaw_bias_filter_.update(pose, *twist, 0.1);
-    DEBUG_INFO(get_logger(), "[1DEKF] filtered_yaw_bias = %f", diagnostic_yaw_bias_filter_.get_x());
+    DEBUG_INFO(get_logger(), "[1DKF] filtered_yaw_bias = %f", diagnostic_yaw_bias_filter_.get_x());
   }
 }
 

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -435,9 +435,7 @@ void EKFLocalizer::updateSimple1DFilters(
   if (twist_queue_.size() > 0) {
     auto twist = twist_queue_.back();
     diagnostic_yaw_bias_filter_.update(pose, *twist, 0.1);
-    DEBUG_INFO(
-      get_logger(), "[1DEKF] filtered_yaw_bias = %f",
-      diagnostic_yaw_bias_filter_.get_x());
+    DEBUG_INFO(get_logger(), "[1DEKF] filtered_yaw_bias = %f", diagnostic_yaw_bias_filter_.get_x());
   }
 }
 


### PR DESCRIPTION
## Description

Adding diagnostic yaw bias (calibration error between the LiDAR and base_link in yaw angle) filter in the EKF package.

Backgrounds:

1. There is an option to turn on the Yaw-bias-estimation option in EKF, which jointly optimizes the fusion poses and calibration error.
2. However, there will be cases where turning on yaw-bias-estimation could lower the localization accuracy. 
3. We hope to monitor this calibration error while keeping the original computation of EKF (with or without yaw bias estimation).

As a result, I try to implement a standalone yaw bias estimator in parallel to the EKF process, while utilizing the existing infrastructure in EKF.

## Related links

[TIER IV Internal Link](https://tier4.atlassian.net/wiki/spaces/~6061477cafe465006afac8aa/pages/2920055763/Yaw+Bias+Monitoring) a confluence page illustrates the mathematical principle of this PR, including a python script and demonstrative performance. 

## Tests performed

When tested in an internal bag with stable running, we got some results indicating that there is no significant yaw-bias error. I have also tested cases where I made an inaccurate initialization and the estimator could still converge to a healthy result.

[TIER IV Internal Bag1](https://console.data-search.tier4.jp/projects/prd_jt/environments/9ba5b2bc-9b8e-438a-aba6-342d19c876a5/rosbags/5f75e961-43b3-4119-9a96-7893487baaf6)
![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/d4148661-4717-4e64-a498-16a225412f64)

When tested in an internal bag with low-speed running (many stopping cases), the filter will almost stop updating because of unreliable data. [TIRE IV Internal Bag2](https://console.data-search.tier4.jp/projects/prd_jt/environments/9ba5b2bc-9b8e-438a-aba6-342d19c876a5/rosbags/b3c878c9-2555-49d5-b063-47e368be2d51). There will be no extra error reports in this case.

Then we manually add a bias in the obtained orientation when running on [TIER IV Internal Bag1](https://console.data-search.tier4.jp/projects/prd_jt/environments/9ba5b2bc-9b8e-438a-aba6-342d19c876a5/rosbags/5f75e961-43b3-4119-9a96-7893487baaf6). The code correctly compute the bias in yaw angle and produce diagnostic information.
![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/e6a3dd27-729c-46c8-b71f-4496c16c2bcb)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

The estimator requires both twist input and pose input to take effect.  
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

The computational burden is not large. One more 1D KF filter is adopted.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
