### PR TITLE
refactor(operation_mode_transition_manager): rework parameters

### DIFF
--- a/control/operation_mode_transition_manager/README.md
+++ b/control/operation_mode_transition_manager/README.md
@@ -83,6 +83,8 @@ For the backward compatibility (to be removed):
 
 ## Parameters
 
+{{ json_to_markdown("control/operation_mode_transition_manager/schema/operation_mode_transition_manager.schema.json") }}
+
 | Name                               | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                   | Default value |
 | :--------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
 | `transition_timeout`               | `double` | If the state transition is not completed within this time, it is considered a transition failure.                                                                                                                                                                                                                                                                                                                             | 10.0          |

--- a/control/operation_mode_transition_manager/schema/operation_mode_transition_manager.schema.json
+++ b/control/operation_mode_transition_manager/schema/operation_mode_transition_manager.schema.json
@@ -118,19 +118,18 @@
             "speed_upper_threshold": {
               "type": "number",
               "description": "The velocity deviation between control command and ego vehicle must be within this threshold to complete Autonomous transition.",
-              "default": "2.0",
-              "minimum": 0.0
+              "default": "2.0"
             },
             "speed_lower_threshold": {
               "type": "number",
               "description": "The velocity deviation between control command and ego vehicle must be within this threshold to complete Autonomous transition.",
-              "default": "-2.0",
-              "INSERT_BOUND_CONDITION(S)": "INSERT_BOUND_VALUE(S)"
+              "default": "-2.0"
             },
             "yaw_threshold": {
               "type": "number",
               "description": "The yaw angle between trajectory and ego vehicle must be within this threshold to complete Autonomous transition.",
-              "default": "0,262"
+              "default": "0,262",
+              "minimum": -3.142
             }
           },
           "required": [

--- a/control/operation_mode_transition_manager/schema/operation_mode_transition_manager.schema.json
+++ b/control/operation_mode_transition_manager/schema/operation_mode_transition_manager.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Operation Mode Transition Manager Node",
+  "type": "object",
+  "definitions": {
+    "operation_mode_transition_manager": {
+      "type": "object",
+      "properties": {
+        "transition_timeout": {
+          "type": "number",
+          "description": "If the state transition is not completed within this time, it is considered a transition failure.",
+          "default": "10.0",
+          "minimum": 0.0
+        },
+        "frequency_hz": {
+          "type": "number",
+          "description": "running hz",
+          "default": "10.0",
+          "minimum": 0.0
+        },
+        "enable_engage_on_driving": {
+          "type": "boolean",
+          "description": "Set true if you want to engage the autonomous driving mode while the vehicle is driving. If set to false, it will deny Engage in any situation where the vehicle speed is not zero. Note that if you use this feature without adjusting the parameters, it may cause issues like sudden deceleration. Before using, please ensure the engage condition and the vehicle_cmd_gate transition filter are appropriately adjusted.",
+          "default": "false"
+        },
+        "check_engage_condition": {
+          "type": "boolean",
+          "description": "If false, autonomous transition is always available.",
+          "default": "false"
+        },
+        "nearest_dist_deviation_threshold": {
+          "type": "number",
+          "description": "distance threshold used to find nearest trajectory point [m]",
+          "default": "3.0",
+          "minimum": 0.0
+        },
+        "nearest_yaw_deviation_threshold": {
+          "type": "number",
+          "description": "angle threshold used to find nearest trajectory point [rad]",
+          "default": "1.57",
+          "minimum": -3.142
+        },
+        "engage_acceptable_limits": {
+          "type": "object",
+          "properties": {
+            "allow_autonomous_in_stopped": {
+              "type": "boolean",
+              "description": "If true, autonomous transition is available when the vehicle is stopped even if other checks fail.",
+              "default": "true"
+            },
+            "dist_threshold": {
+              "type": "number",
+              "description": "The distance between the trajectory and ego vehicle must be within this distance for Autonomous transition.",
+              "default": "1.5",
+              "minimum": 0.0
+            },
+            "yaw_threshold": {
+              "type": "number",
+              "description": "The yaw angle between trajectory and ego vehicle must be within this threshold for Autonomous transition.",
+              "default": "0.524",
+              "minimum": -3.142
+            },
+            "speed_upper_threshold": {
+              "type": "number",
+              "description": "The velocity deviation between control command and ego vehicle must be within this threshold for Autonomous transition.",
+              "default": "10.0"
+            },
+            "speed_lower_threshold": {
+              "type": "number",
+              "description": "The velocity deviation between control command and ego vehicle must be within this threshold for Autonomous transition.",
+              "default": "-10.0"
+            },
+            "acc_threshold": {
+              "type": "number",
+              "description": "The control command acceleration must be less than this threshold for Autonomous transition.",
+              "default": "1.5",
+              "minimum": 0.0
+            },
+            "lateral_acc_threshold": {
+              "type": "number",
+              "description": "The control command lateral acceleration must be less than this threshold for Autonomous transition.",
+              "default": "1.0",
+              "minimum": 0.0
+            },
+            "lateral_acc_diff_threshold": {
+              "type": "number",
+              "description": "The lateral acceleration deviation between the control command must be less than this threshold for Autonomous transition.",
+              "default": "0.5",
+              "minimum": 0.0
+            }
+          },
+          "required": [
+            "allow_autonomous_in_stopped",
+            "dist_threshold",
+            "yaw_threshold",
+            "speed_upper_threshold",
+            "speed_lower_threshold",
+            "acc_threshold",
+            "lateral_acc_threshold",
+            "lateral_acc_diff_threshold"
+          ]
+        },
+        "stable_check": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "type": "number",
+              "description": "The stable condition must be satisfied for this duration to complete the transition.",
+              "default": "0.1",
+              "minimum": 0.0
+            },
+            "dist_threshold": {
+              "type": "number",
+              "description": "The distance between the trajectory and ego vehicle must be within this distance to complete Autonomous transition.",
+              "default": "1.5",
+              "minimum": 0.0
+            },
+            "speed_upper_threshold": {
+              "type": "number",
+              "description": "The velocity deviation between control command and ego vehicle must be within this threshold to complete Autonomous transition.",
+              "default": "2.0",
+              "minimum": 0.0
+            },
+            "speed_lower_threshold": {
+              "type": "number",
+              "description": "The velocity deviation between control command and ego vehicle must be within this threshold to complete Autonomous transition.",
+              "default": "-2.0",
+              "INSERT_BOUND_CONDITION(S)": "INSERT_BOUND_VALUE(S)"
+            },
+            "yaw_threshold": {
+              "type": "number",
+              "description": "The yaw angle between trajectory and ego vehicle must be within this threshold to complete Autonomous transition.",
+              "default": "0,262"
+            }
+          },
+          "required": [
+            "duration",
+            "dist_threshold",
+            "speed_upper_threshold",
+            "speed_lower_threshold",
+            "yaw_threshold"
+          ]
+        }
+      },
+      "required": [
+        "transition_timeout",
+        "frequency_hz",
+        "enable_engage_on_driving",
+        "check_engage_condition",
+        "nearest_dist_deviation_threshold",
+        "nearest_yaw_deviation_threshold",
+        "engage_acceptable_limits",
+        "stable_check"
+      ]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/operation_mode_transition_manager"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -77,7 +77,7 @@ AutonomousMode::AutonomousMode(rclcpp::Node * node)
   // params for mode change completed
   {
     auto & p = stable_check_param_;
-    p.duration = node->get_parameter("stable_check.duration").as_double();
+    p.duration = node->declare_parameter<double>("stable_check.duration");
     p.dist_threshold = node->declare_parameter<double>("stable_check.dist_threshold");
     p.speed_upper_threshold = node->declare_parameter<double>("stable_check.speed_upper_threshold");
     p.speed_lower_threshold = node->declare_parameter<double>("stable_check.speed_lower_threshold");

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -77,7 +77,7 @@ AutonomousMode::AutonomousMode(rclcpp::Node * node)
   // params for mode change completed
   {
     auto & p = stable_check_param_;
-    p.duration = node->declare_parameter<double>("stable_check.duration");
+    p.duration = node->get_parameter("stable_check.duration").as_double();
     p.dist_threshold = node->declare_parameter<double>("stable_check.dist_threshold");
     p.speed_upper_threshold = node->declare_parameter<double>("stable_check.speed_upper_threshold");
     p.speed_lower_threshold = node->declare_parameter<double>("stable_check.speed_lower_threshold");


### PR DESCRIPTION
## Description
Implement the ROS Node configuration layout described in https://github.com/orgs/autowarefoundation/discussions/3371 for the `operation_mode_transition_manager` package.

- Remove the default value from the source code in order to ensure all parameter values are passed from the parameter files.
- Create the schema

## Tests performed
Package successfully build and launch locally.
`colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to operation_mode_transition_manager`

## Effects on system behavior
More reliable and faster parameter configuration file creation.

## Pre-review checklist for the PR author
The PR author **must** check the checkboxes below when creating the PR.
- [x] I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [x] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

## In-review checklist for the PR reviewers
The PR reviewers **must** check the checkboxes below before approval.
- [x] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author
The PR author **must** check the checkboxes below before merging.
- [x] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
