### PR TITLE
fix(surround_obstacle_checker): prevent crash when all checks for object types to are set to false

### DIFF
--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -141,6 +141,10 @@ private:
   std::shared_ptr<const rclcpp::Time> last_obstacle_found_time_;
 
   std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
+
+  bool use_dynamic_object_;
+
+  std::unordered_map<std::string, int> label_map_;
 };
 }  // namespace surround_obstacle_checker
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -149,19 +149,22 @@ Polygon2d createSelfPolygon(
 SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options)
 : Node("surround_obstacle_checker_node", node_options)
 {
+  label_map_ = {
+    {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
+    {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
+    {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
+    {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
   // Parameters
   {
     auto & p = node_param_;
 
     // for object label
-    std::unordered_map<std::string, int> label_map{
-      {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
-      {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
-      {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
-      {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
-    for (const auto & label_pair : label_map) {
-      p.enable_check_map.emplace(
-        label_pair.second, this->declare_parameter<bool>(label_pair.first + ".enable_check"));
+    use_dynamic_object_ = false;
+    for (const auto & label_pair : label_map_) {
+      const bool check_current_label =
+        this->declare_parameter<bool>(label_pair.first + ".enable_check");
+      p.enable_check_map.emplace(label_pair.second, check_current_label);
+      use_dynamic_object_ = use_dynamic_object_ || check_current_label;
       p.surround_check_front_distance_map.emplace(
         label_pair.second,
         this->declare_parameter<double>(label_pair.first + ".surround_check_front_distance"));
@@ -245,13 +248,7 @@ std::array<double, 3> SurroundObstacleCheckerNode::getCheckDistances(
       node_param_.pointcloud_surround_check_back_distance};
   }
 
-  std::unordered_map<std::string, int> label_map{
-    {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
-    {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
-    {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
-    {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
-
-  const int int_label = label_map.at(str_label);
+  const int int_label = label_map_.at(str_label);
   return {
     node_param_.surround_check_front_distance_map.at(int_label),
     node_param_.surround_check_side_distance_map.at(int_label),
@@ -261,6 +258,14 @@ std::array<double, 3> SurroundObstacleCheckerNode::getCheckDistances(
 rcl_interfaces::msg::SetParametersResult SurroundObstacleCheckerNode::onParam(
   const std::vector<rclcpp::Parameter> & parameters)
 {
+  use_dynamic_object_ = false;
+  for (const auto & label_pair : label_map_) {
+    bool & check_current_label = node_param_.enable_check_map.at(label_pair.second);
+    tier4_autoware_utils::updateParam<bool>(
+      parameters, label_pair.first + ".enable_check", check_current_label);
+    use_dynamic_object_ = use_dynamic_object_ || check_current_label;
+  }
+
   tier4_autoware_utils::updateParam<std::string>(
     parameters, "debug_footprint_label", node_param_.debug_footprint_label);
   const auto check_distances = getCheckDistances(node_param_.debug_footprint_label);
@@ -289,29 +294,18 @@ void SurroundObstacleCheckerNode::onTimer()
   if (node_param_.pointcloud_enable_check && !pointcloud_ptr_) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for pointcloud info...");
-    return;
   }
 
-  const bool use_dynamic_object =
-    node_param_.enable_check_map.at(ObjectClassification::UNKNOWN) ||
-    node_param_.enable_check_map.at(ObjectClassification::CAR) ||
-    node_param_.enable_check_map.at(ObjectClassification::TRUCK) ||
-    node_param_.enable_check_map.at(ObjectClassification::BUS) ||
-    node_param_.enable_check_map.at(ObjectClassification::TRAILER) ||
-    node_param_.enable_check_map.at(ObjectClassification::MOTORCYCLE) ||
-    node_param_.enable_check_map.at(ObjectClassification::BICYCLE) ||
-    node_param_.enable_check_map.at(ObjectClassification::PEDESTRIAN);
+  if (use_dynamic_object_ && !object_ptr_) {
+    RCLCPP_INFO_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object
+      info...");
+  }
 
-  if (!use_dynamic_object) {
+  if (!node_param_.pointcloud_enable_check && !use_dynamic_object_) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */,
-      "Surround check is disabled for all object types.");
-    return;
-  }
-  if (!object_ptr_) {
-    RCLCPP_INFO_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
-    return;
+      "Surround obstacle check is disabled for all dynamic object types and for pointcloud check.");
   }
 
   const auto nearest_obstacle = getNearestObstacle();
@@ -429,7 +423,7 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPoint
     getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
 
   if (!transform_stamped) {
-    return {};
+    return boost::none;
   }
 
   Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.get().transform).cast<float>();
@@ -466,11 +460,13 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPoint
 
 boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamicObject() const
 {
+  if (!object_ptr_ || !use_dynamic_object_) return boost::none;
+
   const auto transform_stamped =
     getTransform(object_ptr_->header.frame_id, "base_link", object_ptr_->header.stamp, 0.5);
 
   if (!transform_stamped) {
-    return {};
+    return boost::none;
   }
 
   tf2::Transform tf_src2target;
@@ -487,7 +483,6 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynam
     if (!node_param_.enable_check_map.at(label)) {
       continue;
     }
-
     const double front_margin = node_param_.surround_check_front_distance_map.at(label);
     const double side_margin = node_param_.surround_check_side_distance_map.at(label);
     const double back_margin = node_param_.surround_check_back_distance_map.at(label);

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -414,7 +414,11 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacle() cons
 
 boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCloud() const
 {
-  if (!node_param_.pointcloud_enable_check || pointcloud_ptr_->data.empty()) {
+  if (!node_param_.pointcloud_enable_check || !pointcloud_ptr_) {
+    return boost::none;
+  }
+
+  if (pointcloud_ptr_->data.empty()) {
     return boost::none;
   }
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -298,8 +298,7 @@ void SurroundObstacleCheckerNode::onTimer()
 
   if (use_dynamic_object_ && !object_ptr_) {
     RCLCPP_INFO_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object
-      info...");
+      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
   }
 
   if (!node_param_.pointcloud_enable_check && !use_dynamic_object_) {

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -301,7 +301,14 @@ void SurroundObstacleCheckerNode::onTimer()
     node_param_.enable_check_map.at(ObjectClassification::MOTORCYCLE) ||
     node_param_.enable_check_map.at(ObjectClassification::BICYCLE) ||
     node_param_.enable_check_map.at(ObjectClassification::PEDESTRIAN);
-  if (use_dynamic_object && !object_ptr_) {
+
+  if (!use_dynamic_object) {
+    RCLCPP_INFO_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000 /* ms */,
+      "Surround check is disabled for all object types.");
+    return;
+  }
+  if (!object_ptr_) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
     return;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
<!--

-->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e588cb4</samp>

Refactor and improve `SurroundObstacleCheckerNode` for planning. This change introduces two new member variables to optimize the dynamic object check, fixes a bug with the optional return type, and adds some input validation. The changes affect `node.cpp` and `node.hpp` files.

Refactor `surround_obstacle_checker` node to skip surround check if all checks for object types to false (and throw an Info message accordingly) or if there is no object pointer.

Solves this issue: https://github.com/autowarefoundation/autoware.universe/issues/5642
## Tests performed
in PSim set all checks for object types to false, check if there is a crash or not -> NO crashes with this fix.


https://github.com/autowarefoundation/autoware.universe/assets/25967964/b3207577-68ac-4a6d-b215-be0379d51cdc


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Prevents crashes when all obstacle targets are disabled

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
