### PR TITLE
chore: add glog_component for pointcloud_container

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -474,7 +474,13 @@ class GroundSegmentationPipeline:
 def launch_setup(context, *args, **kwargs):
     pipeline = GroundSegmentationPipeline(context)
 
-    components = []
+    glog_component = ComposableNode(
+        package="glog_component",
+        plugin="GlogComponent",
+        name="glog_component",
+    )
+
+    components = [glog_component]
     components.extend(
         pipeline.create_single_frame_obstacle_segmentation_components(
             input_topic=LaunchConfiguration("input/pointcloud"),


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This to add glog_component for debugging when a node of pointcloud_container crashed. 

## Tests performed

Confirmed by logging_simulator that glob_component was executed.
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/890ca548-7575-4aa5-be2b-36a11e40253f)

If an error is added in one of pointcloud_container's node, for example voxel_based_compare_map_filter_nodelet.cpp 
 `sed -i -z 's|pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);\n|pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);\n  throw std::runtime_error("error!!!!!!!!!!!!!!!!!!");\n|' ./src/universe/autoware.universe/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp`

It will throw out some stack trace for debugging as bellow
```

[component_container_mt-1] terminate called after throwing an instance of 'std::runtime_error'
[component_container_mt-1]   what():  error!!!!!!!!!!!!!!!!!!
[component_container_mt-1] *** Aborted at 1701252545 (unix time) try "date -d @1701252545" if you are using GNU date ***
[component_container_mt-1] PC: @                0x0 (unknown)
[component_container_mt-1] *** SIGABRT (@0x3e800089a03) received by PID 563715 (TID 0x7fbdd4ff9640) from PID 563715; stack trace: ***
[component_container_mt-1]     @     0x7fbdfc111046 (unknown)
[component_container_mt-1]     @     0x7fbe00442520 (unknown)
[component_container_mt-1]     @     0x7fbe004969fc pthread_kill
[component_container_mt-1]     @     0x7fbe00442476 raise
[component_container_mt-1]     @     0x7fbe004287f3 abort
[component_container_mt-1]     @     0x7fbe008a2b9e (unknown)
[component_container_mt-1]     @     0x7fbe008ae20c (unknown)
[component_container_mt-1]     @     0x7fbe008ae277 std::terminate()
[component_container_mt-1]     @     0x7fbe008ae4d8 __cxa_throw
[component_container_mt-1]     @     0x7fbce4521170 _ZN24compare_map_segmentation35VoxelBasedCompareMapFilterComponent6filterERKSt10shared_ptrIKN11sensor_msgs3msg12PointCloud2_ISaIvEEEERKS1_ISt6vectorIiSaIiEEERS6_.cold
[component_container_mt-1]     @     0x7fbdd1c03144 pointcloud_preprocessor::Filter::computePublish()
[component_container_mt-1]     @     0x7fbdd1c04fd1 pointcloud_preprocessor::Filter::input_indices_callback()
[component_container_mt-1]     @     0x7fbdd1c236bf std::_Function_handler<>::_M_invoke()
[component_container_mt-1]     @     0x7fbdf4470e57 _ZNSt8__detail9__variant17__gen_vtable_implINS0_
```


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
