### PR TITLE
fix(crosswalk): don't stop in front of the crosswalk if vehicle stuck in intersection

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -27,6 +27,7 @@
 
       # param for stuck vehicles
       stuck_vehicle:
+        enable_stuck_check_in_intersection: false # [-] flag to enable stuck vehicle checking for crosswalk which is in intersection
         stuck_vehicle_velocity: 1.0 # [m/s] maximum velocity threshold whether the vehicle is stuck
         max_stuck_vehicle_lateral_offset: 2.0 # [m] maximum lateral offset for stuck vehicle position should be looked
         stuck_vehicle_attention_range: 10.0 # [m] the detection area is defined as X meters behind the crosswalk

--- a/planning/behavior_velocity_crosswalk_module/include/behavior_velocity_crosswalk_module/util.hpp
+++ b/planning/behavior_velocity_crosswalk_module/include/behavior_velocity_crosswalk_module/util.hpp
@@ -82,7 +82,7 @@ struct DebugData
   std::vector<std::vector<geometry_msgs::msg::Point>> obj_polygons;
 };
 
-std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
+std::vector<std::pair<int64_t, lanelet::ConstLanelet>> getCrosswalksOnPath(
   const geometry_msgs::msg::Pose & current_pose,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const lanelet::LaneletMapPtr lanelet_map,

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -121,6 +121,7 @@ public:
     double max_slow_down_accel;
     double no_relax_velocity;
     // param for stuck vehicle
+    bool enable_stuck_check_in_intersection{false};
     double stuck_vehicle_velocity;
     double max_stuck_vehicle_lateral_offset;
     double stuck_vehicle_attention_range;
@@ -299,9 +300,10 @@ public:
   };
 
   CrosswalkModule(
-    rclcpp::Node & node, const int64_t module_id, const std::optional<int64_t> & reg_elem_id,
-    const lanelet::LaneletMapPtr & lanelet_map_ptr, const PlannerParam & planner_param,
-    const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock);
+    rclcpp::Node & node, const int64_t lane_id, const int64_t module_id,
+    const std::optional<int64_t> & reg_elem_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+    const PlannerParam & planner_param, const rclcpp::Logger & logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
@@ -405,6 +407,8 @@ private:
   rclcpp::Publisher<tier4_debug_msgs::msg::StringStamped>::SharedPtr collision_info_pub_;
 
   lanelet::ConstLanelet crosswalk_;
+
+  lanelet::ConstLanelet road_;
 
   lanelet::ConstLineStrings3d stop_lines_;
 

--- a/planning/behavior_velocity_walkway_module/src/manager.cpp
+++ b/planning/behavior_velocity_walkway_module/src/manager.cpp
@@ -75,7 +75,7 @@ void WalkwayModuleManager::launchNewModules(const PathWithLaneId & path)
     planner_data_->current_odometry->pose, path, rh->getLaneletMapPtr(), rh->getOverallGraphPtr());
 
   for (const auto & crosswalk : crosswalk_lanelets) {
-    launch(crosswalk, false);
+    launch(crosswalk.second, false);
   }
 }
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5ee3bc2</samp>

This pull request enhances the crosswalk module to handle different types of crosswalks and road situations. It adds and modifies some parameters, variables, and functions in the `CrosswalkModuleManager`, `CrosswalkModule`, and `PlannerParam` classes, and in the `util.cpp` and `util.hpp` files. It also updates the `crosswalk.param.yaml` configuration file and the `manager.cpp` file in the walkway module to support the changes. The main goal is to improve the behavior of the module in complex scenarios where multiple crosswalks and traffic lights are present.

Related Ticket: https://tier4.atlassian.net/browse/RT1-4093
Related PR: https://github.com/autowarefoundation/autoware_launch/pull/714

---

Add new option to skip stuck vehicle checking for crosswalk in intersection. It seems that the vehilce doesn't have to stop in front of the crosswalk even when there is stopped vehicle in intersection because such a vehicle are basically going to move in almost all following situations.

```yaml
      # param for stuck vehicles
      stuck_vehicle:
        enable_stuck_check_in_intersection: false # [-] flag to enable stuck vehicle checking for crosswalk which is in intersection
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/c8f5c5b6-3c84-41ad-b550-ca5430f29de4)

Crosswalk module skips stuck vehicle checking for crosswalks which are satisfied with following conditions:

1. Is in intersection.
2. Is controlled by traffic lights.

![Screenshot from 2023-11-30 10-27-29](https://github.com/autowarefoundation/autoware.universe/assets/44889564/4f18dafb-a2bd-44cc-b21e-0a15c6228aa1)

Therefore, the stuck checking still enables for simple crosswalk like this:

![Screenshot from 2023-11-30 10-26-41](https://github.com/autowarefoundation/autoware.universe/assets/44889564/96501b95-09ff-4269-8ef5-b08a9a138864)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS
](https://evaluation.tier4.jp/evaluation/reports/9b3faae8-0c5f-5a41-8d26-737b21c75afb?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Change crosswalk module behavior for stuck vehicle.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
