### PR TITLE
feat(dyanmic_avoidance): deal with oncoming forked predicted path

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -320,9 +320,14 @@ private:
   LatLonOffset getLateralLongitudinalOffset(
     const std::vector<PathPointWithLaneId> & ego_path, const geometry_msgs::msg::Pose & obj_pose,
     const autoware_auto_perception_msgs::msg::Shape & obj_shape) const;
+  double calcValidStartLengthToAvoid(
+    const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
+    const size_t obj_seg_idx, const PredictedPath & obj_path,
+    const autoware_auto_perception_msgs::msg::Shape & obj_shape) const;
   MinMaxValue calcMinMaxLongitudinalOffsetToAvoid(
     const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
     const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
+    const PredictedPath & obj_path, const autoware_auto_perception_msgs::msg::Shape & obj_shape,
     const double time_to_collision) const;
   MinMaxValue calcMinMaxLateralOffsetToAvoid(
     const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,


### PR DESCRIPTION
## Description

The current dynamic avoidance module cannot deal with the oncoming object's path well where the object's path is forked from the ego's path.
This PR fixed the issue by calculating the distance between the object's path and ego's path.

**before**
The left side of the drivable area around the ego is modified unexpectedly.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/86263de7-abe2-4d46-9ff7-fb3d0a9e3d43)

**after**
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/f084a6a2-d02f-488e-b455-278fa356c1c1)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Better handling of the oncoming object's path in dynamic avoidance


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
