### PR TITLE
chore(ci): enable cron trigger for spell-check-all

### DIFF
--- a/.github/workflows/spell-check-all.yaml
+++ b/.github/workflows/spell-check-all.yaml
@@ -2,6 +2,8 @@ name: spell-check-all
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
   spell-check-all:


### PR DESCRIPTION
## Description

For continuous tracking of number of cspell errors, I added a schedule trigger to `spell-check-all` workflow.

## Tests performed

This workflow is run correctly on this branch.
https://github.com/autowarefoundation/autoware.universe/actions/runs/7082321085

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
