### PR TITLE
feat(goal_planner): keep decided path

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
@@ -246,6 +246,7 @@ struct PreviousPullOverData
     found_path = false;
     is_safe = false;
     safety_status = SafetyStatus{};
+    has_decided_path = false;
   }
 
   std::shared_ptr<PathWithLaneId> stop_path{nullptr};
@@ -253,6 +254,7 @@ struct PreviousPullOverData
   bool found_path{false};
   bool is_safe{false};
   SafetyStatus safety_status{};
+  bool has_decided_path{false};
 };
 
 class GoalPlannerModule : public SceneModuleInterface

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -854,10 +854,13 @@ void GoalPlannerModule::updateSteeringFactor(
     pose, distance, SteeringFactor::GOAL_PLANNER, steering_factor_direction, type, "");
 }
 
-// NOTE: Once this function returns true, it will continue to return true thereafter. Because
-// selectPullOverPath() will not select new path.
 bool GoalPlannerModule::hasDecidedPath() const
 {
+  // Once this function returns true, it will continue to return true thereafter
+  if (prev_data_.has_decided_path) {
+    return true;
+  }
+
   // if path is not safe, not decided
   if (!thread_safe_data_.foundPullOverPath()) {
     return false;
@@ -1033,6 +1036,8 @@ void GoalPlannerModule::updatePreviousData(const BehaviorModuleOutput & output)
   // for the next loop setOutput().
   // this is used to determine whether to generate a new stop path or keep the current stop path.
   prev_data_.found_path = thread_safe_data_.foundPullOverPath();
+
+  prev_data_.has_decided_path = hasDecidedPath();
 
   // This is related to safety check, so if it is disabled, return here.
   if (!parameters_->safety_check_params.enable_safety_check) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

keep has_decided_path if deciding once


Fixed a problem that after a path decision is made, if the path is not safe, the decision is aborted, resulting in no updateRTCStatus in manual mode and no update isExecutionReady

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

evaluator_description: feat/keep_dicide
2023/11/25 https://evaluation.tier4.jp/evaluation/reports/43420698-cb2f-53fc-8026-f0c23683027e/?project_id=prd_jt



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
