### PR TITLE
fix(system_monitor): fix uninitialized diag level of process monitor

### DIFF
--- a/system/system_monitor/include/system_monitor/process_monitor/diag_task.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/diag_task.hpp
@@ -52,7 +52,7 @@ public:
    * @brief constructor
    * @param [in] name diagnostics status name
    */
-  explicit DiagTask(const std::string & name) : DiagnosticTask(name) {}
+  explicit DiagTask(const std::string & name) : DiagnosticTask(name) { level_ = DiagStatus::STALE; }
 
   /**
    * @brief main loop
@@ -60,8 +60,6 @@ public:
    */
   void run(diagnostic_updater::DiagnosticStatusWrapper & stat)
   {
-    stat.summary(level_, message_);
-
     if (level_ != DiagStatus::OK) {
       stat.add("content", content_);
     } else {


### PR DESCRIPTION
## Description

Fix the process monitor outputting uninitialized diag level

## Tests performed

1. Run `ros2 launch system_monitor system_monitor.launch.xml`
2. Run `ros2 topic echo /diagnostics | grep process_monitor -B1` in another terminal.

Before
```
- level: "\x90"
  name: 'process_monitor: High-load Proc[0]'
--
- level: "\x03"
  name: 'process_monitor: High-load Proc[1]'
--
- level: ç
  name: 'process_monitor: High-load Proc[2]'
--
- level: ç
  name: 'process_monitor: High-load Proc[3]'
--
- level: "\0"
  name: 'process_monitor: High-load Proc[4]'
--
- level: '4'
  name: 'process_monitor: High-mem Proc[0]'
--
- level: '4'
  name: 'process_monitor: High-mem Proc[1]'
--
- level: "\x91"
  name: 'process_monitor: High-mem Proc[2]'
--
- level: "\0"
  name: 'process_monitor: High-mem Proc[3]'
--
- level: "\0"
  name: 'process_monitor: High-mem Proc[4]'
```

After
```

- level: "\x03"
  name: 'process_monitor: High-load Proc[0]'
--
- level: "\x03"
  name: 'process_monitor: High-load Proc[1]'
--
- level: "\x03"
  name: 'process_monitor: High-load Proc[2]'
--
- level: "\x03"
  name: 'process_monitor: High-load Proc[3]'
--
- level: "\x03"
  name: 'process_monitor: High-load Proc[4]'
--
- level: "\x03"
  name: 'process_monitor: High-mem Proc[0]'
--
- level: "\x03"
  name: 'process_monitor: High-mem Proc[1]'
--
- level: "\x03"
  name: 'process_monitor: High-mem Proc[2]'
--
- level: "\x03"
  name: 'process_monitor: High-mem Proc[3]'
--
- level: "\x03"
  name: 'process_monitor: High-mem Proc[4]'
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
