### PR TITLE
feat(blind_spot): consider opposite adjacent lane for wrong vehicles

### DIFF
--- a/planning/behavior_velocity_blind_spot_module/config/blind_spot.param.yaml
+++ b/planning/behavior_velocity_blind_spot_module/config/blind_spot.param.yaml
@@ -8,4 +8,5 @@
       max_future_movement_time: 10.0 # [second]
       threshold_yaw_diff: 0.523 # [rad]
       adjacent_extend_width: 1.5 # [m]
+      opposite_adjacent_extend_width: 1.5 # [m]
       enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval

--- a/planning/behavior_velocity_blind_spot_module/src/debug.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/debug.cpp
@@ -145,14 +145,12 @@ visualization_msgs::msg::MarkerArray BlindSpotModule::createDebugMarkerArray()
 
   appendMarkerArray(
     createLaneletPolygonsMarkerArray(
-      debug_data_.conflict_areas_for_blind_spot, "conflict_area_for_blind_spot", module_id_, 0.0,
-      0.5, 0.5),
+      debug_data_.conflict_areas, "conflict_area", module_id_, 0.0, 0.5, 0.5),
     &debug_marker_array, now);
 
   appendMarkerArray(
     createLaneletPolygonsMarkerArray(
-      debug_data_.detection_areas_for_blind_spot, "detection_area_for_blind_spot", module_id_, 0.5,
-      0.0, 0.0),
+      debug_data_.detection_areas, "detection_area", module_id_, 0.5, 0.0, 0.0),
     &debug_marker_array, now);
 
   appendMarkerArray(

--- a/planning/behavior_velocity_blind_spot_module/src/manager.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/manager.cpp
@@ -48,6 +48,8 @@ BlindSpotModuleManager::BlindSpotModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".threshold_yaw_diff");
   planner_param_.adjacent_extend_width =
     getOrDeclareParameter<double>(node, ns + ".adjacent_extend_width");
+  planner_param_.opposite_adjacent_extend_width =
+    getOrDeclareParameter<double>(node, ns + ".opposite_adjacent_extend_width");
 }
 
 void BlindSpotModuleManager::launchNewModules(

--- a/planning/behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.cpp
@@ -548,6 +548,7 @@ std::optional<BlindSpotPolygons> BlindSpotModule::generateBlindSpotPolygons(
     for (const auto lane_id : point.lane_ids) {
       if (lane_id == lane_id_) {
         found_intersection_lane = true;
+        lane_ids.push_back(lane_id);
         break;
       }
       // make lane_ids unique

--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace behavior_velocity_planner
@@ -176,9 +177,9 @@ private:
    * @param pass_judge_line_idx  generated pass judge line index
    * @return false when generation failed
    */
-  bool generateStopLine(
+  std::optional<std::pair<size_t, size_t>> generateStopLine(
     const lanelet::ConstLanelets straight_lanelets,
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx) const;
+    autoware_auto_planning_msgs::msg::PathWithLaneId * path) const;
 
   /**
    * @brief Insert a point to target path

--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -38,6 +38,8 @@ struct BlindSpotPolygons
 {
   std::vector<lanelet::CompoundPolygon3d> conflict_areas;
   std::vector<lanelet::CompoundPolygon3d> detection_areas;
+  std::vector<lanelet::CompoundPolygon3d> opposite_conflict_areas;
+  std::vector<lanelet::CompoundPolygon3d> opposite_detection_areas;
 };
 
 class BlindSpotModule : public SceneModuleInterface
@@ -50,8 +52,10 @@ public:
     geometry_msgs::msg::Pose virtual_wall_pose;
     geometry_msgs::msg::Pose stop_point_pose;
     geometry_msgs::msg::Pose judge_point_pose;
-    std::vector<lanelet::CompoundPolygon3d> conflict_areas_for_blind_spot;
-    std::vector<lanelet::CompoundPolygon3d> detection_areas_for_blind_spot;
+    std::vector<lanelet::CompoundPolygon3d> conflict_areas;
+    std::vector<lanelet::CompoundPolygon3d> detection_areas;
+    std::vector<lanelet::CompoundPolygon3d> opposite_conflict_areas;
+    std::vector<lanelet::CompoundPolygon3d> opposite_detection_areas;
     autoware_auto_perception_msgs::msg::PredictedObjects conflicting_targets;
   };
 
@@ -67,6 +71,7 @@ public:
     double threshold_yaw_diff;   //! threshold of yaw difference between ego and target object
     double
       adjacent_extend_width;  //! the width of extended detection/conflict area on adjacent lane
+    double opposite_adjacent_extend_width;
   };
 
   BlindSpotModule(
@@ -117,6 +122,8 @@ private:
   lanelet::ConstLanelet generateHalfLanelet(const lanelet::ConstLanelet lanelet) const;
 
   lanelet::ConstLanelet generateExtendedAdjacentLanelet(
+    const lanelet::ConstLanelet lanelet, const TurnDirection direction) const;
+  lanelet::ConstLanelet generateExtendedOppositeAdjacentLanelet(
     const lanelet::ConstLanelet lanelet, const TurnDirection direction) const;
 
   /**


### PR DESCRIPTION
## Description

Add the feature to consider wrong vehicles on the adjacent opposite lane to some extent

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/695

## Related links

https://tier4.atlassian.net/browse/RT1-3027

## Tests performed

evaluator: https://evaluation.tier4.jp/evaluation/reports/0edea585-2686-5670-80e4-11bdf643eb6c?project_id=prd_jt

The blind spot polygon is generated on the opposite side

https://github.com/autowarefoundation/autoware.universe/assets/28677420/9862f92e-e143-490a-aab9-23912fc910c2

## Notes for reviewers

none.

## Interface changes

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
