### PR TITLE
refactor(tier4_autoware_utils): boost optional to std optional

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/marker_helper.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/marker_helper.hpp
@@ -19,8 +19,7 @@
 
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <string>
 
 namespace tier4_autoware_utils
@@ -75,7 +74,7 @@ visualization_msgs::msg::Marker createDeletedDefaultMarker(
 void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
   visualization_msgs::msg::MarkerArray * marker_array,
-  const boost::optional<rclcpp::Time> & current_time = {});
+  const std::optional<rclcpp::Time> & current_time = {});
 
 }  // namespace tier4_autoware_utils
 

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -18,7 +18,6 @@
   <depend>builtin_interfaces</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>libboost-dev</depend>
   <depend>logging_demo</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/common/tier4_autoware_utils/src/ros/marker_helper.cpp
+++ b/common/tier4_autoware_utils/src/ros/marker_helper.cpp
@@ -57,13 +57,13 @@ visualization_msgs::msg::Marker createDeletedDefaultMarker(
 void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
   visualization_msgs::msg::MarkerArray * marker_array,
-  const boost::optional<rclcpp::Time> & current_time)
+  const std::optional<rclcpp::Time> & current_time)
 {
   for (const auto & marker : additional_marker_array.markers) {
     marker_array->markers.push_back(marker);
 
     if (current_time) {
-      marker_array->markers.back().header.stamp = current_time.get();
+      marker_array->markers.back().header.stamp = current_time.value();
     }
   }
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3044e89</samp>

The pull request migrates the marker helper utilities in `tier4_autoware_utils` from `boost::optional` to `std::optional`, to reduce dependency on Boost and improve compatibility with modern C++ standards. It also updates the `package.xml` file accordingly.

## Related Links

[Libraries and modules mixes between boost::optional and std::optional #5732](https://github.com/autowarefoundation/autoware.universe/issues/5732)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
