### PR TITLE
fix(drivable_area_expansion): fix bug when reusing previous path points

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -71,16 +71,15 @@ void reuse_previous_poses(
     if (first_idx && deviation < params.max_reuse_deviation) {
       LineString2d path_ls;
       for (const auto & p : path.points) path_ls.push_back(convert_point(p.point.pose.position));
-      PointDistance closest_projection;
-      closest_projection.distance = std::numeric_limits<double>::max();
       for (auto idx = *first_idx; idx < prev_poses.size(); ++idx) {
+        double lateral_offset = std::numeric_limits<double>::max();
         for (auto segment_idx = 0LU; segment_idx + 1 < path_ls.size(); ++segment_idx) {
           const auto projection = point_to_line_projection(
             convert_point(prev_poses[idx].position), path_ls[segment_idx],
             path_ls[segment_idx + 1]);
-          if (projection.distance < closest_projection.distance) closest_projection = projection;
+          lateral_offset = std::min(projection.distance, lateral_offset);
         }
-        if (closest_projection.distance > params.max_reuse_deviation) break;
+        if (lateral_offset > params.max_reuse_deviation) break;
         cropped_poses.push_back(prev_poses[idx]);
         cropped_curvatures.push_back(prev_curvatures[idx]);
       }

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -60,10 +60,10 @@ void reuse_previous_poses(
   for (const auto & p : path.right_bound) right_bound.push_back(convert_point(p));
   LineString2d prev_poses_ls;
   for (const auto & p : prev_poses) prev_poses_ls.push_back(convert_point(p.position));
-  auto prev_poses_accross_bounds = boost::geometry::intersects(left_bound, prev_poses_ls) ||
-                                   boost::geometry::intersects(right_bound, prev_poses_ls);
+  auto prev_poses_across_bounds = boost::geometry::intersects(left_bound, prev_poses_ls) ||
+                                  boost::geometry::intersects(right_bound, prev_poses_ls);
 
-  if (!ego_is_behind && !ego_is_far && prev_poses.size() > 1 && !prev_poses_accross_bounds) {
+  if (!ego_is_behind && !ego_is_far && prev_poses.size() > 1 && !prev_poses_across_bounds) {
     const auto first_idx =
       motion_utils::findNearestSegmentIndex(prev_poses, path.points.front().point.pose);
     const auto deviation =


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In order to provide a more stable output, the dynamic drivable area expansion reuses previous points of the path if they move by less than the `reuse_max_deviation` parameter. This can cause situations where the previous points are _behind_ the (non expanded) drivable area bounds. This could cause bugs in the expansion and yield wrong expanded drivable area.

This PR adds a check for this case to prevent bugs from occurring.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Evaluator (TIER IV INTERNAL LINK): 
- https://evaluation.tier4.jp/evaluation/reports/02817151-361b-592f-81f8-cdef75c7f5da?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/a7918c0e-7ce8-5437-b469-bc64ce7cb597?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
