### PR TITLE
fix(behavior_velocity_planner): fix json schema

### DIFF
--- a/planning/behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
+++ b/planning/behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
@@ -42,7 +42,7 @@
           "description": "max jerk of the vehicle"
         },
         "is_publish_debug_path": {
-          "type": "number",
+          "type": "boolean",
           "default": "false",
           "description": "is publish debug path?"
         }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3fc8a9f</samp>

Changed the type of `is_publish_debug_path` property in `behavior_velocity_planner.schema.json` from number to boolean. This improves the schema consistency and accuracy, and avoids parsing errors.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See CI/CD result.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
