### PR TITLE
fix(system_error_monitor): avoid invalid access to nullptr

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -702,7 +702,9 @@ bool AutowareErrorMonitor::onClearEmergencyService(
 void AutowareErrorMonitor::loggingErrors(
   const autoware_auto_system_msgs::msg::HazardStatus & hazard_status)
 {
-  if (isInNoFaultCondition(*autoware_state_, *current_gate_mode_)) {
+  if (
+    autoware_state_ && current_gate_mode_ &&
+    isInNoFaultCondition(*autoware_state_, *current_gate_mode_)) {
     RCLCPP_DEBUG(get_logger(), "Autoware is in no-fault condition.");
     return;
   }


### PR DESCRIPTION
## Description
The loggingErrors() function is called through the publishHazardStatus function even when isDataReady is false. Therefore, there is a possibility of invalid access to null autoware_state_ and current_gate_mode_, causing the system_error_monitor to crash. This PR has been addressed and fixed.
<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/5522
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I launched the logging_simulator/rosbag and confirmed that the system_error_monitor no longer crashes.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
none
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
As the description
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
