### PR TITLE
refactor(vehicle_external_cmd_converter): rework parameters

### DIFF
--- a/vehicle/external_cmd_converter/schema/external_cmd_converter.json
+++ b/vehicle/external_cmd_converter/schema/external_cmd_converter.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for external_cmd_converter",
+  "type": "object",
+  "definitions": {
+    "velodyne_monitor": {
+      "type": "object",
+      "properties": {
+        "ref_vel_gain": {
+          "type": "number",
+          "default": 3.0
+        },
+        "timer_rate": {
+          "type": "number",
+          "default": 10.0,
+          "description": "timer's update rate."
+        },
+        "wait_for_first_topic": {
+          "type": "boolean",
+          "default": "true",
+          "description": "if time out check is done after receiving first topic."
+        },
+        "control_command_timeout": {
+          "type": "number",
+          "default": 1.0,
+          "description": "time out check for control command."
+        },
+        "emergency_stop_timeout": {
+          "type": "number",
+          "default": 3.0,
+          "description": "time out check for emergency stop command."
+        }
+      },
+      "required": [
+        "ref_vel_gain",
+        "timer_rate",
+        "wait_for_first_topic",
+        "control_command_timeout",
+        "emergency_stop_timeout"
+      ]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/external_cmd_converter"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}

--- a/vehicle/external_cmd_converter/src/node.cpp
+++ b/vehicle/external_cmd_converter/src/node.cpp
@@ -47,7 +47,7 @@ ExternalCmdConverterNode::ExternalCmdConverterNode(const rclcpp::NodeOptions & n
   // Parameter for Hz check
   const double timer_rate = declare_parameter<number>("timer_rate");
   wait_for_first_topic_ = declare_parameter<boolean>("wait_for_first_topic");
-  control_command_timeout_ = declare_parameter<number>("control_command_timeout");
+  control_command_timeout_ = declare_parameter<double>("control_command_timeout");
   emergency_stop_timeout_ = declare_parameter<number>("emergency_stop_timeout");
 
   const auto period_ns = rclcpp::Rate(timer_rate).period();

--- a/vehicle/external_cmd_converter/src/node.cpp
+++ b/vehicle/external_cmd_converter/src/node.cpp
@@ -48,7 +48,7 @@ ExternalCmdConverterNode::ExternalCmdConverterNode(const rclcpp::NodeOptions & n
   const double timer_rate = declare_parameter<number>("timer_rate");
   wait_for_first_topic_ = declare_parameter<boolean>("wait_for_first_topic");
   control_command_timeout_ = declare_parameter<double>("control_command_timeout");
-  emergency_stop_timeout_ = declare_parameter<number>("emergency_stop_timeout");
+  emergency_stop_timeout_ = declare_parameter<double>("emergency_stop_timeout");
 
   const auto period_ns = rclcpp::Rate(timer_rate).period();
   rate_check_timer_ = rclcpp::create_timer(

--- a/vehicle/external_cmd_converter/src/node.cpp
+++ b/vehicle/external_cmd_converter/src/node.cpp
@@ -42,13 +42,13 @@ ExternalCmdConverterNode::ExternalCmdConverterNode(const rclcpp::NodeOptions & n
     std::bind(&ExternalCmdConverterNode::onEmergencyStopHeartbeat, this, _1));
 
   // Parameter
-  ref_vel_gain_ = declare_parameter("ref_vel_gain", 3.0);
+  ref_vel_gain_ = declare_parameter<number>("ref_vel_gain");
 
   // Parameter for Hz check
-  const double timer_rate = declare_parameter("timer_rate", 10.0);
-  wait_for_first_topic_ = declare_parameter("wait_for_first_topic", true);
-  control_command_timeout_ = declare_parameter("control_command_timeout", 1.0);
-  emergency_stop_timeout_ = declare_parameter("emergency_stop_timeout", 3.0);
+  const double timer_rate = declare_parameter<number>("timer_rate");
+  wait_for_first_topic_ = declare_parameter<boolean>("wait_for_first_topic");
+  control_command_timeout_ = declare_parameter<number>("control_command_timeout");
+  emergency_stop_timeout_ = declare_parameter<number>("emergency_stop_timeout");
 
   const auto period_ns = rclcpp::Rate(timer_rate).period();
   rate_check_timer_ = rclcpp::create_timer(

--- a/vehicle/external_cmd_converter/src/node.cpp
+++ b/vehicle/external_cmd_converter/src/node.cpp
@@ -42,11 +42,11 @@ ExternalCmdConverterNode::ExternalCmdConverterNode(const rclcpp::NodeOptions & n
     std::bind(&ExternalCmdConverterNode::onEmergencyStopHeartbeat, this, _1));
 
   // Parameter
-  ref_vel_gain_ = declare_parameter<number>("ref_vel_gain");
+  ref_vel_gain_ = declare_parameter<double>("ref_vel_gain");
 
   // Parameter for Hz check
-  const double timer_rate = declare_parameter<number>("timer_rate");
-  wait_for_first_topic_ = declare_parameter<boolean>("wait_for_first_topic");
+  const double timer_rate = declare_parameter<double>("timer_rate");
+  wait_for_first_topic_ = declare_parameter<bool>("wait_for_first_topic");
   control_command_timeout_ = declare_parameter<double>("control_command_timeout");
   emergency_stop_timeout_ = declare_parameter<double>("emergency_stop_timeout");
 


### PR DESCRIPTION
## Description

Implement the ROS Node configuration layout described in https://github.com/orgs/autowarefoundation/discussions/3371 for the vehicle_external_cmd_converter

1. Remove the default value from the source code in order to ensure all parameter values are passed from the parameter files.

 2.create schema

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
