### PR TITLE
feat(tier4_autoware_utils): intersection result with z

### DIFF
--- a/common/tier4_autoware_utils/src/geometry/geometry.cpp
+++ b/common/tier4_autoware_utils/src/geometry/geometry.cpp
@@ -378,6 +378,7 @@ std::optional<geometry_msgs::msg::Point> intersect(
   geometry_msgs::msg::Point intersect_point;
   intersect_point.x = t * p1.x + (1.0 - t) * p2.x;
   intersect_point.y = t * p1.y + (1.0 - t) * p2.y;
+  intersect_point.z = t * p1.z + (1.0 - t) * p2.z;
   return intersect_point;
 }
 


### PR DESCRIPTION
## Description

Since the z value is not interpolated by the intersection function, the driavble area's z position is wrong with dynamic_avoidance module.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/b21698ab-aa2a-4abe-bfd4-09eff900fe9a)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
