### PR TITLE
feat(tier4_autoware_utils): add yaw argument in calcOffsetPose

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -462,7 +462,8 @@ bool isDrivingForward(const Pose1 & src_pose, const Pose2 & dst_pose)
  * pose.
  */
 geometry_msgs::msg::Pose calcOffsetPose(
-  const geometry_msgs::msg::Pose & p, const double x, const double y, const double z);
+  const geometry_msgs::msg::Pose & p, const double x, const double y, const double z,
+  const double yaw = 0.0);
 
 /**
  * @brief Calculate a point by linear interpolation.

--- a/common/tier4_autoware_utils/src/geometry/geometry.cpp
+++ b/common/tier4_autoware_utils/src/geometry/geometry.cpp
@@ -327,12 +327,13 @@ double calcCurvature(
  * pose.
  */
 geometry_msgs::msg::Pose calcOffsetPose(
-  const geometry_msgs::msg::Pose & p, const double x, const double y, const double z)
+  const geometry_msgs::msg::Pose & p, const double x, const double y, const double z,
+  const double yaw)
 {
   geometry_msgs::msg::Pose pose;
   geometry_msgs::msg::Transform transform;
   transform.translation = createTranslation(x, y, z);
-  transform.rotation = createQuaternion(0.0, 0.0, 0.0, 1.0);
+  transform.rotation = createQuaternionFromYaw(yaw);
   tf2::Transform tf_pose;
   tf2::Transform tf_offset;
   tf2::fromMsg(transform, tf_offset);

--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -1138,6 +1138,7 @@ TEST(geometry, calcOffsetPose)
   using tier4_autoware_utils::createQuaternionFromRPY;
   using tier4_autoware_utils::deg2rad;
 
+  // Only translation
   {
     geometry_msgs::msg::Pose p_in;
     p_in.position = createPoint(1.0, 2.0, 3.0);
@@ -1184,6 +1185,40 @@ TEST(geometry, calcOffsetPose)
     EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
     EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.25881904510252068);
     EXPECT_DOUBLE_EQ(p_out.orientation.w, 0.96592582628906831);
+  }
+
+  // Only rotation
+  {
+    geometry_msgs::msg::Pose p_in;
+    p_in.position = createPoint(2.0, 1.0, 1.0);
+    p_in.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(30));
+
+    const auto p_out = calcOffsetPose(p_in, 0.0, 0.0, 0.0, deg2rad(20));
+
+    EXPECT_DOUBLE_EQ(p_out.position.x, 2.0);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 1.0);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 1.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
+    EXPECT_NEAR(p_out.orientation.z, 0.42261826174069944, epsilon);
+    EXPECT_NEAR(p_out.orientation.w, 0.9063077870366499, epsilon);
+  }
+
+  // Both translation and rotation
+  {
+    geometry_msgs::msg::Pose p_in;
+    p_in.position = createPoint(2.0, 1.0, 1.0);
+    p_in.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(30));
+
+    const auto p_out = calcOffsetPose(p_in, 2.0, 0.0, -1.0, deg2rad(20));
+
+    EXPECT_DOUBLE_EQ(p_out.position.x, 3.73205080756887729);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 2.0);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
+    EXPECT_NEAR(p_out.orientation.z, 0.42261826174069944, epsilon);
+    EXPECT_NEAR(p_out.orientation.w, 0.9063077870366499, epsilon);
   }
 }
 


### PR DESCRIPTION
## Description

Added a yaw argument in tier4_autoware_utils::calcOffsetPose, and its test.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
