### PR TITLE
fix(external_cmd_converter): define timer_rate parameter

### DIFF
--- a/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.py
+++ b/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.py
@@ -53,6 +53,11 @@ def generate_launch_description():
             description="gain for external command accel",
         ),
         DeclareLaunchArgument(
+            "timer_rate",
+            default_value="10.0",
+            description="timer's update rate",
+        ),
+        DeclareLaunchArgument(
             "wait_for_first_topic",
             default_value="true",
             description="disable topic disruption detection until subscribing first topics",
@@ -118,6 +123,7 @@ def generate_launch_description():
                     _create_mapping_tuple("csv_path_accel_map"),
                     _create_mapping_tuple("csv_path_brake_map"),
                     _create_mapping_tuple("ref_vel_gain"),
+                    _create_mapping_tuple("timer_rate"),
                     _create_mapping_tuple("wait_for_first_topic"),
                     _create_mapping_tuple("control_command_timeout"),
                     _create_mapping_tuple("emergency_stop_timeout"),

--- a/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.xml
+++ b/vehicle/external_cmd_converter/launch/external_cmd_converter.launch.xml
@@ -6,6 +6,7 @@
 
   <!-- settings -->
   <arg name="ref_vel_gain" default="3.0"/>
+  <arg name="timer_rate" default="10.0"/>
   <arg name="wait_for_first_topic" default="true"/>
   <arg name="control_command_timeout" default="1.0"/>
   <arg name="emergency_stop_timeout" default="3.0"/>
@@ -26,6 +27,7 @@
     <param name="csv_path_accel_map" value="$(var csv_path_accel_map)"/>
     <param name="csv_path_brake_map" value="$(var csv_path_brake_map)"/>
     <param name="ref_vel_gain" value="$(var ref_vel_gain)"/>
+    <param name="timer_rate" value="$(var timer_rate)"/>
     <param name="wait_for_first_topic" value="$(var wait_for_first_topic)"/>
     <param name="control_command_timeout" value="$(var control_command_timeout)"/>
     <param name="emergency_stop_timeout" value="$(var emergency_stop_timeout)"/>


### PR DESCRIPTION
## Description

The commit introduces a missing launch argument `timer_rate` to the external_cmd_converter. This parameter is used to set the update rate of the timer. The default value for this parameter is 10.0. The changes have been reflected in both .py and .xml launch files.

The error was ocurring when psim is launched as follows
![Screenshot from 2023-11-30 09-09-44](https://github.com/autowarefoundation/autoware.universe/assets/32741405/ae737988-fd4b-4f37-b49f-53ee40e1aab1)


<!-- Write a brief description of this PR. -->

## Tests performed

confirmed error disappeared with this change

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
