### PR TITLE
fix(mission_planner): fix check_reroute_safety

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -726,9 +726,6 @@ bool MissionPlanner::check_reroute_safety(
     return false;
   }
 
-  // find the index of the original route that has same idx with the front segment of the new route
-  const auto target_front_primitives = target_route.segments.front().primitives;
-
   auto hasSamePrimitives = [](
                              const std::vector<LaneletPrimitive> & original_primitives,
                              const std::vector<LaneletPrimitive> & target_primitives) {
@@ -745,15 +742,55 @@ bool MissionPlanner::check_reroute_safety(
     return is_same;
   };
 
-  // find idx that matches the target primitives
-  size_t start_idx = original_route.segments.size();
-  for (size_t i = 0; i < original_route.segments.size(); ++i) {
-    const auto & original_primitives = original_route.segments.at(i).primitives;
-    if (hasSamePrimitives(original_primitives, target_front_primitives)) {
-      start_idx = i;
-      break;
+  // find idx of original primitives that matches the target primitives
+  const auto start_idx_opt = std::invoke([&]() -> std::optional<size_t> {
+    /*
+     * find the index of the original route that has same idx with the front segment of the new
+     * route
+     *
+     *                          start_idx
+     * +-----------+-----------+-----------+-----------+-----------+
+     * |           |           |           |           |           |
+     * +-----------+-----------+-----------+-----------+-----------+
+     * |           |           |           |           |           |
+     * +-----------+-----------+-----------+-----------+-----------+
+     *  original    original    original    original    original
+     *                          target      target      target
+     */
+    const auto target_front_primitives = target_route.segments.front().primitives;
+    for (size_t i = 0; i < original_route.segments.size(); ++i) {
+      const auto & original_primitives = original_route.segments.at(i).primitives;
+      if (hasSamePrimitives(original_primitives, target_front_primitives)) {
+        return i;
+      }
     }
+
+    /*
+     * find the target route that has same idx with the front segment of the original route
+     *
+     *                          start_idx
+     * +-----------+-----------+-----------+-----------+-----------+
+     * |           |           |           |           |           |
+     * +-----------+-----------+-----------+-----------+-----------+
+     * |           |           |           |           |           |
+     * +-----------+-----------+-----------+-----------+-----------+
+     * 　　　　　　　　　　　　　　　original    original    original
+     *  target      target      target      target      target
+     */
+    const auto original_front_primitives = original_route.segments.front().primitives;
+    for (size_t i = 0; i < target_route.segments.size(); ++i) {
+      const auto & target_primitives = target_route.segments.at(i).primitives;
+      if (hasSamePrimitives(target_primitives, original_front_primitives)) {
+        return 0;
+      }
+    }
+
+    return std::nullopt;
+  });
+  if (!start_idx_opt.has_value()) {
+    return false;
   }
+  const size_t start_idx = start_idx_opt.value();
 
   // find last idx that matches the target primitives
   size_t end_idx = start_idx;


### PR DESCRIPTION
## Description

fix https://github.com/autowarefoundation/autoware.universe/pull/3460 for case (2)

(1)
```
    /*
     * find the index of the original route that has same idx with the front segment of the new
     * route
     *
     *                          start_idx
     * +-----------+-----------+-----------+-----------+-----------+
     * |           |           |           |           |           |
     * +-----------+-----------+-----------+-----------+-----------+
     * |           |           |           |           |           |
     * +-----------+-----------+-----------+-----------+-----------+
     *  original    original    original    original    original
     *                          target      target      target
     */
```

(2)
```
    /*
     * find the target route that has same idx with the front segment of the original route
     *
     *                          start_idx
     * +-----------+-----------+-----------+-----------+-----------+
     * |           |           |           |           |           |
     * +-----------+-----------+-----------+-----------+-----------+
     * |           |           |           |           |           |
     * +-----------+-----------+-----------+-----------+-----------+
     * 　　　　　　　　　　　　　　　original    original    original
     *  target      target      target      target      target
     */
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

evaluator_description: fix/check_reroute_safety
2023/12/04 https://evaluation.tier4.jp/evaluation/reports/ed44e2e1-f287-5ef3-84c7-7502af486585/?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
