### PR TITLE
refactor(start_planner): refactor debug and safety check logic

### DIFF
--- a/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
@@ -119,8 +119,7 @@
         # EgoPredictedPath
         ego_predicted_path:
           min_velocity: 0.0
-          acceleration: 1.0
-          max_velocity: 1.0
+          min_acceleration: 1.0
           time_horizon_for_front_object: 10.0
           time_horizon_for_rear_object: 10.0
           time_resolution: 0.5

--- a/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
+++ b/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
@@ -83,8 +83,7 @@
         # EgoPredictedPath
         ego_predicted_path:
           min_velocity: 0.0
-          acceleration: 1.0
-          max_velocity: 1.0
+          min_acceleration: 1.0
           time_horizon_for_front_object: 10.0
           time_horizon_for_rear_object: 10.0
           time_resolution: 0.5

--- a/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
+++ b/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
@@ -2,15 +2,13 @@
   ros__parameters:
     start_planner:
 
-      verbose: false
-
       th_arrived_distance: 1.0
       th_stopped_velocity: 0.01
       th_stopped_time: 1.0
       collision_check_margin: 1.0
       collision_check_distance_from_end: 1.0
       th_moving_object_velocity: 1.0
-      th_distance_to_middle_of_the_road: 0.1
+      th_distance_to_middle_of_the_road: 0.5
       center_line_path_interval: 1.0
       # shift pull out
       enable_shift_pull_out: true
@@ -24,7 +22,7 @@
       maximum_curvature: 0.07
       # geometric pull out
       enable_geometric_pull_out: true
-      divide_pull_out_path: false
+      divide_pull_out_path: true
       geometric_pull_out_velocity: 1.0
       arc_path_interval: 1.0
       lane_departure_margin: 0.2
@@ -140,3 +138,7 @@
           # temporary
           backward_path_length: 30.0
           forward_path_length: 100.0
+
+      # debug
+      debug:
+        print_debug_info: false

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -129,6 +129,11 @@ private:
 
   bool canTransitIdleToRunningState() override;
 
+  /**
+   * @brief init member variables.
+   */
+  void initVariables();
+
   void initializeSafetyCheckParameters();
 
   bool receivedNewRoute() const;
@@ -200,7 +205,8 @@ private:
   PredictedObjects filterStopObjectsInPullOutLanes(
     const lanelet::ConstLanelets & pull_out_lanes, const double velocity_threshold) const;
   bool hasFinishedPullOut() const;
-  bool isBackwardDrivingComplete() const;
+  bool hasFinishedBackwardDriving() const;
+  bool checkCollisionWithDynamicObjects() const;
   bool isStopped();
   bool isStuck();
   bool hasFinishedCurrentPath();

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -136,6 +136,7 @@ private:
 
   void initializeSafetyCheckParameters();
 
+  bool requiresDynamicObjectsCollisionDetection() const;
   bool receivedNewRoute() const;
 
   bool isModuleRunning() const;
@@ -206,7 +207,7 @@ private:
     const lanelet::ConstLanelets & pull_out_lanes, const double velocity_threshold) const;
   bool hasFinishedPullOut() const;
   bool hasFinishedBackwardDriving() const;
-  bool checkCollisionWithDynamicObjects() const;
+  bool hasCollisionWithDynamicObjects() const;
   bool isStopped();
   bool isStuck();
   bool hasFinishedCurrentPath();

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -46,7 +46,6 @@ struct StartPlannerParameters
   double collision_check_distance_from_end{0.0};
   double th_moving_object_velocity{0.0};
   double center_line_path_interval{0.0};
-  bool verbose{false};
 
   // shift pull out
   bool enable_shift_pull_out{false};
@@ -93,6 +92,8 @@ struct StartPlannerParameters
   utils::path_safety_checker::EgoPredictedPathParams ego_predicted_path_params{};
   utils::path_safety_checker::ObjectsFilteringParams objects_filtering_params{};
   utils::path_safety_checker::SafetyCheckParams safety_check_params{};
+
+  bool print_debug_info{false};
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
@@ -255,9 +255,7 @@ GoalPlannerModuleManager::GoalPlannerModuleManager(
     p.ego_predicted_path_params.min_velocity =
       node->declare_parameter<double>(ego_path_ns + "min_velocity");
     p.ego_predicted_path_params.acceleration =
-      node->declare_parameter<double>(ego_path_ns + "acceleration");
-    p.ego_predicted_path_params.max_velocity =
-      node->declare_parameter<double>(ego_path_ns + "max_velocity");
+      node->declare_parameter<double>(ego_path_ns + "min_acceleration");
     p.ego_predicted_path_params.time_horizon_for_front_object =
       node->declare_parameter<double>(ego_path_ns + "time_horizon_for_front_object");
     p.ego_predicted_path_params.time_horizon_for_rear_object =

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -171,9 +171,7 @@ StartPlannerModuleManager::StartPlannerModuleManager(
     p.ego_predicted_path_params.min_velocity =
       node->declare_parameter<double>(ego_path_ns + "min_velocity");
     p.ego_predicted_path_params.acceleration =
-      node->declare_parameter<double>(ego_path_ns + "acceleration");
-    p.ego_predicted_path_params.max_velocity =
-      node->declare_parameter<double>(ego_path_ns + "max_velocity");
+      node->declare_parameter<double>(ego_path_ns + "min_acceleration");
     p.ego_predicted_path_params.time_horizon_for_front_object =
       node->declare_parameter<double>(ego_path_ns + "time_horizon_for_front_object");
     p.ego_predicted_path_params.time_horizon_for_rear_object =

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -33,7 +33,6 @@ StartPlannerModuleManager::StartPlannerModuleManager(
 
   std::string ns = "start_planner.";
 
-  p.verbose = node->declare_parameter<bool>(ns + "verbose");
   p.th_arrived_distance = node->declare_parameter<double>(ns + "th_arrived_distance");
   p.th_stopped_velocity = node->declare_parameter<double>(ns + "th_stopped_velocity");
   p.th_stopped_time = node->declare_parameter<double>(ns + "th_stopped_time");
@@ -274,6 +273,12 @@ StartPlannerModuleManager::StartPlannerModuleManager(
       node->declare_parameter<double>(rss_ns + "longitudinal_distance_min_threshold");
     p.safety_check_params.rss_params.longitudinal_velocity_delta_time =
       node->declare_parameter<double>(rss_ns + "longitudinal_velocity_delta_time");
+  }
+
+  // debug
+  std::string debug_ns = ns + "debug.";
+  {
+    p.print_debug_info = node->declare_parameter<bool>(debug_ns + "print_debug_info");
   }
 
   // validation of parameters

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -38,6 +38,12 @@
 
 using motion_utils::calcLongitudinalOffsetPose;
 using tier4_autoware_utils::calcOffsetPose;
+using behavior_path_planner::utils::start_goal_planner_common::initializeCollisionCheckDebugMap;
+
+// set as macro so that calling function name will be printed.
+// debug print is heavy. turn on only when debugging.
+#define DEBUG_PRINT(...) \
+  RCLCPP_DEBUG_EXPRESSION(getLogger(), parameters_->print_debug_info, __VA_ARGS__)
 
 namespace behavior_path_planner
 {
@@ -107,44 +113,69 @@ BehaviorModuleOutput StartPlannerModule::run()
 
 void StartPlannerModule::processOnEntry()
 {
-  // Initialize safety checker
-  if (parameters_->safety_check_params.enable_safety_check) {
-    initializeSafetyCheckParameters();
-    utils::start_goal_planner_common::initializeCollisionCheckDebugMap(
-      start_planner_data_.collision_check);
-  }
+  initVariables();
 }
 
 void StartPlannerModule::processOnExit()
 {
+  initVariables();
+}
+
+void StartPlannerModule::initVariables()
+{
   resetPathCandidate();
   resetPathReference();
   debug_marker_.markers.clear();
+  initializeSafetyCheckParameters();
+  initializeCollisionCheckDebugMap(start_planner_data_.collision_check);
 }
 
 void StartPlannerModule::updateData()
 {
-  if (isBackwardDrivingComplete()) {
+  if (receivedNewRoute()) {
+    resetStatus();
+    DEBUG_PRINT("StartPlannerModule::updateData() received new route, reset status");
+  }
+
+  if (hasFinishedBackwardDriving()) {
     updateStatusAfterBackwardDriving();
+    DEBUG_PRINT("StartPlannerModule::updateData() completed backward driving");
   } else {
     status_.backward_driving_complete = false;
   }
 
-  if (receivedNewRoute()) {
-    status_ = PullOutStatus();
+  status_.is_safe_dynamic_objects = checkCollisionWithDynamicObjects();
+}
+
+bool StartPlannerModule::hasFinishedBackwardDriving() const
+{
+  // check ego car is close enough to pull out start pose and stopped
+  const auto current_pose = planner_data_->self_odometry->pose.pose;
+  const auto distance =
+    tier4_autoware_utils::calcDistance2d(current_pose, status_.pull_out_start_pose);
+
+  const bool is_near = distance < parameters_->th_arrived_distance;
+  const double ego_vel = utils::l2Norm(planner_data_->self_odometry->twist.twist.linear);
+  const bool is_stopped = ego_vel < parameters_->th_stopped_velocity;
+
+  const bool back_finished = !status_.driving_forward && is_near && is_stopped;
+  if (back_finished) {
+    RCLCPP_INFO(getLogger(), "back finished");
   }
-  // check safety status when driving forward
-  if (parameters_->safety_check_params.enable_safety_check && status_.driving_forward) {
-    status_.is_safe_dynamic_objects = isSafePath();
-  } else {
-    status_.is_safe_dynamic_objects = true;
-  }
+
+  return back_finished;
 }
 
 bool StartPlannerModule::receivedNewRoute() const
 {
   return !planner_data_->prev_route_id ||
          *planner_data_->prev_route_id != planner_data_->route_handler->getRouteUuid();
+}
+
+bool StartPlannerModule::checkCollisionWithDynamicObjects() const
+{
+  return !(parameters_->safety_check_params.enable_safety_check && status_.driving_forward) ||
+         isSafePath();
 }
 
 bool StartPlannerModule::isExecutionRequested() const
@@ -211,25 +242,35 @@ bool StartPlannerModule::isMoving() const
          parameters_->th_stopped_velocity;
 }
 
+bool StartPlannerModule::isStopped()
+{
+  odometry_buffer_.push_back(planner_data_->self_odometry);
+  // Delete old data in buffer
+  while (rclcpp::ok()) {
+    const auto time_diff = rclcpp::Time(odometry_buffer_.back()->header.stamp) -
+                           rclcpp::Time(odometry_buffer_.front()->header.stamp);
+    if (time_diff.seconds() < parameters_->th_stopped_time) {
+      break;
+    }
+    odometry_buffer_.pop_front();
+  }
+  return !std::any_of(
+    odometry_buffer_.begin(), odometry_buffer_.end(), [this](const auto & odometry) {
+      return utils::l2Norm(odometry->twist.twist.linear) > parameters_->th_stopped_velocity;
+    });
+}
+
 bool StartPlannerModule::isExecutionReady() const
 {
-  // when found_pull_out_path is false,the path is not generated and approval shouldn't be
-  // allowed
-  if (!status_.found_pull_out_path) {
-    RCLCPP_ERROR_THROTTLE(getLogger(), *clock_, 5000, "Pull over path is not found");
-    return false;
-  }
+  // Evaluate safety. The situation is not safe if any of the following conditions are met:
+  // 1. pull out path has not been found
+  // 2. waiting for approval and there is a collision with dynamic objects
+  const bool is_safe =
+    status_.found_pull_out_path && (!isWaitingApproval() || checkCollisionWithDynamicObjects());
 
-  if (
-    parameters_->safety_check_params.enable_safety_check && status_.driving_forward &&
-    isWaitingApproval()) {
-    if (!isSafePath()) {
-      RCLCPP_ERROR_THROTTLE(getLogger(), *clock_, 5000, "Path is not safe against dynamic objects");
-      stop_pose_ = planner_data_->self_odometry->pose.pose;
-      return false;
-    }
-  }
-  return true;
+  if (!is_safe) stop_pose_ = planner_data_->self_odometry->pose.pose;
+
+  return is_safe;
 }
 
 bool StartPlannerModule::canTransitSuccessState()
@@ -461,8 +502,7 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
 
 void StartPlannerModule::resetStatus()
 {
-  PullOutStatus initial_status;
-  status_ = initial_status;
+  status_ = PullOutStatus{};
 }
 
 void StartPlannerModule::incrementPathIndex()
@@ -722,7 +762,7 @@ void StartPlannerModule::updatePullOutStatus()
   const auto pull_out_lanes = start_planner_utils::getPullOutLanes(
     planner_data_, planner_data_->parameters.backward_path_length + parameters_->max_back_distance);
 
-  if (isBackwardDrivingComplete()) {
+  if (hasFinishedBackwardDriving()) {
     updateStatusAfterBackwardDriving();
   } else {
     status_.backward_path = start_planner_utils::getBackwardPath(
@@ -864,48 +904,6 @@ bool StartPlannerModule::hasFinishedPullOut() const
   const bool has_finished = arclength_current.length - arclength_pull_out_end.length > offset;
 
   return has_finished;
-}
-
-bool StartPlannerModule::isBackwardDrivingComplete() const
-{
-  // check ego car is close enough to pull out start pose and stopped
-  const auto current_pose = planner_data_->self_odometry->pose.pose;
-  const auto distance =
-    tier4_autoware_utils::calcDistance2d(current_pose, status_.pull_out_start_pose);
-
-  const bool is_near = distance < parameters_->th_arrived_distance;
-  const double ego_vel = utils::l2Norm(planner_data_->self_odometry->twist.twist.linear);
-  const bool is_stopped = ego_vel < parameters_->th_stopped_velocity;
-
-  const bool back_finished = !status_.driving_forward && is_near && is_stopped;
-  if (back_finished) {
-    RCLCPP_INFO(getLogger(), "back finished");
-  }
-
-  return back_finished;
-}
-
-bool StartPlannerModule::isStopped()
-{
-  odometry_buffer_.push_back(planner_data_->self_odometry);
-  // Delete old data in buffer
-  while (rclcpp::ok()) {
-    const auto time_diff = rclcpp::Time(odometry_buffer_.back()->header.stamp) -
-                           rclcpp::Time(odometry_buffer_.front()->header.stamp);
-    if (time_diff.seconds() < parameters_->th_stopped_time) {
-      break;
-    }
-    odometry_buffer_.pop_front();
-  }
-  bool is_stopped = true;
-  for (const auto & odometry : odometry_buffer_) {
-    const double ego_vel = utils::l2Norm(odometry->twist.twist.linear);
-    if (ego_vel > parameters_->th_stopped_velocity) {
-      is_stopped = false;
-      break;
-    }
-  }
-  return is_stopped;
 }
 
 bool StartPlannerModule::isStuck()
@@ -1262,8 +1260,7 @@ void StartPlannerModule::setDebugData() const
     add(showSafetyCheckInfo(start_planner_data_.collision_check, "object_debug_info"));
     add(showPredictedPath(start_planner_data_.collision_check, "ego_predicted_path"));
     add(showPolygon(start_planner_data_.collision_check, "ego_and_target_polygon_relation"));
-    utils::start_goal_planner_common::initializeCollisionCheckDebugMap(
-      start_planner_data_.collision_check);
+    initializeCollisionCheckDebugMap(start_planner_data_.collision_check);
   }
 
   // Visualize planner type text
@@ -1285,9 +1282,6 @@ void StartPlannerModule::setDebugData() const
     marker.lifetime = life_time;
     planner_type_marker_array.markers.push_back(marker);
     add(planner_type_marker_array);
-  }
-  if (parameters_->verbose) {
-    logPullOutStatus();
   }
 }
 

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -36,9 +36,9 @@
 #include <utility>
 #include <vector>
 
+using behavior_path_planner::utils::start_goal_planner_common::initializeCollisionCheckDebugMap;
 using motion_utils::calcLongitudinalOffsetPose;
 using tier4_autoware_utils::calcOffsetPose;
-using behavior_path_planner::utils::start_goal_planner_common::initializeCollisionCheckDebugMap;
 
 // set as macro so that calling function name will be printed.
 // debug print is heavy. turn on only when debugging.

--- a/planning/behavior_path_planner/src/utils/start_goal_planner_common/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/start_goal_planner_common/utils.cpp
@@ -133,8 +133,7 @@ void updatePathProperty(
 {
   // If acceleration is close to 0, the ego predicted path will be too short, so a minimum value is
   // necessary to ensure a reasonable path length.
-  // TODO(Sugahara): define them as parameter
-  const double min_accel_for_ego_predicted_path = 1.0;
+  const double min_accel_for_ego_predicted_path = ego_predicted_path_params->min_acceleration;
   const double acceleration =
     std::max(pairs_terminal_velocity_and_accel.second, min_accel_for_ego_predicted_path);
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -150,6 +150,7 @@ struct IntegralPredictedPolygonParams
 struct EgoPredictedPathParams
 {
   double min_velocity{0.0};                   ///< Minimum velocity.
+  double min_acceleration{0.0};               ///< Minimum acceleration
   double acceleration{0.0};                   ///< Acceleration value.
   double max_velocity{0.0};                   ///< Maximum velocity.
   double time_horizon_for_front_object{0.0};  ///< Time horizon for front object.


### PR DESCRIPTION
## Description

This [PR](https://github.com/autowarefoundation/autoware_launch/pull/719) should be merged first!!!

This commit refactors the start_planner module in several ways:
- The verbose parameter is removed from the YAML configuration file and replaced with a print_debug_info parameter under a new debug section.
- A new function, initVariables(), is introduced to initialize member variables, which is called during processOnEntry() and processOnExit().
- The function isBackwardDrivingComplete() is renamed to hasFinishedBackwardDriving() to better reflect its purpose. It also includes additional debug prints.
- A new function, checkCollisionWithDynamicObjects(), is introduced to encapsulate the logic for checking collisions with dynamic objects.
- The function isExecutionReady() is modified to use the new checkCollisionWithDynamicObjects() function.
- The function resetStatus() is simplified by directly assigning an empty PullOutStatus object to status_.
- The function updatePullOutStatus() now uses the new hasFinishedBackwardDriving() function.
- The logging of pull out status is now controlled by the new print_debug_info parameter rather than the removed verbose parameter.

These changes improve the clarity of the code and make it easier to control debug output.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] PASS TIERIV INTERNAL SCENARIOS
  - [ ] [release scenarios](https://evaluation.tier4.jp/evaluation/reports/2ad42aa4-73d4-59d5-ae11-9499a3203f74?project_id=prd_jt)
  - [ ] [future scenarios](https://evaluation.tier4.jp/evaluation/reports/74647215-1795-5e59-b4ba-b7195b02cc28?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
