### PR TITLE
feat(component_state_monitor): monitor pose_estimator output

### DIFF
--- a/system/component_state_monitor/config/topics.yaml
+++ b/system/component_state_monitor/config/topics.yaml
@@ -50,6 +50,19 @@
     error_rate: 1.0
     timeout: 1.0
 
+- module: localization
+  mode: [online, logging_simulation]
+  type: autonomous
+  args:
+    node_name_suffix: pose_estimator_pose
+    topic: /localization/pose_estimator/pose_with_covariance
+    topic_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    best_effort: false
+    transient_local: false
+    warn_rate: 5.0
+    error_rate: 1.0
+    timeout: 1.0
+
 - module: perception
   mode: [online, logging_simulation]
   type: launch


### PR DESCRIPTION
## Description

I would like to propose to monitor the output of `ndt_scan_matcher` which remains to be a critical source for accurate localization. Since most of the components assume that the localization is accurate, it is crucial to detect it's failure, and I would like to make the system as safe as possible with this PR.

[INTERNAL LINK 1](https://star4.slack.com/archives/CEL0DR2S2/p1700200987504589)
[INTERNAL LINK 2](https://star4.slack.com/archives/CEV8XMJBV/p1700204369731349)
<!-- Write a brief description of this PR. -->

Should be merged with https://github.com/autowarefoundation/autoware_launch/pull/692

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Run logging simulator and confirmed that it does not raise any emergency (=False positives)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

This will surely increase the number of emergency, but we expect the amount to be quite limited. On the contrary, we will now be able to catch the state of NDT and raise emergency as quickly as possible, resulting in a safer system. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
