### PR TITLE
ci(sync-files): remove stale label pre-commands

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -12,8 +12,6 @@
     - source: .github/PULL_REQUEST_TEMPLATE/standard-change.md
     - source: .github/dependabot.yaml
     - source: .github/stale.yml
-      pre-commands: |
-        sd "staleLabel: stale" "staleLabel: status:stale" {source}
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml


### PR DESCRIPTION
## Description

Part of:
- https://github.com/autowarefoundation/autoware/issues/3955

Now that
- https://github.com/autowarefoundation/autoware/pull/3993
is merged, this code is not necessary anymore.

Continuation of:
- https://github.com/autowarefoundation/autoware.universe/pull/5474

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
