### PR TITLE
refactor(landmark_manager): move `calc_new_self_pose` from ar_tag_based_localizer to landmark_manger

### DIFF
--- a/localization/landmark_based_localizer/ar_tag_based_localizer/src/ar_tag_based_localizer.hpp
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/src/ar_tag_based_localizer.hpp
@@ -90,8 +90,6 @@ private:
   void cam_info_callback(const CameraInfo::ConstSharedPtr & msg);
   void ekf_pose_callback(const PoseWithCovarianceStamped::ConstSharedPtr & msg);
   std::vector<landmark_manager::Landmark> detect_landmarks(const Image::ConstSharedPtr & msg);
-  Pose calculate_new_self_pose(
-    const std::vector<landmark_manager::Landmark> & detected_landmarks, const Pose & self_pose);
 
   // Parameters
   float marker_size_{};
@@ -126,7 +124,7 @@ private:
   aruco::CameraParameters cam_param_;
   bool cam_info_received_;
   std::unique_ptr<SmartPoseBuffer> ekf_pose_buffer_;
-  std::map<std::string, Pose> landmark_map_;
+  landmark_manager::LandmarkManager landmark_manager_;
 };
 
 #endif  // AR_TAG_BASED_LOCALIZER_HPP_

--- a/localization/landmark_based_localizer/landmark_manager/include/landmark_manager/landmark_manager.hpp
+++ b/localization/landmark_based_localizer/landmark_manager/include/landmark_manager/landmark_manager.hpp
@@ -22,6 +22,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -48,6 +49,8 @@ public:
     const geometry_msgs::msg::Pose & self_pose) const;
 
 private:
+  // To allow multiple landmarks with the same id to be registered on a vector_map,
+  // manage vectors by having them in a std::map.
   // landmarks_map_["<id>"] = [pose0, pose1, ...]
   std::map<std::string, std::vector<geometry_msgs::msg::Pose>> landmarks_map_;
 };

--- a/localization/landmark_based_localizer/landmark_manager/include/landmark_manager/landmark_manager.hpp
+++ b/localization/landmark_based_localizer/landmark_manager/include/landmark_manager/landmark_manager.hpp
@@ -34,12 +34,23 @@ struct Landmark
   geometry_msgs::msg::Pose pose;
 };
 
-std::vector<Landmark> parse_landmarks(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
-  const std::string & target_subtype, const rclcpp::Logger & logger);
+class LandmarkManager
+{
+public:
+  void parse_landmarks(
+    const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
+    const std::string & target_subtype, const rclcpp::Logger & logger);
 
-visualization_msgs::msg::MarkerArray convert_landmarks_to_marker_array_msg(
-  const std::vector<Landmark> & landmarks);
+  visualization_msgs::msg::MarkerArray get_landmarks_as_marker_array_msg() const;
+
+  geometry_msgs::msg::Pose calculate_new_self_pose(
+    const std::vector<landmark_manager::Landmark> & detected_landmarks,
+    const geometry_msgs::msg::Pose & self_pose) const;
+
+private:
+  // landmarks_map_["<id>"] = [pose0, pose1, ...]
+  std::map<std::string, std::vector<geometry_msgs::msg::Pose>> landmarks_map_;
+};
 
 }  // namespace landmark_manager
 

--- a/localization/landmark_based_localizer/landmark_manager/package.xml
+++ b/localization/landmark_based_localizer/landmark_manager/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
+  <depend>localization_util</depend>
   <depend>rclcpp</depend>
   <depend>tf2_eigen</depend>
 


### PR DESCRIPTION
## Description

Moved `calc_new_self_pose` from ar_tag_based_localizer to landmark_manger

This is introduced to share the same implementation as the LiDAR Marker Localizer.

## Tests performed

It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

* Before: mean_error[m]	0.614
* After : mean_error[m] 0.613

## Effects on system behavior

There are no effects on system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
