### PR TITLE
feat(obstacle_cruise_planner): prior generation of collision distance

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -120,7 +120,7 @@ struct StopObstacle : public TargetObstacleInterface
   }
   Shape shape;
   geometry_msgs::msg::Point
-    collision_point;  // TODO: takagi; this member variable still used in
+    collision_point;  // TODO(yuki_takagi): this member variable still used in
                       // calculateMarginFromObstacleOnCurve() and  should be removed as it can be
                       // replaced by ”dist_to_collide_on_decimated_traj”
   double dist_to_collide_on_decimated_traj;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -110,16 +110,20 @@ struct StopObstacle : public TargetObstacleInterface
     const std::string & arg_uuid, const rclcpp::Time & arg_stamp,
     const geometry_msgs::msg::Pose & arg_pose, const Shape & arg_shape,
     const double arg_lon_velocity, const double arg_lat_velocity,
-    const geometry_msgs::msg::Point arg_collision_point, const double arg_dist_to_collide)
+    const geometry_msgs::msg::Point arg_collision_point,
+    const double arg_dist_to_collide_on_decimated_traj)
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_lon_velocity, arg_lat_velocity),
     shape(arg_shape),
     collision_point(arg_collision_point),
-    dist_to_collide(arg_dist_to_collide)
+    dist_to_collide_on_decimated_traj(arg_dist_to_collide_on_decimated_traj)
   {
   }
   Shape shape;
-  geometry_msgs::msg::Point collision_point;
-  double dist_to_collide;
+  geometry_msgs::msg::Point
+    collision_point;  // TODO: takagi; this member variable still used in
+                      // calculateMarginFromObstacleOnCurve() and  should be removed as it can be
+                      // replaced by ”dist_to_collide_on_decimated_traj”
+  double dist_to_collide_on_decimated_traj;
 };
 
 struct CruiseObstacle : public TargetObstacleInterface

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -110,14 +110,16 @@ struct StopObstacle : public TargetObstacleInterface
     const std::string & arg_uuid, const rclcpp::Time & arg_stamp,
     const geometry_msgs::msg::Pose & arg_pose, const Shape & arg_shape,
     const double arg_lon_velocity, const double arg_lat_velocity,
-    const geometry_msgs::msg::Point arg_collision_point)
+    const geometry_msgs::msg::Point arg_collision_point, const double arg_dist_to_collide)
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_lon_velocity, arg_lat_velocity),
     shape(arg_shape),
-    collision_point(arg_collision_point)
+    collision_point(arg_collision_point),
+    dist_to_collide(arg_dist_to_collide)
   {
   }
   Shape shape;
   geometry_msgs::msg::Point collision_point;
+  double dist_to_collide;
 };
 
 struct CruiseObstacle : public TargetObstacleInterface

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -70,9 +70,6 @@ private:
   std::optional<geometry_msgs::msg::Point> createCollisionPointForStopObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle) const;
-  std::optional<double> calcCollisionDistanceForStopObstacle(
-    const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
-    const Obstacle & obstacle) const;
   std::optional<CruiseObstacle> createCruiseObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle, const double precise_lat_dist);

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -70,6 +70,9 @@ private:
   std::optional<geometry_msgs::msg::Point> createCollisionPointForStopObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle) const;
+  std::optional<double> calcCollisionDistanceForStopObstacle(
+    const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
+    const Obstacle & obstacle) const;
   std::optional<CruiseObstacle> createCruiseObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle, const double precise_lat_dist);
@@ -91,7 +94,7 @@ private:
 
   void checkConsistency(
     const rclcpp::Time & current_time, const PredictedObjects & predicted_objects,
-    const std::vector<TrajectoryPoint> & traj_points, std::vector<StopObstacle> & stop_obstacles);
+    std::vector<StopObstacle> & stop_obstacles);
   void publishVelocityLimit(
     const std::optional<VelocityLimit> & vel_limit, const std::string & module_name);
   void publishDebugMarker() const;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -107,6 +107,7 @@ public:
     slow_down_debug_multi_array_.stamp = current_time;
     return slow_down_debug_multi_array_;
   }
+  double getSafeDistanceMargin() const { return longitudinal_info_.safe_distance_margin; }
 
 protected:
   // Parameters

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -42,9 +42,10 @@ std::optional<double> calcCollisionDistanceForStopObstacle(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
   const Obstacle & obstacle);
 
-std::optional<geometry_msgs::msg::Point> getCollisionPoint(
+std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
-  const Obstacle & obstacle, const bool is_driving_forward);
+  const Obstacle & obstacle, const bool is_driving_forward,
+  const vehicle_info_util::VehicleInfo & vehicle_info);
 
 std::vector<PointWithStamp> getCollisionPoints(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -38,10 +38,6 @@ Polygon2d createOneStepPolygon(
   const std::vector<geometry_msgs::msg::Pose> & current_poses,
   const vehicle_info_util::VehicleInfo & vehicle_info, const double lat_margin);
 
-std::optional<double> calcCollisionDistanceForStopObstacle(
-  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
-  const Obstacle & obstacle);
-
 std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const Obstacle & obstacle, const bool is_driving_forward,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -38,6 +38,10 @@ Polygon2d createOneStepPolygon(
   const std::vector<geometry_msgs::msg::Pose> & current_poses,
   const vehicle_info_util::VehicleInfo & vehicle_info, const double lat_margin);
 
+std::optional<double> calcCollisionDistanceForStopObstacle(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
+  const Obstacle & obstacle);
+
 std::optional<geometry_msgs::msg::Point> getCollisionPoint(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const Obstacle & obstacle, const bool is_driving_forward);

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -37,7 +37,6 @@ PoseWithStamp getCurrentObjectPose(
   const rclcpp::Time & current_time, const bool use_prediction);
 
 std::optional<StopObstacle> getClosestStopObstacle(
-  const std::vector<TrajectoryPoint> & traj_points,
   const std::vector<StopObstacle> & stop_obstacles);
 
 template <class T>

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -30,36 +30,6 @@
 #include <algorithm>
 #include <chrono>
 
-#define debug(var)                                                      \
-  do {                                                                  \
-    std::cerr << __func__ << ": " << __LINE__ << ", " << #var << " : "; \
-    view(var);                                                          \
-  } while (0)
-template <typename T>
-void view(T e)
-{
-  std::cerr << e << std::endl;
-}
-template <typename T>
-void view(const std::vector<T> & v)
-{
-  for (const auto & e : v) {
-    std::cerr << e << " ";
-  }
-  std::cerr << std::endl;
-}
-template <typename T>
-void view(const std::vector<std::vector<T>> & vv)
-{
-  for (const auto & v : vv) {
-    view(v);
-  }
-}
-#define line()                                                                         \
-  {                                                                                    \
-    std::cerr << "(" << __FILE__ << ") " << __func__ << ": " << __LINE__ << std::endl; \
-  }
-
 namespace
 {
 VelocityLimitClearCommand createVelocityLimitClearCommandMessage(

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -24,8 +24,6 @@
 #include "tier4_autoware_utils/ros/update_param.hpp"
 
 #include <boost/format.hpp>
-#include <boost/geometry/algorithms/distance.hpp>
-#include <boost/geometry/algorithms/intersects.hpp>
 
 #include <algorithm>
 #include <chrono>

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -823,7 +823,8 @@ std::vector<TrajectoryPoint> ObstacleCruisePlannerNode::decimateTrajectoryPoints
 
   // extend trajectory
   const auto extended_traj_points = extendTrajectoryPoints(
-    decimated_traj_points, p.goal_extension_length, p.goal_extension_interval);
+    decimated_traj_points, planner_ptr_->getSafeDistanceMargin(),
+    p.decimate_trajectory_step_length);
   if (extended_traj_points.size() < 2) {
     return traj_points;
   }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1038,20 +1038,15 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
     traj_points, vehicle_info_, ego_odom_ptr_->pose.pose, p.max_lat_margin_for_stop);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
-    traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_);
+    traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);
   if (!collision_point) {
     return std::nullopt;
   }
 
-  const auto dist_to_collide = polygon_utils::calcCollisionDistanceForStopObstacle(
-    traj_points, traj_polys_with_lat_margin, obstacle);
-  if (!dist_to_collide) {
-    return std::nullopt;
-  }
-
   const auto [tangent_vel, normal_vel] = projectObstacleVelocityToTrajectory(traj_points, obstacle);
-  return StopObstacle{obstacle.uuid, obstacle.stamp, obstacle.pose,    obstacle.shape,
-                      tangent_vel,   normal_vel,     *collision_point, *dist_to_collide};
+  return StopObstacle{
+    obstacle.uuid, obstacle.stamp, obstacle.pose,          obstacle.shape,
+    tangent_vel,   normal_vel,     collision_point->first, collision_point->second};
 }
 
 std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacle(

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -24,6 +24,37 @@
 
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
+
+#define debug(var)                                                      \
+  do {                                                                  \
+    std::cerr << __func__ << ": " << __LINE__ << ", " << #var << " : "; \
+    view(var);                                                          \
+  } while (0)
+template <typename T>
+void view(T e)
+{
+  std::cerr << e << std::endl;
+}
+template <typename T>
+void view(const std::vector<T> & v)
+{
+  for (const auto & e : v) {
+    std::cerr << e << " ";
+  }
+  std::cerr << std::endl;
+}
+template <typename T>
+void view(const std::vector<std::vector<T>> & vv)
+{
+  for (const auto & v : vv) {
+    view(v);
+  }
+}
+#define line()                                                                         \
+  {                                                                                    \
+    std::cerr << "(" << __FILE__ << ") " << __func__ << ": " << __LINE__ << std::endl; \
+  }
+
 namespace
 {
 StopSpeedExceeded createStopSpeedExceededMsg(
@@ -38,6 +69,7 @@ StopSpeedExceeded createStopSpeedExceededMsg(
 tier4_planning_msgs::msg::StopReasonArray makeStopReasonArray(
   const rclcpp::Time & current_time, const geometry_msgs::msg::Pose & stop_pose,
   const StopObstacle & stop_obstacle)
+
 {
   // create header
   std_msgs::msg::Header header;
@@ -257,8 +289,7 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
     "stop planning");
 
   // Get Closest Stop Obstacle
-  const auto closest_stop_obstacle =
-    obstacle_cruise_utils::getClosestStopObstacle(planner_data.traj_points, stop_obstacles);
+  const auto closest_stop_obstacle = obstacle_cruise_utils::getClosestStopObstacle(stop_obstacles);
   if (!closest_stop_obstacle) {
     // delete marker
     const auto markers =
@@ -269,113 +300,85 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
     return planner_data.traj_points;
   }
 
-  // Get Closest Obstacle Stop Distance
-  const double closest_obstacle_dist = motion_utils::calcSignedArcLength(
-    planner_data.traj_points, 0, closest_stop_obstacle->collision_point);
-
   const auto ego_segment_idx =
     ego_nearest_param_.findSegmentIndex(planner_data.traj_points, planner_data.ego_pose);
-  const auto negative_dist_to_ego = motion_utils::calcSignedArcLength(
-    planner_data.traj_points, planner_data.ego_pose.position, ego_segment_idx, 0);
-  const double dist_to_ego = -negative_dist_to_ego;
+  double dist_to_collide_on_ref_traj =
+    motion_utils::calcSignedArcLength(planner_data.traj_points, 0, ego_segment_idx) +
+    closest_stop_obstacle->dist_to_collide;
 
-  const double margin_from_obstacle =
-    calculateMarginFromObstacleOnCurve(planner_data, *closest_stop_obstacle);
+  double candidate_margin_from_obstacle = longitudinal_info_.safe_distance_margin;
+  if (enable_approaching_on_curve_) {
+    candidate_margin_from_obstacle =
+      calculateMarginFromObstacleOnCurve(planner_data, *closest_stop_obstacle);
+  }
+
+  // Use terminal margin (terminal_safe_distance_margin) for obstacle stop
+  const auto ref_traj_length = motion_utils::calcSignedArcLength(
+    planner_data.traj_points, 0, planner_data.traj_points.size() - 1);
+  if (dist_to_collide_on_ref_traj > ref_traj_length) {
+    candidate_margin_from_obstacle = longitudinal_info_.terminal_safe_distance_margin;
+  }
 
   // If behavior stop point is ahead of the closest_obstacle_stop point within a certain margin
   // we set closest_obstacle_stop_distance to closest_behavior_stop_distance
-  const double margin_from_obstacle_considering_behavior_module = [&]() {
-    const size_t nearest_segment_idx =
-      findEgoSegmentIndex(planner_data.traj_points, planner_data.ego_pose);
-    const auto closest_behavior_stop_idx =
-      motion_utils::searchZeroVelocityIndex(planner_data.traj_points, nearest_segment_idx + 1);
-
-    if (!closest_behavior_stop_idx) {
-      return margin_from_obstacle;
+  const auto closest_behavior_stop_idx =
+    motion_utils::searchZeroVelocityIndex(planner_data.traj_points, ego_segment_idx + 1);
+  if (closest_behavior_stop_idx) {
+    const double closest_behavior_stop_dist_on_ref_traj =
+      motion_utils::calcSignedArcLength(planner_data.traj_points, 0, *closest_behavior_stop_idx);
+    const double stop_dist_diff = closest_behavior_stop_dist_on_ref_traj -
+                                  (dist_to_collide_on_ref_traj - candidate_margin_from_obstacle);
+    if (0.0 < stop_dist_diff && stop_dist_diff < candidate_margin_from_obstacle) {
+      candidate_margin_from_obstacle = min_behavior_stop_margin_;
     }
-
-    const double closest_behavior_stop_dist_from_ego = motion_utils::calcSignedArcLength(
-      planner_data.traj_points, planner_data.ego_pose.position, nearest_segment_idx,
-      *closest_behavior_stop_idx);
-
-    if (*closest_behavior_stop_idx == planner_data.traj_points.size() - 1) {
-      // Closest behavior stop point is the end point
-      const double closest_obstacle_stop_dist_from_ego =
-        closest_obstacle_dist - dist_to_ego - longitudinal_info_.terminal_safe_distance_margin -
-        abs_ego_offset;
-      const double stop_dist_diff =
-        closest_behavior_stop_dist_from_ego - closest_obstacle_stop_dist_from_ego;
-      if (stop_dist_diff < margin_from_obstacle) {
-        // Use terminal margin (terminal_safe_distance_margin) for obstacle stop
-        return longitudinal_info_.terminal_safe_distance_margin;
-      }
-    } else {
-      const double closest_obstacle_stop_dist_from_ego =
-        closest_obstacle_dist - dist_to_ego - margin_from_obstacle - abs_ego_offset;
-      const double stop_dist_diff =
-        closest_behavior_stop_dist_from_ego - closest_obstacle_stop_dist_from_ego;
-      if (0.0 < stop_dist_diff && stop_dist_diff < margin_from_obstacle) {
-        // Use shorter margin (min_behavior_stop_margin) for obstacle stop
-        return min_behavior_stop_margin_;
-      }
-    }
-    return margin_from_obstacle;
-  }();
-
-  const auto [stop_margin_from_obstacle, will_collide_with_obstacle] = [&]() {
-    // Check feasibility to stop
-    if (suppress_sudden_obstacle_stop_) {
-      const double closest_obstacle_stop_dist =
-        closest_obstacle_dist - margin_from_obstacle_considering_behavior_module - abs_ego_offset;
-
-      // Calculate feasible stop margin (Check the feasibility)
-      const double feasible_stop_dist = calcMinimumDistanceToStop(
-                                          planner_data.ego_vel, longitudinal_info_.limit_max_accel,
-                                          longitudinal_info_.limit_min_accel) +
-                                        dist_to_ego;
-
-      if (closest_obstacle_stop_dist < feasible_stop_dist) {
-        const auto feasible_margin_from_obstacle =
-          margin_from_obstacle_considering_behavior_module -
-          (feasible_stop_dist - closest_obstacle_stop_dist);
-        return std::make_pair(feasible_margin_from_obstacle, true);
-      }
-    }
-    return std::make_pair(margin_from_obstacle_considering_behavior_module, false);
-  }();
+  }
 
   // Generate Output Trajectory
-  const double zero_vel_dist = [&]() {
-    const double current_zero_vel_dist =
-      std::max(0.0, closest_obstacle_dist - abs_ego_offset - stop_margin_from_obstacle);
+  double candidate_zero_vel_dist =
+    std::max(0.0, dist_to_collide_on_ref_traj - candidate_margin_from_obstacle);
 
-    // Hold previous stop distance if necessary
-    if (
-      std::abs(planner_data.ego_vel) < longitudinal_info_.hold_stop_velocity_threshold &&
-      prev_stop_distance_info_) {
-      // NOTE: We assume that the current trajectory's front point is ahead of the previous
-      // trajectory's front point.
-      const size_t traj_front_point_prev_seg_idx =
-        motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
-          prev_stop_distance_info_->first, planner_data.traj_points.front().pose);
-      const double diff_dist_front_points = motion_utils::calcSignedArcLength(
-        prev_stop_distance_info_->first, 0, planner_data.traj_points.front().pose.position,
-        traj_front_point_prev_seg_idx);
+  // Check feasibility to stop
+  bool will_collide_with_obstacle = false;
+  if (suppress_sudden_obstacle_stop_) {
+    // Calculate feasible stop margin (Check the feasibility)
+    const double feasible_stop_dist =
+      calcMinimumDistanceToStop(
+        planner_data.ego_vel, longitudinal_info_.limit_max_accel,
+        longitudinal_info_.limit_min_accel) +
+      motion_utils::calcSignedArcLength(
+        planner_data.traj_points, 0, planner_data.ego_pose.position);
 
-      const double prev_zero_vel_dist = prev_stop_distance_info_->second - diff_dist_front_points;
-      if (
-        std::abs(prev_zero_vel_dist - current_zero_vel_dist) <
-        longitudinal_info_.hold_stop_distance_threshold) {
-        return prev_zero_vel_dist;
-      }
+    if (candidate_zero_vel_dist < feasible_stop_dist) {
+      will_collide_with_obstacle = true;
+      candidate_zero_vel_dist = feasible_stop_dist;
     }
+  }
 
-    return current_zero_vel_dist;
-  }();
+  // Hold previous stop distance if necessary
+  if (
+    std::abs(planner_data.ego_vel) < longitudinal_info_.hold_stop_velocity_threshold &&
+    prev_stop_distance_info_) {
+    // NOTE: We assume that the current trajectory's front point is ahead of the previous
+    // trajectory's front point.
+    const size_t traj_front_point_prev_seg_idx =
+      motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+        prev_stop_distance_info_->first, planner_data.traj_points.front().pose);
+    const double diff_dist_front_points = motion_utils::calcSignedArcLength(
+      prev_stop_distance_info_->first, 0, planner_data.traj_points.front().pose.position,
+      traj_front_point_prev_seg_idx);
+
+    const double prev_zero_vel_dist = prev_stop_distance_info_->second - diff_dist_front_points;
+    if (
+      std::abs(prev_zero_vel_dist - candidate_zero_vel_dist) <
+      longitudinal_info_.hold_stop_distance_threshold) {
+      candidate_zero_vel_dist = prev_zero_vel_dist;
+    }
+  }
 
   // Insert stop point
   auto output_traj_points = planner_data.traj_points;
-  const auto zero_vel_idx = motion_utils::insertStopPoint(0, zero_vel_dist, output_traj_points);
+  const auto zero_vel_idx =
+    motion_utils::insertStopPoint(0, candidate_zero_vel_dist, output_traj_points);
   if (zero_vel_idx) {
     // virtual wall marker for stop obstacle
     const auto markers = motion_utils::createStopVirtualWallMarker(
@@ -396,17 +399,17 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
       createStopSpeedExceededMsg(planner_data.current_time, will_collide_with_obstacle);
     stop_speed_exceeded_pub_->publish(stop_speed_exceeded_msg);
 
-    prev_stop_distance_info_ = std::make_pair(output_traj_points, zero_vel_dist);
+    prev_stop_distance_info_ = std::make_pair(output_traj_points, candidate_zero_vel_dist);
   }
 
   stop_planning_debug_info_.set(
     StopPlanningDebugInfo::TYPE::STOP_CURRENT_OBSTACLE_DISTANCE,
-    closest_obstacle_dist - abs_ego_offset);  // TODO(murooka)
+    closest_stop_obstacle->dist_to_collide);  // TODO(murooka)
   stop_planning_debug_info_.set(
     StopPlanningDebugInfo::TYPE::STOP_CURRENT_OBSTACLE_VELOCITY, closest_stop_obstacle->velocity);
 
   stop_planning_debug_info_.set(
-    StopPlanningDebugInfo::TYPE::STOP_TARGET_OBSTACLE_DISTANCE, stop_margin_from_obstacle);
+    StopPlanningDebugInfo::TYPE::STOP_TARGET_OBSTACLE_DISTANCE, candidate_margin_from_obstacle);
   stop_planning_debug_info_.set(StopPlanningDebugInfo::TYPE::STOP_TARGET_VELOCITY, 0.0);
   stop_planning_debug_info_.set(StopPlanningDebugInfo::TYPE::STOP_TARGET_ACCELERATION, 0.0);
 
@@ -421,10 +424,6 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
 double PlannerInterface::calculateMarginFromObstacleOnCurve(
   const PlannerData & planner_data, const StopObstacle & stop_obstacle) const
 {
-  if (!enable_approaching_on_curve_) {
-    return longitudinal_info_.safe_distance_margin;
-  }
-
   const double abs_ego_offset = planner_data.is_driving_forward
                                   ? std::abs(vehicle_info_.max_longitudinal_offset_m)
                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);
@@ -721,8 +720,8 @@ PlannerInterface::calculateDistanceToSlowDownWithConstraints(
     }
 
     // NOTE: This min_relative_vel forces the relative velocity positive if the ego velocity is
-    // lower than the obstacle velocity. Without this, the slow down feature will flicker where the
-    // ego velocity is very close to the obstacle velocity.
+    // lower than the obstacle velocity. Without this, the slow down feature will flicker where
+    // the ego velocity is very close to the obstacle velocity.
     constexpr double min_relative_vel = 1.0;
     const double time_to_collision = (dist_to_front_collision - dist_to_ego - abs_ego_offset) /
                                      std::max(min_relative_vel, relative_vel);

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -305,8 +305,6 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
     motion_utils::calcSignedArcLength(planner_data.traj_points, 0, ego_segment_idx) +
     closest_stop_obstacle->dist_to_collide;
 
-  // If behavior stop point is ahead of the closest_obstacle_stop point within a certain margin
-  // we set closest_obstacle_stop_distance to closest_behavior_stop_distance
   const double margin_from_obstacle_considering_behavior_module = [&]() {
     const double margin_from_obstacle =
       calculateMarginFromObstacleOnCurve(planner_data, *closest_stop_obstacle);

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -25,36 +25,6 @@
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
-#define debug(var)                                                      \
-  do {                                                                  \
-    std::cerr << __func__ << ": " << __LINE__ << ", " << #var << " : "; \
-    view(var);                                                          \
-  } while (0)
-template <typename T>
-void view(T e)
-{
-  std::cerr << e << std::endl;
-}
-template <typename T>
-void view(const std::vector<T> & v)
-{
-  for (const auto & e : v) {
-    std::cerr << e << " ";
-  }
-  std::cerr << std::endl;
-}
-template <typename T>
-void view(const std::vector<std::vector<T>> & vv)
-{
-  for (const auto & v : vv) {
-    view(v);
-  }
-}
-#define line()                                                                         \
-  {                                                                                    \
-    std::cerr << "(" << __FILE__ << ") " << __func__ << ": " << __LINE__ << std::endl; \
-  }
-
 namespace
 {
 StopSpeedExceeded createStopSpeedExceededMsg(

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -271,9 +271,9 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
 
   const auto ego_segment_idx =
     ego_nearest_param_.findSegmentIndex(planner_data.traj_points, planner_data.ego_pose);
-  double dist_to_collide_on_ref_traj =
+  const double dist_to_collide_on_ref_traj =
     motion_utils::calcSignedArcLength(planner_data.traj_points, 0, ego_segment_idx) +
-    closest_stop_obstacle->dist_to_collide;
+    closest_stop_obstacle->dist_to_collide_on_decimated_traj;
 
   const double margin_from_obstacle_considering_behavior_module = [&]() {
     const double margin_from_obstacle =
@@ -373,7 +373,7 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
 
   stop_planning_debug_info_.set(
     StopPlanningDebugInfo::TYPE::STOP_CURRENT_OBSTACLE_DISTANCE,
-    closest_stop_obstacle->dist_to_collide);  // TODO(murooka)
+    closest_stop_obstacle->dist_to_collide_on_decimated_traj);
   stop_planning_debug_info_.set(
     StopPlanningDebugInfo::TYPE::STOP_CURRENT_OBSTACLE_VELOCITY, closest_stop_obstacle->velocity);
 

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -152,20 +152,20 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const auto bumper_pose = tier4_autoware_utils::calcOffsetPose(
     traj_points.at(collision_info->first).pose, x_diff_to_bumper, 0.0, 0.0);
 
-  std::optional<double> max_collison_length = std::nullopt;
-  std::optional<geometry_msgs::msg::Point> max_collison_point = std::nullopt;
+  std::optional<double> max_collision_length = std::nullopt;
+  std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;
   for (const auto & poly_vertex : collision_info->second) {
     const double dist_from_bumper =
       std::abs(tier4_autoware_utils::inverseTransformPoint(poly_vertex.point, bumper_pose).x);
 
-    if (!max_collison_length.has_value() || dist_from_bumper > *max_collison_length) {
-      max_collison_length = dist_from_bumper;
-      max_collison_point = poly_vertex.point;
+    if (!max_collision_length.has_value() || dist_from_bumper > *max_collision_length) {
+      max_collision_length = dist_from_bumper;
+      max_collision_point = poly_vertex.point;
     }
   }
   return std::make_pair(
-    *max_collison_point, motion_utils::calcSignedArcLength(traj_points, 0, collision_info->first) -
-                           *max_collison_length);
+    *max_collision_point, motion_utils::calcSignedArcLength(traj_points, 0, collision_info->first) -
+                            *max_collision_length);
 }
 
 // NOTE: max_lat_dist is used for efficient calculation to suppress boost::geometry's polygon

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -147,15 +147,14 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
     return std::nullopt;
   }
 
-  //TODO (takagi): incomplete implementation for backward trajectory
+  // TODO (takagi): incomplete implementation for backward trajectory
   const auto x_diff_to_bumper = is_driving_forward ? vehicle_info.max_longitudinal_offset_m
                                                    : vehicle_info.min_longitudinal_offset_m;
 
   std::optional<double> nearest_dist = std::nullopt;
   std::optional<geometry_msgs::msg::Point> nearest_point = std::nullopt;
-  double index_dist = motion_utils::calcSignedArcLength(traj_points, 0, collision_info->first);
   for (const auto & collision_point : collision_info->second) {
-    double dist_from_baselink = tier4_autoware_utils::inverseTransformPoint(
+    const double dist_from_baselink = tier4_autoware_utils::inverseTransformPoint(
                                   collision_point.point, traj_points.at(collision_info->first).pose)
                                   .x;
 

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -17,36 +17,6 @@
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 
-#define debug(var)                                                      \
-  do {                                                                  \
-    std::cerr << __func__ << ": " << __LINE__ << ", " << #var << " : "; \
-    view(var);                                                          \
-  } while (0)
-template <typename T>
-void view(T e)
-{
-  std::cerr << e << std::endl;
-}
-template <typename T>
-void view(const std::vector<T> & v)
-{
-  for (const auto & e : v) {
-    std::cerr << e << " ";
-  }
-  std::cerr << std::endl;
-}
-template <typename T>
-void view(const std::vector<std::vector<T>> & vv)
-{
-  for (const auto & v : vv) {
-    view(v);
-  }
-}
-#define line()                                                                         \
-  {                                                                                    \
-    std::cerr << "(" << __FILE__ << ") " << __func__ << ": " << __LINE__ << std::endl; \
-  }
-
 namespace
 {
 void appendPointToPolygon(Polygon2d & polygon, const geometry_msgs::msg::Point & geom_point)

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -18,36 +18,6 @@
 #include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 
-#define debug(var)                                                      \
-  do {                                                                  \
-    std::cerr << __func__ << ": " << __LINE__ << ", " << #var << " : "; \
-    view(var);                                                          \
-  } while (0)
-template <typename T>
-void view(T e)
-{
-  std::cerr << e << std::endl;
-}
-template <typename T>
-void view(const std::vector<T> & v)
-{
-  for (const auto & e : v) {
-    std::cerr << e << " ";
-  }
-  std::cerr << std::endl;
-}
-template <typename T>
-void view(const std::vector<std::vector<T>> & vv)
-{
-  for (const auto & v : vv) {
-    view(v);
-  }
-}
-#define line()                                                                         \
-  {                                                                                    \
-    std::cerr << "(" << __FILE__ << ") " << __func__ << ": " << __LINE__ << std::endl; \
-  }
-
 namespace
 {
 void appendPointToPolygon(Polygon2d & polygon, const geometry_msgs::msg::Point & geom_point)
@@ -164,25 +134,6 @@ Polygon2d createOneStepPolygon(
 
   return hull_polygon;
 }
-
-// std::optional<double> calcCollisionDistanceForStopObstacle(
-//   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
-//   const Obstacle & obstacle)
-// {
-//   auto obstacle_polygon = tier4_autoware_utils::toPolygon2d(obstacle.pose, obstacle.shape);
-//   for (size_t col_i = 0; col_i < traj_polys.size(); ++col_i) {
-//     if (boost::geometry::intersects(traj_polys.at(col_i), obstacle_polygon)) {
-//       try {
-//         double prev_index_dist =
-//           boost::geometry::distance(traj_polys.at(col_i - 1), obstacle_polygon);
-//         return motion_utils::calcSignedArcLength(traj_points, 0, col_i - 1) + prev_index_dist;
-//       } catch (std::out_of_range & ex) {
-//         return 0.0;
-//       }
-//     }
-//   }
-//   return std::nullopt;
-// }
 
 std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -100,7 +100,8 @@ std::optional<StopObstacle> getClosestStopObstacle(const std::vector<StopObstacl
   std::optional<StopObstacle> candidate_obstacle = std::nullopt;
   for (const auto & stop_obstacle : stop_obstacles) {
     if (
-      !candidate_obstacle || stop_obstacle.dist_to_collide_on_decimated_traj < candidate_obstacle->dist_to_collide_on_decimated_traj) {
+      !candidate_obstacle || stop_obstacle.dist_to_collide_on_decimated_traj <
+                               candidate_obstacle->dist_to_collide_on_decimated_traj) {
       candidate_obstacle = stop_obstacle;
     }
   }

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -95,24 +95,16 @@ PoseWithStamp getCurrentObjectPose(
   return PoseWithStamp{obj_base_time, *interpolated_pose};
 }
 
-std::optional<StopObstacle> getClosestStopObstacle(
-  const std::vector<TrajectoryPoint> & traj_points,
-  const std::vector<StopObstacle> & stop_obstacles)
+std::optional<StopObstacle> getClosestStopObstacle(const std::vector<StopObstacle> & stop_obstacles)
 {
-  if (stop_obstacles.empty()) {
-    return std::nullopt;
-  }
-
-  std::optional<StopObstacle> closest_stop_obstacle = std::nullopt;
-  double dist_to_closest_stop_obstacle = std::numeric_limits<double>::max();
+  std::optional<StopObstacle> candidate_obstacle = std::nullopt;
   for (const auto & stop_obstacle : stop_obstacles) {
-    const double dist_to_stop_obstacle =
-      motion_utils::calcSignedArcLength(traj_points, 0, stop_obstacle.collision_point);
-    if (dist_to_stop_obstacle < dist_to_closest_stop_obstacle) {
-      dist_to_closest_stop_obstacle = dist_to_stop_obstacle;
-      closest_stop_obstacle = stop_obstacle;
+    if (
+      !candidate_obstacle ||
+      stop_obstacle.dist_to_collide < candidate_obstacle->dist_to_collide) {
+      candidate_obstacle = stop_obstacle;
     }
   }
-  return closest_stop_obstacle;
+  return candidate_obstacle;
 }
 }  // namespace obstacle_cruise_utils

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -100,8 +100,7 @@ std::optional<StopObstacle> getClosestStopObstacle(const std::vector<StopObstacl
   std::optional<StopObstacle> candidate_obstacle = std::nullopt;
   for (const auto & stop_obstacle : stop_obstacles) {
     if (
-      !candidate_obstacle ||
-      stop_obstacle.dist_to_collide < candidate_obstacle->dist_to_collide) {
+      !candidate_obstacle || stop_obstacle.dist_to_collide < candidate_obstacle->dist_to_collide) {
       candidate_obstacle = stop_obstacle;
     }
   }

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -100,7 +100,7 @@ std::optional<StopObstacle> getClosestStopObstacle(const std::vector<StopObstacl
   std::optional<StopObstacle> candidate_obstacle = std::nullopt;
   for (const auto & stop_obstacle : stop_obstacles) {
     if (
-      !candidate_obstacle || stop_obstacle.dist_to_collide < candidate_obstacle->dist_to_collide) {
+      !candidate_obstacle || stop_obstacle.dist_to_collide_on_decimated_traj < candidate_obstacle->dist_to_collide_on_decimated_traj) {
       candidate_obstacle = stop_obstacle;
     }
   }


### PR DESCRIPTION
## Description
BEFORE:
The current implementation calculate the stop point by the closest collision point.
This cause inappropriate behavior for looped trajectories.
![image-20231020-104158](https://github.com/autowarefoundation/autoware.universe/assets/141538661/a1ecafe2-3438-403b-a886-2bb50674f993)


AFTER:
![Screenshot from 2023-11-17 16-54-44](https://github.com/autowarefoundation/autoware.universe/assets/141538661/d98b92d5-ec34-4e5b-9843-c2ebb81661ea)


The followings are achieved by this PR, 
- Proper handling of collision in extended trajectory is achieved (It is the main motivation of this PR).
- The stop point modification around the goal point is now working properly.
- `goal_extension_length` and `goal_extension_interval` may be no longer used and `safe_distance_margin` and `decimate_trajectory_step_length` are used instead.


This PR similar to https://github.com/autowarefoundation/autoware.universe/pull/5512, but this PR maintain more compatibility.
In other words, the function that included in the above PR  _This PR contains the similar feature to https://github.com/autowarefoundation/autoware.universe/pull/4952, and therefore approaching on curve is now provided as default setting._ is obsoleted.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
psim tests and Tier4 internal tests was performed in success.
No degrade directly related to this PR founds.
https://evaluation.tier4.jp/evaluation/reports/52d22759-d1af-5896-b016-3b45e73d4138?project_id=prd_jt


## Notes for reviewers
While no longer used parameters remain, I will remove these parameters after this PR has been agreed upon.

## Interface changes
No interface changes.

## Effects on system behavior
Minor bugs mentioned above have been fixed.
The slow down planning and the cruise planning may not changed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
