### PR TITLE
feat(avoidance): keep stopping until all shift lines are registered

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -231,6 +231,10 @@
         stop_buffer: 1.0                                # [m]
 
       policy:
+        # policy for rtc request. select "per_shift_line" or "per_avoidance_maneuver".
+        # "per_shift_line": request approval for each shift line.
+        # "per_avoidance_maneuver": request approval for avoidance maneuver (avoid + return).
+        make_approval_request: "per_shift_line"
         # policy for vehicle slow down behavior. select "best_effort" or "reliable".
         # "best_effort": slow down deceleration & jerk are limited by constraints.
         #                but there is a possibility that the vehicle can't stop in front of the vehicle.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -286,6 +286,9 @@ struct AvoidanceParameters
   bool use_shorten_margin_immediately{false};
 
   // policy
+  std::string policy_approval{"per_shift_line"};
+
+  // policy
   std::string policy_deceleration{"best_effort"};
 
   // policy

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -292,6 +292,7 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   // policy
   {
     std::string ns = "avoidance.policy.";
+    p.policy_approval = getOrDeclareParameter<std::string>(*node, ns + "make_approval_request");
     p.policy_deceleration = getOrDeclareParameter<std::string>(*node, ns + "deceleration");
     p.policy_lateral_margin = getOrDeclareParameter<std::string>(*node, ns + "lateral_margin");
     p.use_shorten_margin_immediately =

--- a/planning/behavior_path_planner/src/utils/avoidance/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/shift_line_generator.cpp
@@ -35,6 +35,11 @@ bool isBestEffort(const std::string & policy)
   return policy == "best_effort";
 }
 
+bool perManeuver(const std::string & policy)
+{
+  return policy == "per_avoidance_maneuver";
+}
+
 AvoidLine merge(const AvoidLine & line1, const AvoidLine & line2, const UUID id)
 {
   AvoidLine ret{};
@@ -1213,11 +1218,18 @@ AvoidLineArray ShiftLineGenerator::findNewShiftLine(
       break;
     }
 
-    if (!is_ignore_shift(candidate)) {
-      const auto new_shift_lines = get_subsequent_shift(i);
-      debug.step4_new_shift_line = new_shift_lines;
-      return new_shift_lines;
+    if (is_ignore_shift(candidate)) {
+      continue;
     }
+
+    if (perManeuver(parameters_->policy_approval)) {
+      debug.step4_new_shift_line = shift_lines;
+      return shift_lines;
+    }
+
+    const auto new_shift_lines = get_subsequent_shift(i);
+    debug.step4_new_shift_line = new_shift_lines;
+    return new_shift_lines;
   }
 
   return {};


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at abf7691</samp>

This pull request adds a feature to the `AvoidanceModule` that allows the vehicle to request approval from the RTC for the avoidance maneuver based on a configurable policy. The policy can be set to either `shift_line` or `maneuver` in the `avoidance.param.yaml` file.

Please reveiw following PR at first:
https://github.com/autowarefoundation/autoware_launch/pull/699

---

Previously, avoidance module made rtc requests for each shift line. Then, operator had to approve several times to avoid object and return original lane during driving.

In this PR, I added new option in order to execute avoidance maneuver by only once approval manupulation. If the parameter `policy.approval` is set to `maneuver`, the module makes requests per avoidance maneuver (avoid + return).

```yaml
      policy:
        # policy for rtc request. select "shift_line" or "maneuver".
        # "shift_line": request approval for each shift line.
        # "maneuver": request approval for avoidance maneuver (avoid + return).
        approval: "shift_line"
```

#### `policy.approval: shift_line`

https://github.com/autowarefoundation/autoware.universe/assets/44889564/1aead94c-543c-4a51-aee3-36fbbfe4269a

#### `policy.approval: maneuver`

https://github.com/autowarefoundation/autoware.universe/assets/44889564/63ab71b9-3c3a-4813-b0d0-fabb62a72a9a

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/c485f1b7-5c44-5b6f-9f20-8cb278c93305?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
