### PR TITLE
feat(pointpainting): add build only option for tensort engine

### DIFF
--- a/perception/image_projection_based_fusion/docs/pointpainting-fusion.md
+++ b/perception/image_projection_based_fusion/docs/pointpainting-fusion.md
@@ -43,6 +43,7 @@ The lidar points are projected onto the output of an image-only 2d object detect
 | `encoder_engine_path`           | string | `""`          | path to VoxelFeatureEncoder TensorRT Engine file            |
 | `head_onnx_path`                | string | `""`          | path to DetectionHead ONNX file                             |
 | `head_engine_path`              | string | `""`          | path to DetectionHead TensorRT Engine file                  |
+| `build_only`                    | bool   | `false`       | shutdown the node after TensorRT engine file is built       |
 
 ## Assumptions / Known limits
 

--- a/perception/image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
@@ -24,7 +24,7 @@
   <arg name="model_param_path" default="$(find-pkg-share image_projection_based_fusion)/config/$(var model_name).param.yaml"/>
   <arg name="class_remapper_param_path" default="$(find-pkg-share lidar_centerpoint)/config/detection_class_remapper.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share image_projection_based_fusion)/config/roi_sync.param.yaml"/>
-  <arg name="build_only" default="true" description="shutdown node after TensorRT engine file is built"/>
+  <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
 
   <!-- for eval variable-->
   <arg name="input_rois_number" default="$(var input/rois_number)"/>

--- a/perception/image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
@@ -24,6 +24,7 @@
   <arg name="model_param_path" default="$(find-pkg-share image_projection_based_fusion)/config/$(var model_name).param.yaml"/>
   <arg name="class_remapper_param_path" default="$(find-pkg-share lidar_centerpoint)/config/detection_class_remapper.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share image_projection_based_fusion)/config/roi_sync.param.yaml"/>
+  <arg name="build_only" default="true" description="shutdown node after TensorRT engine file is built"/>
 
   <!-- for eval variable-->
   <arg name="input_rois_number" default="$(var input/rois_number)"/>
@@ -54,6 +55,7 @@
       <param from="$(var sync_param_path)"/>
       <param from="$(var class_remapper_param_path)"/>
       <param name="rois_number" value="$(var input/rois_number)"/>
+      <param name="build_only" value="$(var build_only)"/>
 
       <!-- rois, camera and info -->
       <param name="input/rois0" value="$(var input/rois0)"/>

--- a/perception/image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -193,6 +193,11 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
     encoder_param, head_param, densification_param, config);
 
   obj_pub_ptr_ = this->create_publisher<DetectedObjects>("~/output/objects", rclcpp::QoS{1});
+
+  if (this->declare_parameter("build_only", false)) {
+    RCLCPP_INFO(this->get_logger(), "TensorRT engine is built and shutdown node.");
+    rclcpp::shutdown();
+  }
 }
 
 void PointPaintingFusionNode::preprocess(sensor_msgs::msg::PointCloud2 & painted_pointcloud_msg)


### PR DESCRIPTION
## Description

the option to build tensorrt engine without inference

check with
` ros2 launch image_projection_based_fusion pointpainting_fusion.launch.xml input/rois0:=/perception/object_recognition/detection/rois0 input/camera_info0:=/sensing/camera/camera0/camera_info input/rois1:=/perception/object_recognition/detection/rois1 input/camera_info1:=/sensing/camera/camera1/camera_info input/rois2:=/perception/object_recognition/detection/rois2 input/camera_info2:=/sensing/camera/camera2/camera_info input/rois3:=/perception/object_recognition/detection/rois3 input/camera_info3:=/sensing/camera/camera3/camera_info input/rois4:=/perception/object_recognition/detection/rois4 input/camera_info4:=/sensing/camera/camera4/camera_info input/rois5:=/perception/object_recognition/detection/rois5 input/camera_info5:=/sensing/camera/camera5/camera_info input/rois_number:=6  input/pointcloud:=/sensing/lidar/top/outlier_filtered/pointcloud`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
