### PR TITLE
fix(mission_planner): use ClearRoute instead of Trigger to prevent dying

### DIFF
--- a/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
@@ -32,7 +32,7 @@ struct SetMrmRoute
 
 struct ClearMrmRoute
 {
-  using Service = std_srvs::srv::Trigger;
+  using Service = autoware_adapi_v1_msgs::srv::ClearRoute;
   static constexpr char name[] = "~/srv/clear_mrm_route";
 };
 

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -497,7 +497,7 @@ void MissionPlanner::on_clear_mrm_route(
   if (!normal_route_) {
     clear_mrm_route();
     change_state(RouteState::Message::UNSET);
-    res->success = true;
+    res->status.success = true;
     return;
   }
 
@@ -506,7 +506,7 @@ void MissionPlanner::on_clear_mrm_route(
     clear_mrm_route();
     change_route(*normal_route_);
     change_state(RouteState::Message::SET);
-    res->success = true;
+    res->status.success = true;
     return;
   }
 
@@ -523,12 +523,12 @@ void MissionPlanner::on_clear_mrm_route(
     change_mrm_route(*mrm_route_);
     change_route(*normal_route_);
     change_state(RouteState::Message::SET);
-    res->success = false;
+    res->status.success = false;
   } else {
     clear_mrm_route();
     change_route(new_route);
     change_state(RouteState::Message::SET);
-    res->success = true;
+    res->status.success = true;
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

use ClearRoute instead of Trigger to prevent dying.

ServiceException from Trigger can not be caught.


tier4 internal slack
https://star4.slack.com/archives/C03QW0GU6P7/p1701669957434089

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
