### PR TITLE
fix(mission_planner): fix clear_mrm_route

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -487,9 +487,12 @@ void MissionPlanner::on_clear_mrm_route(
   if (!mrm_route_) {
     throw component_interface_utils::NoEffectWarning("MRM route is not set");
   }
-  if (reroute_availability_ && !reroute_availability_->availability) {
+  if (
+    state_.state == RouteState::Message::SET && reroute_availability_ &&
+    !reroute_availability_->availability) {
     throw component_interface_utils::ServiceException(
-      ResponseCode::ERROR_INVALID_STATE, "Cannot reroute as the planner is not in lane following.");
+      ResponseCode::ERROR_INVALID_STATE,
+      "Cannot clear MRM route as the planner is not lane following before arriving at the goal.");
   }
 
   change_state(RouteState::Message::CHANGING);
@@ -563,7 +566,7 @@ void MissionPlanner::on_modified_goal(const ModifiedGoal::Message::ConstSharedPt
     if (new_route.segments.empty()) {
       change_mrm_route(*mrm_route_);
       change_state(RouteState::Message::SET);
-      RCLCPP_ERROR(get_logger(), "The planned route is empty.");
+      RCLCPP_ERROR(get_logger(), "The planned MRM route is empty.");
       return;
     }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

  // Check reroute availability only when state is SET.
  // This allows clear even if the module is running after the ARRIVED GOAL.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
