### PR TITLE
fix(map_based_prediction): limit the size of predicted path

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -995,6 +995,7 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
 
         for (auto & predicted_path : predicted_paths) {
           predicted_path.confidence = predicted_path.confidence / sum_confidence;
+          if(predicted_object.kinematics.predicted_paths.size() >= 100) break;
           predicted_object.kinematics.predicted_paths.push_back(predicted_path);
         }
         output.objects.push_back(predicted_object);


### PR DESCRIPTION
## Description

This PR limits the size of predicted path added to autoware_auto_perception_msgs/PredictedObjectKinematics which has size of 100 max.


## Tests performed
You can check with the attached scenario.

<!-- Describe how you have tested this PR. -->
[ShalunScenario.zip](https://github.com/autowarefoundation/autoware.universe/files/13542511/ShalunScenario.zip)

1. Modify the file path for lanelet2 map and pointcloud map to the extracted map file path.
2. run the following command: `ros2 launch scenario_test_runner scenario_test_runner.launch.py architecture_type:=awf/universe record:=false sensor_model:=sample_sensor_kit vehicle_model:=sample_vehicle scenario:='<path_to_scenario_file>' launch_rviz:=False initialize_duration:=90`

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
None.

## Effects on system behavior
It reduces the chance of segmentation fault happening in perception stack.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
