### PR TITLE
perf(image_projection_based_fusion): replace std::bitset

### DIFF
--- a/perception/image_projection_based_fusion/src/pointpainting_fusion/voxel_generator.cpp
+++ b/perception/image_projection_based_fusion/src/pointpainting_fusion/voxel_generator.cpp
@@ -61,7 +61,13 @@ std::size_t VoxelGenerator::pointsToVoxels(
       point[3] = time_lag;
       // decode the class value back to one-hot binary and assign it to point
       std::fill(point.begin() + 4, point.end(), 0);
-      point[4 + *class_iter] = 1;
+      auto class_value = static_cast<int>(*class_iter);
+      auto iter = point.begin() + 4;
+      while (class_value > 0) {
+        *iter = class_value % 2;
+        class_value /= 2;
+        ++iter;
+      }
 
       out_of_range = false;
       for (std::size_t di = 0; di < config_.point_dim_size_; di++) {

--- a/perception/image_projection_based_fusion/src/pointpainting_fusion/voxel_generator.cpp
+++ b/perception/image_projection_based_fusion/src/pointpainting_fusion/voxel_generator.cpp
@@ -60,10 +60,8 @@ std::size_t VoxelGenerator::pointsToVoxels(
       point[2] = point_current.z();
       point[3] = time_lag;
       // decode the class value back to one-hot binary and assign it to point
-      for (std::size_t i = 1; i <= config_.class_size_; i++) {
-        auto decode = std::bitset<8>(*class_iter).to_string();
-        point[3 + i] = decode[-i] == 1 ? 1 : 0;
-      }
+      std::fill(point.begin() + 4, point.end(), 0);
+      point[4 + *class_iter] = 1;
 
       out_of_range = false;
       for (std::size_t di = 0; di < config_.point_dim_size_; di++) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
`std::bitset<8>(*class_iter).to_string()` seems too slow.
https://stackoverflow.com/questions/28265621/c-program-using-bitset-running-pretty-slow

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I have tested with a rosbag and a standalone launch file and modified source to output process time.
Before(no stress)
```
[pointpainting_fusion_node-3] preprocess: 34.269
[pointpainting_fusion_node-3] inference: 0.595
[pointpainting_fusion_node-3] postprocess: 27.488
[pointpainting_fusion_node-3] detect: 67.074
[pointpainting_fusion_node-3] preprocess: 30.979
[pointpainting_fusion_node-3] inference: 0.989
[pointpainting_fusion_node-3] postprocess: 27.701
[pointpainting_fusion_node-3] detect: 62.201
[pointpainting_fusion_node-3] preprocess: 29.456
[pointpainting_fusion_node-3] inference: 0.382
[pointpainting_fusion_node-3] postprocess: 27.757
[pointpainting_fusion_node-3] detect: 62.854
[pointpainting_fusion_node-3] preprocess: 32.826
[pointpainting_fusion_node-3] inference: 0.377
[pointpainting_fusion_node-3] postprocess: 27.505
[pointpainting_fusion_node-3] detect: 64.493
[pointpainting_fusion_node-3] preprocess: 34.255
[pointpainting_fusion_node-3] inference: 0.309
[pointpainting_fusion_node-3] postprocess: 27.784
[pointpainting_fusion_node-3] detect: 65.803
[pointpainting_fusion_node-3] preprocess: 33.278
[pointpainting_fusion_node-3] inference: 0.412
[pointpainting_fusion_node-3] postprocess: 27.482
[pointpainting_fusion_node-3] detect: 65.218
```
Before(with stress)
```
[pointpainting_fusion_node-3] preprocess: 72.99
[pointpainting_fusion_node-3] inference: 0.535
[pointpainting_fusion_node-3] postprocess: 28.187
[pointpainting_fusion_node-3] detect: 105.636
[pointpainting_fusion_node-3] preprocess: 71.207
[pointpainting_fusion_node-3] inference: 0.578
[pointpainting_fusion_node-3] postprocess: 27.168
[pointpainting_fusion_node-3] detect: 101.846
[pointpainting_fusion_node-3] preprocess: 68.217
[pointpainting_fusion_node-3] inference: 0.577
[pointpainting_fusion_node-3] postprocess: 29.383
[pointpainting_fusion_node-3] detect: 101.413
[pointpainting_fusion_node-3] preprocess: 67.276
[pointpainting_fusion_node-3] inference: 0.591
[pointpainting_fusion_node-3] postprocess: 23.111
[pointpainting_fusion_node-3] detect: 93.579
[pointpainting_fusion_node-3] preprocess: 70.176
[pointpainting_fusion_node-3] inference: 0.677
[pointpainting_fusion_node-3] postprocess: 26.646
[pointpainting_fusion_node-3] detect: 101.435
```
After(no stress)
```
[pointpainting_fusion_node-3] preprocess: 23.071
[pointpainting_fusion_node-3] inference: 0.259
[pointpainting_fusion_node-3] postprocess: 28.208
[pointpainting_fusion_node-3] detect: 54.027
[pointpainting_fusion_node-3] preprocess: 25.096
[pointpainting_fusion_node-3] inference: 0.253
[pointpainting_fusion_node-3] postprocess: 28.261
[pointpainting_fusion_node-3] detect: 56.786
[pointpainting_fusion_node-3] preprocess: 17.582
[pointpainting_fusion_node-3] inference: 0.296
[pointpainting_fusion_node-3] postprocess: 29.002
[pointpainting_fusion_node-3] detect: 48.532
[pointpainting_fusion_node-3] preprocess: 31.449
[pointpainting_fusion_node-3] inference: 0.391
[pointpainting_fusion_node-3] postprocess: 28.815
[pointpainting_fusion_node-3] detect: 64.62
[pointpainting_fusion_node-3] preprocess: 23.222
[pointpainting_fusion_node-3] inference: 0.267
[pointpainting_fusion_node-3] postprocess: 28.205
[pointpainting_fusion_node-3] detect: 54.673
[pointpainting_fusion_node-3] preprocess: 23.887
[pointpainting_fusion_node-3] inference: 0.391
[pointpainting_fusion_node-3] postprocess: 28.994
[pointpainting_fusion_node-3] detect: 55.837
[pointpainting_fusion_node-3] preprocess: 22.653
[pointpainting_fusion_node-3] inference: 0.447
[pointpainting_fusion_node-3] postprocess: 29.175
[pointpainting_fusion_node-3] detect: 55.116
[pointpainting_fusion_node-3] preprocess: 25.449
[pointpainting_fusion_node-3] inference: 0.26
[pointpainting_fusion_node-3] postprocess: 28.565
[pointpainting_fusion_node-3] detect: 58.153
[pointpainting_fusion_node-3] preprocess: 18.299
[pointpainting_fusion_node-3] inference: 0.384
[pointpainting_fusion_node-3] postprocess: 28.077
[pointpainting_fusion_node-3] detect: 48.638
[pointpainting_fusion_node-3] preprocess: 22.034
[pointpainting_fusion_node-3] inference: 0.342
[pointpainting_fusion_node-3] postprocess: 28.987
[pointpainting_fusion_node-3] detect: 54.962
[pointpainting_fusion_node-3] preprocess: 20.343
[pointpainting_fusion_node-3] inference: 0.352
[pointpainting_fusion_node-3] postprocess: 28.182
[pointpainting_fusion_node-3] detect: 54.174
[pointpainting_fusion_node-3] preprocess: 16.311
[pointpainting_fusion_node-3] inference: 0.261
[pointpainting_fusion_node-3] postprocess: 28.08
[pointpainting_fusion_node-3] detect: 46.109
```
After(with stress)
```
[pointpainting_fusion_node-3] preprocess: 31.552
[pointpainting_fusion_node-3] inference: 0.494
[pointpainting_fusion_node-3] postprocess: 23.464
[pointpainting_fusion_node-3] detect: 58.267
[pointpainting_fusion_node-3] preprocess: 30.529
[pointpainting_fusion_node-3] inference: 0.508
[pointpainting_fusion_node-3] postprocess: 23.729
[pointpainting_fusion_node-3] detect: 57.191
[pointpainting_fusion_node-3] preprocess: 30.338
[pointpainting_fusion_node-3] inference: 0.49
[pointpainting_fusion_node-3] postprocess: 23.023
[pointpainting_fusion_node-3] detect: 56.492
[pointpainting_fusion_node-3] preprocess: 27.535
[pointpainting_fusion_node-3] inference: 0.492
[pointpainting_fusion_node-3] postprocess: 22.638
[pointpainting_fusion_node-3] detect: 53.166
[pointpainting_fusion_node-3] preprocess: 29.533
[pointpainting_fusion_node-3] inference: 0.507
[pointpainting_fusion_node-3] postprocess: 21.862
[pointpainting_fusion_node-3] detect: 54.831
[pointpainting_fusion_node-3] preprocess: 30.351
[pointpainting_fusion_node-3] inference: 0.531
[pointpainting_fusion_node-3] postprocess: 21.787
[pointpainting_fusion_node-3] detect: 56.53
[pointpainting_fusion_node-3] preprocess: 25.857
[pointpainting_fusion_node-3] inference: 0.491
[pointpainting_fusion_node-3] postprocess: 19.725
[pointpainting_fusion_node-3] detect: 48.367
```


Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
