### PR TITLE
fix(obstacle_cruise): proper handle with backward paths in the polygon expansion

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -557,8 +557,9 @@ std::vector<Polygon2d> ObstacleCruisePlannerNode::createOneStepPolygons(
   const double step_length = p.decimate_trajectory_step_length;
   const double time_to_convergence = p.time_to_convergence;
 
-  const auto nearest_pose =
-    traj_points.at(*motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose)).pose;
+  const size_t nearest_idx =
+    motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose.position);
+  const auto nearest_pose = traj_points.at(nearest_idx).pose;
   const auto current_ego_pose_error =
     tier4_autoware_utils::inverseTransformPose(current_ego_pose, nearest_pose);
   const double current_ego_lat_error = current_ego_pose_error.position.y;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -557,13 +557,15 @@ std::vector<Polygon2d> ObstacleCruisePlannerNode::createOneStepPolygons(
   const double step_length = p.decimate_trajectory_step_length;
   const double time_to_convergence = p.time_to_convergence;
 
-  std::vector<Polygon2d> polygons;
-  const double current_ego_lat_error =
-    motion_utils::calcLateralOffset(traj_points, current_ego_pose.position);
-  const double current_ego_yaw_error =
-    motion_utils::calcYawDeviation(traj_points, current_ego_pose);
+  const auto nearest_pose =
+    traj_points.at(*motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose)).pose;
+  const auto current_ego_pose_error =
+    tier4_autoware_utils::inverseTransformPose(current_ego_pose, nearest_pose);
+  const double current_ego_lat_error = current_ego_pose_error.position.y;
+  const double current_ego_yaw_error = tf2::getYaw(current_ego_pose_error.orientation);
   double time_elapsed = 0.0;
 
+  std::vector<Polygon2d> polygons;
   std::vector<geometry_msgs::msg::Pose> last_poses = {traj_points.at(0).pose};
   if (is_enable_current_pose_consideration) {
     last_poses.push_back(current_ego_pose);
@@ -586,7 +588,7 @@ std::vector<Polygon2d> ObstacleCruisePlannerNode::createOneStepPolygons(
         tier4_autoware_utils::transformPose(indexed_pose_err, traj_points.at(i).pose));
 
       if (traj_points.at(i).longitudinal_velocity_mps != 0.0) {
-        time_elapsed += step_length / traj_points.at(i).longitudinal_velocity_mps;
+        time_elapsed += step_length / std::abs(traj_points.at(i).longitudinal_velocity_mps);
       } else {
         time_elapsed = std::numeric_limits<double>::max();
       }


### PR DESCRIPTION
## Description
Bug fix of the function introduced in https://github.com/autowarefoundation/autoware.universe/pull/5036
Proper handling with backwad paths is achived

## Tests performed
psim test performed 
Before:
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/6b192b17-b610-4604-a05f-38491accd1c5)


After:
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/a323a58f-a071-4cc1-9fd3-e76df04c795c)
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/aa8e1c81-41a6-4a1d-a033-634e9baab3fe)



<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior
See Description

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
