### PR TITLE
refactor(motion_utils): stop using CAPACITY from Trajectory message

### DIFF
--- a/common/motion_utils/src/trajectory/tmp_conversion.cpp
+++ b/common/motion_utils/src/trajectory/tmp_conversion.cpp
@@ -36,12 +36,7 @@ autoware_auto_planning_msgs::msg::Trajectory convertToTrajectory(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & trajectory)
 {
   autoware_auto_planning_msgs::msg::Trajectory output{};
-  for (const auto & pt : trajectory) {
-    output.points.push_back(pt);
-    if (output.points.size() >= output.CAPACITY) {
-      break;
-    }
-  }
+  for (const auto & pt : trajectory) output.points.push_back(pt);
   return output;
 }
 

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -803,17 +803,6 @@ TEST(trajectory, convertToTrajectory)
     const auto traj = convertToTrajectory(traj_input);
     EXPECT_EQ(traj.points.size(), traj_input.size());
   }
-
-  // Clipping check
-  {
-    const auto traj_input = generateTestTrajectoryPointArray(10000, 1.0);
-    const auto traj = convertToTrajectory(traj_input);
-    EXPECT_EQ(traj.points.size(), traj.CAPACITY);
-    // Value check
-    for (size_t i = 0; i < traj.points.size(); ++i) {
-      EXPECT_EQ(traj.points.at(i), traj_input.at(i));
-    }
-  }
 }
 
 TEST(trajectory, convertToTrajectoryPointArray)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
After this PR the `CAPACITY` constant from the `Trajectory`  message is no longer used in the universe code.
Required by https://github.com/autowarefoundation/autoware_msgs/pull/76

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
