### PR TITLE
feat(radar_object_tracker): change to use use_radar_tracking_fusion as true

### DIFF
--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -103,7 +103,7 @@
   <!-- Radar long range integration methods -->
   <arg
     name="use_radar_tracking_fusion"
-    default="false"
+    default="true"
     description="if use_radar_tracking_fusion:=true, radar information is merged in tracking launch. Otherwise, radar information is merged in detection launch."
   />
 


### PR DESCRIPTION
Set default parameter `use_radar_tracking_fusion` to true

## Description

<!-- Write a brief description of this PR. -->

## Tests performed
By logging simulator.launch with `perception_mode:=camera_lidar_radar_fusion` option

- Confirmed that /perception/object_recognition/tracking/radar_object_tracker has been launched
- The topic names are connected as intended.
![image](https://github.com/autowarefoundation/autoware.universe/assets/37187849/77943588-d94d-4757-9206-8f78e6e5f390)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
