### PR TITLE
fix(avoidance): reset output path when the module transits success status

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -517,6 +517,8 @@ struct AvoidancePlanningData
 
   bool valid{false};
 
+  bool success{false};
+
   bool comfortable{false};
 
   bool avoid_required{false};

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/scene.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/scene.hpp
@@ -73,6 +73,8 @@ public:
   std::shared_ptr<AvoidanceDebugMsgArray> get_debug_msg_array() const;
 
 private:
+  bool isSatisfiedSuccessCondition(const AvoidancePlanningData & data) const;
+
   bool canTransitSuccessState() override;
 
   bool canTransitFailureState() override { return false; }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e7c341d</samp>

This pull request adds a new function `isSatifiedSuccessCodition` to the `AvoidanceModule` class to check the success conditions for the avoidance planning data. It also updates the related functions and data structures to use the new function and handle the successful cases of avoidance. The changes affect the files `avoidance_module.cpp`, `avoidance_module.hpp`, and `avoidance_module_data.hpp`.

---

This PR fixed the endless loop bug in behavior path planner.

### What is problem?

When the avoidance module return success state for the reason that there is no target objects, the endless loop occures.

1. object is ignored as `TooNearToCenterline`.
2. avoidance module cancels avoidance path and return success state. (but the output path is still shifted.)
3. planner manager removes avoidance module.
4. planner manager passes avoidance module output path for each module and check request module.
5. avoidance module returns execution request based on its own last output.
6. ...

https://github.com/autowarefoundation/autoware.universe/assets/44889564/d76d1674-0ebf-4575-a832-be9dd1cade4b

```
[component_container_mt-29] [ERROR 1701127462.634577196] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: avoid line for path_shifter must have parent_id.
[component_container_mt-29] [INFO 1701127462.655110098] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: No objects. Cancel avoidance path. Exit.
[component_container_mt-29] [INFO 1701127462.715158171] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: No objects. Cancel avoidance path. Exit.
[component_container_mt-29] [ERROR 1701127462.749412840] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: avoid line for path_shifter must have parent_id.
[component_container_mt-29] [INFO 1701127462.767202547] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: No objects. Cancel avoidance path. Exit.
[component_container_mt-29] [INFO 1701127462.822984446] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: No objects. Cancel avoidance path. Exit.
[component_container_mt-29] [ERROR 1701127462.855613483] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: avoid line for path_shifter must have parent_id.
[component_container_mt-29] [INFO 1701127462.873763925] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: No objects. Cancel avoidance path. Exit.
[component_container_mt-29] [INFO 1701127462.925050774] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance]: No objects. Cancel avoidance path. Exit.
```

### How to fix?

When the avoidance module return success state, it should not modify input path any more. Therefore, I changed process flow a little bit and added reset process in `plan()` so that the avoidance module can return just intput path if it is in success state.

```c++
  if (data.success) {
    removeRegisteredShiftLines();
  }
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/e1bf238c-0c97-56e9-9966-8c01e52c4304?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
