### PR TITLE
refactor(pose_instability_detector, ar_tag_based_localizer): specify file path using get_package_share_directory

### DIFF
--- a/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>aruco</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_msgs</depend>

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/test/test.cpp
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/test/test.cpp
@@ -14,6 +14,7 @@
 
 #include "../src/ar_tag_based_localizer.hpp"
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
@@ -29,8 +30,8 @@ protected:
   void SetUp() override
   {
     const std::string yaml_path =
-      "../../install/ar_tag_based_localizer/share/ar_tag_based_localizer/config/"
-      "ar_tag_based_localizer.param.yaml";
+      ament_index_cpp::get_package_share_directory("ar_tag_based_localizer") +
+      "/config/ar_tag_based_localizer.param.yaml";
 
     rcl_params_t * params_st = rcl_yaml_node_struct_init(rcl_get_default_allocator());
     if (!rcl_parse_yaml_file(yaml_path.c_str(), params_st)) {

--- a/localization/pose_instability_detector/package.xml
+++ b/localization/pose_instability_detector/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/pose_instability_detector/test/test.cpp
+++ b/localization/pose_instability_detector/test/test.cpp
@@ -15,6 +15,7 @@
 #include "../src/pose_instability_detector.hpp"
 #include "test_message_helper_node.hpp"
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
@@ -35,8 +36,8 @@ protected:
   void SetUp() override
   {
     const std::string yaml_path =
-      "../../install/pose_instability_detector/share/pose_instability_detector/config/"
-      "pose_instability_detector.param.yaml";
+      ament_index_cpp::get_package_share_directory("pose_instability_detector") +
+      "/config/pose_instability_detector.param.yaml";
 
     rcl_params_t * params_st = rcl_yaml_node_struct_init(rcl_get_default_allocator());
     if (!rcl_parse_yaml_file(yaml_path.c_str(), params_st)) {


### PR DESCRIPTION
## Description
By using `ament_index_cpp::get_package_share_directory`, the path to the config file can be specified from the package path.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

```
colcon test --event-handlers console_cohesion+ \
   --packages-select ar_tag_based_localizer pose_instability_detector
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

It does not effect the system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
