### PR TITLE
fix(autoware_auto_msgs_adapter): fix predicted path test

### DIFF
--- a/system/autoware_auto_msgs_adapter/test/test_msg_predicted_objects.cpp
+++ b/system/autoware_auto_msgs_adapter/test/test_msg_predicted_objects.cpp
@@ -65,7 +65,10 @@ autoware_perception_msgs::msg::PredictedObjects generate_perception_msg()
   kin.initial_acceleration_with_covariance.accel.angular.y = 0;
   kin.initial_acceleration_with_covariance.accel.angular.z = 0;
 
-  for (size_t i = 0; i < 10; i++) {
+  constexpr size_t path_size = 10;
+  kin.predicted_paths.resize(1);
+  kin.predicted_paths[0].path.resize(path_size);
+  for (size_t i = 0; i < path_size; i++) {
     kin.predicted_paths[0].path[i].position.x = i;
     kin.predicted_paths[0].path[i].position.y = 0;
     kin.predicted_paths[0].path[i].position.z = 0;


### PR DESCRIPTION
## Description

Close #5742
Fixed a bug that was accessing out of range with vector in predicted path test.

## Tests performed

`colcon test --packages-select autoware_auto_msgs_adapter`

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
