### PR TITLE
feat(avoidance): don't avoid merging vehicle

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -336,6 +336,14 @@ struct ObjectData  // avoidance target
 
   PredictedObject object;
 
+  // object behavior.
+  enum class Behavior {
+    NONE = 0,
+    MERGING,
+    DEVIATING,
+  };
+  Behavior behavior{Behavior::NONE};
+
   // lateral position of the CoM, in Frenet coordinate from ego-pose
   double to_centerline;
 

--- a/planning/behavior_path_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_avoidance_module/src/debug.cpp
@@ -557,6 +557,8 @@ MarkerArray createDebugMarkerArray(
     addObjects(data.other_objects, std::string("NotNeedAvoidance"));
     addObjects(data.other_objects, std::string("LessThanExecutionThreshold"));
     addObjects(data.other_objects, std::string("TooNearToGoal"));
+    addObjects(data.other_objects, std::string("ParallelToEgoLane"));
+    addObjects(data.other_objects, std::string("MergingToEgoLane"));
   }
 
   // shift line pre-process

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -333,6 +333,34 @@ bool isParallelToEgoLane(const ObjectData & object, const double threshold)
   return yaw_deviation < threshold || yaw_deviation > M_PI - threshold;
 }
 
+bool isMergingToEgoLane(const ObjectData & object)
+{
+  const auto & object_pose = object.object.kinematics.initial_pose_with_covariance.pose;
+  const auto closest_pose =
+    lanelet::utils::getClosestCenterPose(object.overhang_lanelet, object_pose.position);
+  const auto yaw_deviation = calcYawDeviation(closest_pose, object_pose);
+
+  if (isOnRight(object)) {
+    if (yaw_deviation < 0.0 && -1.0 * M_PI_2 < yaw_deviation) {
+      return false;
+    }
+
+    if (yaw_deviation > M_PI_2) {
+      return false;
+    }
+  } else {
+    if (yaw_deviation > 0.0 && M_PI_2 > yaw_deviation) {
+      return false;
+    }
+
+    if (yaw_deviation < -1.0 * M_PI_2) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool isObjectOnRoadShoulder(
   ObjectData & object, const std::shared_ptr<RouteHandler> & route_handler,
   const std::shared_ptr<AvoidanceParameters> & parameters)
@@ -587,6 +615,17 @@ bool isSatisfiedWithNonVehicleCondition(
   return true;
 }
 
+ObjectData::Behavior getObjectBehavior(
+  ObjectData & object, const std::shared_ptr<AvoidanceParameters> & parameters)
+{
+  if (isParallelToEgoLane(object, parameters->object_check_yaw_deviation)) {
+    return ObjectData::Behavior::NONE;
+  }
+
+  return isMergingToEgoLane(object) ? ObjectData::Behavior::MERGING
+                                    : ObjectData::Behavior::DEVIATING;
+}
+
 bool isSatisfiedWithVehicleCondition(
   ObjectData & object, const AvoidancePlanningData & data,
   const std::shared_ptr<const PlannerData> & planner_data,
@@ -594,7 +633,14 @@ bool isSatisfiedWithVehicleCondition(
 {
   using boost::geometry::within;
 
+  object.behavior = getObjectBehavior(object, parameters);
   object.is_within_intersection = isWithinIntersection(object, planner_data->route_handler);
+
+  // always ignore all merging objects.
+  if (object.behavior == ObjectData::Behavior::MERGING) {
+    object.reason = "MergingToEgoLane";
+    return false;
+  }
 
   // from here condition check for vehicle type objects.
   if (isForceAvoidanceTarget(object, data, planner_data, parameters)) {
@@ -623,7 +669,7 @@ bool isSatisfiedWithVehicleCondition(
     return true;
   }
 
-  if (isParallelToEgoLane(object, parameters->object_check_yaw_deviation)) {
+  if (object.behavior == ObjectData::Behavior::NONE) {
     object.reason = "ParallelToEgoLane";
     return false;
   }

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -636,15 +636,15 @@ bool isSatisfiedWithVehicleCondition(
   object.behavior = getObjectBehavior(object, parameters);
   object.is_within_intersection = isWithinIntersection(object, planner_data->route_handler);
 
+  // from here condition check for vehicle type objects.
+  if (isForceAvoidanceTarget(object, data, planner_data, parameters)) {
+    return true;
+  }
+
   // always ignore all merging objects.
   if (object.behavior == ObjectData::Behavior::MERGING) {
     object.reason = "MergingToEgoLane";
     return false;
-  }
-
-  // from here condition check for vehicle type objects.
-  if (isForceAvoidanceTarget(object, data, planner_data, parameters)) {
-    return true;
   }
 
   // Object is on center line -> ignore.

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -669,6 +669,11 @@ bool isSatisfiedWithVehicleCondition(
     return true;
   }
 
+  std::string turn_direction = object.overhang_lanelet.attributeOr("turn_direction", "else");
+  if (turn_direction == "straight") {
+    return true;
+  }
+
   if (object.behavior == ObjectData::Behavior::NONE) {
     object.reason = "ParallelToEgoLane";
     return false;


### PR DESCRIPTION
## Description

In this PR, I defined 3 types of object behavior:

- `NONE`
- `MERGING`
- `DEVIATING`

### `Behavior::NONE`

Most of all parked vehicle are categolized `Behavior::NONE`.

(e.g. parked vehicle on road shoulder.)
![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/43fd0b1b-829e-46e2-afe6-44b6ee9aa9c9)

### `Behavior::MERGING`

If the object try merging to ego lane, it's categolized this behavior. Basically, the ego vehicle yields merging vehicle and does **NOT** execute avoidance maneuver.

(e.g. merging from private road.)
![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/de77f4f8-0f19-4d66-b179-d4e3625367bb)

### `Behavior::DEVIATING`

If the object try moving adjacent lane or somewhere else, it's categolized this behavior. In this case, the ego vehicle try avoidance the object because the ego doesn't have to follow it anymore.

(e.g. u-turn in intersection.)
![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/79ff7f3a-7615-4b36-a389-6ced52462cae)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/34a60ee2-f729-56be-a864-c54b5207dc85?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
