### PR TITLE
fix(ekf_localizer): fixed bug where calculation of delay_step may be incorrect when timer callback is stuck 

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -163,8 +163,8 @@ private:
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
 
-  //!< @brief accumulated time for timer callback
-  rclcpp::Duration accumulated_time_;
+  //!< @brief accumulated time for prediction in timer callback
+  rclcpp::Duration accumulated_lap_time_;
 
   /**
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time
@@ -192,9 +192,9 @@ private:
   void callbackInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
 
   /**
-   * @brief update predict frequency
+   * @brief measure lap time of timer callback
    */
-  void updatePredictFrequency();
+  void measureLapTime();
 
   /**
    * @brief get transform from frame_id

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -135,7 +135,7 @@ private:
   //!< @brief time for ekf calculation callback
   rclcpp::TimerBase::SharedPtr timer_control_;
   //!< @brief last predict time
-  std::shared_ptr<const rclcpp::Time> last_predict_time_;
+  rclcpp::Time last_predict_time_;
   //!< @brief trigger_node service
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr service_trigger_node_;
 
@@ -155,8 +155,6 @@ private:
 
   const HyperParameters params_;
 
-  double ekf_dt_;
-
   bool is_activated_;
 
   EKFDiagnosticInfo pose_diag_info_;
@@ -164,6 +162,9 @@ private:
 
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
+
+  //!< @brief accumulated time for timer callback
+  rclcpp::Duration accumulated_time_;
 
   /**
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -158,12 +158,6 @@ private:
   double ekf_rate_;
   double ekf_dt_;
 
-  /* process noise variance for discrete model */
-  double proc_cov_yaw_d_;       //!< @brief  discrete yaw process noise
-  double proc_cov_yaw_bias_d_;  //!< @brief  discrete yaw bias process noise
-  double proc_cov_vx_d_;        //!< @brief  discrete process noise in d_vx=0
-  double proc_cov_wz_d_;        //!< @brief  discrete process noise in d_wz=0
-
   bool is_activated_;
 
   EKFDiagnosticInfo pose_diag_info_;

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -155,7 +155,6 @@ private:
 
   const HyperParameters params_;
 
-  double ekf_rate_;
   double ekf_dt_;
 
   bool is_activated_;

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -49,11 +49,6 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
   pose_queue_(params_.pose_smoothing_steps),
   twist_queue_(params_.twist_smoothing_steps)
 {
-  /* convert to continuous to discrete */
-  proc_cov_vx_d_ = std::pow(params_.proc_stddev_vx_c * ekf_dt_, 2.0);
-  proc_cov_wz_d_ = std::pow(params_.proc_stddev_wz_c * ekf_dt_, 2.0);
-  proc_cov_yaw_d_ = std::pow(params_.proc_stddev_yaw_c * ekf_dt_, 2.0);
-
   is_activated_ = false;
 
   /* initialize ros system */
@@ -112,11 +107,6 @@ void EKFLocalizer::updatePredictFrequency()
       ekf_rate_ = 1.0 / (get_clock()->now() - *last_predict_time_).seconds();
       DEBUG_INFO(get_logger(), "[EKF] update ekf_rate_ to %f hz", ekf_rate_);
       ekf_dt_ = 1.0 / std::max(ekf_rate_, 0.1);
-
-      /* Update discrete proc_cov*/
-      proc_cov_vx_d_ = std::pow(params_.proc_stddev_vx_c * ekf_dt_, 2.0);
-      proc_cov_wz_d_ = std::pow(params_.proc_stddev_wz_c * ekf_dt_, 2.0);
-      proc_cov_yaw_d_ = std::pow(params_.proc_stddev_yaw_c * ekf_dt_, 2.0);
     }
   }
   last_predict_time_ = std::make_shared<const rclcpp::Time>(get_clock()->now());


### PR DESCRIPTION
## Description

In the `measurementUpdatePose` and `measurementUpdateTwist` of ekf_module.cpp, a variable `delay_step`, which is used for extracting previous states in the EKF, have been computed by the following. 
```
const int delay_step = std::roundf(delay_time / dt);
```
Currently, the devisor `dt` is the measured lap time of the timer_callback, but since ekf_localizer is a single thread node, the lap time of the timer callback may be different than expected. Generally, the lap time gets once longer when other callbacks provoke, and then gets shorter to catch up. This results to incorrect extracting of previous states. Thanks to the damping strategy in the EKF, this bug hasn't been exposed as a critical outcome, but yet it should be solved.

To solve this, I implemented a feature that the ekf_localizer will perform prediction forcefully according to its `prediction_frequency` defined in ekf_localizer.param.yaml. The ekf_localizer will measure and accumulate the lap time of the timer callback, and performs prediction when it exceeds the period (calculated from `prediction frequency`)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
