### PR TITLE
feat(dynamic_avoidance): added several min_object_vel parameters

### DIFF
--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -28,10 +28,12 @@
         cut_in_object:
           min_time_to_start_cut_in: 1.0 # [s]
           min_lon_offset_ego_to_object: 0.0 # [m]
+          min_object_vel: 0.5 # [m/s]
 
         cut_out_object:
           max_time_from_outside_ego_path: 2.0 # [s]
           min_object_lat_vel: 0.3 # [m/s]
+          min_object_vel: 0.5 # [m/s]
 
         crossing_object:
           min_overtaking_object_vel: 1.0
@@ -41,7 +43,7 @@
 
         front_object:
           max_object_angle: 0.785
-          min_vel: -0.5                      # [m/s] The value is negative considering the noisy velocity of the stopped vehicle.
+          min_object_vel: -0.5               # [m/s] The value is negative considering the noisy velocity of the stopped vehicle.
           max_ego_path_lat_cover_ratio: 0.3  # [-] The object will be ignored if the ratio of the object covering the ego's path is higher than this value.
 
       drivable_area_generation:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -71,8 +71,10 @@ struct DynamicAvoidanceParameters
 
   double min_time_to_start_cut_in{0.0};
   double min_lon_offset_ego_to_cut_in_object{0.0};
+  double min_cut_in_object_vel{0.0};
   double max_time_from_outside_ego_path_for_cut_out{0.0};
   double min_cut_out_object_lat_vel{0.0};
+  double min_cut_out_object_vel{0.0};
   double max_front_object_angle{0.0};
   double min_front_object_vel{0.0};
   double max_front_object_ego_path_lat_cover_ratio{0.0};

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -502,7 +502,9 @@ void DynamicAvoidanceModule::updateTargetObjects()
     const bool is_object_aligned_to_path =
       std::abs(obj_angle) < parameters_->max_front_object_angle ||
       M_PI - parameters_->max_front_object_angle < std::abs(obj_angle);
-    if (object.is_object_on_ego_path && is_object_aligned_to_path) {
+    if (
+      object.is_object_on_ego_path && is_object_aligned_to_path &&
+      parameters_->min_front_object_vel < object.vel) {
       RCLCPP_INFO_EXPRESSION(
         getLogger(), parameters_->enable_debug_info,
         "[DynamicAvoidance] Ignore obstacle (%s) since it is to be followed.", obj_uuid.c_str());
@@ -684,6 +686,11 @@ bool DynamicAvoidanceModule::willObjectCutIn(
   const double obj_tangent_vel, const LatLonOffset & lat_lon_offset,
   PolygonGenerationMethod & polygon_generation_method) const
 {
+  // Ignore oncoming object
+  if (obj_tangent_vel < parameters_->min_cut_in_object_vel) {
+    return false;
+  }
+
   // Check if ego's path and object's path are close.
   const bool will_object_cut_in = [&]() {
     for (const auto & predicted_path_point : predicted_path.path) {
@@ -723,7 +730,7 @@ DynamicAvoidanceModule::DecisionWithReason DynamicAvoidanceModule::willObjectCut
   const std::optional<DynamicAvoidanceObject> & prev_object) const
 {
   // Ignore oncoming object
-  if (obj_tangent_vel < 0) {
+  if (obj_tangent_vel < parameters_->min_cut_out_object_vel) {
     return DecisionWithReason{false};
   }
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -63,17 +63,20 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
       node->declare_parameter<double>(ns + "cut_in_object.min_time_to_start_cut_in");
     p.min_lon_offset_ego_to_cut_in_object =
       node->declare_parameter<double>(ns + "cut_in_object.min_lon_offset_ego_to_object");
+    p.min_cut_in_object_vel = node->declare_parameter<double>(ns + "cut_in_object.min_object_vel");
 
     p.max_time_from_outside_ego_path_for_cut_out =
       node->declare_parameter<double>(ns + "cut_out_object.max_time_from_outside_ego_path");
     p.min_cut_out_object_lat_vel =
       node->declare_parameter<double>(ns + "cut_out_object.min_object_lat_vel");
+    p.min_cut_out_object_vel =
+      node->declare_parameter<double>(ns + "cut_out_object.min_object_vel");
 
     p.max_front_object_angle =
       node->declare_parameter<double>(ns + "front_object.max_object_angle");
-    p.min_front_object_vel = node->declare_parameter<double>(ns + "front_object.min_vel");
     p.max_front_object_ego_path_lat_cover_ratio =
       node->declare_parameter<double>(ns + "front_object.max_ego_path_lat_cover_ratio");
+    p.min_front_object_vel = node->declare_parameter<double>(ns + "front_object.min_object_vel");
 
     p.min_overtaking_crossing_object_vel =
       node->declare_parameter<double>(ns + "crossing_object.min_overtaking_object_vel");
@@ -160,19 +163,22 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
     updateParam<double>(
       parameters, ns + "cut_in_object.min_lon_offset_ego_to_object",
       p->min_lon_offset_ego_to_cut_in_object);
+    updateParam<double>(parameters, ns + "cut_in_object.min_object_vel", p->min_cut_in_object_vel);
 
     updateParam<double>(
       parameters, ns + "cut_out_object.max_time_from_outside_ego_path",
       p->max_time_from_outside_ego_path_for_cut_out);
     updateParam<double>(
       parameters, ns + "cut_out_object.min_object_lat_vel", p->min_cut_out_object_lat_vel);
+    updateParam<double>(
+      parameters, ns + "cut_out_object.min_object_vel", p->min_cut_out_object_vel);
 
     updateParam<double>(
       parameters, ns + "front_object.max_object_angle", p->max_front_object_angle);
-    updateParam<double>(parameters, ns + "front_object.min_vel", p->min_front_object_vel);
     updateParam<double>(
       parameters, ns + "front_object.max_ego_path_lat_cover_ratio",
       p->max_front_object_ego_path_lat_cover_ratio);
+    updateParam<double>(parameters, ns + "front_object.min_object_vel", p->min_front_object_vel);
 
     updateParam<double>(
       parameters, ns + "crossing_object.min_overtaking_object_vel",


### PR DESCRIPTION
## Description

Added several min_object_vel parameters in dynamic_avoidance module

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
