### PR TITLE
fix(geo_pose_projector): fix -Werror=deprecated-declarations

### DIFF
--- a/localization/geo_pose_projector/src/geo_pose_projector.cpp
+++ b/localization/geo_pose_projector/src/geo_pose_projector.cpp
@@ -36,7 +36,8 @@ GeoPoseProjector::GeoPoseProjector()
 
   // Subscribe to geo_pose topic
   geo_pose_sub_ = create_subscription<GeoPoseWithCovariance>(
-    "input_geo_pose", 10, [this](const GeoPoseWithCovariance::SharedPtr msg) { on_geo_pose(msg); });
+    "input_geo_pose", 10,
+    [this](const GeoPoseWithCovariance::ConstSharedPtr msg) { on_geo_pose(msg); });
 
   // Publish pose topic
   pose_pub_ = create_publisher<PoseWithCovariance>("output_pose", 10);
@@ -49,7 +50,7 @@ GeoPoseProjector::GeoPoseProjector()
   }
 }
 
-void GeoPoseProjector::on_geo_pose(const GeoPoseWithCovariance::SharedPtr msg)
+void GeoPoseProjector::on_geo_pose(const GeoPoseWithCovariance::ConstSharedPtr msg)
 {
   if (!projector_info_) {
     RCLCPP_WARN_THROTTLE(

--- a/localization/geo_pose_projector/src/geo_pose_projector.hpp
+++ b/localization/geo_pose_projector/src/geo_pose_projector.hpp
@@ -39,7 +39,7 @@ public:
   GeoPoseProjector();
 
 private:
-  void on_geo_pose(const GeoPoseWithCovariance::SharedPtr msg);
+  void on_geo_pose(const GeoPoseWithCovariance::ConstSharedPtr msg);
 
   component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
   rclcpp::Subscription<GeoPoseWithCovariance>::SharedPtr geo_pose_sub_;


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f1781b</samp>

Refactored `geo_pose_projector` node to use `ConstSharedPtr` for `input_geo_pose` messages. This improves const-correctness and avoids unnecessary copies of the message data.

---

Fix build error.

```
/home/satoshi/pilot-auto/src/autoware/universe/localization/geo_pose_projector/src/geo_pose_projector.cpp:38:61:   required from here
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:391:21: error: ‘void rclcpp::AnySubscriptionCallback<MessageT, AllocatorT>::set_deprecated(std::function<void(std::shared_ptr<_Yp>)>) [with SetT = geographic_msgs::msg::GeoPoseWithCovarianceStamped_<std::allocator<void> >; MessageT = geographic_msgs::msg::GeoPoseWithCovarianceStamped_<std::allocator<void> >; AllocatorT = std::allocator<void>]’ is deprecated: use 'void(std::shared_ptr<const MessageT>)' instead [-Werror=deprecated-declarations]
  391 |       set_deprecated(static_cast<typename scbth::callback_type>(callback));
      |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:408:3: note: declared here
  408 |   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
      |   ^~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Complete build process correctly in my PC.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
