### PR TITLE
fix: include mussp library into the packages to avoid duplicates

### DIFF
--- a/perception/multi_object_tracker/CMakeLists.txt
+++ b/perception/multi_object_tracker/CMakeLists.txt
@@ -31,9 +31,6 @@ set(MULTI_OBJECT_TRACKER_SRC
   src/tracker/model/unknown_tracker.cpp
   src/tracker/model/pass_through_tracker.cpp
   src/data_association/data_association.cpp
-)
-
-ament_auto_add_library(mu_successive_shortest_path SHARED
   src/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
 )
 
@@ -42,7 +39,6 @@ ament_auto_add_library(multi_object_tracker_node SHARED
 )
 
 target_link_libraries(multi_object_tracker_node
-  mu_successive_shortest_path
   Eigen3::Eigen
 )
 

--- a/perception/object_merger/CMakeLists.txt
+++ b/perception/object_merger/CMakeLists.txt
@@ -18,17 +18,13 @@ include_directories(
     ${EIGEN3_INCLUDE_DIR}
 )
 
-ament_auto_add_library(mu_successive_shortest_path SHARED
-  src/object_association_merger/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
-)
-
 ament_auto_add_library(object_association_merger SHARED
   src/object_association_merger/data_association/data_association.cpp
+  src/object_association_merger/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
   src/object_association_merger/node.cpp
 )
 
 target_link_libraries(object_association_merger
-  mu_successive_shortest_path
   Eigen3::Eigen
 )
 

--- a/perception/radar_object_tracker/CMakeLists.txt
+++ b/perception/radar_object_tracker/CMakeLists.txt
@@ -18,11 +18,6 @@ include_directories(
     ${EIGEN3_INCLUDE_DIR}
 )
 
-# Targets
-ament_auto_add_library(mu_successive_shortest_path SHARED
-  src/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
-)
-
 ament_auto_add_library(radar_object_tracker_node SHARED
   src/radar_object_tracker_node/radar_object_tracker_node.cpp
   src/tracker/model/tracker_base.cpp
@@ -30,10 +25,10 @@ ament_auto_add_library(radar_object_tracker_node SHARED
   src/tracker/model/constant_turn_rate_motion_tracker.cpp
   src/utils/utils.cpp
   src/data_association/data_association.cpp
+  src/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
 )
 
 target_link_libraries(radar_object_tracker_node
-  mu_successive_shortest_path
   Eigen3::Eigen
   yaml-cpp
   nlohmann_json::nlohmann_json # for debug

--- a/perception/tracking_object_merger/CMakeLists.txt
+++ b/perception/tracking_object_merger/CMakeLists.txt
@@ -21,19 +21,15 @@ include_directories(
     ${EIGEN3_INCLUDE_DIR}
 )
 
-ament_auto_add_library(mu_successive_shortest_path SHARED
-  src/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
-)
-
 ament_auto_add_library(decorative_tracker_merger_node SHARED
   src/data_association/data_association.cpp
+  src/data_association/mu_successive_shortest_path/mu_successive_shortest_path_wrapper.cpp
   src/decorative_tracker_merger.cpp
   src/utils/utils.cpp
   src/utils/tracker_state.cpp
 )
 
 target_link_libraries(decorative_tracker_merger_node
-  mu_successive_shortest_path
   Eigen3::Eigen
 )
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR moves the mussp libraries into their respective package libraries to avoid conflicts when packages are being installed as Debian packages.

See https://github.com/autowarefoundation/autoware-deb-packages/issues/51

Fixes #5705 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
