### PR TITLE
refactor(common, control, planning): replace boost::optional with std::optional

### DIFF
--- a/common/motion_utils/include/motion_utils/distance/distance.hpp
+++ b/common/motion_utils/include/motion_utils/distance/distance.hpp
@@ -15,17 +15,16 @@
 #ifndef MOTION_UTILS__DISTANCE__DISTANCE_HPP_
 #define MOTION_UTILS__DISTANCE__DISTANCE_HPP_
 
-#include <boost/optional.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <optional>
 #include <tuple>
 #include <vector>
 
 namespace motion_utils
 {
-boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
+std::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double current_vel, const double target_vel, const double current_acc, const double acc_min,
   const double jerk_acc, const double jerk_dec);
 

--- a/common/motion_utils/include/motion_utils/trajectory/interpolation.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/interpolation.hpp
@@ -21,10 +21,9 @@
 #include "autoware_auto_planning_msgs/msg/path_with_lane_id.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 
-#include <boost/optional.hpp>
-
 #include <algorithm>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 

--- a/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
@@ -18,12 +18,11 @@
 #include "autoware_auto_planning_msgs/msg/path_with_lane_id.hpp"
 #include <geometry_msgs/msg/point.hpp>
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <utility>
 namespace motion_utils
 {
-boost::optional<std::pair<size_t, size_t>> getPathIndexRangeWithLaneId(
+std::optional<std::pair<size_t, size_t>> getPathIndexRangeWithLaneId(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int64_t target_lane_id);
 
 size_t findNearestIndexFromLaneId(

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -26,10 +26,9 @@
 #include <autoware_auto_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory_point.hpp>
 
-#include <boost/optional.hpp>
-
 #include <algorithm>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -93,10 +92,10 @@ void validateNonSharpAngle(
  * @return (forward / backward) driving (true / false)
  */
 template <class T>
-boost::optional<bool> isDrivingForward(const T & points)
+std::optional<bool> isDrivingForward(const T & points)
 {
   if (points.size() < 2) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // check the first point direction
@@ -106,13 +105,13 @@ boost::optional<bool> isDrivingForward(const T & points)
   return tier4_autoware_utils::isDrivingForward(first_pose, second_pose);
 }
 
-extern template boost::optional<bool>
+extern template std::optional<bool>
 isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &);
-extern template boost::optional<bool>
+extern template std::optional<bool>
 isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &);
-extern template boost::optional<bool>
+extern template std::optional<bool>
 isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
 
@@ -123,10 +122,10 @@ isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>
  * @return (forward / backward) driving (true, false, none "if velocity is zero")
  */
 template <class T>
-boost::optional<bool> isDrivingForwardWithTwist(const T & points_with_twist)
+std::optional<bool> isDrivingForwardWithTwist(const T & points_with_twist)
 {
   if (points_with_twist.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
   if (points_with_twist.size() == 1) {
     if (0.0 < tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.front())) {
@@ -134,20 +133,20 @@ boost::optional<bool> isDrivingForwardWithTwist(const T & points_with_twist)
     } else if (0.0 > tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.front())) {
       return false;
     } else {
-      return boost::none;
+      return std::nullopt;
     }
   }
 
   return isDrivingForward(points_with_twist);
 }
 
-extern template boost::optional<bool>
+extern template std::optional<bool>
 isDrivingForwardWithTwist<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &);
-extern template boost::optional<bool>
+extern template std::optional<bool>
 isDrivingForwardWithTwist<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &);
-extern template boost::optional<bool>
+extern template std::optional<bool>
 isDrivingForwardWithTwist<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
 
@@ -209,7 +208,7 @@ removeOverlapPoints<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoin
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-boost::optional<size_t> searchZeroVelocityIndex(
+std::optional<size_t> searchZeroVelocityIndex(
   const T & points_with_twist, const size_t src_idx, const size_t dst_idx)
 {
   try {
@@ -229,7 +228,7 @@ boost::optional<size_t> searchZeroVelocityIndex(
   return {};
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const size_t src_idx, const size_t dst_idx);
@@ -242,7 +241,7 @@ searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::Trajectory
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-boost::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t src_idx)
+std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t src_idx)
 {
   try {
     validateNonEmpty(points_with_twist);
@@ -254,7 +253,7 @@ boost::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, con
   return searchZeroVelocityIndex(points_with_twist, src_idx, points_with_twist.size());
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const size_t src_idx);
@@ -266,12 +265,12 @@ searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::Trajectory
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-boost::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist)
+std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist)
 {
   return searchZeroVelocityIndex(points_with_twist, 0, points_with_twist.size());
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist);
 
@@ -329,7 +328,7 @@ findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>
  * @return index of nearest point (index or none if not found)
  */
 template <class T>
-boost::optional<size_t> findNearestIndex(
+std::optional<size_t> findNearestIndex(
   const T & points, const geometry_msgs::msg::Pose & pose,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max())
@@ -363,20 +362,24 @@ boost::optional<size_t> findNearestIndex(
     min_idx = i;
     is_nearest_found = true;
   }
-  return is_nearest_found ? boost::optional<size_t>(min_idx) : boost::none;
+
+  if (is_nearest_found) {
+    return min_idx;
+  }
+  return std::nullopt;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max());
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max());
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
@@ -507,7 +510,7 @@ findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::Trajectory
  * @return nearest index
  */
 template <class T>
-boost::optional<size_t> findNearestSegmentIndex(
+std::optional<size_t> findNearestSegmentIndex(
   const T & points, const geometry_msgs::msg::Pose & pose,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max())
@@ -515,7 +518,7 @@ boost::optional<size_t> findNearestSegmentIndex(
   const auto nearest_idx = findNearestIndex(points, pose, max_dist, max_yaw);
 
   if (!nearest_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   if (*nearest_idx == 0) {
@@ -534,17 +537,17 @@ boost::optional<size_t> findNearestSegmentIndex(
   return *nearest_idx;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max());
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max());
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
@@ -998,7 +1001,7 @@ calcCurvatureAndArcLength<std::vector<autoware_auto_planning_msgs::msg::Trajecto
  * container with zero longitudinal velocity
  */
 template <class T>
-boost::optional<double> calcDistanceToForwardStopPoint(
+std::optional<double> calcDistanceToForwardStopPoint(
   const T & points_with_twist, const size_t src_idx = 0)
 {
   try {
@@ -1011,13 +1014,13 @@ boost::optional<double> calcDistanceToForwardStopPoint(
   const auto closest_stop_idx =
     searchZeroVelocityIndex(points_with_twist, src_idx, points_with_twist.size());
   if (!closest_stop_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   return std::max(0.0, calcSignedArcLength(points_with_twist, src_idx, *closest_stop_idx));
 }
 
-extern template boost::optional<double>
+extern template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const size_t src_idx = 0);
@@ -1032,7 +1035,7 @@ calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::Tra
  * @return offset point
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const T & points, const size_t src_idx, const double offset, const bool throw_exception = false)
 {
   try {
@@ -1087,15 +1090,15 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   return {};
 }
 
-extern template boost::optional<geometry_msgs::msg::Point>
+extern template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points, const size_t src_idx,
   const double offset, const bool throw_exception = false);
-extern template boost::optional<geometry_msgs::msg::Point>
+extern template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const size_t src_idx, const double offset, const bool throw_exception = false);
-extern template boost::optional<geometry_msgs::msg::Point>
+extern template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const size_t src_idx, const double offset, const bool throw_exception = false);
@@ -1109,7 +1112,7 @@ calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::Trajec
  * @return offset point
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
 {
   try {
@@ -1132,15 +1135,15 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   return calcLongitudinalOffsetPoint(points, src_seg_idx, offset + signed_length_src_offset);
 }
 
-extern template boost::optional<geometry_msgs::msg::Point>
+extern template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset);
-extern template boost::optional<geometry_msgs::msg::Point>
+extern template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Point & src_point, const double offset);
-extern template boost::optional<geometry_msgs::msg::Point>
+extern template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset);
@@ -1156,7 +1159,7 @@ calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::Trajec
  * @return offset pose
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const size_t src_idx, const double offset,
   const bool set_orientation_from_position_direction = true, const bool throw_exception = false)
 {
@@ -1228,17 +1231,17 @@ boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   return {};
 }
 
-extern template boost::optional<geometry_msgs::msg::Pose>
+extern template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points, const size_t src_idx,
   const double offset, const bool set_orientation_from_position_direction = true,
   const bool throw_exception = false);
-extern template boost::optional<geometry_msgs::msg::Pose>
+extern template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const size_t src_idx, const double offset,
   const bool set_orientation_from_position_direction = true, const bool throw_exception = false);
-extern template boost::optional<geometry_msgs::msg::Pose>
+extern template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const size_t src_idx, const double offset,
@@ -1255,7 +1258,7 @@ calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::Traject
  * @return offset pose
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset,
   const bool set_orientation_from_position_direction = true)
 {
@@ -1275,17 +1278,17 @@ boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
     set_orientation_from_position_direction);
 }
 
-extern template boost::optional<geometry_msgs::msg::Pose>
+extern template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset,
   const bool set_orientation_from_position_direction = true);
-extern template boost::optional<geometry_msgs::msg::Pose>
+extern template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Point & src_point, const double offset,
   const bool set_orientation_from_position_direction = true);
-extern template boost::optional<geometry_msgs::msg::Pose>
+extern template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset,
@@ -1301,7 +1304,7 @@ calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::Traject
  * @return index of segment id, where point is inserted
  */
 template <class T>
-boost::optional<size_t> insertTargetPoint(
+std::optional<size_t> insertTargetPoint(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target, T & points,
   const double overlap_threshold = 1e-3)
 {
@@ -1339,7 +1342,7 @@ boost::optional<size_t> insertTargetPoint(
 
   geometry_msgs::msg::Pose target_pose;
   {
-    const auto p_base = is_driving_forward.get() ? p_back : p_front;
+    const auto p_base = is_driving_forward.value() ? p_back : p_front;
     const auto pitch = tier4_autoware_utils::calcElevationAngle(p_target, p_base);
     const auto yaw = tier4_autoware_utils::calcAzimuthAngle(p_target, p_base);
 
@@ -1352,7 +1355,7 @@ boost::optional<size_t> insertTargetPoint(
 
   geometry_msgs::msg::Pose base_pose;
   {
-    const auto p_base = is_driving_forward.get() ? p_front : p_back;
+    const auto p_base = is_driving_forward.value() ? p_front : p_back;
     const auto pitch = tier4_autoware_utils::calcElevationAngle(p_base, p_target);
     const auto yaw = tier4_autoware_utils::calcAzimuthAngle(p_base, p_target);
 
@@ -1361,7 +1364,7 @@ boost::optional<size_t> insertTargetPoint(
   }
 
   if (!overlap_with_front && !overlap_with_back) {
-    if (is_driving_forward.get()) {
+    if (is_driving_forward.value()) {
       tier4_autoware_utils::setPose(base_pose, points.at(seg_idx));
     } else {
       tier4_autoware_utils::setPose(base_pose, points.at(seg_idx + 1));
@@ -1377,17 +1380,17 @@ boost::optional<size_t> insertTargetPoint(
   return seg_idx;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
@@ -1404,18 +1407,18 @@ insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
  * @return index of segment id, where point is inserted
  */
 template <class T>
-boost::optional<size_t> insertTargetPoint(
+std::optional<size_t> insertTargetPoint(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target, T & points,
   const double overlap_threshold = 1e-3)
 {
   validateNonEmpty(points);
 
   if (insert_point_length < 0.0) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // Get Nearest segment index
-  boost::optional<size_t> segment_idx = boost::none;
+  std::optional<size_t> segment_idx = std::nullopt;
   for (size_t i = 1; i < points.size(); ++i) {
     // TODO(Mamoru Sobue): find accumulated sum beforehand
     const double length = calcSignedArcLength(points, 0, i);
@@ -1426,23 +1429,23 @@ boost::optional<size_t> insertTargetPoint(
   }
 
   if (!segment_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   return insertTargetPoint(*segment_idx, p_target, points, overlap_threshold);
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
@@ -1459,18 +1462,18 @@ insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
  * @return index of insert point
  */
 template <class T>
-boost::optional<size_t> insertTargetPoint(
+std::optional<size_t> insertTargetPoint(
   const size_t src_segment_idx, const double insert_point_length, T & points,
   const double overlap_threshold = 1e-3)
 {
   validateNonEmpty(points);
 
   if (src_segment_idx >= points.size() - 1) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // Get Nearest segment index
-  boost::optional<size_t> segment_idx = boost::none;
+  std::optional<size_t> segment_idx = std::nullopt;
   if (0.0 <= insert_point_length) {
     for (size_t i = src_segment_idx + 1; i < points.size(); ++i) {
       const double length = calcSignedArcLength(points, src_segment_idx, i);
@@ -1490,7 +1493,7 @@ boost::optional<size_t> insertTargetPoint(
   }
 
   if (!segment_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // Get Target Point
@@ -1505,17 +1508,17 @@ boost::optional<size_t> insertTargetPoint(
   return insertTargetPoint(*segment_idx, p_target, points, overlap_threshold);
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const size_t src_segment_idx, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const size_t src_segment_idx, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t src_segment_idx, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
@@ -1535,7 +1538,7 @@ insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
  * @return index of insert point
  */
 template <class T>
-boost::optional<size_t> insertTargetPoint(
+std::optional<size_t> insertTargetPoint(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length, T & points,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3)
@@ -1543,12 +1546,12 @@ boost::optional<size_t> insertTargetPoint(
   validateNonEmpty(points);
 
   if (insert_point_length < 0.0) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const auto nearest_segment_idx = findNearestSegmentIndex(points, src_pose, max_dist, max_yaw);
   if (!nearest_segment_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const double offset_length =
@@ -1558,19 +1561,19 @@ boost::optional<size_t> insertTargetPoint(
     *nearest_segment_idx, insert_point_length + offset_length, points, overlap_threshold);
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
@@ -1587,20 +1590,20 @@ insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
  * @return index of stop point
  */
 template <class T>
-boost::optional<size_t> insertStopPoint(
+std::optional<size_t> insertStopPoint(
   const size_t src_segment_idx, const double distance_to_stop_point, T & points_with_twist,
   const double overlap_threshold = 1e-3)
 {
   validateNonEmpty(points_with_twist);
 
   if (distance_to_stop_point < 0.0 || src_segment_idx >= points_with_twist.size() - 1) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const auto stop_idx = insertTargetPoint(
     src_segment_idx, distance_to_stop_point, points_with_twist, overlap_threshold);
   if (!stop_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   for (size_t i = *stop_idx; i < points_with_twist.size(); ++i) {
@@ -1610,17 +1613,17 @@ boost::optional<size_t> insertStopPoint(
   return stop_idx;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const size_t src_segment_idx, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const size_t src_segment_idx, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t src_segment_idx, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
@@ -1635,13 +1638,13 @@ insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
  * @return index of stop point
  */
 template <class T>
-boost::optional<size_t> insertStopPoint(
+std::optional<size_t> insertStopPoint(
   const double distance_to_stop_point, T & points_with_twist, const double overlap_threshold = 1e-3)
 {
   validateNonEmpty(points_with_twist);
 
   if (distance_to_stop_point < 0.0) {
-    return boost::none;
+    return std::nullopt;
   }
 
   double accumulated_length = 0;
@@ -1656,20 +1659,20 @@ boost::optional<size_t> insertStopPoint(
     accumulated_length += length;
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
@@ -1689,7 +1692,7 @@ insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
  * @return index of stop point
  */
 template <class T>
-boost::optional<size_t> insertStopPoint(
+std::optional<size_t> insertStopPoint(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   T & points_with_twist, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3)
@@ -1697,14 +1700,14 @@ boost::optional<size_t> insertStopPoint(
   validateNonEmpty(points_with_twist);
 
   if (distance_to_stop_point < 0.0) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const auto stop_idx = insertTargetPoint(
     src_pose, distance_to_stop_point, points_with_twist, max_dist, max_yaw, overlap_threshold);
 
   if (!stop_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   for (size_t i = *stop_idx; i < points_with_twist.size(); ++i) {
@@ -1714,19 +1717,19 @@ boost::optional<size_t> insertStopPoint(
   return stop_idx;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3);
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
@@ -1743,7 +1746,7 @@ insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
  * @return index of stop point
  */
 template <class T>
-boost::optional<size_t> insertStopPoint(
+std::optional<size_t> insertStopPoint(
   const size_t stop_seg_idx, const geometry_msgs::msg::Point & stop_point, T & points_with_twist,
   const double overlap_threshold = 1e-3)
 {
@@ -1751,17 +1754,17 @@ boost::optional<size_t> insertStopPoint(
     motion_utils::insertTargetPoint(stop_seg_idx, stop_point, points_with_twist, overlap_threshold);
 
   if (!insert_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
-  for (size_t i = insert_idx.get(); i < points_with_twist.size(); ++i) {
+  for (size_t i = insert_idx.value(); i < points_with_twist.size(); ++i) {
     tier4_autoware_utils::setLongitudinalVelocity(0.0, points_with_twist.at(i));
   }
 
   return insert_idx;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t stop_seg_idx, const geometry_msgs::msg::Point & stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
@@ -1775,7 +1778,7 @@ insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
  * @param points_with_twist output points of trajectory, path, ... (with velocity)
  */
 template <class T>
-boost::optional<size_t> insertDecelPoint(
+std::optional<size_t> insertDecelPoint(
   const geometry_msgs::msg::Point & src_point, const double distance_to_decel_point,
   const double velocity, T & points_with_twist)
 {
@@ -1786,14 +1789,14 @@ boost::optional<size_t> insertDecelPoint(
     return {};
   }
 
-  const auto seg_idx = findNearestSegmentIndex(points_with_twist, decel_point.get());
-  const auto insert_idx = insertTargetPoint(seg_idx, decel_point.get(), points_with_twist);
+  const auto seg_idx = findNearestSegmentIndex(points_with_twist, decel_point.value());
+  const auto insert_idx = insertTargetPoint(seg_idx, decel_point.value(), points_with_twist);
 
   if (!insert_idx) {
     return {};
   }
 
-  for (size_t i = insert_idx.get(); i < points_with_twist.size(); ++i) {
+  for (size_t i = insert_idx.value(); i < points_with_twist.size(); ++i) {
     const auto & original_velocity =
       tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.at(i));
     tier4_autoware_utils::setLongitudinalVelocity(
@@ -1803,7 +1806,7 @@ boost::optional<size_t> insertDecelPoint(
   return insert_idx;
 }
 
-extern template boost::optional<size_t>
+extern template std::optional<size_t>
 insertDecelPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const geometry_msgs::msg::Point & src_point, const double distance_to_decel_point,
   const double velocity,
@@ -2183,7 +2186,7 @@ extern template size_t findFirstNearestSegmentIndexWithSoftConstraints<
  * longitudinal velocity
  */
 template <class T>
-boost::optional<double> calcDistanceToForwardStopPoint(
+std::optional<double> calcDistanceToForwardStopPoint(
   const T & points_with_twist, const geometry_msgs::msg::Pose & pose,
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max())
@@ -2199,14 +2202,14 @@ boost::optional<double> calcDistanceToForwardStopPoint(
     motion_utils::findNearestSegmentIndex(points_with_twist, pose, max_dist, max_yaw);
 
   if (!nearest_segment_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const auto stop_idx = motion_utils::searchZeroVelocityIndex(
     points_with_twist, *nearest_segment_idx + 1, points_with_twist.size());
 
   if (!stop_idx) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const auto closest_stop_dist =
@@ -2215,17 +2218,17 @@ boost::optional<double> calcDistanceToForwardStopPoint(
   return std::max(0.0, closest_stop_dist);
 }
 
-extern template boost::optional<double>
+extern template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max());
-extern template boost::optional<double>
+extern template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max());
-extern template boost::optional<double>
+extern template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const geometry_msgs::msg::Pose & pose, const double max_dist = std::numeric_limits<double>::max(),

--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -91,7 +91,7 @@ std::tuple<double, double, double> update(
  * @param (t_during_min_acc) duration of constant deceleration [s]
  * @return moving distance until velocity is reached vt [m]
  */
-boost::optional<double> calcDecelDistPlanType1(
+std::optional<double> calcDecelDistPlanType1(
   const double v0, const double vt, const double a0, const double am, const double ja,
   const double jd, const double t_during_min_acc)
 {
@@ -155,7 +155,7 @@ boost::optional<double> calcDecelDistPlanType1(
  * @param (jd) minimum jerk [m/sss]
  * @return moving distance until velocity is reached vt [m]
  */
-boost::optional<double> calcDecelDistPlanType2(
+std::optional<double> calcDecelDistPlanType2(
   const double v0, const double vt, const double a0, const double ja, const double jd)
 {
   constexpr double epsilon = 1e-3;
@@ -212,7 +212,7 @@ boost::optional<double> calcDecelDistPlanType2(
  * @param (ja) maximum jerk [m/sss]
  * @return moving distance until velocity is reached vt [m]
  */
-boost::optional<double> calcDecelDistPlanType3(
+std::optional<double> calcDecelDistPlanType3(
   const double v0, const double vt, const double a0, const double ja)
 {
   constexpr double epsilon = 1e-3;
@@ -234,7 +234,7 @@ boost::optional<double> calcDecelDistPlanType3(
 }
 }  // namespace
 
-boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
+std::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double current_vel, const double target_vel, const double current_acc, const double acc_min,
   const double jerk_acc, const double jerk_dec)
 {

--- a/common/motion_utils/src/trajectory/path_with_lane_id.cpp
+++ b/common/motion_utils/src/trajectory/path_with_lane_id.cpp
@@ -24,7 +24,7 @@
 namespace motion_utils
 {
 
-boost::optional<std::pair<size_t, size_t>> getPathIndexRangeWithLaneId(
+std::optional<std::pair<size_t, size_t>> getPathIndexRangeWithLaneId(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int64_t target_lane_id)
 {
   size_t start_idx = 0;  // NOTE: to prevent from maybe-uninitialized error

--- a/common/motion_utils/src/trajectory/trajectory.cpp
+++ b/common/motion_utils/src/trajectory/trajectory.cpp
@@ -26,24 +26,24 @@ template void validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::Tra
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
 
 //
-template boost::optional<bool>
+template std::optional<bool>
 isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &);
-template boost::optional<bool>
+template std::optional<bool>
 isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &);
-template boost::optional<bool>
+template std::optional<bool>
 isDrivingForward<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
 
 //
-template boost::optional<bool>
+template std::optional<bool>
 isDrivingForwardWithTwist<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &);
-template boost::optional<bool>
+template std::optional<bool>
 isDrivingForwardWithTwist<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &);
-template boost::optional<bool>
+template std::optional<bool>
 isDrivingForwardWithTwist<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
 
@@ -61,19 +61,19 @@ removeOverlapPoints<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoin
   const size_t start_idx);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const size_t src_idx, const size_t dst_idx);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const size_t src_idx);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist);
 
@@ -90,15 +90,15 @@ template size_t findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::T
   const geometry_msgs::msg::Point & point);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);
-template boost::optional<size_t>
+template std::optional<size_t>
 findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);
-template boost::optional<size_t>
+template std::optional<size_t>
 findNearestIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);
@@ -131,15 +131,15 @@ findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::Trajectory
   const geometry_msgs::msg::Point & point);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);
-template boost::optional<size_t>
+template std::optional<size_t>
 findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);
-template boost::optional<size_t>
+template std::optional<size_t>
 findNearestSegmentIndex<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);
@@ -261,201 +261,201 @@ calcCurvatureAndArcLength<std::vector<autoware_auto_planning_msgs::msg::Trajecto
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points);
 
 //
-template boost::optional<double>
+template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const size_t src_idx);
 
 //
-template boost::optional<geometry_msgs::msg::Point>
+template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points, const size_t src_idx,
   const double offset, const bool throw_exception);
-template boost::optional<geometry_msgs::msg::Point>
+template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const size_t src_idx, const double offset, const bool throw_exception);
-template boost::optional<geometry_msgs::msg::Point>
+template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const size_t src_idx, const double offset, const bool throw_exception);
 
 //
-template boost::optional<geometry_msgs::msg::Point>
+template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset);
-template boost::optional<geometry_msgs::msg::Point>
+template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Point & src_point, const double offset);
-template boost::optional<geometry_msgs::msg::Point>
+template std::optional<geometry_msgs::msg::Point>
 calcLongitudinalOffsetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset);
 
 //
-template boost::optional<geometry_msgs::msg::Pose>
+template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points, const size_t src_idx,
   const double offset, const bool set_orientation_from_position_direction,
   const bool throw_exception);
-template boost::optional<geometry_msgs::msg::Pose>
+template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const size_t src_idx, const double offset, const bool set_orientation_from_position_direction,
   const bool throw_exception);
-template boost::optional<geometry_msgs::msg::Pose>
+template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const size_t src_idx, const double offset, const bool set_orientation_from_position_direction,
   const bool throw_exception);
 
 //
-template boost::optional<geometry_msgs::msg::Pose>
+template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset,
   const bool set_orientation_from_position_direction);
-template boost::optional<geometry_msgs::msg::Pose>
+template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Point & src_point, const double offset,
   const bool set_orientation_from_position_direction);
-template boost::optional<geometry_msgs::msg::Pose>
+template std::optional<geometry_msgs::msg::Pose>
 calcLongitudinalOffsetPose<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const geometry_msgs::msg::Point & src_point, const double offset,
   const bool set_orientation_from_position_direction);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const size_t src_segment_idx, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const size_t src_segment_idx, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t src_segment_idx, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
   const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points, const double max_dist,
   const double max_yaw, const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double max_dist, const double max_yaw, const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertTargetPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double insert_point_length,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points, const double max_dist,
   const double max_yaw, const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const size_t src_segment_idx, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const double overlap_threshold = 1e-3);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const size_t src_segment_idx, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const double overlap_threshold = 1e-3);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t src_segment_idx, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const double overlap_threshold = 1e-3);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPoint> & points_with_twist,
   const double max_dist, const double max_yaw, const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points_with_twist,
   const double max_dist, const double max_yaw, const double overlap_threshold);
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const geometry_msgs::msg::Pose & src_pose, const double distance_to_stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const double max_dist, const double max_yaw, const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const size_t stop_seg_idx, const geometry_msgs::msg::Point & stop_point,
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const double overlap_threshold);
 
 //
-template boost::optional<size_t>
+template std::optional<size_t>
 insertDecelPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const geometry_msgs::msg::Point & src_point, const double distance_to_decel_point,
   const double velocity,
@@ -539,7 +539,7 @@ template size_t findFirstNearestSegmentIndexWithSoftConstraints<
   const geometry_msgs::msg::Pose & pose, const double dist_threshold, const double yaw_threshold);
 
 //
-template boost::optional<double>
+template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points_with_twist,
   const geometry_msgs::msg::Pose & pose, const double max_dist, const double max_yaw);

--- a/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
@@ -124,7 +124,7 @@ bool VehicleArrivalChecker::isVehicleStoppedAtStopPoint(const double stop_durati
     return false;
   }
 
-  return std::abs(motion_utils::calcSignedArcLength(trajectory_ptr_->points, p, idx.get())) <
+  return std::abs(motion_utils::calcSignedArcLength(trajectory_ptr_->points, p, idx.value())) <
          th_arrived_distance_m;
 }
 

--- a/common/motion_utils/test/src/trajectory/test_path_with_lane_id.cpp
+++ b/common/motion_utils/test/src/trajectory/test_path_with_lane_id.cpp
@@ -85,7 +85,7 @@ TEST(path_with_lane_id, getPathIndexRangeWithLaneId)
     }
     {
       const auto res = getPathIndexRangeWithLaneId(points, 4);
-      EXPECT_EQ(res, boost::none);
+      EXPECT_EQ(res, std::nullopt);
     }
   }
 
@@ -93,7 +93,7 @@ TEST(path_with_lane_id, getPathIndexRangeWithLaneId)
   {
     PathWithLaneId points;
     const auto res = getPathIndexRangeWithLaneId(points, 4);
-    EXPECT_EQ(res, boost::none);
+    EXPECT_EQ(res, std::nullopt);
   }
 }
 

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -856,7 +856,7 @@ TEST(trajectory, calcDistanceToForwardStopPointFromIndex)
   // Boundary1 (Edge of the input trajectory)
   {
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, 0);
-    EXPECT_NEAR(dist.get(), 50.0, epsilon);
+    EXPECT_NEAR(dist.value(), 50.0, epsilon);
   }
 
   // Boundary2 (Edge of the input trajectory)
@@ -868,13 +868,13 @@ TEST(trajectory, calcDistanceToForwardStopPointFromIndex)
   // Boundary3 (On the Stop Point)
   {
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, 50);
-    EXPECT_NEAR(dist.get(), 0.0, epsilon);
+    EXPECT_NEAR(dist.value(), 0.0, epsilon);
   }
 
   // Boundary4 (Right before the stop point)
   {
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, 49);
-    EXPECT_NEAR(dist.get(), 1.0, epsilon);
+    EXPECT_NEAR(dist.value(), 1.0, epsilon);
   }
 
   // Boundary5 (Right behind the stop point)
@@ -886,7 +886,7 @@ TEST(trajectory, calcDistanceToForwardStopPointFromIndex)
   // Random
   {
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, 20);
-    EXPECT_NEAR(dist.get(), 30.0, epsilon);
+    EXPECT_NEAR(dist.value(), 30.0, epsilon);
   }
 }
 
@@ -914,7 +914,7 @@ TEST(trajectory, calcDistanceToForwardStopPointFromPose)
   {
     const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose);
-    EXPECT_NEAR(dist.get(), 50.0, epsilon);
+    EXPECT_NEAR(dist.value(), 50.0, epsilon);
   }
 
   // Trajectory Edge2
@@ -928,7 +928,7 @@ TEST(trajectory, calcDistanceToForwardStopPointFromPose)
   {
     const auto pose = createPose(-10.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose);
-    EXPECT_NEAR(dist.get(), 60.0, epsilon);
+    EXPECT_NEAR(dist.value(), 60.0, epsilon);
   }
 
   // Out of Trajectory2
@@ -942,14 +942,14 @@ TEST(trajectory, calcDistanceToForwardStopPointFromPose)
   {
     const auto pose = createPose(-30.0, 50.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose);
-    EXPECT_NEAR(dist.get(), 80.0, epsilon);
+    EXPECT_NEAR(dist.value(), 80.0, epsilon);
   }
 
   // Boundary Condition1
   {
     const auto pose = createPose(50.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose);
-    EXPECT_NEAR(dist.get(), 0.0, epsilon);
+    EXPECT_NEAR(dist.value(), 0.0, epsilon);
   }
 
   // Boundary Condition2
@@ -963,14 +963,14 @@ TEST(trajectory, calcDistanceToForwardStopPointFromPose)
   {
     const auto pose = createPose(49.9, 0.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose);
-    EXPECT_NEAR(dist.get(), 0.1, epsilon);
+    EXPECT_NEAR(dist.value(), 0.1, epsilon);
   }
 
   // Random
   {
     const auto pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose);
-    EXPECT_NEAR(dist.get(), 47.0, epsilon);
+    EXPECT_NEAR(dist.value(), 47.0, epsilon);
   }
 }
 
@@ -985,14 +985,14 @@ TEST(trajectory, calcDistanceToForwardStopPoint_DistThreshold)
   {
     const auto pose = createPose(-4.9, 0.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose, 5.0);
-    EXPECT_NEAR(dist.get(), 54.9, epsilon);
+    EXPECT_NEAR(dist.value(), 54.9, epsilon);
   }
 
   // Boundary Condition2
   {
     const auto pose = createPose(-5.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose, 5.0);
-    EXPECT_NEAR(dist.get(), 55.0, epsilon);
+    EXPECT_NEAR(dist.value(), 55.0, epsilon);
   }
 
   // Boundary Condition3
@@ -1007,7 +1007,7 @@ TEST(trajectory, calcDistanceToForwardStopPoint_DistThreshold)
     {
       const auto pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, 0.0);
       const auto dist = calcDistanceToForwardStopPoint(traj_input.points, pose, 5.0);
-      EXPECT_NEAR(dist.get(), 47.0, epsilon);
+      EXPECT_NEAR(dist.value(), 47.0, epsilon);
     }
 
     {
@@ -1034,14 +1034,14 @@ TEST(trajectory, calcDistanceToForwardStopPoint_YawThreshold)
       const auto pose = createPose(x, 0.0, 0.0, 0.0, 0.0, deg2rad(29.9));
       const auto dist =
         calcDistanceToForwardStopPoint(traj_input.points, pose, max_d, deg2rad(30.0));
-      EXPECT_NEAR(dist.get(), 48.0, epsilon);
+      EXPECT_NEAR(dist.value(), 48.0, epsilon);
     }
 
     {
       const auto pose = createPose(x, 0.0, 0.0, 0.0, 0.0, deg2rad(30.0));
       const auto dist =
         calcDistanceToForwardStopPoint(traj_input.points, pose, max_d, deg2rad(30.0));
-      EXPECT_NEAR(dist.get(), 48.0, epsilon);
+      EXPECT_NEAR(dist.value(), 48.0, epsilon);
     }
 
     {
@@ -1058,7 +1058,7 @@ TEST(trajectory, calcDistanceToForwardStopPoint_YawThreshold)
       const auto pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, deg2rad(15.0));
       const auto dist =
         calcDistanceToForwardStopPoint(traj_input.points, pose, max_d, deg2rad(20.0));
-      EXPECT_NEAR(dist.get(), 47.0, epsilon);
+      EXPECT_NEAR(dist.value(), 47.0, epsilon);
     }
 
     {
@@ -1096,10 +1096,10 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
     for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
       const auto p_out = calcLongitudinalOffsetPoint(traj.points, i, std::min(len, d_back));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().z, 0.0, epsilon);
 
       x_ans += 0.1;
     }
@@ -1114,10 +1114,10 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
     for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
       const auto p_out = calcLongitudinalOffsetPoint(traj.points, i, std::max(len, d_front));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().z, 0.0, epsilon);
 
       x_ans -= 0.1;
     }
@@ -1127,14 +1127,14 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
   {
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, 0, total_length + epsilon);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // No found
   {
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, 9, -total_length - epsilon);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // No found(Trajectory size is 1)
@@ -1142,7 +1142,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     const auto p_out = calcLongitudinalOffsetPoint(one_point_traj.points, 0.0, 0.0);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 }
 
@@ -1171,10 +1171,10 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
     for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
       const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, std::min(len, d_back));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().z, 0.0, epsilon);
 
       x_ans += 0.1;
     }
@@ -1191,10 +1191,10 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
     for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
       const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, std::max(len, d_front));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().z, 0.0, epsilon);
 
       x_ans -= 0.1;
     }
@@ -1205,7 +1205,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
     const auto p_src = createPoint(0.0, 0.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, total_length + 1.0);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // No found
@@ -1213,7 +1213,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
     const auto p_src = createPoint(9.0, 0.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, -total_length - 1.0);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // Out of range(Trajectory size is 1)
@@ -1250,14 +1250,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
       const auto p_out = calcLongitudinalOffsetPose(traj.points, i, std::min(len, d_back));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.w, 1.0, epsilon);
 
       x_ans += 0.1;
     }
@@ -1272,14 +1272,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
       const auto p_out = calcLongitudinalOffsetPose(traj.points, i, std::max(len, d_front));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.w, 1.0, epsilon);
 
       x_ans -= 0.1;
     }
@@ -1289,14 +1289,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
   {
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length + epsilon);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // No found
   {
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 9, -total_length - epsilon);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // No found(Trajectory size is 1)
@@ -1304,7 +1304,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     const auto p_out = calcLongitudinalOffsetPose(one_point_traj.points, 0.0, 0.0);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 }
 
@@ -1338,14 +1338,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, len);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, len * std::cos(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.y, len * std::sin(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.y, len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 
   // Found pose(backward)
@@ -1353,14 +1353,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, -len);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0 - len * std::cos(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0 - len * std::sin(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0 - len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0 - len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 
   // Boundary condition
@@ -1368,14 +1368,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 
   // Boundary condition
@@ -1383,14 +1383,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, 0.0);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 }
 
@@ -1427,14 +1427,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
     const auto ans_quat =
       createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 - 45.0 * ratio));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, len * std::cos(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.y, len * std::sin(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.y, len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 
   // Found pose(backward)
@@ -1445,14 +1445,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
     const auto ans_quat =
       createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0 - len * std::cos(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0 - len * std::sin(deg2rad(45.0)), epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0 - len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0 - len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 
   // Boundary condition
@@ -1460,14 +1460,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length, false);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 
   // Boundary condition
@@ -1475,14 +1475,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, 0.0, false);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 }
 
@@ -1511,14 +1511,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
       const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, std::min(len, d_back));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.w, 1.0, epsilon);
 
       x_ans += 0.1;
     }
@@ -1535,14 +1535,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
       const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, std::max(len, d_front));
 
-      EXPECT_NE(p_out, boost::none);
-      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
-      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+      EXPECT_NE(p_out, std::nullopt);
+      EXPECT_NEAR(p_out.value().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.value().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.w, 1.0, epsilon);
 
       x_ans -= 0.1;
     }
@@ -1553,7 +1553,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     const auto p_src = createPoint(0.0, 0.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, total_length + 1.0);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // No found
@@ -1561,7 +1561,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     const auto p_src = createPoint(9.0, 0.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -total_length - 1.0);
 
-    EXPECT_EQ(p_out, boost::none);
+    EXPECT_EQ(p_out, std::nullopt);
   }
 
   // Out of range(Trajectory size is 1)
@@ -1612,16 +1612,16 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatInterpolation)
       const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, len);
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
 
-      EXPECT_NE(p_out, boost::none);
+      EXPECT_NE(p_out, std::nullopt);
       EXPECT_NEAR(
-        p_out.get().position.x, p_src.x + len * std::cos(deg2rad(45.0)) - deviation, epsilon);
+        p_out.value().position.x, p_src.x + len * std::cos(deg2rad(45.0)) - deviation, epsilon);
       EXPECT_NEAR(
-        p_out.get().position.y, p_src.y + len * std::sin(deg2rad(45.0)) + deviation, epsilon);
-      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+        p_out.value().position.y, p_src.y + len * std::sin(deg2rad(45.0)) + deviation, epsilon);
+      EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
     }
   }
 
@@ -1635,14 +1635,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatInterpolation)
     const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 }
 
@@ -1689,16 +1689,16 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatSphericalInterpolation)
       const auto ans_quat =
         createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 - 45.0 * ratio));
 
-      EXPECT_NE(p_out, boost::none);
+      EXPECT_NE(p_out, std::nullopt);
       EXPECT_NEAR(
-        p_out.get().position.x, p_src.x + len * std::cos(deg2rad(45.0)) - deviation, epsilon);
+        p_out.value().position.x, p_src.x + len * std::cos(deg2rad(45.0)) - deviation, epsilon);
       EXPECT_NEAR(
-        p_out.get().position.y, p_src.y + len * std::sin(deg2rad(45.0)) + deviation, epsilon);
-      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-      EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+        p_out.value().position.y, p_src.y + len * std::sin(deg2rad(45.0)) + deviation, epsilon);
+      EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
     }
   }
 
@@ -1713,14 +1713,14 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatSphericalInterpolation)
       calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset, false);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    EXPECT_NE(p_out, std::nullopt);
+    EXPECT_NEAR(p_out.value().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.value().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.value().orientation.w, ans_quat.w, epsilon);
   }
 }
 
@@ -1745,8 +1745,8 @@ TEST(trajectory, insertTargetPoint)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -1754,7 +1754,7 @@ TEST(trajectory, insertTargetPoint)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -1783,8 +1783,8 @@ TEST(trajectory, insertTargetPoint)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -1792,7 +1792,7 @@ TEST(trajectory, insertTargetPoint)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -1821,8 +1821,8 @@ TEST(trajectory, insertTargetPoint)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -1830,7 +1830,7 @@ TEST(trajectory, insertTargetPoint)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(-30.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -1859,8 +1859,8 @@ TEST(trajectory, insertTargetPoint)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -1876,8 +1876,8 @@ TEST(trajectory, insertTargetPoint)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -1895,7 +1895,7 @@ TEST(trajectory, insertTargetPoint)
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Behind of end point)
@@ -1908,7 +1908,7 @@ TEST(trajectory, insertTargetPoint)
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Huge lateral offset)
@@ -1921,7 +1921,7 @@ TEST(trajectory, insertTargetPoint)
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid base index
@@ -1932,7 +1932,7 @@ TEST(trajectory, insertTargetPoint)
     const auto p_target = createPoint(10.0, 0.0, 0.0);
     const auto insert_idx = insertTargetPoint(segment_idx, p_target, traj_out.points);
 
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Empty
@@ -1969,8 +1969,8 @@ TEST(trajectory, insertTargetPoint_Reverse)
     const auto insert_idx =
       insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -1979,7 +1979,7 @@ TEST(trajectory, insertTargetPoint_Reverse)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(180));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2024,8 +2024,8 @@ TEST(trajectory, insertTargetPoint_OverlapThreshold)
     const auto insert_idx =
       insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2034,7 +2034,7 @@ TEST(trajectory, insertTargetPoint_OverlapThreshold)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2064,8 +2064,8 @@ TEST(trajectory, insertTargetPoint_OverlapThreshold)
     const auto insert_idx =
       insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2083,8 +2083,8 @@ TEST(trajectory, insertTargetPoint_OverlapThreshold)
     const auto insert_idx =
       insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2115,8 +2115,8 @@ TEST(trajectory, insertTargetPoint_Length)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(x_start, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2124,7 +2124,7 @@ TEST(trajectory, insertTargetPoint_Length)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2153,8 +2153,8 @@ TEST(trajectory, insertTargetPoint_Length)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(x_start + 1.1e-3, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2162,7 +2162,7 @@ TEST(trajectory, insertTargetPoint_Length)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2191,8 +2191,8 @@ TEST(trajectory, insertTargetPoint_Length)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(9.0, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2200,7 +2200,7 @@ TEST(trajectory, insertTargetPoint_Length)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2229,8 +2229,8 @@ TEST(trajectory, insertTargetPoint_Length)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(x_start, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2238,7 +2238,7 @@ TEST(trajectory, insertTargetPoint_Length)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(-30.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2267,8 +2267,8 @@ TEST(trajectory, insertTargetPoint_Length)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(x_start + 1e-4, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2284,8 +2284,8 @@ TEST(trajectory, insertTargetPoint_Length)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(x_start - 1e-4, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2300,7 +2300,7 @@ TEST(trajectory, insertTargetPoint_Length)
     const auto p_target = createPoint(-1.0, 0.0, 0.0);
     const auto insert_idx = insertTargetPoint(-1.0, p_target, traj_out.points);
 
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Behind the end point)
@@ -2310,7 +2310,7 @@ TEST(trajectory, insertTargetPoint_Length)
     const auto p_target = createPoint(10.0, 0.0, 0.0);
     const auto insert_idx = insertTargetPoint(10.0, p_target, traj_out.points);
 
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Huge lateral offset)
@@ -2322,7 +2322,7 @@ TEST(trajectory, insertTargetPoint_Length)
     const auto insert_idx = insertTargetPoint(4.0, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Empty
@@ -2355,8 +2355,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(0, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2364,7 +2364,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2393,8 +2393,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(0, x_start + 1.1e-3, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2402,7 +2402,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2431,8 +2431,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(0, 9.0, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2440,7 +2440,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2469,8 +2469,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(0, x_start + 1e-4, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2486,8 +2486,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(0, x_start - 1e-4, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2501,7 +2501,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
 
     const auto insert_idx = insertTargetPoint(0, -1.0, traj_out.points);
 
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Behind the end point)
@@ -2510,7 +2510,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point)
 
     const auto insert_idx = insertTargetPoint(0, 10.0, traj_out.points);
 
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Empty
@@ -2541,8 +2541,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2550,7 +2550,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2581,8 +2581,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2590,7 +2590,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2621,8 +2621,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2630,7 +2630,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2661,8 +2661,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2670,7 +2670,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2701,8 +2701,8 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2710,7 +2710,7 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2734,19 +2734,19 @@ TEST(trajectory, insertTargetPoint_Length_Without_Target_Point_Non_Zero_Start_Id
   // No Insert (Index Out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertTargetPoint(9, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(9, 1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(10, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(10, 1.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(9, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(9, 1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(10, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(10, 1.0, traj_out.points), std::nullopt);
   }
 
   // No Insert (Length out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertTargetPoint(0, 10.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(0, 9.0001, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(5, 5.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(8, 1.0001, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(0, 10.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(0, 9.0001, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(5, 5.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(8, 1.0001, traj_out.points), std::nullopt);
   }
 }
 
@@ -2771,8 +2771,8 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2780,7 +2780,7 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2811,8 +2811,8 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2820,7 +2820,7 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2851,8 +2851,8 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2860,7 +2860,7 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2891,8 +2891,8 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2900,7 +2900,7 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -2924,16 +2924,16 @@ TEST(trajectory, insertTargetPoint_Negative_Length_Without_Target_Point_Non_Zero
   // No Insert (Index Out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertTargetPoint(0, -1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(0, -1.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(0, -1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(0, -1.0, traj_out.points), std::nullopt);
   }
 
   // No Insert (Length out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertTargetPoint(9, -10.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(9, -9.0001, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(1, -1.0001, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(9, -10.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(9, -9.0001, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(1, -1.0001, traj_out.points), std::nullopt);
   }
 }
 
@@ -2959,8 +2959,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -2968,7 +2968,7 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3002,8 +3002,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -3011,7 +3011,7 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       }
 
       {
-        const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+        const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
         const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
         EXPECT_EQ(p_insert.position.x, p_target.x);
         EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3046,8 +3046,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx);
       EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -3069,8 +3069,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -3078,7 +3078,7 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       }
 
       {
-        const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+        const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
         const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
         EXPECT_EQ(p_insert.position.x, p_target.x);
         EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3113,8 +3113,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -3122,7 +3122,7 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       }
 
       {
-        const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+        const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
         const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
         EXPECT_EQ(p_insert.position.x, p_target.x);
         EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3151,8 +3151,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const double src_pose_y = 0.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertTargetPoint(src_pose, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(src_pose, 0.5, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(src_pose, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(src_pose, 0.5, traj_out.points), std::nullopt);
   }
 
   // Insert from the point behind the trajectory (Invalid)
@@ -3162,9 +3162,9 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const double src_pose_y = 3.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertTargetPoint(src_pose, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(src_pose, 1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(src_pose, 10.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(src_pose, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(src_pose, 1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(src_pose, 10.0, traj_out.points), std::nullopt);
   }
 
   // Insert from the point in front of the trajectory (Boundary Condition)
@@ -3179,8 +3179,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -3188,7 +3188,7 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3221,8 +3221,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(src_pose, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
@@ -3230,7 +3230,7 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3258,8 +3258,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const double src_pose_y = 3.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertTargetPoint(src_pose, -1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertTargetPoint(src_pose, -10.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertTargetPoint(src_pose, -1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(src_pose, -10.0, traj_out.points), std::nullopt);
   }
 
   // No Insert (Too Far from the source point)
@@ -3269,8 +3269,8 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
     const double src_pose_y = 3.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertTargetPoint(src_pose, 1.0, traj_out.points, 1.0), boost::none);
-    EXPECT_EQ(insertTargetPoint(src_pose, 10.0, traj_out.points, 1.0), boost::none);
+    EXPECT_EQ(insertTargetPoint(src_pose, 1.0, traj_out.points, 1.0), std::nullopt);
+    EXPECT_EQ(insertTargetPoint(src_pose, 10.0, traj_out.points, 1.0), std::nullopt);
   }
 
   // No Insert (Too large yaw deviation)
@@ -3283,9 +3283,9 @@ TEST(trajectory, insertTargetPoint_Length_from_a_pose)
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, src_yaw);
     const double max_dist = std::numeric_limits<double>::max();
     EXPECT_EQ(
-      insertTargetPoint(src_pose, 1.0, traj_out.points, max_dist, deg2rad(45)), boost::none);
+      insertTargetPoint(src_pose, 1.0, traj_out.points, max_dist, deg2rad(45)), std::nullopt);
     EXPECT_EQ(
-      insertTargetPoint(src_pose, 10.0, traj_out.points, max_dist, deg2rad(45)), boost::none);
+      insertTargetPoint(src_pose, 10.0, traj_out.points, max_dist, deg2rad(45)), std::nullopt);
   }
 }
 
@@ -3310,13 +3310,13 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3324,7 +3324,7 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3355,13 +3355,13 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3369,7 +3369,7 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3400,13 +3400,13 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3414,7 +3414,7 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3445,13 +3445,13 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3459,7 +3459,7 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3490,13 +3490,13 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(start_idx, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3504,7 +3504,7 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3528,19 +3528,19 @@ TEST(trajectory, insertStopPoint_from_a_source_index)
   // No Insert (Index Out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertStopPoint(9, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(9, 1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(10, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(10, 1.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertStopPoint(9, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(9, 1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(10, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(10, 1.0, traj_out.points), std::nullopt);
   }
 
   // No Insert (Length out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertStopPoint(0, 10.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(0, 9.0001, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(5, 5.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(8, 1.0001, traj_out.points), boost::none);
+    EXPECT_EQ(insertStopPoint(0, 10.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(0, 9.0001, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(5, 5.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(8, 1.0001, traj_out.points), std::nullopt);
   }
 }
 
@@ -3564,13 +3564,13 @@ TEST(trajectory, insertStopPoint_from_front_point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(x_start + 2.0, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3578,7 +3578,7 @@ TEST(trajectory, insertStopPoint_from_front_point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3608,13 +3608,13 @@ TEST(trajectory, insertStopPoint_from_front_point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(8.0 + x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3622,7 +3622,7 @@ TEST(trajectory, insertStopPoint_from_front_point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3651,13 +3651,13 @@ TEST(trajectory, insertStopPoint_from_front_point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(9.0, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3665,7 +3665,7 @@ TEST(trajectory, insertStopPoint_from_front_point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3695,13 +3695,13 @@ TEST(trajectory, insertStopPoint_from_front_point)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3709,7 +3709,7 @@ TEST(trajectory, insertStopPoint_from_front_point)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3733,11 +3733,11 @@ TEST(trajectory, insertStopPoint_from_front_point)
   // No Insert (Length out of range)
   {
     auto traj_out = traj;
-    EXPECT_EQ(insertStopPoint(9.0 + 1e-2, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(10.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertStopPoint(9.0 + 1e-2, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(10.0, traj_out.points), std::nullopt);
     EXPECT_EQ(
-      insertStopPoint(-std::numeric_limits<double>::epsilon(), traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(-3.0, traj_out.points), boost::none);
+      insertStopPoint(-std::numeric_limits<double>::epsilon(), traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(-3.0, traj_out.points), std::nullopt);
   }
 }
 
@@ -3763,13 +3763,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3777,7 +3777,7 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3811,13 +3811,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
         } else {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3825,7 +3825,7 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       }
 
       {
-        const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+        const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
         const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
         EXPECT_EQ(p_insert.position.x, p_target.x);
         EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3860,13 +3860,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx);
       EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
         } else {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3888,13 +3888,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
         } else {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3902,7 +3902,7 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       }
 
       {
-        const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+        const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
         const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
         EXPECT_EQ(p_insert.position.x, p_target.x);
         EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3937,13 +3937,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
         } else {
           EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -3951,7 +3951,7 @@ TEST(trajectory, insertStopPoint_from_a_pose)
       }
 
       {
-        const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+        const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
         const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
         EXPECT_EQ(p_insert.position.x, p_target.x);
         EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -3980,8 +3980,8 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const double src_pose_y = 0.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertStopPoint(src_pose, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(src_pose, 0.5, traj_out.points), boost::none);
+    EXPECT_EQ(insertStopPoint(src_pose, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(src_pose, 0.5, traj_out.points), std::nullopt);
   }
 
   // Insert from the point behind the trajectory (Invalid)
@@ -3991,9 +3991,9 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const double src_pose_y = 3.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertStopPoint(src_pose, 0.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(src_pose, 1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(src_pose, 10.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertStopPoint(src_pose, 0.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(src_pose, 1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(src_pose, 10.0, traj_out.points), std::nullopt);
   }
 
   // Insert from the point in front of the trajectory (Boundary Condition)
@@ -4008,13 +4008,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -4022,7 +4022,7 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -4055,13 +4055,13 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(src_pose, x_start, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-      if (i < insert_idx.get()) {
+      if (i < insert_idx.value()) {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 10.0, epsilon);
       } else {
         EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
@@ -4069,7 +4069,7 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -4097,8 +4097,8 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const double src_pose_y = 3.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertStopPoint(src_pose, -1.0, traj_out.points), boost::none);
-    EXPECT_EQ(insertStopPoint(src_pose, -10.0, traj_out.points), boost::none);
+    EXPECT_EQ(insertStopPoint(src_pose, -1.0, traj_out.points), std::nullopt);
+    EXPECT_EQ(insertStopPoint(src_pose, -10.0, traj_out.points), std::nullopt);
   }
 
   // No Insert (Too Far from the source point)
@@ -4108,8 +4108,8 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const double src_pose_y = 3.0;
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_EQ(insertStopPoint(src_pose, 1.0, traj_out.points, 1.0), boost::none);
-    EXPECT_EQ(insertStopPoint(src_pose, 10.0, traj_out.points, 1.0), boost::none);
+    EXPECT_EQ(insertStopPoint(src_pose, 1.0, traj_out.points, 1.0), std::nullopt);
+    EXPECT_EQ(insertStopPoint(src_pose, 10.0, traj_out.points, 1.0), std::nullopt);
   }
 
   // No Insert (Too large yaw deviation)
@@ -4121,8 +4121,9 @@ TEST(trajectory, insertStopPoint_from_a_pose)
     const geometry_msgs::msg::Pose src_pose =
       createPose(src_pose_x, src_pose_y, 0.0, 0.0, 0.0, src_yaw);
     const double max_dist = std::numeric_limits<double>::max();
-    EXPECT_EQ(insertStopPoint(src_pose, 1.0, traj_out.points, max_dist, deg2rad(45)), boost::none);
-    EXPECT_EQ(insertStopPoint(src_pose, 10.0, traj_out.points, max_dist, deg2rad(45)), boost::none);
+    EXPECT_EQ(insertStopPoint(src_pose, 1.0, traj_out.points, max_dist, deg2rad(45)), std::nullopt);
+    EXPECT_EQ(
+      insertStopPoint(src_pose, 10.0, traj_out.points, max_dist, deg2rad(45)), std::nullopt);
   }
 }
 
@@ -4147,23 +4148,23 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
     }
 
-    for (size_t i = 0; i < insert_idx.get(); ++i) {
+    for (size_t i = 0; i < insert_idx.value(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 3.0, epsilon);
     }
-    for (size_t i = insert_idx.get(); i < traj_out.points.size(); ++i) {
+    for (size_t i = insert_idx.value(); i < traj_out.points.size(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -4192,22 +4193,22 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
     }
-    for (size_t i = 0; i < insert_idx.get(); ++i) {
+    for (size_t i = 0; i < insert_idx.value(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 3.0, epsilon);
     }
-    for (size_t i = insert_idx.get(); i < traj_out.points.size(); ++i) {
+    for (size_t i = insert_idx.value(); i < traj_out.points.size(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -4236,22 +4237,22 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
     }
-    for (size_t i = 0; i < insert_idx.get(); ++i) {
+    for (size_t i = 0; i < insert_idx.value(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 3.0, epsilon);
     }
-    for (size_t i = insert_idx.get(); i < traj_out.points.size(); ++i) {
+    for (size_t i = insert_idx.value(); i < traj_out.points.size(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
     }
 
     {
-      const auto p_insert = getPose(traj_out.points.at(insert_idx.get()));
+      const auto p_insert = getPose(traj_out.points.at(insert_idx.value()));
       const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(-30.0));
       EXPECT_EQ(p_insert.position.x, p_target.x);
       EXPECT_EQ(p_insert.position.y, p_target.y);
@@ -4280,17 +4281,17 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
     }
-    for (size_t i = 0; i < insert_idx.get(); ++i) {
+    for (size_t i = 0; i < insert_idx.value(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 3.0, epsilon);
     }
-    for (size_t i = insert_idx.get(); i < traj_out.points.size(); ++i) {
+    for (size_t i = insert_idx.value(); i < traj_out.points.size(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
     }
   }
@@ -4303,17 +4304,17 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(insert_idx, boost::none);
-    EXPECT_EQ(insert_idx.get(), base_idx + 1);
+    EXPECT_NE(insert_idx, std::nullopt);
+    EXPECT_EQ(insert_idx.value(), base_idx + 1);
     EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
     for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
       EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
     }
-    for (size_t i = 0; i < insert_idx.get(); ++i) {
+    for (size_t i = 0; i < insert_idx.value(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 3.0, epsilon);
     }
-    for (size_t i = insert_idx.get(); i < traj_out.points.size(); ++i) {
+    for (size_t i = insert_idx.value(); i < traj_out.points.size(); ++i) {
       EXPECT_NEAR(traj_out.points.at(i).longitudinal_velocity_mps, 0.0, epsilon);
     }
   }
@@ -4328,7 +4329,7 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Behind of end point)
@@ -4341,7 +4342,7 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Huge lateral offset)
@@ -4354,7 +4355,7 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
     EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid base index
@@ -4365,7 +4366,7 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
     const auto p_target = createPoint(10.0, 0.0, 0.0);
     const auto insert_idx = insertStopPoint(segment_idx, p_target, traj_out.points);
 
-    EXPECT_EQ(insert_idx, boost::none);
+    EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Empty
@@ -4398,13 +4399,13 @@ TEST(trajectory, insertDecelPoint_from_a_point)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertDecelPoint(src_point, x_start, decel_velocity, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(getLongitudinalVelocity(traj_out.points.at(i)), 10.0, epsilon);
         } else {
           EXPECT_NEAR(getLongitudinalVelocity(traj_out.points.at(i)), decel_velocity, epsilon);
@@ -4424,13 +4425,13 @@ TEST(trajectory, insertDecelPoint_from_a_point)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertDecelPoint(src_point, x_start, decel_velocity, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx + 1);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx + 1);
       EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(getLongitudinalVelocity(traj_out.points.at(i)), 10.0, epsilon);
         } else {
           EXPECT_NEAR(getLongitudinalVelocity(traj_out.points.at(i)), decel_velocity, epsilon);
@@ -4450,13 +4451,13 @@ TEST(trajectory, insertDecelPoint_from_a_point)
       const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
       const auto insert_idx = insertDecelPoint(src_point, x_start, decel_velocity, traj_out.points);
 
-      EXPECT_NE(insert_idx, boost::none);
-      EXPECT_EQ(insert_idx.get(), base_idx);
+      EXPECT_NE(insert_idx, std::nullopt);
+      EXPECT_EQ(insert_idx.value(), base_idx);
       EXPECT_EQ(traj_out.points.size(), traj.points.size());
 
       for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
         EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
-        if (i < insert_idx.get()) {
+        if (i < insert_idx.value()) {
           EXPECT_NEAR(getLongitudinalVelocity(traj_out.points.at(i)), 10.0, epsilon);
         } else {
           EXPECT_NEAR(getLongitudinalVelocity(traj_out.points.at(i)), decel_velocity, epsilon);

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
@@ -33,6 +33,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -79,7 +80,7 @@ public:
   void setOdomHistory(const Odometry & odom);
   void setSteeringStatus(const SteeringReport & steering);
 
-  boost::optional<int32_t> findCurveRefIdx();
+  std::optional<int32_t> findCurveRefIdx();
   std::pair<bool, int32_t> findClosestPrevWayPointIdx_path_direction();
   double estimateCurvature();
   double estimatePurePursuitCurvature();

--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -94,8 +94,8 @@ std::pair<bool, int32_t> ControlPerformanceAnalysisCore::findClosestPrevWayPoint
     return std::make_pair(false, std::numeric_limits<int32_t>::quiet_NaN());
   }
 
-  idx_prev_wp_ = std::make_unique<int32_t>(closest_segment.get());
-  idx_next_wp_ = std::make_unique<int32_t>(closest_segment.get() + 1);
+  idx_prev_wp_ = std::make_unique<int32_t>(closest_segment.value());
+  idx_next_wp_ = std::make_unique<int32_t>(closest_segment.value() + 1);
   return std::make_pair(true, *idx_prev_wp_);
 }
 
@@ -429,7 +429,7 @@ double ControlPerformanceAnalysisCore::estimateCurvature()
     RCLCPP_WARN(logger_, "Cannot find index of curvature reference waypoint ");
     return 0;
   }
-  const auto idx_curve_ref_wp = idx_curve_ref_wp_optional.get();
+  const auto idx_curve_ref_wp = idx_curve_ref_wp_optional.value();
 
   const auto & points = current_trajectory_ptr_->points;
 

--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -360,13 +361,13 @@ void ControlPerformanceAnalysisCore::setSteeringStatus(const SteeringReport & st
   current_vec_steering_msg_ptr_ = std::make_shared<SteeringReport>(steering);
 }
 
-boost::optional<int32_t> ControlPerformanceAnalysisCore::findCurveRefIdx()
+std::optional<int32_t> ControlPerformanceAnalysisCore::findCurveRefIdx()
 {
   // Get the previous waypoint as the reference
   if (!interpolated_pose_ptr_) {
     RCLCPP_WARN_THROTTLE(
       logger_, clock_, 1000, "Cannot set the curvature_idx, no valid interpolated pose ...");
-    return boost::none;
+    return std::nullopt;
   }
 
   auto fun_distance_cond = [this](auto point_t) {

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -204,7 +204,7 @@ void MPC::setReferenceTrajectory(
     motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
 
   // if driving direction is unknown, use previous value
-  m_is_forward_shift = is_forward_shift ? is_forward_shift.get() : m_is_forward_shift;
+  m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
 
   // path smoothing
   MPCTrajectory mpc_traj_smoothed = mpc_traj_resampled;  // smooth filtered trajectory

--- a/planning/behavior_path_planner/docs/behavior_path_planner_manager_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_manager_design.md
@@ -575,7 +575,7 @@ In addition, while manual driving, the manager always updates **root lanelet** b
       std::max(p.backward_path_length, p.backward_path_length + extra_margin);
 
     const auto lanelet_sequence = route_handler->getLaneletSequence(
-      root_lanelet_.get(), pose, backward_length, std::numeric_limits<double>::max());
+      root_lanelet_.value(), pose, backward_length, std::numeric_limits<double>::max());
 
     lanelet::ConstLanelet closest_lane{};
     if (lanelet::utils::query::getClosestLaneletWithConstrains(

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -132,7 +132,7 @@ public:
     std::for_each(manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->reset(); });
     approved_module_ptrs_.clear();
     candidate_module_ptrs_.clear();
-    root_lanelet_ = boost::none;
+    root_lanelet_ = std::nullopt;
     resetProcessingTime();
   }
 
@@ -424,7 +424,7 @@ private:
 
   std::string getNames(const std::vector<SceneModulePtr> & modules) const;
 
-  boost::optional<lanelet::ConstLanelet> root_lanelet_{boost::none};
+  std::optional<lanelet::ConstLanelet> root_lanelet_{std::nullopt};
 
   std::vector<SceneModuleManagerPtr> manager_ptrs_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -207,9 +207,9 @@ public:
     return direction_;
   }
 
-  boost::optional<Pose> getStopPose() const { return lane_change_stop_pose_; }
+  std::optional<Pose> getStopPose() const { return lane_change_stop_pose_; }
 
-  void resetStopPose() { lane_change_stop_pose_ = boost::none; }
+  void resetStopPose() { lane_change_stop_pose_ = std::nullopt; }
 
 protected:
   virtual lanelet::ConstLanelets getCurrentLanes() const = 0;
@@ -247,7 +247,7 @@ protected:
   PathWithLaneId prev_module_path_{};
   DrivableAreaInfo prev_drivable_area_info_{};
   TurnSignalInfo prev_turn_signal_info_{};
-  boost::optional<Pose> lane_change_stop_pose_{boost::none};
+  std::optional<Pose> lane_change_stop_pose_{std::nullopt};
 
   PathWithLaneId prev_approved_path_{};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -284,7 +284,7 @@ public:
     }
 
     const auto & base_link2front = planner_data_->parameters.base_link2front;
-    return calcOffsetPose(stop_pose_.get(), base_link2front, 0.0, 0.0);
+    return calcOffsetPose(stop_pose_.value(), base_link2front, 0.0, 0.0);
   }
 
   std::optional<Pose> getSlowPose() const
@@ -294,7 +294,7 @@ public:
     }
 
     const auto & base_link2front = planner_data_->parameters.base_link2front;
-    return calcOffsetPose(slow_pose_.get(), base_link2front, 0.0, 0.0);
+    return calcOffsetPose(slow_pose_.value(), base_link2front, 0.0, 0.0);
   }
 
   std::optional<Pose> getDeadPose() const
@@ -304,7 +304,7 @@ public:
     }
 
     const auto & base_link2front = planner_data_->parameters.base_link2front;
-    return calcOffsetPose(dead_pose_.get(), base_link2front, 0.0, 0.0);
+    return calcOffsetPose(dead_pose_.value(), base_link2front, 0.0, 0.0);
   }
 
   void resetWallPoses() const
@@ -538,9 +538,9 @@ protected:
     }
 
     StopFactor stop_factor;
-    stop_factor.stop_pose = stop_pose_.get();
+    stop_factor.stop_pose = stop_pose_.value();
     stop_factor.dist_to_stop_pose =
-      motion_utils::calcSignedArcLength(path.points, getEgoPosition(), stop_pose_.get().position);
+      motion_utils::calcSignedArcLength(path.points, getEgoPosition(), stop_pose_.value().position);
     stop_reason_.stop_factors.push_back(stop_factor);
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -277,7 +277,7 @@ public:
 
   std::string name() const { return name_; }
 
-  boost::optional<Pose> getStopPose() const
+  std::optional<Pose> getStopPose() const
   {
     if (!stop_pose_) {
       return {};
@@ -287,7 +287,7 @@ public:
     return calcOffsetPose(stop_pose_.get(), base_link2front, 0.0, 0.0);
   }
 
-  boost::optional<Pose> getSlowPose() const
+  std::optional<Pose> getSlowPose() const
   {
     if (!slow_pose_) {
       return {};
@@ -297,7 +297,7 @@ public:
     return calcOffsetPose(slow_pose_.get(), base_link2front, 0.0, 0.0);
   }
 
-  boost::optional<Pose> getDeadPose() const
+  std::optional<Pose> getDeadPose() const
   {
     if (!dead_pose_) {
       return {};
@@ -309,9 +309,9 @@ public:
 
   void resetWallPoses() const
   {
-    stop_pose_ = boost::none;
-    slow_pose_ = boost::none;
-    dead_pose_ = boost::none;
+    stop_pose_ = std::nullopt;
+    slow_pose_ = std::nullopt;
+    dead_pose_ = std::nullopt;
   }
 
   rclcpp::Logger getLogger() const { return logger_; }
@@ -603,11 +603,11 @@ protected:
 
   std::unique_ptr<SteeringFactorInterface> steering_factor_interface_ptr_;
 
-  mutable boost::optional<Pose> stop_pose_{boost::none};
+  mutable std::optional<Pose> stop_pose_{std::nullopt};
 
-  mutable boost::optional<Pose> slow_pose_{boost::none};
+  mutable std::optional<Pose> slow_pose_{std::nullopt};
 
-  mutable boost::optional<Pose> dead_pose_{boost::none};
+  mutable std::optional<Pose> dead_pose_{std::nullopt};
 
   mutable MarkerArray info_marker_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -136,21 +136,21 @@ public:
       const auto opt_stop_pose = m.lock()->getStopPose();
       if (!!opt_stop_pose) {
         const auto virtual_wall = createStopVirtualWallMarker(
-          opt_stop_pose.get(), m.lock()->name(), rclcpp::Clock().now(), marker_id);
+          opt_stop_pose.value(), m.lock()->name(), rclcpp::Clock().now(), marker_id);
         appendMarkerArray(virtual_wall, &markers);
       }
 
       const auto opt_slow_pose = m.lock()->getSlowPose();
       if (!!opt_slow_pose) {
         const auto virtual_wall = createSlowDownVirtualWallMarker(
-          opt_slow_pose.get(), m.lock()->name(), rclcpp::Clock().now(), marker_id);
+          opt_slow_pose.value(), m.lock()->name(), rclcpp::Clock().now(), marker_id);
         appendMarkerArray(virtual_wall, &markers);
       }
 
       const auto opt_dead_pose = m.lock()->getDeadPose();
       if (!!opt_dead_pose) {
         const auto virtual_wall = createDeadLineVirtualWallMarker(
-          opt_dead_pose.get(), m.lock()->name(), rclcpp::Clock().now(), marker_id);
+          opt_dead_pose.value(), m.lock()->name(), rclcpp::Clock().now(), marker_id);
         appendMarkerArray(virtual_wall, &markers);
       }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -101,7 +101,7 @@ public:
   std::pair<Pose, double> getIntersectionPoseAndDistance();
 
 private:
-  boost::optional<TurnSignalInfo> getIntersectionTurnSignalInfo(
+  std::optional<TurnSignalInfo> getIntersectionTurnSignalInfo(
     const PathWithLaneId & path, const Pose & current_pose, const double current_vel,
     const size_t current_seg_idx, const RouteHandler & route_handler,
     const double nearest_dist_threshold, const double nearest_yaw_threshold);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -496,7 +496,7 @@ struct AvoidancePlanningData
   ObjectDataArray other_objects;
 
   // nearest object that should be avoid
-  boost::optional<ObjectData> stop_target_object{boost::none};
+  std::optional<ObjectData> stop_target_object{std::nullopt};
 
   // new shift point
   AvoidLineArray new_shift_line{};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/helper.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/helper.hpp
@@ -241,7 +241,7 @@ public:
       getEgoSpeed(), target_velocity, a_now, a_lim, j_lim, -1.0 * j_lim);
 
     if (!!ret) {
-      return ret.get();
+      return ret.value();
     }
 
     return std::numeric_limits<double>::max();

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/shift_line_generator.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/shift_line_generator.hpp
@@ -55,7 +55,7 @@ public:
     if (path_shifter.getShiftLines().empty()) {
       last_ = std::nullopt;
     } else {
-      last_ = path_shifter.getLastShiftLine().get();
+      last_ = path_shifter.getLastShiftLine().value();
     }
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -99,7 +99,7 @@ lanelet::ConstLanelets getExtendLanes(
 
 void insertDecelPoint(
   const Point & p_src, const double offset, const double velocity, PathWithLaneId & path,
-  boost::optional<Pose> & p_out);
+  std::optional<Pose> & p_out);
 
 void fillObjectEnvelopePolygon(
   ObjectData & object_data, const ObjectDataArray & registered_objects, const Pose & closest_pose,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/static_drivable_area.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/static_drivable_area.hpp
@@ -24,7 +24,7 @@ namespace behavior_path_planner::utils
 {
 using drivable_area_expansion::DrivableAreaExpansionParameters;
 
-boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
+std::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
 
 std::vector<DrivableLanes> cutOverlappedLanes(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/geometric_parallel_parking/geometric_parallel_parking.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/geometric_parallel_parking/geometric_parallel_parking.hpp
@@ -128,7 +128,7 @@ private:
   PathPointWithLaneId generateArcPathPoint(
     const Pose & center, const double radius, const double yaw, const bool is_left_turn,
     const bool is_forward);
-  boost::optional<Pose> calcStartPose(
+  std::optional<Pose> calcStartPose(
     const Pose & goal_pose, const lanelet::ConstLanelets & road_lanes,
     const double start_pose_offset, const double R_E_far, const bool is_forward,
     const bool left_side_parking);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/freespace_pull_over.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/freespace_pull_over.hpp
@@ -41,7 +41,7 @@ public:
 
   PullOverPlannerType getPlannerType() const override { return PullOverPlannerType::FREESPACE; }
 
-  boost::optional<PullOverPath> plan(const Pose & goal_pose) override;
+  std::optional<PullOverPath> plan(const Pose & goal_pose) override;
 
 protected:
   std::unique_ptr<AbstractPlanningAlgorithm> planner_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/geometric_pull_over.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/geometric_pull_over.hpp
@@ -45,7 +45,7 @@ public:
   Pose getCr() const { return planner_.getCr(); }
   Pose getCl() const { return planner_.getCl(); }
 
-  boost::optional<PullOverPath> plan(const Pose & goal_pose) override;
+  std::optional<PullOverPath> plan(const Pose & goal_pose) override;
 
   std::vector<PullOverPath> generatePullOverPaths(
     const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/pull_over_planner_base.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/pull_over_planner_base.hpp
@@ -22,8 +22,6 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
-#include <boost/optional.hpp>
-
 #include <memory>
 #include <utility>
 #include <vector>

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/pull_over_planner_base.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/pull_over_planner_base.hpp
@@ -127,7 +127,7 @@ public:
   }
 
   virtual PullOverPlannerType getPlannerType() const = 0;
-  virtual boost::optional<PullOverPath> plan(const Pose & goal_pose) = 0;
+  virtual std::optional<PullOverPath> plan(const Pose & goal_pose) = 0;
 
 protected:
   std::shared_ptr<const PlannerData> planner_data_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/shift_pull_over.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/shift_pull_over.hpp
@@ -38,12 +38,12 @@ public:
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> & occupancy_grid_map);
 
   PullOverPlannerType getPlannerType() const override { return PullOverPlannerType::SHIFT; };
-  boost::optional<PullOverPath> plan(const Pose & goal_pose) override;
+  std::optional<PullOverPath> plan(const Pose & goal_pose) override;
 
 protected:
   PathWithLaneId generateReferencePath(
     const lanelet::ConstLanelets & road_lanes, const Pose & end_pose) const;
-  boost::optional<PullOverPath> generatePullOverPath(
+  std::optional<PullOverPath> generatePullOverPath(
     const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,
     const Pose & goal_pose, const double lateral_jerk) const;
   static double calcBeforeShiftedArcLength(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -144,7 +144,7 @@ std::string getStrDirection(const std::string & name, const Direction direction)
 
 CandidateOutput assignToCandidate(
   const LaneChangePath & lane_change_path, const Point & ego_position);
-boost::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(
+std::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const LaneChangeModuleType type, const Direction & direction);
 
@@ -169,7 +169,7 @@ bool passParkedObject(
   const bool is_goal_in_route, const LaneChangeParameters & lane_change_parameters,
   CollisionCheckDebugMap & object_debug);
 
-boost::optional<size_t> getLeadingStaticObjectIdx(
+std::optional<size_t> getLeadingStaticObjectIdx(
   const RouteHandler & route_handler, const LaneChangePath & lane_change_path,
   const std::vector<ExtendedPredictedObject> & objects,
   const double object_check_min_road_shoulder_width, const double object_shiftable_ratio_threshold);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/safety_check.hpp
@@ -79,13 +79,13 @@ double calcMinimumLongitudinalLength(
   const double front_object_velocity, const double rear_object_velocity,
   const RSSparams & rss_params);
 
-boost::optional<PoseWithVelocityStamped> calcInterpolatedPoseWithVelocity(
+std::optional<PoseWithVelocityStamped> calcInterpolatedPoseWithVelocity(
   const std::vector<PoseWithVelocityStamped> & path, const double relative_time);
 
-boost::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
+std::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
   const std::vector<PoseWithVelocityStamped> & pred_path, const double current_time,
   const VehicleInfo & ego_info);
-boost::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
+std::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
   const std::vector<PoseWithVelocityStamped> & pred_path, const double current_time,
   const Shape & shape);
 template <typename T, typename F>

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_shifter/path_shifter.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_shifter/path_shifter.hpp
@@ -151,7 +151,7 @@ public:
 
   double getLastShiftLength() const;
 
-  boost::optional<ShiftLine> getLastShiftLine() const;
+  std::optional<ShiftLine> getLastShiftLine() const;
 
   /**
    * @brief  Calculate the theoretical lateral jerk by spline shifting for current shift_lines_.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_shifter/path_shifter.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_shifter/path_shifter.hpp
@@ -20,8 +20,6 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
 
-#include <boost/optional.hpp>
-
 #include <string>
 #include <utility>
 #include <vector>

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
@@ -105,7 +105,7 @@ PathWithLaneId calcCenterLinePath(
 
 PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 
-boost::optional<Pose> getFirstStopPoseFromPath(const PathWithLaneId & path);
+std::optional<Pose> getFirstStopPoseFromPath(const PathWithLaneId & path);
 
 BehaviorModuleOutput getReferencePath(
   const lanelet::ConstLanelet & current_lane,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_goal_planner_common/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_goal_planner_common/utils.hpp
@@ -37,7 +37,7 @@ using behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
 using behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
 using behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
 
-boost::optional<double> calcFeasibleDecelDistance(
+std::optional<double> calcFeasibleDecelDistance(
   std::shared_ptr<const PlannerData> planner_data, const double acc_lim, const double jerk_lim,
   const double target_velocity);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/freespace_pull_out.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/freespace_pull_out.hpp
@@ -40,7 +40,7 @@ public:
 
   PlannerType getPlannerType() override { return PlannerType::FREESPACE; }
 
-  boost::optional<PullOutPath> plan(const Pose & start_pose, const Pose & end_pose) override;
+  std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & end_pose) override;
 
 protected:
   std::unique_ptr<AbstractPlanningAlgorithm> planner_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/geometric_pull_out.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/geometric_pull_out.hpp
@@ -29,7 +29,7 @@ public:
   explicit GeometricPullOut(rclcpp::Node & node, const StartPlannerParameters & parameters);
 
   PlannerType getPlannerType() override { return PlannerType::GEOMETRIC; };
-  boost::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
+  std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   GeometricParallelParking planner_;
   ParallelParkingParameters parallel_parking_parameters_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_planner_base.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_planner_base.hpp
@@ -58,7 +58,7 @@ public:
   }
 
   virtual PlannerType getPlannerType() = 0;
-  virtual boost::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
+  virtual std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
 
 protected:
   std::shared_ptr<const PlannerData> planner_data_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_planner_base.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_planner_base.hpp
@@ -23,8 +23,6 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
-#include <boost/optional.hpp>
-
 #include <memory>
 
 namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
@@ -37,7 +37,7 @@ public:
     std::shared_ptr<LaneDepartureChecker> & lane_departure_checker);
 
   PlannerType getPlannerType() override { return PlannerType::SHIFT; };
-  boost::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
+  std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   std::vector<PullOutPath> calcPullOutPaths(
     const RouteHandler & route_handler, const lanelet::ConstLanelets & road_lanes,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -354,7 +354,7 @@ size_t findNearestSegmentIndex(
   const auto nearest_idx =
     motion_utils::findNearestSegmentIndex(points, pose, dist_threshold, yaw_threshold);
   if (nearest_idx) {
-    return nearest_idx.get();
+    return nearest_idx.value();
   }
 
   return motion_utils::findNearestSegmentIndex(points, pose.position);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -204,9 +204,9 @@ double calcLongitudinalDistanceFromEgoToObjects(
 // drivable area generation
 lanelet::ConstLanelets transformToLanelets(const DrivableLanes & drivable_lanes);
 lanelet::ConstLanelets transformToLanelets(const std::vector<DrivableLanes> & drivable_lanes);
-boost::optional<lanelet::ConstLanelet> getRightLanelet(
+std::optional<lanelet::ConstLanelet> getRightLanelet(
   const lanelet::ConstLanelet & current_lane, const lanelet::ConstLanelets & shoulder_lanes);
-boost::optional<lanelet::ConstLanelet> getLeftLanelet(
+std::optional<lanelet::ConstLanelet> getLeftLanelet(
   const lanelet::ConstLanelet & current_lane, const lanelet::ConstLanelets & shoulder_lanes);
 // goal management
 

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -368,7 +368,7 @@ BehaviorModuleOutput PlannerManager::getReferencePath(
     std::max(p.backward_path_length, p.backward_path_length + extra_margin);
 
   const auto lanelet_sequence = route_handler->getLaneletSequence(
-    root_lanelet_.get(), pose, backward_length, std::numeric_limits<double>::max());
+    root_lanelet_.value(), pose, backward_length, std::numeric_limits<double>::max());
 
   lanelet::ConstLanelet closest_lane{};
   if (lanelet::utils::query::getClosestLaneletWithConstrains(
@@ -813,18 +813,18 @@ void PlannerManager::resetRootLanelet(const std::shared_ptr<PlannerData> & data)
   // if root_lanelet is not route lanelets, reset root lanelet.
   // this can be caused by rerouting.
   const auto & route_handler = data->route_handler;
-  if (!route_handler->isRouteLanelet(root_lanelet_.get())) {
+  if (!route_handler->isRouteLanelet(root_lanelet_.value())) {
     root_lanelet_ = root_lanelet;
     return;
   }
 
   // check ego is in same lane
-  if (root_lanelet_.get().id() == root_lanelet.id()) {
+  if (root_lanelet_.value().id() == root_lanelet.id()) {
     return;
   }
 
   // check ego is in next lane
-  const auto next_lanelets = route_handler->getRoutingGraphPtr()->following(root_lanelet_.get());
+  const auto next_lanelets = route_handler->getRoutingGraphPtr()->following(root_lanelet_.value());
   for (const auto & next : next_lanelets) {
     if (next.id() == root_lanelet.id()) {
       return;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -424,7 +424,7 @@ bool AvoidanceModule::canYieldManeuver(const AvoidancePlanningData & data) const
   const auto stopped_for_the_object =
     getEgoSpeed() < TH_STOP_SPEED && std::abs(data.to_stop_line) < TH_STOP_POSITION;
 
-  const auto id = data.stop_target_object.get().object.object_id;
+  const auto id = data.stop_target_object.value().object.object_id;
   const auto same_id_obj = std::find_if(
     ego_stopped_objects_.begin(), ego_stopped_objects_.end(),
     [&id](const auto & o) { return o.object.object_id == id; });
@@ -436,7 +436,7 @@ bool AvoidanceModule::canYieldManeuver(const AvoidancePlanningData & data) const
 
   // registered objects whom the ego stopped for at the moment of stopping.
   if (stopped_for_the_object) {
-    ego_stopped_objects_.push_back(data.stop_target_object.get());
+    ego_stopped_objects_.push_back(data.stop_target_object.value());
   }
 
   return true;
@@ -610,7 +610,7 @@ void AvoidanceModule::fillDebugData(
     return;
   }
 
-  const auto o_front = data.stop_target_object.get();
+  const auto o_front = data.stop_target_object.value();
   const auto object_type = utils::getHighestProbLabel(o_front.object.classification);
   const auto object_parameter = parameters_->object_parameters.at(object_type);
   const auto & additional_buffer_longitudinal =
@@ -1572,7 +1572,7 @@ void AvoidanceModule::insertWaitPoint(
   }
 
   // If target object can be stopped for, insert a deceleration point and return
-  if (data.stop_target_object.get().is_stoppable) {
+  if (data.stop_target_object.value().is_stoppable) {
     utils::avoidance::insertDecelPoint(
       getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
     return;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -790,13 +790,13 @@ std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> DynamicAvoidanceModule
     // left lane
     const auto opt_left_lane = rh->getLeftLanelet(lane);
     if (opt_left_lane) {
-      left_lanes.push_back(opt_left_lane.get());
+      left_lanes.push_back(opt_left_lane.value());
     }
 
     // right lane
     const auto opt_right_lane = rh->getRightLanelet(lane);
     if (opt_right_lane) {
-      right_lanes.push_back(opt_right_lane.get());
+      right_lanes.push_back(opt_right_lane.value());
     }
 
     const auto right_opposite_lanes = rh->getRightOppositeLanelets(lane);

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -1703,7 +1703,7 @@ bool GoalPlannerModule::isCrossingPossible(
     if (neighboring_lane) {
       // Check if the neighboring lane is in the end_lane_sequence
       end_it =
-        std::find(end_lane_sequence.rbegin(), end_lane_sequence.rend(), neighboring_lane.get());
+        std::find(end_lane_sequence.rbegin(), end_lane_sequence.rend(), neighboring_lane.value());
       if (end_it != end_lane_sequence.rend()) {
         return true;
       }

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -1155,7 +1156,7 @@ PathWithLaneId GoalPlannerModule::generateStopPath() const
   //     (In the case of the curve lane, the position is not aligned due to the
   //     difference between the outer and inner sides)
   // 4. feasible stop
-  const auto stop_pose = std::invoke([&]() -> boost::optional<Pose> {
+  const auto stop_pose = std::invoke([&]() -> std::optional<Pose> {
     if (thread_safe_data_.foundPullOverPath()) {
       return thread_safe_data_.get_pull_over_path()->start_pose;
     }
@@ -1163,7 +1164,7 @@ PathWithLaneId GoalPlannerModule::generateStopPath() const
       return thread_safe_data_.get_closest_start_pose().value();
     }
     if (!decel_pose) {
-      return boost::optional<Pose>{};
+      return std::nullopt;
     }
     return decel_pose.value();
   });
@@ -1665,7 +1666,7 @@ bool GoalPlannerModule::isCrossingPossible(
 
   // Lambda function to get the neighboring lanelet based on left_side_parking_
   auto getNeighboringLane =
-    [&](const lanelet::ConstLanelet & lane) -> boost::optional<lanelet::ConstLanelet> {
+    [&](const lanelet::ConstLanelet & lane) -> std::optional<lanelet::ConstLanelet> {
     lanelet::ConstLanelet neighboring_lane{};
     if (left_side_parking_) {
       if (route_handler->getLeftShoulderLanelet(lane, &neighboring_lane)) {
@@ -1698,7 +1699,7 @@ bool GoalPlannerModule::isCrossingPossible(
     }
 
     // Traverse the lanes horizontally until the end_lane_sequence is reached
-    boost::optional<lanelet::ConstLanelet> neighboring_lane = getNeighboringLane(current_lane);
+    std::optional<lanelet::ConstLanelet> neighboring_lane = getNeighboringLane(current_lane);
     if (neighboring_lane) {
       // Check if the neighboring lane is in the end_lane_sequence
       end_it =

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -483,7 +483,7 @@ lanelet::ConstLanelets NormalLaneChange::getLaneChangeLanes(
   const auto backward_length = lane_change_parameters_->backward_lane_length;
 
   return route_handler->getLaneletSequence(
-    lane_change_lane.get(), getEgoPose(), backward_length, forward_length);
+    lane_change_lane.value(), getEgoPose(), backward_length, forward_length);
 }
 
 bool NormalLaneChange::isNearEndOfCurrentLanes(

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -122,7 +122,7 @@ bool SideShiftModule::canTransitSuccessState()
   const auto isOffsetDiffAlmostZero = [this]() noexcept {
     const auto last_sp = path_shifter_.getLastShiftLine();
     if (last_sp) {
-      const auto length = std::fabs(last_sp.get().end_shift_length);
+      const auto length = std::fabs(last_sp.value().end_shift_length);
       const auto lateral_offset = std::fabs(requested_lateral_offset_);
       const auto offset_diff = lateral_offset - length;
       if (!isAlmostZero(offset_diff)) {

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -124,7 +124,7 @@ std::pair<Pose, double> TurnSignalDecider::getIntersectionPoseAndDistance()
   return std::make_pair(intersection_pose_point_, intersection_distance_);
 }
 
-boost::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
+std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
   const PathWithLaneId & path, const Pose & current_pose, const double current_vel,
   const size_t current_seg_idx, const RouteHandler & route_handler,
   const double nearest_dist_threshold, const double nearest_yaw_threshold)

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -1047,7 +1047,7 @@ lanelet::ConstLanelets getExtendLanes(
 
 void insertDecelPoint(
   const Point & p_src, const double offset, const double velocity, PathWithLaneId & path,
-  boost::optional<Pose> & p_out)
+  std::optional<Pose> & p_out)
 {
   const auto decel_point = calcLongitudinalOffsetPoint(path.points, p_src, offset);
 

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -975,14 +975,14 @@ lanelet::ConstLanelets getTargetLanelets(
 
     const auto opt_left_lane = rh->getLeftLanelet(lane);
     if (opt_left_lane) {
-      target_lanelets.push_back(opt_left_lane.get());
+      target_lanelets.push_back(opt_left_lane.value());
     } else {
       l_offset = left_offset;
     }
 
     const auto opt_right_lane = rh->getRightLanelet(lane);
     if (opt_right_lane) {
-      target_lanelets.push_back(opt_right_lane.get());
+      target_lanelets.push_back(opt_right_lane.value());
     } else {
       r_offset = right_offset;
     }
@@ -1056,8 +1056,8 @@ void insertDecelPoint(
     return;
   }
 
-  const auto seg_idx = findNearestSegmentIndex(path.points, decel_point.get());
-  const auto insert_idx = insertTargetPoint(seg_idx, decel_point.get(), path.points);
+  const auto seg_idx = findNearestSegmentIndex(path.points, decel_point.value());
+  const auto insert_idx = insertTargetPoint(seg_idx, decel_point.value(), path.points);
 
   if (!insert_idx) {
     // TODO(Satoshi OTA)  Think later the process in the case of no decel point found.
@@ -1065,7 +1065,7 @@ void insertDecelPoint(
   }
 
   const auto insertVelocity = [&insert_idx](PathWithLaneId & path, const float v) {
-    for (size_t i = insert_idx.get(); i < path.points.size(); ++i) {
+    for (size_t i = insert_idx.value(); i < path.points.size(); ++i) {
       const auto & original_velocity = path.points.at(i).point.longitudinal_velocity_mps;
       path.points.at(i).point.longitudinal_velocity_mps = std::min(original_velocity, v);
     }
@@ -1073,7 +1073,7 @@ void insertDecelPoint(
 
   insertVelocity(path, velocity);
 
-  p_out = getPose(path.points.at(insert_idx.get()));
+  p_out = getPose(path.points.at(insert_idx.value()));
 }
 
 void fillObjectEnvelopePolygon(
@@ -1677,12 +1677,12 @@ lanelet::ConstLanelets getAdjacentLane(
   for (const auto & lane : ego_succeeding_lanes) {
     const auto opt_left_lane = rh->getLeftLanelet(lane);
     if (!is_right_shift && opt_left_lane) {
-      lanes.push_back(opt_left_lane.get());
+      lanes.push_back(opt_left_lane.value());
     }
 
     const auto opt_right_lane = rh->getRightLanelet(lane);
     if (is_right_shift && opt_right_lane) {
-      lanes.push_back(opt_right_lane.get());
+      lanes.push_back(opt_right_lane.value());
     }
 
     const auto right_opposite_lanes = rh->getRightOppositeLanelets(lane);

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -106,7 +106,7 @@ geometry_msgs::msg::Point calcLongitudinalOffsetGoalPoint(
 
 namespace behavior_path_planner::utils::drivable_area_processing
 {
-boost::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectBound(
+std::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectBound(
   const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2,
   const std::vector<geometry_msgs::msg::Point> & bound, const size_t seg_idx1,
   const size_t seg_idx2)
@@ -125,7 +125,7 @@ boost::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectBound(
       return result;
     }
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 double calcDistanceFromPointToSegment(
@@ -515,7 +515,7 @@ namespace behavior_path_planner::utils
 {
 using tier4_autoware_utils::Point2d;
 
-boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
+std::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
 {
   auto overlaps = [](const DrivableLanes & lanes, const DrivableLanes & target_lanes) {
     const auto lanelets = utils::transformToLanelets(lanes);
@@ -1447,7 +1447,7 @@ void makeBoundLongitudinallyMonotonic(
 
   const auto get_intersect_idx = [](
                                    const auto & bound_with_pose, const auto start_idx,
-                                   const auto & p1, const auto & p2) -> boost::optional<size_t> {
+                                   const auto & p1, const auto & p2) -> std::optional<size_t> {
     std::vector<std::pair<size_t, Point>> intersects;
     for (size_t i = start_idx; i < bound_with_pose.size() - 1; i++) {
       const auto opt_intersect =
@@ -1461,7 +1461,7 @@ void makeBoundLongitudinallyMonotonic(
     }
 
     if (intersects.empty()) {
-      return boost::none;
+      return std::nullopt;
     }
 
     std::sort(intersects.begin(), intersects.end(), [&](const auto & a, const auto & b) {

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -88,7 +88,7 @@ geometry_msgs::msg::Point calcLongitudinalOffsetStartPoint(
   const auto offset_point =
     motion_utils::calcLongitudinalOffsetPoint(points, nearest_segment_idx, offset_length + offset);
 
-  return offset_point ? offset_point.get() : points.at(nearest_segment_idx);
+  return offset_point ? offset_point.value() : points.at(nearest_segment_idx);
 }
 
 geometry_msgs::msg::Point calcLongitudinalOffsetGoalPoint(
@@ -100,7 +100,7 @@ geometry_msgs::msg::Point calcLongitudinalOffsetGoalPoint(
   const auto offset_point =
     motion_utils::calcLongitudinalOffsetPoint(points, nearest_segment_idx, offset_length + offset);
 
-  return offset_point ? offset_point.get() : points.at(nearest_segment_idx + 1);
+  return offset_point ? offset_point.value() : points.at(nearest_segment_idx + 1);
 }
 }  // namespace
 
@@ -444,7 +444,7 @@ std::vector<PolygonPoint> getPolygonPointsInsideBounds(
     const auto start_point_on_bound = motion_utils::calcLongitudinalOffsetPoint(
       bound, start_point.bound_seg_idx, start_point.lon_dist_to_segment);
     if (start_point_on_bound) {
-      start_point.point = start_point_on_bound.get();
+      start_point.point = start_point_on_bound.value();
       valid_inside_polygon.insert(valid_inside_polygon.begin(), start_point);
     }
   }
@@ -453,7 +453,7 @@ std::vector<PolygonPoint> getPolygonPointsInsideBounds(
     const auto end_point_on_bound = motion_utils::calcLongitudinalOffsetPoint(
       bound, end_point.bound_seg_idx, end_point.lon_dist_to_segment);
     if (end_point_on_bound) {
-      end_point.point = end_point_on_bound.get();
+      end_point.point = end_point_on_bound.value();
       valid_inside_polygon.insert(valid_inside_polygon.end(), end_point);
     }
   }
@@ -1492,7 +1492,7 @@ void makeBoundLongitudinallyMonotonic(
       }
 
       if (i + 1 == path_points.size()) {
-        for (size_t j = intersect_idx.get(); j < bound_with_pose.size(); j++) {
+        for (size_t j = intersect_idx.value(); j < bound_with_pose.size(); j++) {
           if (j + 1 == bound_with_pose.size()) {
             const auto yaw =
               calcAzimuthAngle(bound_with_pose.at(j - 1).position, bound_with_pose.at(j).position);
@@ -1504,14 +1504,14 @@ void makeBoundLongitudinallyMonotonic(
           }
         }
       } else {
-        for (size_t j = intersect_idx.get() + 1; j < bound_with_pose.size(); j++) {
+        for (size_t j = intersect_idx.value() + 1; j < bound_with_pose.size(); j++) {
           set_orientation(ret, j, getPose(path_points.at(i)).orientation);
         }
       }
 
       constexpr size_t OVERLAP_CHECK_NUM = 3;
       start_bound_idx =
-        intersect_idx.get() < OVERLAP_CHECK_NUM ? 0 : intersect_idx.get() - OVERLAP_CHECK_NUM;
+        intersect_idx.value() < OVERLAP_CHECK_NUM ? 0 : intersect_idx.value() - OVERLAP_CHECK_NUM;
     }
 
     return ret;

--- a/planning/behavior_path_planner/src/utils/geometric_parallel_parking/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/utils/geometric_parallel_parking/geometric_parallel_parking.cpp
@@ -23,6 +23,8 @@
 #include <interpolation/spline_interpolation.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
 
+#include <optional>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -341,7 +343,7 @@ std::optional<Pose> GeometricParallelParking::calcStartPose(
                       : std::pow(R_E_far, 2) - std::pow(arc_coordinates.distance / 2 + R_E_far, 2);
   if (squared_distance_to_arc_connect < 0) {
     // may be current_pose is behind the lane
-    return boost::none;
+    return std::nullopt;
   }
   const double dx_sign = is_forward ? -1 : 1;
   const double dx = 2 * std::sqrt(squared_distance_to_arc_connect) * dx_sign;

--- a/planning/behavior_path_planner/src/utils/geometric_parallel_parking/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/utils/geometric_parallel_parking/geometric_parallel_parking.cpp
@@ -326,7 +326,7 @@ bool GeometricParallelParking::planPullOut(
   return false;
 }
 
-boost::optional<Pose> GeometricParallelParking::calcStartPose(
+std::optional<Pose> GeometricParallelParking::calcStartPose(
   const Pose & goal_pose, const lanelet::ConstLanelets & road_lanes, const double start_pose_offset,
   const double R_E_far, const bool is_forward, const bool left_side_parking)
 {

--- a/planning/behavior_path_planner/src/utils/goal_planner/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/freespace_pull_over.cpp
@@ -44,7 +44,7 @@ FreespacePullOver::FreespacePullOver(
   }
 }
 
-boost::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
+std::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
 {
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
 

--- a/planning/behavior_path_planner/src/utils/goal_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/geometric_pull_over.cpp
@@ -39,7 +39,7 @@ GeometricPullOver::GeometricPullOver(
   planner_.setParameters(parallel_parking_parameters_);
 }
 
-boost::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
+std::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
 {
   const auto & route_handler = planner_data_->route_handler;
 

--- a/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
@@ -23,7 +23,6 @@
 #include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 
 #include <boost/geometry/algorithms/union.hpp>
-#include <boost/optional.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
 

--- a/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
@@ -36,7 +36,7 @@ ShiftPullOver::ShiftPullOver(
   left_side_parking_{parameters.parking_policy == ParkingPolicy::LEFT_SIDE}
 {
 }
-boost::optional<PullOverPath> ShiftPullOver::plan(const Pose & goal_pose)
+std::optional<PullOverPath> ShiftPullOver::plan(const Pose & goal_pose)
 {
   const auto & route_handler = planner_data_->route_handler;
   const double min_jerk = parameters_.minimum_lateral_jerk;
@@ -99,7 +99,7 @@ PathWithLaneId ShiftPullOver::generateReferencePath(
   return road_lane_reference_path;
 }
 
-boost::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
+std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
   const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,
   const Pose & goal_pose, const double lateral_jerk) const
 {

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -752,7 +752,7 @@ CandidateOutput assignToCandidate(
   return candidate_output;
 }
 
-boost::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(
+std::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const LaneChangeModuleType type, const Direction & direction)
 {
@@ -996,7 +996,7 @@ bool passParkedObject(
   return false;
 }
 
-boost::optional<size_t> getLeadingStaticObjectIdx(
+std::optional<size_t> getLeadingStaticObjectIdx(
   const RouteHandler & route_handler, const LaneChangePath & lane_change_path,
   const std::vector<ExtendedPredictedObject> & objects,
   const double object_check_min_road_shoulder_width, const double object_shiftable_ratio_threshold)
@@ -1011,7 +1011,7 @@ boost::optional<size_t> getLeadingStaticObjectIdx(
   const auto & path_end = path.points.back();
 
   double dist_lc_start_to_leading_obj = 0.0;
-  boost::optional<size_t> leading_obj_idx = boost::none;
+  std::optional<size_t> leading_obj_idx = std::nullopt;
   for (size_t obj_idx = 0; obj_idx < objects.size(); ++obj_idx) {
     const auto & obj = objects.at(obj_idx);
     const auto & obj_pose = obj.initial_pose.pose;

--- a/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
@@ -248,12 +248,12 @@ double calcMinimumLongitudinalLength(
   return rss_params.longitudinal_velocity_delta_time * std::abs(max_vel) + lon_threshold;
 }
 
-boost::optional<PoseWithVelocityStamped> calcInterpolatedPoseWithVelocity(
+std::optional<PoseWithVelocityStamped> calcInterpolatedPoseWithVelocity(
   const std::vector<PoseWithVelocityStamped> & path, const double relative_time)
 {
   // Check if relative time is in the valid range
   if (path.empty() || relative_time < 0.0) {
-    return boost::none;
+    return std::nullopt;
   }
 
   constexpr double epsilon = 1e-6;
@@ -272,10 +272,10 @@ boost::optional<PoseWithVelocityStamped> calcInterpolatedPoseWithVelocity(
     }
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
-boost::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
+std::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
   const std::vector<PoseWithVelocityStamped> & pred_path, const double current_time,
   const VehicleInfo & ego_info)
 {
@@ -298,7 +298,7 @@ boost::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVeloci
   return PoseWithVelocityAndPolygonStamped{current_time, pose, velocity, ego_polygon};
 }
 
-boost::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
+std::optional<PoseWithVelocityAndPolygonStamped> getInterpolatedPoseWithVelocityAndPolygonStamped(
   const std::vector<PoseWithVelocityAndPolygonStamped> & pred_path, const double current_time,
   const Shape & shape)
 {

--- a/planning/behavior_path_planner/src/utils/path_shifter/path_shifter.cpp
+++ b/planning/behavior_path_planner/src/utils/path_shifter/path_shifter.cpp
@@ -630,7 +630,7 @@ double PathShifter::getLastShiftLength() const
   return furthest->end_shift_length;
 }
 
-boost::optional<ShiftLine> PathShifter::getLastShiftLine() const
+std::optional<ShiftLine> PathShifter::getLastShiftLine() const
 {
   if (shift_lines_.empty()) {
     return {};

--- a/planning/behavior_path_planner/src/utils/start_goal_planner_common/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/start_goal_planner_common/utils.cpp
@@ -19,7 +19,7 @@ namespace behavior_path_planner::utils::start_goal_planner_common
 
 using motion_utils::calcDecelDistWithJerkAndAccConstraints;
 
-boost::optional<double> calcFeasibleDecelDistance(
+std::optional<double> calcFeasibleDecelDistance(
   std::shared_ptr<const PlannerData> planner_data, const double acc_lim, const double jerk_lim,
   const double target_velocity)
 {

--- a/planning/behavior_path_planner/src/utils/start_planner/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/freespace_pull_out.cpp
@@ -44,7 +44,7 @@ FreespacePullOut::FreespacePullOut(
   }
 }
 
-boost::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const Pose & end_pose)
+std::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const Pose & end_pose)
 {
   const auto & route_handler = planner_data_->route_handler;
   const double backward_path_length = planner_data_->parameters.backward_path_length;

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -37,7 +37,7 @@ GeometricPullOut::GeometricPullOut(rclcpp::Node & node, const StartPlannerParame
   planner_.setParameters(parallel_parking_parameters_);
 }
 
-boost::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const Pose & goal_pose)
+std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const Pose & goal_pose)
 {
   PullOutPath output;
 

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -42,7 +42,7 @@ ShiftPullOut::ShiftPullOut(
 {
 }
 
-boost::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pose & goal_pose)
+std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pose & goal_pose)
 {
   const auto & route_handler = planner_data_->route_handler;
   const auto & common_parameters = planner_data_->parameters;
@@ -52,7 +52,7 @@ boost::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const P
     planner_data_->parameters.backward_path_length + parameters_.max_back_distance;
   const auto pull_out_lanes = getPullOutLanes(planner_data_, backward_path_length);
   if (pull_out_lanes.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const auto road_lanes = utils::getExtendedCurrentLanes(
@@ -61,7 +61,7 @@ boost::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const P
   // find candidate paths
   auto pull_out_paths = calcPullOutPaths(*route_handler, road_lanes, start_pose, goal_pose);
   if (pull_out_paths.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // extract stop objects in pull out lane for collision check
@@ -155,7 +155,7 @@ boost::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const P
     return pull_out_path;
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
 std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(

--- a/planning/behavior_path_planner/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/traffic_light_utils.cpp
@@ -85,7 +85,7 @@ double getDistanceToNextTrafficLight(
     lanelet::utils::to2D(lanelet_point).basicPoint());
 
   for (const auto & element : current_lanelet.regulatoryElementsAs<lanelet::TrafficLight>()) {
-    lanelet::ConstLineString3d lanelet_stop_lines = element->stopLine().get();
+    lanelet::ConstLineString3d lanelet_stop_lines = element->stopLine().value();
 
     const auto to_stop_line = lanelet::geometry::toArcCoordinates(
       lanelet::utils::to2D(current_lanelet.centerline()),
@@ -112,7 +112,7 @@ double getDistanceToNextTrafficLight(
     }
 
     for (const auto & element : llt.regulatoryElementsAs<lanelet::TrafficLight>()) {
-      lanelet::ConstLineString3d lanelet_stop_lines = element->stopLine().get();
+      lanelet::ConstLineString3d lanelet_stop_lines = element->stopLine().value();
 
       const auto to_stop_line = lanelet::geometry::toArcCoordinates(
         lanelet::utils::to2D(llt.centerline()),

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -356,7 +356,7 @@ bool setGoal(
     if (!min_dist_out_of_circle_index_opt) {
       return false;
     }
-    const size_t min_dist_out_of_circle_index = min_dist_out_of_circle_index_opt.get();
+    const size_t min_dist_out_of_circle_index = min_dist_out_of_circle_index_opt.value();
 
     // create output points
     output_ptr->points.reserve(output_ptr->points.size() + min_dist_out_of_circle_index + 3);
@@ -935,23 +935,23 @@ std::optional<double> getSignedDistanceFromBoundary(
   }
   // If only one of them found the closest bound, return the found lateral distance.
   if (!rear_lateral_distance_with_idx) {
-    return front_lateral_distance_with_idx.get().first;
+    return front_lateral_distance_with_idx.value().first;
   } else if (!front_lateral_distance_with_idx) {
-    return rear_lateral_distance_with_idx.get().first;
+    return rear_lateral_distance_with_idx.value().first;
   }
   // If both corners found their closest bound, return the maximum (for left side) or the minimum
   // (for right side) lateral distance.
-  double lateral_distance =
-    left_side
-      ? std::max(
-          rear_lateral_distance_with_idx.get().first, front_lateral_distance_with_idx.get().first)
-      : std::min(
-          rear_lateral_distance_with_idx.get().first, front_lateral_distance_with_idx.get().first);
+  double lateral_distance = left_side ? std::max(
+                                          rear_lateral_distance_with_idx.value().first,
+                                          front_lateral_distance_with_idx.value().first)
+                                      : std::min(
+                                          rear_lateral_distance_with_idx.value().first,
+                                          front_lateral_distance_with_idx.value().first);
 
   // Iterate through all segments between the segments closest to the rear and front corners.
   // Update the lateral distance in case any of these inner segments are closer to the vehicle.
-  for (size_t i = rear_lateral_distance_with_idx.get().second + 1;
-       i < front_lateral_distance_with_idx.get().second; i++) {
+  for (size_t i = rear_lateral_distance_with_idx.value().second + 1;
+       i < front_lateral_distance_with_idx.value().second; i++) {
     Pose bound_pose;
     bound_pose.position = lanelet::utils::conversion::toGeomMsgPt(bound_line_2d[i]);
     bound_pose.orientation = vehicle_pose.orientation;

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -271,13 +271,13 @@ bool exists(std::vector<T> vec, T element)
   return std::find(vec.begin(), vec.end(), element) != vec.end();
 }
 
-boost::optional<size_t> findIndexOutOfGoalSearchRange(
+std::optional<size_t> findIndexOutOfGoalSearchRange(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const Pose & goal, const int64_t goal_lane_id,
   const double max_dist = std::numeric_limits<double>::max())
 {
   if (points.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // find goal index
@@ -299,7 +299,7 @@ boost::optional<size_t> findIndexOutOfGoalSearchRange(
       }
     }
     if (!found) {
-      return boost::none;
+      return std::nullopt;
     }
   }
 
@@ -627,7 +627,7 @@ lanelet::ConstLanelets transformToLanelets(const std::vector<DrivableLanes> & dr
   return lanes;
 }
 
-boost::optional<lanelet::ConstLanelet> getRightLanelet(
+std::optional<lanelet::ConstLanelet> getRightLanelet(
   const lanelet::ConstLanelet & current_lane, const lanelet::ConstLanelets & shoulder_lanes)
 {
   for (const auto & shoulder_lane : shoulder_lanes) {
@@ -639,7 +639,7 @@ boost::optional<lanelet::ConstLanelet> getRightLanelet(
   return {};
 }
 
-boost::optional<lanelet::ConstLanelet> getLeftLanelet(
+std::optional<lanelet::ConstLanelet> getLeftLanelet(
   const lanelet::ConstLanelet & current_lane, const lanelet::ConstLanelets & shoulder_lanes)
 {
   for (const auto & shoulder_lane : shoulder_lanes) {
@@ -881,12 +881,12 @@ std::optional<double> getSignedDistanceFromBoundary(
   // Find the closest bound segment that contains the corner point in the X-direction
   // and calculate the lateral distance from that segment.
   const auto calcLateralDistanceFromBound =
-    [&](const Point & vehicle_corner_point) -> boost::optional<std::pair<double, size_t>> {
+    [&](const Point & vehicle_corner_point) -> std::optional<std::pair<double, size_t>> {
     Pose vehicle_corner_pose{};
     vehicle_corner_pose.position = vehicle_corner_point;
     vehicle_corner_pose.orientation = vehicle_pose.orientation;
 
-    boost::optional<std::pair<double, size_t>> lateral_distance_with_idx{};
+    std::optional<std::pair<double, size_t>> lateral_distance_with_idx{};
 
     // Euclidean distance to find the closest segment containing the corner point.
     double min_distance = std::numeric_limits<double>::max();
@@ -920,13 +920,13 @@ std::optional<double> getSignedDistanceFromBoundary(
     if (lateral_distance_with_idx) {
       return lateral_distance_with_idx;
     }
-    return boost::optional<std::pair<double, size_t>>{};
+    return std::nullopt;
   };
 
   // Calculate the lateral distance for both the rear and front corners of the vehicle.
-  const boost::optional<std::pair<double, size_t>> rear_lateral_distance_with_idx =
+  const std::optional<std::pair<double, size_t>> rear_lateral_distance_with_idx =
     calcLateralDistanceFromBound(rear_corner_point);
-  const boost::optional<std::pair<double, size_t>> front_lateral_distance_with_idx =
+  const std::optional<std::pair<double, size_t>> front_lateral_distance_with_idx =
     calcLateralDistanceFromBound(front_corner_point);
 
   // If no closest bound segment was found for both corners, return an empty optional.
@@ -1325,7 +1325,7 @@ lanelet::ConstLanelets extendNextLane(
   // Add next lane
   const auto next_lanes = route_handler->getNextLanelets(extended_lanes.back());
   if (!next_lanes.empty()) {
-    boost::optional<lanelet::ConstLanelet> target_next_lane;
+    std::optional<lanelet::ConstLanelet> target_next_lane;
     if (!only_in_route) {
       target_next_lane = next_lanes.front();
     }
@@ -1354,7 +1354,7 @@ lanelet::ConstLanelets extendPrevLane(
   // Add previous lane
   const auto prev_lanes = route_handler->getPreviousLanelets(extended_lanes.front());
   if (!prev_lanes.empty()) {
-    boost::optional<lanelet::ConstLanelet> target_prev_lane;
+    std::optional<lanelet::ConstLanelet> target_prev_lane;
     if (!only_in_route) {
       target_prev_lane = prev_lanes.front();
     }

--- a/planning/behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.cpp
@@ -130,7 +130,7 @@ bool BlindSpotModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
     *path = input_path;  // reset path
     return false;
   }
-  const size_t closest_idx = closest_idx_opt.get();
+  const size_t closest_idx = closest_idx_opt.value();
 
   /* set judge line dist */
   const double current_vel = planner_data_->current_velocity->twist.linear.x;
@@ -141,7 +141,7 @@ bool BlindSpotModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   const auto stop_point_pose = path->points.at(stop_line_idx).point.pose;
   const auto ego_segment_idx =
     motion_utils::findNearestSegmentIndex(input_path.points, current_pose);
-  if (ego_segment_idx == boost::none) return true;
+  if (!ego_segment_idx) return true;
   const size_t stop_point_segment_idx =
     motion_utils::findNearestSegmentIndex(input_path.points, stop_point_pose.position);
   const auto distance_until_stop = motion_utils::calcSignedArcLength(
@@ -258,8 +258,8 @@ bool BlindSpotModule::generateStopLine(
       RCLCPP_DEBUG(logger_, "No conflicting line found.");
       return false;
     }
-    stop_idx_ip =
-      std::max(first_idx_conflicting_lane_opt.get() - 1 - margin_idx_dist - base2front_idx_dist, 0);
+    stop_idx_ip = std::max(
+      first_idx_conflicting_lane_opt.value() - 1 - margin_idx_dist - base2front_idx_dist, 0);
   } else {
     boost::optional<geometry_msgs::msg::Pose> intersection_enter_point_opt =
       getStartPointFromLaneLet(lane_id_);
@@ -269,11 +269,11 @@ bool BlindSpotModule::generateStopLine(
     }
 
     geometry_msgs::msg::Pose intersection_enter_pose;
-    intersection_enter_pose = intersection_enter_point_opt.get();
+    intersection_enter_pose = intersection_enter_point_opt.value();
     const auto stop_idx_ip_opt =
       motion_utils::findNearestIndex(path_ip.points, intersection_enter_pose, 10.0, M_PI_4);
     if (stop_idx_ip_opt) {
-      stop_idx_ip = stop_idx_ip_opt.get();
+      stop_idx_ip = stop_idx_ip_opt.value();
     }
 
     stop_idx_ip = std::max(stop_idx_ip - base2front_idx_dist, 0);
@@ -384,8 +384,8 @@ bool BlindSpotModule::checkObstacleInBlindSpot(
   const auto areas_opt = generateBlindSpotPolygons(
     lanelet_map_ptr, routing_graph_ptr, path, closest_idx, stop_line_pose);
   if (!!areas_opt) {
-    debug_data_.detection_areas_for_blind_spot = areas_opt.get().detection_areas;
-    debug_data_.conflict_areas_for_blind_spot = areas_opt.get().conflict_areas;
+    debug_data_.detection_areas_for_blind_spot = areas_opt.value().detection_areas;
+    debug_data_.conflict_areas_for_blind_spot = areas_opt.value().conflict_areas;
 
     autoware_auto_perception_msgs::msg::PredictedObjects objects = *objects_ptr;
     cutPredictPathWithDuration(&objects, planner_param_.max_future_movement_time);
@@ -397,8 +397,8 @@ bool BlindSpotModule::checkObstacleInBlindSpot(
         continue;
       }
 
-      const auto & detection_areas = areas_opt.get().detection_areas;
-      const auto & conflict_areas = areas_opt.get().conflict_areas;
+      const auto & detection_areas = areas_opt.value().detection_areas;
+      const auto & conflict_areas = areas_opt.value().conflict_areas;
       const bool exist_in_detection_area =
         std::any_of(detection_areas.begin(), detection_areas.end(), [&object](const auto & area) {
           return bg::within(
@@ -543,7 +543,7 @@ boost::optional<BlindSpotPolygons> BlindSpotModule::generateBlindSpotPolygons(
         : (turn_direction_ == TurnDirection::RIGHT ? (routing_graph_ptr->adjacentRight(lane))
                                                    : boost::none);
     if (adj) {
-      const auto half_lanelet = generateExtendedAdjacentLanelet(adj.get(), turn_direction_);
+      const auto half_lanelet = generateExtendedAdjacentLanelet(adj.value(), turn_direction_);
       adjacent_lanelets.push_back(half_lanelet);
     }
   }

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -148,15 +148,6 @@ StopFactor createStopFactor(
   return stop_factor;
 }
 
-std::optional<geometry_msgs::msg::Pose> toStdOptional(
-  const boost::optional<geometry_msgs::msg::Pose> & boost_pose)
-{
-  if (boost_pose) {
-    return *boost_pose;
-  }
-  return std::nullopt;
-}
-
 tier4_debug_msgs::msg::StringStamped createStringStampedMessage(
   const rclcpp::Time & now, const int64_t module_id_,
   const std::vector<std::tuple<std::string, CollisionPoint, CollisionState>> & collision_points)
@@ -242,8 +233,8 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
 
   std::optional<geometry_msgs::msg::Pose> default_stop_pose = std::nullopt;
   if (p_stop_line.has_value()) {
-    default_stop_pose = toStdOptional(
-      calcLongitudinalOffsetPose(path->points, p_stop_line->first, p_stop_line->second));
+    default_stop_pose =
+      calcLongitudinalOffsetPose(path->points, p_stop_line->first, p_stop_line->second);
   }
 
   // Resample path sparsely for less computation cost
@@ -486,8 +477,8 @@ std::pair<double, double> CrosswalkModule::clampAttentionRangeByNeighborCrosswal
     return std::make_pair(near_attention_range, far_attention_range);
   }
 
-  const auto near_idx = findNearestSegmentIndex(ego_path.points, p_near.get());
-  const auto far_idx = findNearestSegmentIndex(ego_path.points, p_far.get()) + 1;
+  const auto near_idx = findNearestSegmentIndex(ego_path.points, p_near.value());
+  const auto far_idx = findNearestSegmentIndex(ego_path.points, p_far.value()) + 1;
 
   std::set<int64_t> lane_ids;
   for (size_t i = near_idx; i < far_idx; ++i) {
@@ -575,8 +566,8 @@ std::pair<double, double> CrosswalkModule::clampAttentionRangeByNeighborCrosswal
     calcLongitudinalOffsetPoint(ego_path.points, ego_pos, far_attention_range);
 
   if (update_p_near && update_p_far) {
-    debug_data_.range_near_point = update_p_near.get();
-    debug_data_.range_far_point = update_p_far.get();
+    debug_data_.range_near_point = update_p_near.value();
+    debug_data_.range_far_point = update_p_far.value();
   }
 
   RCLCPP_INFO_EXPRESSION(
@@ -732,7 +723,7 @@ void CrosswalkModule::applySafetySlowDownSpeed(
     const auto & p_safety_slow =
       calcLongitudinalOffsetPoint(ego_path.points, ego_pos, safety_slow_point_range);
 
-    insertDecelPointWithDebugInfo(p_safety_slow.get(), safety_slow_down_speed, output);
+    insertDecelPointWithDebugInfo(p_safety_slow.value(), safety_slow_down_speed, output);
 
     if (safety_slow_point_range < 0.0) {
       passed_safety_slow_point_ = true;

--- a/planning/behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_detection_area_module/src/scene.cpp
@@ -110,7 +110,7 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason *
       return false;
     }
 
-    modified_stop_pose = ego_pos_on_path.get();
+    modified_stop_pose = ego_pos_on_path.value();
     modified_stop_line_seg_idx = current_seg_idx;
   }
 

--- a/planning/behavior_velocity_no_drivable_lane_module/src/scene.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/scene.cpp
@@ -57,7 +57,7 @@ bool NoDrivableLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason 
 
   if (path_no_drivable_lane_polygon_intersection.first_intersection_point) {
     first_intersection_point =
-      path_no_drivable_lane_polygon_intersection.first_intersection_point.get();
+      path_no_drivable_lane_polygon_intersection.first_intersection_point.value();
     distance_ego_first_intersection = motion_utils::calcSignedArcLength(
       path->points, planner_data_->current_odometry->pose.position, first_intersection_point);
     distance_ego_first_intersection -= planner_data_->vehicle_info_.max_longitudinal_offset_m;
@@ -141,7 +141,7 @@ void NoDrivableLaneModule::handle_approaching_state(PathWithLaneId * path, StopR
   geometry_msgs::msg::Point target_point;
 
   if (op_target_point) {
-    target_point = op_target_point.get();
+    target_point = op_target_point.value();
   }
 
   const auto target_segment_idx = motion_utils::findNearestSegmentIndex(path->points, target_point);
@@ -150,7 +150,7 @@ void NoDrivableLaneModule::handle_approaching_state(PathWithLaneId * path, StopR
     motion_utils::insertTargetPoint(target_segment_idx, target_point, path->points, 5e-2);
   size_t target_point_idx;
   if (op_target_point_idx) {
-    target_point_idx = op_target_point_idx.get();
+    target_point_idx = op_target_point_idx.value();
   }
 
   geometry_msgs::msg::Point stop_point =
@@ -162,7 +162,7 @@ void NoDrivableLaneModule::handle_approaching_state(PathWithLaneId * path, StopR
   // Get stop point and stop factor
   {
     tier4_planning_msgs::msg::StopFactor stop_factor;
-    const auto & stop_pose = op_stop_pose.get();
+    const auto & stop_pose = op_stop_pose.value();
     stop_factor.stop_pose = stop_pose;
     stop_factor.stop_factor_points.push_back(stop_point);
     planning_utils::appendStopReason(stop_factor, stop_reason);
@@ -172,7 +172,7 @@ void NoDrivableLaneModule::handle_approaching_state(PathWithLaneId * path, StopR
     const auto virtual_wall_pose = motion_utils::calcLongitudinalOffsetPose(
       path->points, stop_pose.position, debug_data_.base_link2front);
 
-    debug_data_.stop_pose = virtual_wall_pose.get();
+    debug_data_.stop_pose = virtual_wall_pose.value();
   }
 
   const size_t current_seg_idx = findEgoSegmentIndex(path->points);
@@ -225,7 +225,7 @@ void NoDrivableLaneModule::handle_inside_no_drivable_lane_state(
     const auto & virtual_wall_pose = motion_utils::calcLongitudinalOffsetPose(
       path->points, stop_pose.position, debug_data_.base_link2front);
 
-    debug_data_.stop_pose = virtual_wall_pose.get();
+    debug_data_.stop_pose = virtual_wall_pose.value();
   }
 
   // Move to stopped state if stopped
@@ -248,7 +248,7 @@ void NoDrivableLaneModule::handle_stopped_state(PathWithLaneId * path, StopReaso
   }
 
   SegmentIndexWithPose ego_pos_on_path;
-  ego_pos_on_path.pose = stopped_pose.get();
+  ego_pos_on_path.pose = stopped_pose.value();
   ego_pos_on_path.index = findEgoSegmentIndex(path->points);
 
   // Insert stop pose
@@ -267,7 +267,7 @@ void NoDrivableLaneModule::handle_stopped_state(PathWithLaneId * path, StopReaso
     const auto virtual_wall_pose = motion_utils::calcLongitudinalOffsetPose(
       path->points, stop_pose.position, debug_data_.base_link2front);
 
-    debug_data_.stop_pose = virtual_wall_pose.get();
+    debug_data_.stop_pose = virtual_wall_pose.value();
   }
 }
 

--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -298,7 +298,7 @@ Polygon2d NoStoppingAreaModule::generateEgoNoStoppingAreaLanePolygon(
       logger_, *clock_, 1000 /* ms */, "motion_utils::findNearestIndex fail");
     return ego_area;
   }
-  const size_t closest_idx = closest_idx_opt.get();
+  const size_t closest_idx = closest_idx_opt.value();
 
   const int num_ignore_nearest = 1;  // Do not consider nearest lane polygon
   size_t ego_area_start_idx = closest_idx + num_ignore_nearest;

--- a/planning/behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
@@ -112,7 +112,7 @@ bool OcclusionSpotModule::modifyPathVelocity(
   const geometry_msgs::msg::Point start_point = path_interpolated.points.at(0).point.pose.position;
   const auto ego_segment_idx = motion_utils::findNearestSegmentIndex(
     path_interpolated.points, ego_pose, param_.dist_thr, param_.angle_thr);
-  if (ego_segment_idx == boost::none) return true;
+  if (!ego_segment_idx) return true;
   const size_t start_point_segment_idx =
     motion_utils::findNearestSegmentIndex(path_interpolated.points, start_point);
   const auto offset = motion_utils::calcSignedArcLength(

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -384,7 +384,7 @@ autoware_auto_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath
 
   // TODO(someone): support backward path
   const auto is_driving_forward = motion_utils::isDrivingForward(input_path_msg->points);
-  is_driving_forward_ = is_driving_forward ? is_driving_forward.get() : is_driving_forward_;
+  is_driving_forward_ = is_driving_forward ? is_driving_forward.value() : is_driving_forward_;
   if (!is_driving_forward_) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 3000,

--- a/planning/behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner_common/src/utilization/util.cpp
@@ -629,12 +629,12 @@ boost::optional<geometry_msgs::msg::Pose> insertDecelPoint(
     return {};
   }
 
-  for (size_t i = insert_idx.get(); i < output.points.size(); ++i) {
+  for (size_t i = insert_idx.value(); i < output.points.size(); ++i) {
     const auto & original_velocity = output.points.at(i).point.longitudinal_velocity_mps;
     output.points.at(i).point.longitudinal_velocity_mps =
       std::min(original_velocity, target_velocity);
   }
-  return tier4_autoware_utils::getPose(output.points.at(insert_idx.get()));
+  return tier4_autoware_utils::getPose(output.points.at(insert_idx.value()));
 }
 
 // TODO(murooka): remove this function for u-turn and crossing-path
@@ -648,7 +648,7 @@ boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
     return {};
   }
 
-  return tier4_autoware_utils::getPose(output.points.at(insert_idx.get()));
+  return tier4_autoware_utils::getPose(output.points.at(insert_idx.value()));
 }
 
 boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
@@ -660,7 +660,7 @@ boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
     return {};
   }
 
-  return tier4_autoware_utils::getPose(output.points.at(insert_idx.get()));
+  return tier4_autoware_utils::getPose(output.points.at(insert_idx.value()));
 }
 
 std::set<lanelet::Id> getAssociativeIntersectionLanelets(

--- a/planning/behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.cpp
@@ -508,7 +508,7 @@ bool RunOutModule::checkCollisionWithPolygon() const
   return false;
 }
 
-boost::optional<geometry_msgs::msg::Pose> RunOutModule::calcStopPoint(
+std::optional<geometry_msgs::msg::Pose> RunOutModule::calcStopPoint(
   const boost::optional<DynamicObstacle> & dynamic_obstacle, const PathWithLaneId & path,
   const geometry_msgs::msg::Pose & current_pose, const float current_vel,
   const float current_acc) const
@@ -558,7 +558,7 @@ boost::optional<geometry_msgs::msg::Pose> RunOutModule::calcStopPoint(
     RCLCPP_WARN_STREAM(logger_, "failed to calculate stop distance.");
 
     // force to insert zero velocity
-    stop_dist = boost::make_optional<double>(dist_to_collision);
+    stop_dist = std::make_optional<double>(dist_to_collision);
   }
 
   debug_ptr_->setDebugValues(DebugValues::TYPE::STOP_DISTANCE, *stop_dist);
@@ -595,7 +595,7 @@ boost::optional<geometry_msgs::msg::Pose> RunOutModule::calcStopPoint(
 }
 
 void RunOutModule::insertStopPoint(
-  const boost::optional<geometry_msgs::msg::Pose> stop_point,
+  const std::optional<geometry_msgs::msg::Pose> stop_point,
   autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
   // no stop point

--- a/planning/behavior_velocity_run_out_module/src/scene.hpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.hpp
@@ -23,6 +23,7 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -106,13 +107,13 @@ private:
   std::vector<geometry_msgs::msg::Point> createBoundingBoxForRangedPoints(
     const PoseWithRange & pose_with_range, const float x_offset, const float y_offset) const;
 
-  boost::optional<geometry_msgs::msg::Pose> calcStopPoint(
+  std::optional<geometry_msgs::msg::Pose> calcStopPoint(
     const boost::optional<DynamicObstacle> & dynamic_obstacle, const PathWithLaneId & path,
     const geometry_msgs::msg::Pose & current_pose, const float current_vel,
     const float current_acc) const;
 
   void insertStopPoint(
-    const boost::optional<geometry_msgs::msg::Pose> stop_point,
+    const std::optional<geometry_msgs::msg::Pose> stop_point,
     autoware_auto_planning_msgs::msg::PathWithLaneId & path);
 
   void insertVelocityForState(

--- a/planning/behavior_velocity_run_out_module/src/utils.cpp
+++ b/planning/behavior_velocity_run_out_module/src/utils.cpp
@@ -359,7 +359,7 @@ Polygons2d createDetectionAreaPolygon(
     initial_vel, target_vel, initial_acc, planning_dec, jerk_acc, jerk_dec);
 
   if (!stop_dist) {
-    stop_dist = boost::make_optional<double>(0.0);
+    stop_dist = std::make_optional<double>(0.0);
   }
 
   // create detection area polygon
@@ -403,7 +403,7 @@ Polygons2d createMandatoryDetectionAreaPolygon(
     initial_vel, target_vel, initial_acc, planning_dec, jerk_acc, jerk_dec);
 
   if (!stop_dist) {
-    stop_dist = boost::make_optional<double>(0.0);
+    stop_dist = std::make_optional<double>(0.0);
   }
 
   // create detection area polygon

--- a/planning/behavior_velocity_speed_bump_module/src/util.cpp
+++ b/planning/behavior_velocity_speed_bump_module/src/util.cpp
@@ -142,7 +142,7 @@ bool insertConstSpeedToPathSection(
   return true;
 }
 
-boost::optional<size_t> insertPointWithOffset(
+std::optional<size_t> insertPointWithOffset(
   const geometry_msgs::msg::Point & src_point, const double longitudinal_offset,
   std::vector<PathPointWithLaneId> & output, const double overlap_threshold)
 {

--- a/planning/behavior_velocity_speed_bump_module/src/util.hpp
+++ b/planning/behavior_velocity_speed_bump_module/src/util.hpp
@@ -20,6 +20,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -62,7 +63,7 @@ bool insertConstSpeedToPathSection(
   std::vector<PathPointWithLaneId> & output, const size_t start_idx, const size_t end_idx,
   const float speed);
 
-boost::optional<size_t> insertPointWithOffset(
+std::optional<size_t> insertPointWithOffset(
   const geometry_msgs::msg::Point & src_point, const double longitudinal_offset,
   std::vector<PathPointWithLaneId> & output, const double overlap_threshold = 1e-3);
 

--- a/planning/behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_stop_line_module/src/scene.cpp
@@ -124,7 +124,7 @@ bool StopLineModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop
       }
 
       SegmentIndexWithPose ego_pos_on_path;
-      ego_pos_on_path.pose = stopped_pose.get();
+      ego_pos_on_path.pose = stopped_pose.value();
       ego_pos_on_path.index = findEgoSegmentIndex(path->points);
 
       // Insert stop pose

--- a/planning/behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -555,7 +555,7 @@ void VirtualTrafficLightModule::insertStopVelocityAtStopLine(
         motion_utils::calcLongitudinalOffsetPoint(path->points, ego_pose.position, 0.0);
 
       if (ego_pos_on_path) {
-        new_collision.point = ego_pos_on_path.get();
+        new_collision.point = ego_pos_on_path.value();
         new_collision.index = ego_seg_idx;
         insertStopVelocityAtCollision(new_collision, 0.0, path);
       }

--- a/planning/behavior_velocity_walkway_module/src/scene_walkway.cpp
+++ b/planning/behavior_velocity_walkway_module/src/scene_walkway.cpp
@@ -128,11 +128,11 @@ bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_
 
     /* get stop point and stop factor */
     StopFactor stop_factor;
-    stop_factor.stop_pose = stop_pose.get();
+    stop_factor.stop_pose = stop_pose.value();
     stop_factor.stop_factor_points.push_back(path_intersects.front());
     planning_utils::appendStopReason(stop_factor, stop_reason);
     velocity_factor_.set(
-      path->points, planner_data_->current_odometry->pose, stop_pose.get(),
+      path->points, planner_data_->current_odometry->pose, stop_pose.value(),
       VelocityFactor::UNKNOWN);
 
     // use arc length to identify if ego vehicle is in front of walkway stop or not.

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -698,14 +698,14 @@ void MotionVelocitySmootherNode::insertBehindVelocity(
           prev_output_, output.at(i).pose, node_param_.ego_nearest_dist_threshold,
           node_param_.ego_nearest_yaw_threshold);
         if (opt_nearest_seg_idx) {
-          return opt_nearest_seg_idx.get();
+          return opt_nearest_seg_idx.value();
         }
 
         // with distance threshold
         const auto opt_second_nearest_seg_idx = motion_utils::findNearestSegmentIndex(
           prev_output_, output.at(i).pose, node_param_.ego_nearest_dist_threshold);
         if (opt_second_nearest_seg_idx) {
-          return opt_second_nearest_seg_idx.get();
+          return opt_second_nearest_seg_idx.value();
         }
 
         return motion_utils::findNearestSegmentIndex(prev_output_, output.at(i).pose.position);

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -45,7 +45,7 @@ protected:  // for the static_centerline_optimizer package
     bool isDrivingForward(const std::vector<PathPoint> & path_points)
     {
       const auto is_driving_forward = motion_utils::isDrivingForward(path_points);
-      is_driving_forward_ = is_driving_forward ? is_driving_forward.get() : is_driving_forward_;
+      is_driving_forward_ = is_driving_forward ? is_driving_forward.value() : is_driving_forward_;
       return is_driving_forward_;
     }
 

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -57,7 +57,7 @@ void setZeroVelocityAfterStopPoint(std::vector<TrajectoryPoint> & traj_points)
 {
   const auto opt_zero_vel_idx = motion_utils::searchZeroVelocityIndex(traj_points);
   if (opt_zero_vel_idx) {
-    for (size_t i = opt_zero_vel_idx.get(); i < traj_points.size(); ++i) {
+    for (size_t i = opt_zero_vel_idx.value(); i < traj_points.size(); ++i) {
       traj_points.at(i).longitudinal_velocity_mps = 0.0;
     }
   }
@@ -447,7 +447,7 @@ void ObstacleAvoidancePlanner::applyInputVelocity(
   // insert stop point explicitly
   const auto stop_idx = motion_utils::searchZeroVelocityIndex(forward_cropped_input_traj_points);
   if (stop_idx) {
-    const auto & input_stop_pose = forward_cropped_input_traj_points.at(stop_idx.get()).pose;
+    const auto & input_stop_pose = forward_cropped_input_traj_points.at(stop_idx.value()).pose;
     // NOTE: motion_utils::findNearestSegmentIndex is used instead of
     // trajectory_utils::findEgoSegmentIndex
     //       for the case where input_traj_points is much longer than output_traj_points, and the

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -502,7 +502,7 @@ void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr ms
   *debug_data_ptr_ = DebugData();
 
   const auto is_driving_forward = motion_utils::isDrivingForwardWithTwist(traj_points);
-  is_driving_forward_ = is_driving_forward ? is_driving_forward.get() : is_driving_forward_;
+  is_driving_forward_ = is_driving_forward ? is_driving_forward.value() : is_driving_forward_;
 
   // 1. Convert predicted objects to obstacles which are
   //    (1) with a proper label

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -346,12 +346,12 @@ std::tuple<double, double> OptimizationBasedPlanner::calcInitialMotion(
           rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),
           "calcInitialMotion : vehicle speed is low (%.3f), and desired speed is high (%.3f). Use "
           "engage speed (%.3f) until vehicle speed reaches engage_vel_thr (%.3f). stop_dist = %.3f",
-          vehicle_speed, target_vel, engage_velocity_, engage_vel_thr, stop_dist.get());
+          vehicle_speed, target_vel, engage_velocity_, engage_vel_thr, stop_dist.value());
         return std::make_tuple(initial_vel, initial_acc);
       } else if (stop_dist) {
         RCLCPP_DEBUG(
           rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),
-          "calcInitialMotion : stop point is close (%.3f[m]). no engage.", stop_dist.get());
+          "calcInitialMotion : stop point is close (%.3f[m]). no engage.", stop_dist.value());
       }
     } else if (target_vel > 0.0) {
       auto clock{rclcpp::Clock{RCL_ROS_TIME}};
@@ -449,7 +449,7 @@ std::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
       MarkerArray wall_msg;
 
       const auto markers = motion_utils::createSlowDownVirtualWallMarker(
-        marker_pose.get(), "obstacle to follow", current_time, 0);
+        marker_pose.value(), "obstacle to follow", current_time, 0);
       tier4_autoware_utils::appendMarkerArray(markers, &wall_msg);
 
       // publish rviz marker
@@ -603,7 +603,7 @@ std::optional<double> OptimizationBasedPlanner::calcTrajectoryLengthFromCurrentP
   const auto dist_to_closest_stop_point = motion_utils::calcDistanceToForwardStopPoint(
     traj_points, ego_pose, ego_nearest_param_.dist_threshold, ego_nearest_param_.yaw_threshold);
   if (dist_to_closest_stop_point) {
-    return std::min(traj_length, dist_to_closest_stop_point.get());
+    return std::min(traj_length, dist_to_closest_stop_point.value());
   }
 
   return traj_length;

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -496,7 +496,7 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::doCruiseWithTrajectory(
     return cruise_traj_points;
   }
 
-  for (size_t i = zero_vel_idx_opt.get(); i < cruise_traj_points.size(); ++i) {
+  for (size_t i = zero_vel_idx_opt.value(); i < cruise_traj_points.size(); ++i) {
     cruise_traj_points.at(i).longitudinal_velocity_mps = 0.0;
   }
 

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -546,12 +546,12 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
   const auto insert_point_in_trajectory = [&](const double lon_dist) -> std::optional<size_t> {
     const auto inserted_idx = motion_utils::insertTargetPoint(0, lon_dist, slow_down_traj_points);
     if (inserted_idx) {
-      if (inserted_idx.get() + 1 <= slow_down_traj_points.size() - 1) {
+      if (inserted_idx.value() + 1 <= slow_down_traj_points.size() - 1) {
         // zero-order hold for velocity interpolation
-        slow_down_traj_points.at(inserted_idx.get()).longitudinal_velocity_mps =
-          slow_down_traj_points.at(inserted_idx.get() + 1).longitudinal_velocity_mps;
+        slow_down_traj_points.at(inserted_idx.value()).longitudinal_velocity_mps =
+          slow_down_traj_points.at(inserted_idx.value() + 1).longitudinal_velocity_mps;
       }
-      return inserted_idx.get();
+      return inserted_idx.value();
     }
     return std::nullopt;
   };

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -57,6 +57,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -151,7 +152,7 @@ private:
 
   std::unique_ptr<AdaptiveCruiseController> acc_controller_;
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
-  boost::optional<SlowDownSection> latest_slow_down_section_{boost::none};
+  std::optional<SlowDownSection> latest_slow_down_section_{std::nullopt};
   std::vector<ObstacleWithDetectionTime> obstacle_history_{};
   std::vector<PredictedObjectWithDetectionTime> predicted_object_history_{};
   tf2_ros::Buffer tf_buffer_{get_clock()};

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -325,7 +325,7 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
 
   // TODO(someone): support backward path
   const auto is_driving_forward = motion_utils::isDrivingForwardWithTwist(input_msg->points);
-  is_driving_forward_ = is_driving_forward ? is_driving_forward.get() : is_driving_forward_;
+  is_driving_forward_ = is_driving_forward ? is_driving_forward.value() : is_driving_forward_;
   if (!is_driving_forward_) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 3000, "Backward path is NOT supported. publish input as it is.");
@@ -1064,7 +1064,7 @@ void ObstacleStopPlannerNode::insertVelocity(
           current_stop_pos.index = findFirstNearestSegmentIndexWithSoftConstraints(
             output, ego_pose, node_param_.ego_nearest_dist_threshold,
             node_param_.ego_nearest_yaw_threshold);
-          current_stop_pos.point.pose = ego_pos_on_path.get();
+          current_stop_pos.point.pose = ego_pos_on_path.value();
 
           insertStopPoint(current_stop_pos, output, planner_data.stop_reason_diag);
 
@@ -1117,8 +1117,8 @@ void ObstacleStopPlannerNode::insertVelocity(
 
   if (node_param_.enable_slow_down && latest_slow_down_section_) {
     // check whether ego is in slow down section or not
-    const auto & p_start = latest_slow_down_section_.get().start_point.pose.position;
-    const auto & p_end = latest_slow_down_section_.get().end_point.pose.position;
+    const auto & p_start = latest_slow_down_section_.value().start_point.pose.position;
+    const auto & p_end = latest_slow_down_section_.value().end_point.pose.position;
     const auto reach_slow_down_start_point =
       isInFrontOfTargetPoint(planner_data.current_pose, p_start);
     const auto reach_slow_down_end_point = isInFrontOfTargetPoint(planner_data.current_pose, p_end);

--- a/planning/obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/obstacle_stop_planner/src/planner_utils.cpp
@@ -66,10 +66,10 @@ boost::optional<std::pair<double, double>> calcFeasibleMarginAndVelocity(
       continue;
     }
 
-    if (stop_dist.get() + p.longitudinal_forward_margin < dist_baselink_to_obstacle) {
+    if (stop_dist.value() + p.longitudinal_forward_margin < dist_baselink_to_obstacle) {
       RCLCPP_DEBUG(
         logger, "[found plan] dist:%-6.2f jerk:%-6.2f margin:%-6.2f v0:%-6.2f vt:%-6.2f",
-        stop_dist.get(), planning_jerk, p.longitudinal_forward_margin, p.slow_down_velocity,
+        stop_dist.value(), planning_jerk, p.longitudinal_forward_margin, p.slow_down_velocity,
         current_vel);
       return std::make_pair(p.longitudinal_forward_margin, p.slow_down_velocity);
     }
@@ -88,11 +88,12 @@ boost::optional<std::pair<double, double>> calcFeasibleMarginAndVelocity(
       return {};
     }
 
-    if (stop_dist.get() + p.min_longitudinal_forward_margin < dist_baselink_to_obstacle) {
-      const auto planning_margin = dist_baselink_to_obstacle - stop_dist.get();
+    if (stop_dist.value() + p.min_longitudinal_forward_margin < dist_baselink_to_obstacle) {
+      const auto planning_margin = dist_baselink_to_obstacle - stop_dist.value();
       RCLCPP_DEBUG(
         logger, "[relax margin] dist:%-6.2f jerk:%-6.2f margin:%-6.2f v0:%-6.2f vt%-6.2f",
-        stop_dist.get(), p.slow_down_min_jerk, planning_margin, p.slow_down_velocity, current_vel);
+        stop_dist.value(), p.slow_down_min_jerk, planning_margin, p.slow_down_velocity,
+        current_vel);
       return std::make_pair(planning_margin, p.slow_down_velocity);
     }
   }

--- a/planning/path_smoother/include/path_smoother/elastic_band_smoother.hpp
+++ b/planning/path_smoother/include/path_smoother/elastic_band_smoother.hpp
@@ -43,7 +43,7 @@ protected:
     bool isDrivingForward(const std::vector<PathPoint> & path_points)
     {
       const auto is_driving_forward = motion_utils::isDrivingForward(path_points);
-      is_driving_forward_ = is_driving_forward ? is_driving_forward.get() : is_driving_forward_;
+      is_driving_forward_ = is_driving_forward ? is_driving_forward.value() : is_driving_forward_;
       return is_driving_forward_;
     }
 

--- a/planning/path_smoother/src/elastic_band_smoother.cpp
+++ b/planning/path_smoother/src/elastic_band_smoother.cpp
@@ -55,7 +55,7 @@ void setZeroVelocityAfterStopPoint(std::vector<TrajectoryPoint> & traj_points)
 {
   const auto opt_zero_vel_idx = motion_utils::searchZeroVelocityIndex(traj_points);
   if (opt_zero_vel_idx) {
-    for (size_t i = opt_zero_vel_idx.get(); i < traj_points.size(); ++i) {
+    for (size_t i = opt_zero_vel_idx.value(); i < traj_points.size(); ++i) {
       traj_points.at(i).longitudinal_velocity_mps = 0.0;
     }
   }
@@ -284,7 +284,7 @@ void ElasticBandSmoother::applyInputVelocity(
   // insert stop point explicitly
   const auto stop_idx = motion_utils::searchZeroVelocityIndex(forward_cropped_input_traj_points);
   if (stop_idx) {
-    const auto & input_stop_pose = forward_cropped_input_traj_points.at(stop_idx.get()).pose;
+    const auto & input_stop_pose = forward_cropped_input_traj_points.at(stop_idx.value()).pose;
     // NOTE: motion_utils::findNearestSegmentIndex is used instead of
     // trajectory_utils::findEgoSegmentIndex
     //       for the case where input_traj_points is much longer than output_traj_points, and the

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -31,6 +31,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace route_handler
@@ -112,7 +113,7 @@ public:
    * @param the lanelet of interest
    * @return vector of lanelet having same direction if true
    */
-  boost::optional<lanelet::ConstLanelet> getRightLanelet(
+  std::optional<lanelet::ConstLanelet> getRightLanelet(
     const lanelet::ConstLanelet & lanelet, const bool enable_same_root = false,
     const bool get_shoulder_lane = false) const;
 
@@ -123,7 +124,7 @@ public:
    * @param the lanelet of interest
    * @return vector of lanelet having same direction if true
    */
-  boost::optional<lanelet::ConstLanelet> getLeftLanelet(
+  std::optional<lanelet::ConstLanelet> getLeftLanelet(
     const lanelet::ConstLanelet & lanelet, const bool enable_same_root = false,
     const bool get_shoulder_lane = false) const;
   lanelet::ConstLanelets getNextLanelets(const lanelet::ConstLanelet & lanelet) const;
@@ -331,9 +332,9 @@ public:
   PathWithLaneId getCenterLinePath(
     const lanelet::ConstLanelets & lanelet_sequence, const double s_start, const double s_end,
     bool use_exact = true) const;
-  boost::optional<lanelet::ConstLanelet> getLaneChangeTarget(
+  std::optional<lanelet::ConstLanelet> getLaneChangeTarget(
     const lanelet::ConstLanelets & lanelets, const Direction direction = Direction::NONE) const;
-  boost::optional<lanelet::ConstLanelet> getLaneChangeTargetExceptPreferredLane(
+  std::optional<lanelet::ConstLanelet> getLaneChangeTargetExceptPreferredLane(
     const lanelet::ConstLanelets & lanelets, const Direction direction) const;
   bool getRightLaneChangeTargetExceptPreferredLane(
     const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const;


### PR DESCRIPTION
## Description

Before ros-galactic, `boost::optional` is used for optional values. However, upon changing to galactic and now Humble, C++17 is supported. Due to the `Autoware.Universe` code is not properly standardize, developer who preferred using standard library started to use `std::optional`. This has cause some issue, as some library is using `boost::optional` while some module using `std::optional` and it has caused both library is used.

As the code base is started to grow, so does the technical debt caused by such issue. Although some library (for example lanelet) uses boost, it is not a reason to allow mix and match. Therefore, in this PR, I proposed we try to standardize the library as much as possible by replacing boost::optional with std::optional.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/5732

## Tests performed

[TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/748d1b32-3c81-5d4c-a21c-52a90f88d8d3?project_id=prd_jt)

## Notes for reviewers

There might be some packages that remains, so probably I will fix it in other PR.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
