### PR TITLE
feat(dynamic_avoidance): accurate decision of front vehicle to avoid

### DIFF
--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -41,9 +41,10 @@
 
         front_object:
           max_object_angle: 0.785
+          min_vel: -0.5                      # [m/s] The value is negative considering the noisy velocity of the stopped vehicle.
+          max_ego_path_lat_cover_ratio: 0.3  # [-] The object will be ignored if the ratio of the object covering the ego's path is higher than this value.
 
       drivable_area_generation:
-        polygon_generation_method: "object_path_base" # choose "ego_path_base" and "object_path_base"
         object_path_base:
           min_longitudinal_polygon_margin: 3.0 # [m]
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -74,6 +74,8 @@ struct DynamicAvoidanceParameters
   double max_time_from_outside_ego_path_for_cut_out{0.0};
   double min_cut_out_object_lat_vel{0.0};
   double max_front_object_angle{0.0};
+  double min_front_object_vel{0.0};
+  double max_front_object_ego_path_lat_cover_ratio{0.0};
   double min_overtaking_crossing_object_vel{0.0};
   double max_overtaking_crossing_object_angle{0.0};
   double min_oncoming_crossing_object_vel{0.0};
@@ -324,10 +326,10 @@ private:
     const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
     const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
     const double time_to_collision) const;
-  MinMaxValue calcMinMaxLateralOffsetToAvoid(
+  std::optional<MinMaxValue> calcMinMaxLateralOffsetToAvoid(
     const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
-    const Polygon2d & obj_points, const bool is_collision_left, const double obj_normal_vel,
-    const std::optional<DynamicAvoidanceObject> & prev_object) const;
+    const Polygon2d & obj_points, const double obj_vel, const bool is_collision_left,
+    const double obj_normal_vel, const std::optional<DynamicAvoidanceObject> & prev_object) const;
 
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -569,11 +569,20 @@ void DynamicAvoidanceModule::updateTargetObjects()
     const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
       path_points_for_object_polygon, object.pose, obj_points, object.vel, time_to_collision);
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoid(
-      path_points_for_object_polygon, obj_points, is_collision_left, object.lat_vel, prev_object);
+      path_points_for_object_polygon, obj_points, object.vel, is_collision_left, object.lat_vel,
+      prev_object);
+    if (!lat_offset_to_avoid) {
+      RCLCPP_INFO_EXPRESSION(
+        getLogger(), parameters_->enable_debug_info,
+        "[DynamicAvoidance] Ignore obstacle (%s) since the object laterally covers the ego's path "
+        "enough",
+        obj_uuid.c_str());
+      continue;
+    }
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObject(
-      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided,
+      obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided,
       polygon_generation_method);
   }
 }
@@ -849,10 +858,10 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLongitudinalOffsetToAvoid(
     obj_lon_offset.max_value + end_length_to_avoid};
 }
 
-MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
+std::optional<MinMaxValue> DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
   const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
-  const Polygon2d & obj_points, const bool is_collision_left, const double obj_normal_vel,
-  const std::optional<DynamicAvoidanceObject> & prev_object) const
+  const Polygon2d & obj_points, const double obj_vel, const bool is_collision_left,
+  const double obj_normal_vel, const std::optional<DynamicAvoidanceObject> & prev_object) const
 {
   // calculate min/max lateral offset from object to path
   const auto obj_lat_abs_offset = [&]() {
@@ -863,12 +872,24 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
         motion_utils::findNearestSegmentIndex(path_points_for_object_polygon, geom_obj_point);
       const double obj_point_lat_offset = motion_utils::calcLateralOffset(
         path_points_for_object_polygon, geom_obj_point, obj_point_seg_idx);
-      obj_lat_abs_offset_vec.push_back(std::abs(obj_point_lat_offset));
+      obj_lat_abs_offset_vec.push_back(obj_point_lat_offset);
     }
     return getMinMaxValues(obj_lat_abs_offset_vec);
   }();
   const double min_obj_lat_abs_offset = obj_lat_abs_offset.min_value;
   const double max_obj_lat_abs_offset = obj_lat_abs_offset.max_value;
+
+  if (parameters_->min_front_object_vel < obj_vel) {
+    const double obj_width_on_ego_path =
+      std::min(max_obj_lat_abs_offset, planner_data_->parameters.vehicle_width / 2.0) -
+      std::max(min_obj_lat_abs_offset, -planner_data_->parameters.vehicle_width / 2.0);
+    if (
+      planner_data_->parameters.vehicle_width *
+        parameters_->max_front_object_ego_path_lat_cover_ratio <
+      obj_width_on_ego_path) {
+      return std::nullopt;
+    }
+  }
 
   // calculate bound min and max lateral offset
   const double min_bound_lat_offset = [&]() {
@@ -876,15 +897,20 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
       std::max(0.0, obj_normal_vel * (is_collision_left ? -1.0 : 1.0)) *
       parameters_->max_time_for_lat_shift;
     const double raw_min_bound_lat_offset =
-      min_obj_lat_abs_offset - parameters_->lat_offset_from_obstacle - lat_abs_offset_to_shift;
+      (is_collision_left ? min_obj_lat_abs_offset : max_obj_lat_abs_offset) -
+      (parameters_->lat_offset_from_obstacle + lat_abs_offset_to_shift) *
+        (is_collision_left ? 1.0 : -1.0);
     const double min_bound_lat_abs_offset_limit =
       planner_data_->parameters.vehicle_width / 2.0 - parameters_->max_lat_offset_to_avoid;
-    return std::max(raw_min_bound_lat_offset, min_bound_lat_abs_offset_limit) *
-           (is_collision_left ? 1.0 : -1.0);
+
+    if (is_collision_left) {
+      return std::max(raw_min_bound_lat_offset, min_bound_lat_abs_offset_limit);
+    }
+    return std::min(raw_min_bound_lat_offset, -min_bound_lat_abs_offset_limit);
   }();
   const double max_bound_lat_offset =
-    (max_obj_lat_abs_offset + parameters_->lat_offset_from_obstacle) *
-    (is_collision_left ? 1.0 : -1.0);
+    (is_collision_left ? max_obj_lat_abs_offset : min_obj_lat_abs_offset) +
+    (is_collision_left ? 1.0 : -1.0) * parameters_->lat_offset_from_obstacle;
 
   // filter min_bound_lat_offset
   const auto prev_min_lat_avoid_to_offset = [&]() -> std::optional<double> {

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -71,6 +71,9 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
 
     p.max_front_object_angle =
       node->declare_parameter<double>(ns + "front_object.max_object_angle");
+    p.min_front_object_vel = node->declare_parameter<double>(ns + "front_object.min_vel");
+    p.max_front_object_ego_path_lat_cover_ratio =
+      node->declare_parameter<double>(ns + "front_object.max_ego_path_lat_cover_ratio");
 
     p.min_overtaking_crossing_object_vel =
       node->declare_parameter<double>(ns + "crossing_object.min_overtaking_object_vel");
@@ -166,6 +169,10 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
 
     updateParam<double>(
       parameters, ns + "front_object.max_object_angle", p->max_front_object_angle);
+    updateParam<double>(parameters, ns + "front_object.min_vel", p->min_front_object_vel);
+    updateParam<double>(
+      parameters, ns + "front_object.max_ego_path_lat_cover_ratio",
+      p->max_front_object_ego_path_lat_cover_ratio);
 
     updateParam<double>(
       parameters, ns + "crossing_object.min_overtaking_object_vel",


### PR DESCRIPTION
## Description
The front vehicle decision whether to avoid or not is wrong sometimes as shown in the following figure.
This PR fixed the issue by calculating how much ratio the object covers the ego's path.

**before**
The dynamic avoidance module tries to avoid the front vehicle unexpectedly.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/a1f41e8f-085e-4924-86d2-b5c3069db5d5)

**after**
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/cd424b54-87c1-42a4-9a39-8fbde013f9c0)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

accurate front vehicle decision for dynamic avoidance

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
