### PR TITLE
feat(avoidance): configurable object type for safety check

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -27,7 +27,6 @@
       # avoidance is performed for the object type with true
       target_object:
         car:
-          is_target: true                              # [-]
           execute_num: 1                               # [-]
           moving_speed_threshold: 1.0                  # [m/s]
           moving_time_threshold: 1.0                   # [s]
@@ -38,7 +37,6 @@
           safety_buffer_longitudinal: 0.0              # [m]
           use_conservative_buffer_longitudinal: true   # [-] When set to true, the base_link2front is added to the longitudinal buffer before avoidance.
         truck:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -49,7 +47,6 @@
           safety_buffer_longitudinal: 0.0
           use_conservative_buffer_longitudinal: true
         bus:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -60,7 +57,6 @@
           safety_buffer_longitudinal: 0.0
           use_conservative_buffer_longitudinal: true
         trailer:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -71,7 +67,6 @@
           safety_buffer_longitudinal: 0.0
           use_conservative_buffer_longitudinal: true
         unknown:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 0.28                 # 1.0km/h
           moving_time_threshold: 1.0
@@ -82,7 +77,6 @@
           safety_buffer_longitudinal: 0.0
           use_conservative_buffer_longitudinal: true
         bicycle:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 0.28                 # 1.0km/h
           moving_time_threshold: 1.0
@@ -93,7 +87,6 @@
           safety_buffer_longitudinal: 1.0
           use_conservative_buffer_longitudinal: true
         motorcycle:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -104,7 +97,6 @@
           safety_buffer_longitudinal: 1.0
           use_conservative_buffer_longitudinal: true
         pedestrian:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 0.28                 # 1.0km/h
           moving_time_threshold: 1.0
@@ -119,6 +111,16 @@
 
       # For target object filtering
       target_filtering:
+        # avoidance target type
+        target_type:
+          car: true                                      # [-]
+          truck: true                                    # [-]
+          bus: true                                      # [-]
+          trailer: true                                  # [-]
+          unknown: true                                  # [-]
+          bicycle: true                                  # [-]
+          motorcycle: true                               # [-]
+          pedestrian: true                               # [-]
         # detection range
         object_check_goal_distance: 20.0                # [m]
         # filtering parking objects
@@ -152,6 +154,16 @@
 
       # For safety check
       safety_check:
+        # safety check target type
+        target_type:
+          car: true                                      # [-]
+          truck: true                                    # [-]
+          bus: true                                      # [-]
+          trailer: true                                  # [-]
+          unknown: false                                 # [-]
+          bicycle: true                                  # [-]
+          motorcycle: true                               # [-]
+          pedestrian: true                               # [-]
         # safety check configuration
         enable: true                                     # [-]
         check_current_lane: false                        # [-]

--- a/planning/behavior_path_planner/config/avoidance_by_lc/avoidance_by_lc.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance_by_lc/avoidance_by_lc.param.yaml
@@ -7,7 +7,6 @@
       # avoidance is performed for the object type with true
       target_object:
         car:
-          is_target: true                              # [-]
           execute_num: 2                               # [-]
           moving_speed_threshold: 1.0                  # [m/s]
           moving_time_threshold: 1.0                   # [s]
@@ -16,7 +15,6 @@
           avoid_margin_lateral: 1.0                    # [m]
           safety_buffer_lateral: 0.7                   # [m]
         truck:
-          is_target: true
           execute_num: 2
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -25,7 +23,6 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
         bus:
-          is_target: true
           execute_num: 2
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -34,7 +31,6 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
         trailer:
-          is_target: true
           execute_num: 2
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -43,7 +39,6 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
         unknown:
-          is_target: true
           execute_num: 1
           moving_speed_threshold: 0.28                 # 1.0km/h
           moving_time_threshold: 1.0
@@ -52,7 +47,6 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.0
         bicycle:
-          is_target: true
           execute_num: 2
           moving_speed_threshold: 0.28                 # 1.0km/h
           moving_time_threshold: 1.0
@@ -61,7 +55,6 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 1.0
         motorcycle:
-          is_target: true
           execute_num: 2
           moving_speed_threshold: 1.0                  # 3.6km/h
           moving_time_threshold: 1.0
@@ -70,7 +63,6 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 1.0
         pedestrian:
-          is_target: true
           execute_num: 2
           moving_speed_threshold: 0.28                 # 1.0km/h
           moving_time_threshold: 1.0
@@ -80,3 +72,16 @@
           safety_buffer_lateral: 1.0
         lower_distance_for_polygon_expansion: 0.0      # [m]
         upper_distance_for_polygon_expansion: 1.0      # [m]
+
+      # For target object filtering
+      target_filtering:
+        # avoidance target type
+        target_type:
+          car: true                                    # [-]
+          truck: true                                  # [-]
+          bus: true                                    # [-]
+          trailer: true                                # [-]
+          unknown: true                                # [-]
+          bicycle: false                               # [-]
+          motorcycle: false                            # [-]
+          pedestrian: false                            # [-]

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -54,7 +54,9 @@ using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 
 struct ObjectParameter
 {
-  bool is_target{false};
+  bool is_avoidance_target{false};
+
+  bool is_safety_check_target{false};
 
   size_t execute_num{1};
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -65,7 +65,6 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   {
     const auto get_object_param = [&](std::string && ns) {
       ObjectParameter param{};
-      param.is_target = getOrDeclareParameter<bool>(*node, ns + "is_target");
       param.execute_num = getOrDeclareParameter<int>(*node, ns + "execute_num");
       param.moving_speed_threshold =
         getOrDeclareParameter<double>(*node, ns + "moving_speed_threshold");
@@ -105,7 +104,24 @@ AvoidanceModuleManager::AvoidanceModuleManager(
 
   // target filtering
   {
+    const auto set_target_flag = [&](const uint8_t & object_type, const std::string & ns) {
+      if (p.object_parameters.count(object_type) == 0) {
+        return;
+      }
+      p.object_parameters.at(object_type).is_avoidance_target =
+        getOrDeclareParameter<bool>(*node, ns);
+    };
+
     std::string ns = "avoidance.target_filtering.";
+    set_target_flag(ObjectClassification::CAR, ns + "target_type.car");
+    set_target_flag(ObjectClassification::TRUCK, ns + "target_type.truck");
+    set_target_flag(ObjectClassification::TRAILER, ns + "target_type.trailer");
+    set_target_flag(ObjectClassification::BUS, ns + "target_type.bus");
+    set_target_flag(ObjectClassification::PEDESTRIAN, ns + "target_type.pedestrian");
+    set_target_flag(ObjectClassification::BICYCLE, ns + "target_type.bicycle");
+    set_target_flag(ObjectClassification::MOTORCYCLE, ns + "target_type.motorcycle");
+    set_target_flag(ObjectClassification::UNKNOWN, ns + "target_type.unknown");
+
     p.object_check_goal_distance =
       getOrDeclareParameter<double>(*node, ns + "object_check_goal_distance");
     p.threshold_distance_object_is_on_center =
@@ -147,7 +163,24 @@ AvoidanceModuleManager::AvoidanceModuleManager(
 
   // safety check general params
   {
+    const auto set_target_flag = [&](const uint8_t & object_type, const std::string & ns) {
+      if (p.object_parameters.count(object_type) == 0) {
+        return;
+      }
+      p.object_parameters.at(object_type).is_safety_check_target =
+        getOrDeclareParameter<bool>(*node, ns);
+    };
+
     std::string ns = "avoidance.safety_check.";
+    set_target_flag(ObjectClassification::CAR, ns + "target_type.car");
+    set_target_flag(ObjectClassification::TRUCK, ns + "target_type.truck");
+    set_target_flag(ObjectClassification::TRAILER, ns + "target_type.trailer");
+    set_target_flag(ObjectClassification::BUS, ns + "target_type.bus");
+    set_target_flag(ObjectClassification::PEDESTRIAN, ns + "target_type.pedestrian");
+    set_target_flag(ObjectClassification::BICYCLE, ns + "target_type.bicycle");
+    set_target_flag(ObjectClassification::MOTORCYCLE, ns + "target_type.motorcycle");
+    set_target_flag(ObjectClassification::UNKNOWN, ns + "target_type.unknown");
+
     p.enable_safety_check = getOrDeclareParameter<bool>(*node, ns + "enable");
     p.check_current_lane = getOrDeclareParameter<bool>(*node, ns + "check_current_lane");
     p.check_shift_side_lane = getOrDeclareParameter<bool>(*node, ns + "check_shift_side_lane");
@@ -346,7 +379,6 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
   const auto update_object_param = [&p, &parameters](
                                      const auto & semantic, const std::string & ns) {
     auto & config = p->object_parameters.at(semantic);
-    updateParam<bool>(parameters, ns + "is_target", config.is_target);
     updateParam<double>(parameters, ns + "moving_speed_threshold", config.moving_speed_threshold);
     updateParam<double>(parameters, ns + "moving_time_threshold", config.moving_time_threshold);
     updateParam<double>(parameters, ns + "max_expand_ratio", config.max_expand_ratio);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -285,7 +285,6 @@ AvoidanceByLaneChangeModuleManager::AvoidanceByLaneChangeModuleManager(
   {
     const auto get_object_param = [&](std::string && ns) {
       ObjectParameter param{};
-      param.is_target = getOrDeclareParameter<bool>(*node, ns + "is_target");
       param.execute_num = getOrDeclareParameter<int>(*node, ns + "execute_num");
       param.moving_speed_threshold =
         getOrDeclareParameter<double>(*node, ns + "moving_speed_threshold");
@@ -321,7 +320,24 @@ AvoidanceByLaneChangeModuleManager::AvoidanceByLaneChangeModuleManager(
 
   // target filtering
   {
+    const auto set_target_flag = [&](const uint8_t & object_type, const std::string & ns) {
+      if (p.object_parameters.count(object_type) == 0) {
+        return;
+      }
+      p.object_parameters.at(object_type).is_avoidance_target =
+        getOrDeclareParameter<bool>(*node, ns);
+    };
+
     std::string ns = "avoidance.target_filtering.";
+    set_target_flag(ObjectClassification::CAR, ns + "target_type.car");
+    set_target_flag(ObjectClassification::TRUCK, ns + "target_type.truck");
+    set_target_flag(ObjectClassification::TRAILER, ns + "target_type.trailer");
+    set_target_flag(ObjectClassification::BUS, ns + "target_type.bus");
+    set_target_flag(ObjectClassification::PEDESTRIAN, ns + "target_type.pedestrian");
+    set_target_flag(ObjectClassification::BICYCLE, ns + "target_type.bicycle");
+    set_target_flag(ObjectClassification::MOTORCYCLE, ns + "target_type.motorcycle");
+    set_target_flag(ObjectClassification::UNKNOWN, ns + "target_type.unknown");
+
     p.object_check_goal_distance =
       getOrDeclareParameter<double>(*node, ns + "object_check_goal_distance");
     p.threshold_distance_object_is_on_center =


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7ddc64c</samp>

This pull request refactors the behavior path planner module to use a new `target_type` parameter group for filtering predicted objects by their type for avoidance and safety check. It removes the `is_target` parameter from various files and adds new fields and functions to the `avoidance_module_data.hpp` and `utils.cpp` files. It also simplifies and unifies the scene module interface and configuration.

Related PR: https://github.com/autowarefoundation/autoware_launch/pull/709
Related Ticket: https://tier4.atlassian.net/browse/RT1-4126

---

Add new parameter so that it can configurate target object type for safety check. Additionally, it ignores UNKNOWN objects in safety check process because UNKNOWN objects detection is unstable and causes unnecessary avoidance canceling for now.

```yaml
      # For safety check
      safety_check:
        # safety check target type
        target_type:
          car: true                                      # [-]
          truck: true                                    # [-]
          bus: true                                      # [-]
          trailer: true                                  # [-]
          unknown: false                                 # [-]
          bicycle: true                                  # [-]
          motorcycle: true                               # [-]
          pedestrian: true                               # [-]
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/e6931160-96f1-4a19-9246-1a488cf4fc0e)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/60222885-58c5-568d-970c-7e0a45513947?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
