### PR TITLE
fix(simple_planning_simulator): fix ego sign pitch problem

### DIFF
--- a/simulator/simple_planning_simulator/README.md
+++ b/simulator/simple_planning_simulator/README.md
@@ -96,6 +96,8 @@ Ego vehicle pitch angle is calculated in the following manner.
 
 ![pitch calculation](./media/pitch-calculation.drawio.svg)
 
+NOTE: driving against the line direction (as depicted in image's bottom row) is not supported and only shown for illustration purposes.
+
 ## Error detection and handling
 
 The only validation on inputs being done is testing for a valid vehicle model type.

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -327,8 +327,9 @@ void SimplePlanningSimulator::on_timer()
 
   // calculate longitudinal acceleration by slope
   constexpr double gravity_acceleration = -9.81;
-  const double ego_pitch_angle = enable_road_slope_simulation_ ? calculate_ego_pitch() : 0.0;
-  const double acc_by_slope = gravity_acceleration * std::sin(ego_pitch_angle);
+  const double ego_pitch_angle = calculate_ego_pitch();
+  const double slope_pitch_angle = enable_road_slope_simulation_ ? -ego_pitch_angle : 0.0;
+  const double acc_by_slope = gravity_acceleration * std::sin(slope_pitch_angle);
 
   // update vehicle dynamics
   {

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -328,8 +328,8 @@ void SimplePlanningSimulator::on_timer()
   // calculate longitudinal acceleration by slope
   constexpr double gravity_acceleration = -9.81;
   const double ego_pitch_angle = calculate_ego_pitch();
-  const double slope_pitch_angle = enable_road_slope_simulation_ ? -ego_pitch_angle : 0.0;
-  const double acc_by_slope = gravity_acceleration * std::sin(slope_pitch_angle);
+  const double slope_angle = enable_road_slope_simulation_ ? -ego_pitch_angle : 0.0;
+  const double acc_by_slope = gravity_acceleration * std::sin(slope_angle);
 
   // update vehicle dynamics
   {


### PR DESCRIPTION
## Description

There is a bug on the simple_planning simulator when enable_road_slope_simulation is true. Currently, the ego pitch angle is negative when the ego vehicle is on a downward slope and positive when on an upwards slope, which causes  trouble when computing the acceleration caused by the slope (the sign is negative when it should be positive and vice versa), causing a wrong simulation output. 

![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/d9381e82-c97a-4ec9-8458-c7f70fd49294)

The original code: 
![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/3bfcfd31-80f5-4957-a702-f205b9566a37)

As you can see on the code picture, if the vehicle is on an upwards slope, the pitch sign is negative but the resulting acceleration will be positive (-9.81 * sin(negative) = positive value) which makes no sense for an upwards slope.

Examples of wrong behavior: 
The vehicle goes uphill, but its acceleration is high, it overshoots its goal

https://github.com/autowarefoundation/autoware.universe/assets/25967964/f6c1e348-9980-4a57-bb8a-8daaa359d9c9

the vehicle wont move downhill

https://github.com/autowarefoundation/autoware.universe/assets/25967964/bd69b128-5842-4c21-952a-6bcb0a105c16

This PR fixes the mentioned problem. Also, now the vehicle pitch simulation should be correct, even if enable_slope_simulation is disabled.

## Tests performed

Tested with uphill and downhill lanelet maps:

Uphill: 


https://github.com/autowarefoundation/autoware.universe/assets/25967964/2bf4b6d2-0af6-4123-a327-2fc9a5c36507


Downhill, the ego vehicle moves, no overshoot:

https://github.com/autowarefoundation/autoware.universe/assets/25967964/7b4b6ef0-1239-4f8b-95fd-fd8362880a8b



## Effects on system behavior

Fixes the acceleration by slope to have the correct sign. Now the simulated ego vehicle can start on a downward slope and it does not overshoot on uphill paths. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
