### PR TITLE
fix(bytetrack): fix uninteded roi value error due to casting int to uint

### DIFF
--- a/perception/bytetrack/src/bytetrack_node.cpp
+++ b/perception/bytetrack/src/bytetrack_node.cpp
@@ -83,10 +83,18 @@ void ByteTrackNode::on_rect(
   bytetrack::ObjectArray objects = bytetrack_->update_tracker(object_array);
   for (const auto & tracked_object : objects) {
     tier4_perception_msgs::msg::DetectedObjectWithFeature object;
-    object.feature.roi.x_offset = tracked_object.x_offset;
-    object.feature.roi.y_offset = tracked_object.y_offset;
-    object.feature.roi.width = tracked_object.width;
-    object.feature.roi.height = tracked_object.height;
+    // fit xy offset to 0 if roi is outside of image
+    const int outside_x = 0 - tracked_object.x_offset;
+    const int outside_y = 0 - tracked_object.y_offset;
+    const int32_t output_x = std::max(tracked_object.x_offset, 0);
+    const int32_t output_y = std::max(tracked_object.y_offset, 0);
+    const int32_t output_width = tracked_object.width - std::max(outside_x, 0);
+    const int32_t output_height = tracked_object.height - std::max(outside_y, 0);
+    // convert int32 to uint32
+    object.feature.roi.x_offset = static_cast<uint32_t>(output_x);
+    object.feature.roi.y_offset = static_cast<uint32_t>(output_y);
+    object.feature.roi.width = static_cast<uint32_t>(output_width);
+    object.feature.roi.height = static_cast<uint32_t>(output_height);
     object.object.existence_probability = tracked_object.score;
     object.object.classification.emplace_back(
       autoware_auto_perception_msgs::build<Label>().label(tracked_object.type).probability(1.0f));

--- a/perception/bytetrack/src/bytetrack_node.cpp
+++ b/perception/bytetrack/src/bytetrack_node.cpp
@@ -84,12 +84,12 @@ void ByteTrackNode::on_rect(
   for (const auto & tracked_object : objects) {
     tier4_perception_msgs::msg::DetectedObjectWithFeature object;
     // fit xy offset to 0 if roi is outside of image
-    const int outside_x = 0 - tracked_object.x_offset;
-    const int outside_y = 0 - tracked_object.y_offset;
+    const int outside_x = std::max(-tracked_object.x_offset, 0);
+    const int outside_y = std::max(-tracked_object.y_offset, 0);
     const int32_t output_x = std::max(tracked_object.x_offset, 0);
     const int32_t output_y = std::max(tracked_object.y_offset, 0);
-    const int32_t output_width = tracked_object.width - std::max(outside_x, 0);
-    const int32_t output_height = tracked_object.height - std::max(outside_y, 0);
+    const int32_t output_width = tracked_object.width - outside_x;
+    const int32_t output_height = tracked_object.height - outside_y;
     // convert int32 to uint32
     object.feature.roi.x_offset = static_cast<uint32_t>(output_x);
     object.feature.roi.y_offset = static_cast<uint32_t>(output_y);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Sometimes bytetrack publish invalid roi with very large  x or y offset value like `4294967293`.
I found this is caused by mis-type casting from bytetrack roi `int32` to ros message roi `uint32`.

So I fixed message conversion part.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c8e94f</samp>

Fix bytetrack node crash when roi is outside of image. Adjust roi values to fit image boundaries and message type in `perception/bytetrack/src/bytetrack_node.cpp`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested with yolo roi and odaiba video image.
Original yolo roi do not publish invalid rois and after this PR, bytetrack also publish invalid rois.

![Screenshot from 2023-11-15 15-31-14](https://github.com/autowarefoundation/autoware.universe/assets/20086766/0ac5f870-3451-45b0-ae7f-a234f2e33b16)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
