### PR TITLE
refactor(virtual_traffic_light): boost::optional to std::optional

### DIFF
--- a/planning/behavior_velocity_virtual_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_virtual_traffic_light_module/package.xml
@@ -21,7 +21,6 @@
   <depend>behavior_velocity_planner_common</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libboost-dev</depend>
   <depend>motion_utils</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>pluginlib</depend>

--- a/planning/behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -27,7 +27,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -50,7 +49,7 @@ public:
     std::string instrument_id{};
     std::vector<tier4_v2x_msgs::msg::KeyValue> custom_tags{};
     tier4_autoware_utils::Point3d instrument_center{};
-    boost::optional<tier4_autoware_utils::LineString3d> stop_line{};
+    std::optional<tier4_autoware_utils::LineString3d> stop_line{};
     tier4_autoware_utils::LineString3d start_line{};
     std::vector<tier4_autoware_utils::LineString3d> end_lines{};
   };
@@ -59,8 +58,8 @@ public:
   {
     geometry_msgs::msg::Pose head_pose{};
     autoware_auto_planning_msgs::msg::PathWithLaneId path{};
-    boost::optional<geometry_msgs::msg::Pose> stop_head_pose_at_stop_line;
-    boost::optional<geometry_msgs::msg::Pose> stop_head_pose_at_end_line;
+    std::optional<geometry_msgs::msg::Pose> stop_head_pose_at_stop_line;
+    std::optional<geometry_msgs::msg::Pose> stop_head_pose_at_end_line;
   };
 
   struct PlannerParam
@@ -103,7 +102,7 @@ private:
     const geometry_msgs::msg::Pose & stop_pose,
     autoware_adapi_v1_msgs::msg::VelocityFactor * velocity_factor);
 
-  boost::optional<size_t> getPathIndexOfFirstEndLine();
+  std::optional<size_t> getPathIndexOfFirstEndLine();
 
   bool isBeforeStartLine(const size_t end_line_idx);
 
@@ -113,7 +112,7 @@ private:
 
   bool isNearAnyEndLine(const size_t end_line_idx);
 
-  boost::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState> findCorrespondingState();
+  std::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState> findCorrespondingState();
 
   bool isStateTimeout(const tier4_v2x_msgs::msg::VirtualTrafficLightState & state);
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a7dc62</samp>

This pull request migrates the `behavior_velocity_virtual_traffic_light_module` from using `boost::optional` to `std::optional` for optional types, as part of the planning package modernization. It updates the `scene.cpp` and `scene.hpp` files and removes the `libboost-dev` dependency from the `package.xml` file.

[Libraries and modules mixes between boost::optional and std::optional #5732](https://github.com/autowarefoundation/autoware.universe/issues/5732)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
