### PR TITLE
refactor(bpp): use pluginlib to load scene module

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -16,6 +16,17 @@
   <arg name="launch_start_planner_module" default="true"/>
   <arg name="launch_side_shift_module" default="true"/>
 
+  <arg name="launch_avoidance_module" default="true"/>
+  <arg name="launch_dynamic_avoidance_module" default="true"/>
+  <arg name="launch_side_shift_module" default="true"/>
+  <arg name="launch_goal_planner_module" default="true"/>
+  <arg name="launch_start_planner_module" default="true"/>
+  <arg name="launch_lane_change_right_module" default="true"/>
+  <arg name="launch_lane_change_left_module" default="true"/>
+  <arg name="launch_external_request_lane_change_right_module" default="true"/>
+  <arg name="launch_external_request_lane_change_left_module" default="true"/>
+  <arg name="launch_avoidance_by_lane_change_module" default="true"/>
+
   <arg name="launch_crosswalk_module" default="true"/>
   <arg name="launch_walkway_module" default="true"/>
   <arg name="launch_traffic_light_module" default="true"/>
@@ -31,6 +42,60 @@
   <arg name="launch_speed_bump_module" default="true"/>
   <arg name="launch_out_of_lane_module" default="true"/>
   <arg name="launch_no_drivable_lane_module" default="true"/>
+
+  <!-- assemble launch config for behavior path planner -->
+  <arg name="behavior_path_planner_launch_modules" default="["/>
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::AvoidanceModuleManager, '&quot;)"
+    if="$(var launch_avoidance_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::DynamicAvoidanceModuleManager, '&quot;)"
+    if="$(var launch_dynamic_avoidance_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::SideShiftModuleManager, '&quot;)"
+    if="$(var launch_side_shift_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::StartPlannerModuleManager, '&quot;)"
+    if="$(var launch_start_planner_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::GoalPlannerModuleManager, '&quot;)"
+    if="$(var launch_goal_planner_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::LaneChangeRightModuleManager, '&quot;)"
+    if="$(var launch_lane_change_right_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::LaneChangeLeftModuleManager, '&quot;)"
+    if="$(var launch_lane_change_left_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::ExternalRequestLaneChangeRightModuleManager, '&quot;)"
+    if="$(var launch_external_request_lane_change_right_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager, '&quot;)"
+    if="$(var launch_external_request_lane_change_left_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::AvoidanceByLaneChangeModuleManager, '&quot;)"
+    if="$(var launch_avoidance_by_lane_change_module)"
+  />
+  <let name="behavior_path_planner_launch_modules" value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + ']'&quot;)"/>
 
   <!-- assemble launch config for behavior velocity planner -->
   <arg name="behavior_velocity_planner_launch_modules" default="["/>
@@ -129,19 +194,10 @@
       <remap from="~/output/modified_goal" to="/planning/scenario_planning/modified_goal"/>
       <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
       <!-- params -->
-      <param name="avoidance.enable_module" value="$(var launch_avoidance_module)"/>
-      <param name="avoidance_by_lc.enable_module" value="$(var launch_avoidance_by_lane_change_module)"/>
-      <param name="dynamic_avoidance.enable_module" value="$(var launch_dynamic_avoidance_module)"/>
-      <param name="lane_change_right.enable_module" value="$(var launch_lane_change_right_module)"/>
-      <param name="lane_change_left.enable_module" value="$(var launch_lane_change_left_module)"/>
-      <param name="external_request_lane_change_left.enable_module" value="$(var launch_external_request_lane_change_left_module)"/>
-      <param name="external_request_lane_change_right.enable_module" value="$(var launch_external_request_lane_change_right_module)"/>
-      <param name="goal_planner.enable_module" value="$(var launch_goal_planner_module)"/>
-      <param name="start_planner.enable_module" value="$(var launch_start_planner_module)"/>
-      <param name="side_shift.enable_module" value="$(var launch_side_shift_module)"/>
       <param from="$(var common_param_path)"/>
       <param from="$(var vehicle_param_file)"/>
       <param from="$(var nearest_search_param_path)"/>
+      <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
       <param from="$(var behavior_path_planner_side_shift_module_param_path)"/>
       <param from="$(var behavior_path_planner_avoidance_module_param_path)"/>
       <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -11,9 +11,7 @@ pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   src/planner_manager.cpp
-  src/steering_factor_interface.cpp
   src/behavior_path_planner_node.cpp
-  src/scene_module/scene_module_visitor.cpp
   src/scene_module/avoidance/avoidance_module.cpp
   src/scene_module/avoidance/manager.cpp
   src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,9 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-ament_auto_add_library(behavior_path_planner_node SHARED
+pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
+
+ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   src/planner_manager.cpp
   src/steering_factor_interface.cpp
   src/behavior_path_planner_node.cpp
@@ -48,17 +50,17 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/marker_utils/lane_change/debug.cpp
 )
 
-target_include_directories(behavior_path_planner_node SYSTEM PUBLIC
+target_include_directories(${PROJECT_NAME}_lib SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}
 )
 
-target_link_libraries(behavior_path_planner_node
+target_link_libraries(${PROJECT_NAME}_lib
   ${OpenCV_LIBRARIES}
 )
 
-rclcpp_components_register_node(behavior_path_planner_node
+rclcpp_components_register_node(${PROJECT_NAME}_lib
   PLUGIN "behavior_path_planner::BehaviorPathPlannerNode"
-  EXECUTABLE behavior_path_planner
+  EXECUTABLE ${PROJECT_NAME}_node
 )
 
 if(BUILD_TESTING)
@@ -68,7 +70,7 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(test_${CMAKE_PROJECT_NAME}_utilities
-    behavior_path_planner_node
+    ${PROJECT_NAME}_lib
   )
 
   ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_avoidance_module
@@ -76,7 +78,7 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(test_${CMAKE_PROJECT_NAME}_avoidance_module
-    behavior_path_planner_node
+    ${PROJECT_NAME}_lib
   )
 
   ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_lane_change_module
@@ -84,14 +86,15 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(test_${CMAKE_PROJECT_NAME}_lane_change_module
-    behavior_path_planner_node
+    ${PROJECT_NAME}_lib
   )
 
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}_node_interface
     test/test_${PROJECT_NAME}_node_interface.cpp
   )
+
   target_link_libraries(test_${PROJECT_NAME}_node_interface
-    behavior_path_planner_node
+    ${PROJECT_NAME}_lib
   )
 endif()
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -16,9 +16,9 @@
 #define BEHAVIOR_PATH_PLANNER__BEHAVIOR_PATH_PLANNER_NODE_HPP_
 
 #include "behavior_path_planner/planner_manager.hpp"
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
-#include "behavior_path_planner/steering_factor_interface.hpp"
 #include "behavior_path_planner_common/data_manager.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/steering_factor_interface.hpp"
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -15,9 +15,9 @@
 #ifndef BEHAVIOR_PATH_PLANNER__PLANNER_MANAGER_HPP_
 #define BEHAVIOR_PATH_PLANNER__PLANNER_MANAGER_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
-#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -21,6 +21,7 @@
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 
+#include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
@@ -104,14 +105,17 @@ public:
 
   /**
    * @brief register managers.
-   * @param manager pointer.
+   * @param node.
+   * @param plugin name.
    */
-  void registerSceneModuleManager(const SceneModuleManagerPtr & manager_ptr)
-  {
-    RCLCPP_INFO(logger_, "register %s module", manager_ptr->name().c_str());
-    manager_ptrs_.push_back(manager_ptr);
-    processing_time_.emplace(manager_ptr->name(), 0.0);
-  }
+  void launchScenePlugin(rclcpp::Node & node, const std::string & name);
+
+  /**
+   * @brief unregister managers.
+   * @param node.
+   * @param plugin name.
+   */
+  void removeScenePlugin(rclcpp::Node & node, const std::string & name);
 
   /**
    * @brief update module parameters. used for dynamic reconfigure.
@@ -433,6 +437,8 @@ private:
   std::vector<SceneModulePtr> candidate_module_ptrs_;
 
   std::unique_ptr<DebugPublisher> debug_publisher_ptr_;
+
+  pluginlib::ClassLoader<SceneModuleManagerInterface> plugin_loader_;
 
   mutable rclcpp::Logger logger_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -15,11 +15,11 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_MODULE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
-#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/avoidance/avoidance_module_data.hpp"
 #include "behavior_path_planner/utils/avoidance/helper.hpp"
 #include "behavior_path_planner/utils/avoidance/shift_line_generator.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp"
 
 #include <rclcpp/rclcpp.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -32,8 +32,9 @@ namespace behavior_path_planner
 class AvoidanceModuleManager : public SceneModuleManagerInterface
 {
 public:
-  AvoidanceModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
+  AvoidanceModuleManager() : SceneModuleManagerInterface{"avoidance"} {}
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -16,8 +16,8 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__MANAGER_HPP_
 
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
 #include "behavior_path_planner/utils/avoidance/avoidance_module_data.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -15,7 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/geometry/boost_geometry.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
@@ -31,8 +31,9 @@ namespace behavior_path_planner
 class DynamicAvoidanceModuleManager : public SceneModuleManagerInterface
 {
 public:
-  DynamicAvoidanceModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
+  DynamicAvoidanceModuleManager() : SceneModuleManagerInterface{"dynamic_avoidance"} {}
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
@@ -16,7 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__MANAGER_HPP_
 
 #include "behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp"
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
@@ -15,7 +15,6 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__GOAL_PLANNER__GOAL_PLANNER_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__GOAL_PLANNER__GOAL_PLANNER_MODULE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/utils/geometric_parallel_parking/geometric_parallel_parking.hpp"
 #include "behavior_path_planner/utils/goal_planner/default_fixed_goal_planner.hpp"
 #include "behavior_path_planner/utils/goal_planner/freespace_pull_over.hpp"
@@ -25,6 +24,7 @@
 #include "behavior_path_planner/utils/goal_planner/shift_pull_over.hpp"
 #include "behavior_path_planner/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.hpp"
 #include "behavior_path_planner/utils/start_goal_planner_common/common_module_data.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 #include "behavior_path_planner_common/utils/utils.hpp"
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
@@ -30,8 +30,9 @@ namespace behavior_path_planner
 class GoalPlannerModuleManager : public SceneModuleManagerInterface
 {
 public:
-  GoalPlannerModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
+  GoalPlannerModuleManager() : SceneModuleManagerInterface{"goal_planner"} {}
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
@@ -16,7 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__GOAL_PLANNER__MANAGER_HPP_
 
 #include "behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp"
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -14,10 +14,10 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__BASE_CLASS_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__BASE_CLASS_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/utils/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner/utils/lane_change/lane_change_path.hpp"
 #include "behavior_path_planner/utils/lane_change/utils.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "behavior_path_planner_common/turn_signal_decider.hpp"
 #include "behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
@@ -19,9 +19,9 @@
 #include "behavior_path_planner/scene_module/lane_change/base_class.hpp"
 #include "behavior_path_planner/scene_module/lane_change/external_request.hpp"
 #include "behavior_path_planner/scene_module/lane_change/normal.hpp"
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/utils/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner/utils/lane_change/lane_change_path.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "behavior_path_planner_common/turn_signal_decider.hpp"
 #include "behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -16,7 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__MANAGER_HPP_
 
 #include "behavior_path_planner/scene_module/lane_change/interface.hpp"
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 #include "route_handler/route_handler.hpp"
 
 #include <rclcpp/rclcpp.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -34,8 +34,12 @@ class LaneChangeModuleManager : public SceneModuleManagerInterface
 {
 public:
   LaneChangeModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
-    const Direction direction, const LaneChangeModuleType type);
+    const std::string & name, const Direction direction, const LaneChangeModuleType type)
+  : SceneModuleManagerInterface{name}, direction_{direction}, type_{type}
+  {
+  }
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override;
 
@@ -49,15 +53,61 @@ protected:
   LaneChangeModuleType type_;
 };
 
+class LaneChangeRightModuleManager : public LaneChangeModuleManager
+{
+public:
+  LaneChangeRightModuleManager()
+  : LaneChangeModuleManager(
+      "lane_change_right", route_handler::Direction::RIGHT, LaneChangeModuleType::NORMAL)
+  {
+  }
+};
+
+class LaneChangeLeftModuleManager : public LaneChangeModuleManager
+{
+public:
+  LaneChangeLeftModuleManager()
+  : LaneChangeModuleManager(
+      "lane_change_left", route_handler::Direction::LEFT, LaneChangeModuleType::NORMAL)
+  {
+  }
+};
+
+class ExternalRequestLaneChangeRightModuleManager : public LaneChangeModuleManager
+{
+public:
+  ExternalRequestLaneChangeRightModuleManager()
+  : LaneChangeModuleManager(
+      "external_request_lane_change_right", route_handler::Direction::RIGHT,
+      LaneChangeModuleType::EXTERNAL_REQUEST)
+  {
+  }
+};
+
+class ExternalRequestLaneChangeLeftModuleManager : public LaneChangeModuleManager
+{
+public:
+  ExternalRequestLaneChangeLeftModuleManager()
+  : LaneChangeModuleManager(
+      "external_request_lane_change_left", route_handler::Direction::LEFT,
+      LaneChangeModuleType::EXTERNAL_REQUEST)
+  {
+  }
+};
+
 class AvoidanceByLaneChangeModuleManager : public LaneChangeModuleManager
 {
 public:
-  AvoidanceByLaneChangeModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
+  AvoidanceByLaneChangeModuleManager()
+  : LaneChangeModuleManager(
+      "avoidance_by_lc", route_handler::Direction::NONE,
+      LaneChangeModuleType::AVOIDANCE_BY_LANE_CHANGE)
+  {
+  }
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override;
-
-  // void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
   std::shared_ptr<AvoidanceByLCParameters> avoidance_parameters_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -17,6 +17,7 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_MANAGER_INTERFACE_HPP_
 
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "tier4_autoware_utils/ros/parameter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -43,39 +44,11 @@ using SceneModuleObserver = std::weak_ptr<SceneModuleInterface>;
 class SceneModuleManagerInterface
 {
 public:
-  SceneModuleManagerInterface(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
-    const std::vector<std::string> & rtc_types)
-  : node_(node),
-    clock_(*node->get_clock()),
-    logger_(node->get_logger().get_child(name)),
-    name_(name),
-    enable_simultaneous_execution_as_approved_module_(
-      config.enable_simultaneous_execution_as_approved_module),
-    enable_simultaneous_execution_as_candidate_module_(
-      config.enable_simultaneous_execution_as_candidate_module),
-    enable_rtc_(config.enable_rtc),
-    keep_last_(config.keep_last),
-    max_module_num_(config.max_module_size),
-    priority_(config.priority)
-  {
-    for (const auto & rtc_type : rtc_types) {
-      const auto snake_case_name = utils::convertToSnakeCase(name);
-      const auto rtc_interface_name =
-        rtc_type == "" ? snake_case_name : snake_case_name + "_" + rtc_type;
-      rtc_interface_ptr_map_.emplace(
-        rtc_type, std::make_shared<RTCInterface>(node, rtc_interface_name, enable_rtc_));
-      objects_of_interest_marker_interface_ptr_map_.emplace(
-        rtc_type, std::make_shared<ObjectsOfInterestMarkerInterface>(node, rtc_interface_name));
-    }
-
-    pub_info_marker_ = node->create_publisher<MarkerArray>("~/info/" + name, 20);
-    pub_debug_marker_ = node->create_publisher<MarkerArray>("~/debug/" + name, 20);
-    pub_virtual_wall_ = node->create_publisher<MarkerArray>("~/virtual_wall/" + name, 20);
-    pub_drivable_lanes_ = node->create_publisher<MarkerArray>("~/drivable_lanes/" + name, 20);
-  }
+  explicit SceneModuleManagerInterface(const std::string & name) : name_{name} {}
 
   virtual ~SceneModuleManagerInterface() = default;
+
+  virtual void init(rclcpp::Node * node) = 0;
 
   void updateIdleModuleInstance()
   {
@@ -215,7 +188,7 @@ public:
     });
   }
 
-  bool canLaunchNewModule() const { return observers_.size() < max_module_num_; }
+  bool canLaunchNewModule() const { return observers_.size() < config_.max_module_size; }
 
   /**
    * Determine if the module is always executable, regardless of the state of other modules.
@@ -234,7 +207,7 @@ public:
       return true;
     }
 
-    return enable_simultaneous_execution_as_approved_module_;
+    return config_.enable_simultaneous_execution_as_approved_module;
   }
 
   virtual bool isSimultaneousExecutableAsCandidateModule() const
@@ -243,10 +216,10 @@ public:
       return true;
     }
 
-    return enable_simultaneous_execution_as_candidate_module_;
+    return config_.enable_simultaneous_execution_as_candidate_module;
   }
 
-  bool isKeepLast() const { return keep_last_; }
+  bool isKeepLast() const { return config_.keep_last; }
 
   void setData(const std::shared_ptr<PlannerData> & planner_data) { planner_data_ = planner_data; }
 
@@ -270,7 +243,7 @@ public:
     pub_debug_marker_->publish(MarkerArray{});
   }
 
-  size_t getPriority() const { return priority_; }
+  size_t getPriority() const { return config_.priority; }
 
   std::string name() const { return name_; }
 
@@ -281,13 +254,51 @@ public:
   virtual void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
 protected:
+  void initInterface(rclcpp::Node * node, const std::vector<std::string> & rtc_types)
+  {
+    using tier4_autoware_utils::getOrDeclareParameter;
+
+    // init manager configuration
+    {
+      std::string ns = name_ + ".";
+      config_.enable_rtc = getOrDeclareParameter<bool>(*node, ns + "enable_rtc");
+      config_.enable_simultaneous_execution_as_approved_module =
+        getOrDeclareParameter<bool>(*node, ns + "enable_simultaneous_execution_as_approved_module");
+      config_.enable_simultaneous_execution_as_candidate_module = getOrDeclareParameter<bool>(
+        *node, ns + "enable_simultaneous_execution_as_candidate_module");
+      config_.keep_last = getOrDeclareParameter<bool>(*node, ns + "keep_last");
+      config_.priority = getOrDeclareParameter<int>(*node, ns + "priority");
+      config_.max_module_size = getOrDeclareParameter<int>(*node, ns + "max_module_size");
+    }
+
+    // init rtc configuration
+    for (const auto & rtc_type : rtc_types) {
+      const auto snake_case_name = utils::convertToSnakeCase(name_);
+      const auto rtc_interface_name =
+        rtc_type == "" ? snake_case_name : snake_case_name + "_" + rtc_type;
+      rtc_interface_ptr_map_.emplace(
+        rtc_type, std::make_shared<RTCInterface>(node, rtc_interface_name, config_.enable_rtc));
+      objects_of_interest_marker_interface_ptr_map_.emplace(
+        rtc_type, std::make_shared<ObjectsOfInterestMarkerInterface>(node, rtc_interface_name));
+    }
+
+    // init publisher
+    {
+      pub_info_marker_ = node->create_publisher<MarkerArray>("~/info/" + name_, 20);
+      pub_debug_marker_ = node->create_publisher<MarkerArray>("~/debug/" + name_, 20);
+      pub_virtual_wall_ = node->create_publisher<MarkerArray>("~/virtual_wall/" + name_, 20);
+      pub_drivable_lanes_ = node->create_publisher<MarkerArray>("~/drivable_lanes/" + name_, 20);
+    }
+
+    // misc
+    {
+      node_ = node;
+    }
+  }
+
   virtual std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() = 0;
 
   rclcpp::Node * node_;
-
-  rclcpp::Clock clock_;
-
-  rclcpp::Logger logger_;
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_info_marker_;
 
@@ -310,18 +321,7 @@ protected:
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>>
     objects_of_interest_marker_interface_ptr_map_;
 
-  bool enable_simultaneous_execution_as_approved_module_{false};
-
-  bool enable_simultaneous_execution_as_candidate_module_{false};
-
-private:
-  bool enable_rtc_;
-
-  bool keep_last_;
-
-  size_t max_module_num_;
-
-  size_t priority_;
+  ModuleConfigParameters config_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
@@ -31,8 +31,9 @@ namespace behavior_path_planner
 class SideShiftModuleManager : public SceneModuleManagerInterface
 {
 public:
-  SideShiftModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
+  SideShiftModuleManager() : SceneModuleManagerInterface{"side_shift"} {}
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
@@ -15,8 +15,8 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SIDE_SHIFT__MANAGER_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SIDE_SHIFT__MANAGER_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
 #include "behavior_path_planner/scene_module/side_shift/side_shift_module.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -15,8 +15,8 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SIDE_SHIFT__SIDE_SHIFT_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SIDE_SHIFT__SIDE_SHIFT_MODULE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/utils/side_shift/side_shift_parameters.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
 
 #include <rclcpp/rclcpp.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
@@ -30,8 +30,9 @@ namespace behavior_path_planner
 class StartPlannerModuleManager : public SceneModuleManagerInterface
 {
 public:
-  StartPlannerModuleManager(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
+  StartPlannerModuleManager() : SceneModuleManagerInterface{"start_planner"} {}
+
+  void init(rclcpp::Node * node) override;
 
   std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
@@ -15,8 +15,8 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__START_PLANNER__MANAGER_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__START_PLANNER__MANAGER_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
 #include "behavior_path_planner/scene_module/start_planner/start_planner_module.hpp"
+#include "behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -15,7 +15,6 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__START_PLANNER__START_PLANNER_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__START_PLANNER__START_PLANNER_MODULE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/utils/geometric_parallel_parking/geometric_parallel_parking.hpp"
 #include "behavior_path_planner/utils/start_goal_planner_common/common_module_data.hpp"
 #include "behavior_path_planner/utils/start_planner/freespace_pull_out.hpp"
@@ -23,6 +22,7 @@
 #include "behavior_path_planner/utils/start_planner/pull_out_path.hpp"
 #include "behavior_path_planner/utils/start_planner/shift_pull_out.hpp"
 #include "behavior_path_planner/utils/start_planner/start_planner_parameters.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 #include "behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
 #include "behavior_path_planner_common/utils/utils.hpp"

--- a/planning/behavior_path_planner/launch/behavior_path_planner.launch.xml
+++ b/planning/behavior_path_planner/launch/behavior_path_planner.launch.xml
@@ -6,17 +6,7 @@
   <arg name="nearest_search_param_path"/>
 
   <!-- launch module -->
-  <arg name="launch_avoidance_module"/>
-  <arg name="launch_avoidance_by_lane_change_module"/>
-  <arg name="launch_dynamic_avoidance_module"/>
-  <arg name="launch_lane_change_right_module"/>
-  <arg name="launch_lane_change_left_module"/>
-  <arg name="launch_external_request_lane_change_right_module"/>
-  <arg name="launch_external_request_lane_change_left_module"/>
-  <arg name="launch_goal_planner_module"/>
-  <arg name="launch_start_planner_module"/>
-  <arg name="launch_side_shift_module"/>
-  <arg name="use_experimental_lane_change_function"/>
+  <arg name="behavior_path_planner_launch_modules"/>
 
   <!-- module config path -->
   <arg name="behavior_path_config_path"/>
@@ -48,17 +38,7 @@
     <remap from="~/output/modified_goal" to="/planning/scenario_planning/modified_goal"/>
     <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
     <!-- params -->
-    <param name="avoidance.enable_module" value="$(var launch_avoidance_module)"/>
-    <param name="avoidance_by_lc.enable_module" value="$(var launch_avoidance_by_lane_change_module)"/>
-    <param name="dynamic_avoidance.enable_module" value="$(var launch_dynamic_avoidance_module)"/>
-    <param name="lane_change_right.enable_module" value="$(var launch_lane_change_right_module)"/>
-    <param name="lane_change_left.enable_module" value="$(var launch_lane_change_left_module)"/>
-    <param name="external_request_lane_change_left.enable_module" value="$(var launch_external_request_lane_change_left_module)"/>
-    <param name="external_request_lane_change_right.enable_module" value="$(var launch_external_request_lane_change_right_module)"/>
-    <param name="goal_planner.enable_module" value="$(var launch_goal_planner_module)"/>
-    <param name="start_planner.enable_module" value="$(var launch_start_planner_module)"/>
-    <param name="side_shift.enable_module" value="$(var launch_side_shift_module)"/>
-    <param name="use_experimental_lane_change_function" value="$(var use_experimental_lane_change_function)"/>
+    <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
     <!-- load config -->
     <param from="$(var common_param_path)"/>
     <param from="$(var vehicle_param_file)"/>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -64,6 +64,7 @@
   <depend>object_recognition_utils</depend>
   <depend>objects_of_interest_marker_interface</depend>
   <depend>planning_test_utils</depend>
+  <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>route_handler</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -51,7 +51,6 @@
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>behavior_path_planner_common</depend>
-  <depend>behaviortree_cpp_v3</depend>
   <depend>freespace_planning_algorithms</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>
@@ -62,13 +61,11 @@
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>
   <depend>object_recognition_utils</depend>
-  <depend>objects_of_interest_marker_interface</depend>
   <depend>planning_test_utils</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>route_handler</depend>
-  <depend>rtc_interface</depend>
   <depend>sensor_msgs</depend>
   <depend>signal_processing</depend>
   <depend>tf2</depend>

--- a/planning/behavior_path_planner/plugins.xml
+++ b/planning/behavior_path_planner/plugins.xml
@@ -1,0 +1,12 @@
+<library path="behavior_path_planner_lib">
+  <class type="behavior_path_planner::AvoidanceModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::StartPlannerModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::GoalPlannerModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::SideShiftModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::DynamicAvoidanceModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::LaneChangeRightModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::LaneChangeLeftModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::ExternalRequestLaneChangeRightModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="behavior_path_planner::AvoidanceByLaneChangeModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+</library>

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -15,8 +15,8 @@
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
 
 #include "behavior_path_planner/marker_utils/avoidance/debug.hpp"
-#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/avoidance/utils.hpp"
+#include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
 #include "behavior_path_planner_common/utils/create_vehicle_footprint.hpp"
 #include "behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp"

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -25,13 +25,13 @@
 
 namespace behavior_path_planner
 {
-
-AvoidanceModuleManager::AvoidanceModuleManager(
-  rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
-: SceneModuleManagerInterface(node, name, config, {"left", "right"})
+void AvoidanceModuleManager::init(rclcpp::Node * node)
 {
   using autoware_auto_perception_msgs::msg::ObjectClassification;
   using tier4_autoware_utils::getOrDeclareParameter;
+
+  // init manager interface
+  initInterface(node, {"left", "right"});
 
   AvoidanceParameters p{};
   // general params
@@ -486,3 +486,7 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
   });
 }
 }  // namespace behavior_path_planner
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  behavior_path_planner::AvoidanceModuleManager, behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -36,7 +36,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
   AvoidanceParameters p{};
   // general params
   {
-    std::string ns = "avoidance.";
+    const std::string ns = "avoidance.";
     p.resample_interval_for_planning =
       getOrDeclareParameter<double>(*node, ns + "resample_interval_for_planning");
     p.resample_interval_for_output =
@@ -53,7 +53,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // drivable area
   {
-    std::string ns = "avoidance.";
+    const std::string ns = "avoidance.";
     p.use_adjacent_lane = getOrDeclareParameter<bool>(*node, ns + "use_adjacent_lane");
     p.use_opposite_lane = getOrDeclareParameter<bool>(*node, ns + "use_opposite_lane");
     p.use_intersection_areas = getOrDeclareParameter<bool>(*node, ns + "use_intersection_areas");
@@ -112,7 +112,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
         getOrDeclareParameter<bool>(*node, ns);
     };
 
-    std::string ns = "avoidance.target_filtering.";
+    const std::string ns = "avoidance.target_filtering.";
     set_target_flag(ObjectClassification::CAR, ns + "target_type.car");
     set_target_flag(ObjectClassification::TRUCK, ns + "target_type.truck");
     set_target_flag(ObjectClassification::TRAILER, ns + "target_type.trailer");
@@ -137,7 +137,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
   }
 
   {
-    std::string ns = "avoidance.target_filtering.force_avoidance.";
+    const std::string ns = "avoidance.target_filtering.force_avoidance.";
     p.enable_force_avoidance_for_stopped_vehicle =
       getOrDeclareParameter<bool>(*node, ns + "enable");
     p.threshold_time_force_avoidance_for_stopped_vehicle =
@@ -151,7 +151,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
   }
 
   {
-    std::string ns = "avoidance.target_filtering.detection_area.";
+    const std::string ns = "avoidance.target_filtering.detection_area.";
     p.use_static_detection_area = getOrDeclareParameter<bool>(*node, ns + "static");
     p.object_check_min_forward_distance =
       getOrDeclareParameter<double>(*node, ns + "min_forward_distance");
@@ -171,7 +171,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
         getOrDeclareParameter<bool>(*node, ns);
     };
 
-    std::string ns = "avoidance.safety_check.";
+    const std::string ns = "avoidance.safety_check.";
     set_target_flag(ObjectClassification::CAR, ns + "target_type.car");
     set_target_flag(ObjectClassification::TRUCK, ns + "target_type.truck");
     set_target_flag(ObjectClassification::TRAILER, ns + "target_type.trailer");
@@ -200,7 +200,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // safety check predicted path params
   {
-    std::string ns = "avoidance.safety_check.";
+    const std::string ns = "avoidance.safety_check.";
     p.ego_predicted_path_params.min_velocity =
       getOrDeclareParameter<double>(*node, ns + "min_velocity");
     p.ego_predicted_path_params.max_velocity =
@@ -217,7 +217,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // safety check rss params
   {
-    std::string ns = "avoidance.safety_check.";
+    const std::string ns = "avoidance.safety_check.";
     p.rss_params.longitudinal_distance_min_threshold =
       getOrDeclareParameter<double>(*node, ns + "longitudinal_distance_min_threshold");
     p.rss_params.longitudinal_velocity_delta_time =
@@ -236,7 +236,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // avoidance maneuver (lateral)
   {
-    std::string ns = "avoidance.avoidance.lateral.";
+    const std::string ns = "avoidance.avoidance.lateral.";
     p.soft_road_shoulder_margin =
       getOrDeclareParameter<double>(*node, ns + "soft_road_shoulder_margin");
     p.hard_road_shoulder_margin =
@@ -255,7 +255,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // avoidance maneuver (longitudinal)
   {
-    std::string ns = "avoidance.avoidance.longitudinal.";
+    const std::string ns = "avoidance.avoidance.longitudinal.";
     p.min_prepare_time = getOrDeclareParameter<double>(*node, ns + "min_prepare_time");
     p.max_prepare_time = getOrDeclareParameter<double>(*node, ns + "max_prepare_time");
     p.min_prepare_distance = getOrDeclareParameter<double>(*node, ns + "min_prepare_distance");
@@ -267,7 +267,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // avoidance maneuver (return shift dead line)
   {
-    std::string ns = "avoidance.avoidance.return_dead_line.";
+    const std::string ns = "avoidance.avoidance.return_dead_line.";
     p.enable_dead_line_for_goal = getOrDeclareParameter<bool>(*node, ns + "goal.enable");
     p.enable_dead_line_for_traffic_light =
       getOrDeclareParameter<bool>(*node, ns + "traffic_light.enable");
@@ -278,20 +278,20 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // yield
   {
-    std::string ns = "avoidance.yield.";
+    const std::string ns = "avoidance.yield.";
     p.yield_velocity = getOrDeclareParameter<double>(*node, ns + "yield_velocity");
   }
 
   // stop
   {
-    std::string ns = "avoidance.stop.";
+    const std::string ns = "avoidance.stop.";
     p.stop_max_distance = getOrDeclareParameter<double>(*node, ns + "max_distance");
     p.stop_buffer = getOrDeclareParameter<double>(*node, ns + "stop_buffer");
   }
 
   // policy
   {
-    std::string ns = "avoidance.policy.";
+    const std::string ns = "avoidance.policy.";
     p.policy_approval = getOrDeclareParameter<std::string>(*node, ns + "make_approval_request");
     p.policy_deceleration = getOrDeclareParameter<std::string>(*node, ns + "deceleration");
     p.policy_lateral_margin = getOrDeclareParameter<std::string>(*node, ns + "lateral_margin");
@@ -309,7 +309,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // constraints (longitudinal)
   {
-    std::string ns = "avoidance.constraints.longitudinal.";
+    const std::string ns = "avoidance.constraints.longitudinal.";
     p.nominal_deceleration = getOrDeclareParameter<double>(*node, ns + "nominal_deceleration");
     p.nominal_jerk = getOrDeclareParameter<double>(*node, ns + "nominal_jerk");
     p.max_deceleration = getOrDeclareParameter<double>(*node, ns + "max_deceleration");
@@ -319,7 +319,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // constraints (lateral)
   {
-    std::string ns = "avoidance.constraints.lateral.";
+    const std::string ns = "avoidance.constraints.lateral.";
     p.velocity_map = getOrDeclareParameter<std::vector<double>>(*node, ns + "velocity");
     p.lateral_max_accel_map =
       getOrDeclareParameter<std::vector<double>>(*node, ns + "max_accel_values");
@@ -347,7 +347,7 @@ void AvoidanceModuleManager::init(rclcpp::Node * node)
 
   // shift line pipeline
   {
-    std::string ns = "avoidance.shift_line_pipeline.";
+    const std::string ns = "avoidance.shift_line_pipeline.";
     p.quantize_filter_threshold =
       getOrDeclareParameter<double>(*node, ns + "trim.quantize_filter_threshold");
     p.same_grad_filter_1_threshold =

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -25,10 +25,11 @@
 namespace behavior_path_planner
 {
 
-DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
-  rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
-: SceneModuleManagerInterface(node, name, config, {""})
+void DynamicAvoidanceModuleManager::init(rclcpp::Node * node)
 {
+  // init manager interface
+  initInterface(node, {""});
+
   DynamicAvoidanceParameters p{};
 
   {  // common
@@ -235,3 +236,8 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
   });
 }
 }  // namespace behavior_path_planner
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  behavior_path_planner::DynamicAvoidanceModuleManager,
+  behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -33,13 +33,13 @@ void DynamicAvoidanceModuleManager::init(rclcpp::Node * node)
   DynamicAvoidanceParameters p{};
 
   {  // common
-    std::string ns = "dynamic_avoidance.common.";
+    const std::string ns = "dynamic_avoidance.common.";
     p.enable_debug_info = node->declare_parameter<bool>(ns + "enable_debug_info");
     p.use_hatched_road_markings = node->declare_parameter<bool>(ns + "use_hatched_road_markings");
   }
 
   {  // target object
-    std::string ns = "dynamic_avoidance.target_object.";
+    const std::string ns = "dynamic_avoidance.target_object.";
     p.avoid_car = node->declare_parameter<bool>(ns + "car");
     p.avoid_truck = node->declare_parameter<bool>(ns + "truck");
     p.avoid_bus = node->declare_parameter<bool>(ns + "bus");
@@ -90,7 +90,7 @@ void DynamicAvoidanceModuleManager::init(rclcpp::Node * node)
   }
 
   {  // drivable_area_generation
-    std::string ns = "dynamic_avoidance.drivable_area_generation.";
+    const std::string ns = "dynamic_avoidance.drivable_area_generation.";
     p.min_obj_path_based_lon_polygon_margin =
       node->declare_parameter<double>(ns + "object_path_base.min_longitudinal_polygon_margin");
     p.lat_offset_from_obstacle = node->declare_parameter<double>(ns + "lat_offset_from_obstacle");

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
@@ -248,10 +248,10 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
       node->declare_parameter<double>(base_ns + "stop_condition.maximum_jerk_for_stop");
   }
 
-  std::string path_safety_check_ns = "goal_planner.path_safety_check.";
+  const std::string path_safety_check_ns = "goal_planner.path_safety_check.";
 
   // EgoPredictedPath
-  std::string ego_path_ns = path_safety_check_ns + "ego_predicted_path.";
+  const std::string ego_path_ns = path_safety_check_ns + "ego_predicted_path.";
   {
     p.ego_predicted_path_params.min_velocity =
       node->declare_parameter<double>(ego_path_ns + "min_velocity");
@@ -270,7 +270,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // ObjectFilteringParams
-  std::string obj_filter_ns = path_safety_check_ns + "target_filtering.";
+  const std::string obj_filter_ns = path_safety_check_ns + "target_filtering.";
   {
     p.objects_filtering_params.safety_check_time_horizon =
       node->declare_parameter<double>(obj_filter_ns + "safety_check_time_horizon");
@@ -295,7 +295,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // ObjectTypesToCheck
-  std::string obj_types_ns = obj_filter_ns + "object_types_to_check.";
+  const std::string obj_types_ns = obj_filter_ns + "object_types_to_check.";
   {
     p.objects_filtering_params.object_types_to_check.check_car =
       node->declare_parameter<bool>(obj_types_ns + "check_car");
@@ -316,7 +316,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // ObjectLaneConfiguration
-  std::string obj_lane_ns = obj_filter_ns + "object_lane_configuration.";
+  const std::string obj_lane_ns = obj_filter_ns + "object_lane_configuration.";
   {
     p.objects_filtering_params.object_lane_configuration.check_current_lane =
       node->declare_parameter<bool>(obj_lane_ns + "check_current_lane");
@@ -331,7 +331,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // SafetyCheckParams
-  std::string safety_check_ns = path_safety_check_ns + "safety_check_params.";
+  const std::string safety_check_ns = path_safety_check_ns + "safety_check_params.";
   {
     p.safety_check_params.enable_safety_check =
       node->declare_parameter<bool>(safety_check_ns + "enable_safety_check");
@@ -349,7 +349,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // RSSparams
-  std::string rss_ns = safety_check_ns + "rss_params.";
+  const std::string rss_ns = safety_check_ns + "rss_params.";
   {
     p.safety_check_params.rss_params.rear_vehicle_reaction_time =
       node->declare_parameter<double>(rss_ns + "rear_vehicle_reaction_time");
@@ -364,7 +364,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // IntegralPredictedPolygonParams
-  std::string integral_ns = safety_check_ns + "integral_predicted_polygon_params.";
+  const std::string integral_ns = safety_check_ns + "integral_predicted_polygon_params.";
   {
     p.safety_check_params.integral_predicted_polygon_params.forward_margin =
       node->declare_parameter<double>(integral_ns + "forward_margin");
@@ -410,7 +410,7 @@ void GoalPlannerModuleManager::updateModuleParams(
 
   auto & p = parameters_;
 
-  [[maybe_unused]] std::string ns = name_ + ".";
+  [[maybe_unused]] const std::string ns = name_ + ".";
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
     if (!observer.expired()) observer.lock()->updateModuleParams(p);

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
@@ -25,11 +25,11 @@
 
 namespace behavior_path_planner
 {
-
-GoalPlannerModuleManager::GoalPlannerModuleManager(
-  rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
-: SceneModuleManagerInterface(node, name, config, {""})
+void GoalPlannerModuleManager::init(rclcpp::Node * node)
 {
+  // init manager interface
+  initInterface(node, {""});
+
   GoalPlannerParameters p;
 
   const std::string base_ns = "goal_planner.";
@@ -70,7 +70,8 @@ GoalPlannerModuleManager::GoalPlannerModuleManager(
       p.parking_policy = ParkingPolicy::RIGHT_SIDE;
     } else {
       RCLCPP_ERROR_STREAM(
-        logger_, "[goal_planner] invalid parking_policy: " << parking_policy_name << std::endl);
+        node->get_logger().get_child(name()),
+        "[goal_planner] invalid parking_policy: " << parking_policy_name << std::endl);
       exit(EXIT_FAILURE);
     }
   }
@@ -384,16 +385,18 @@ GoalPlannerModuleManager::GoalPlannerModuleManager(
   // validation of parameters
   if (p.shift_sampling_num < 1) {
     RCLCPP_FATAL_STREAM(
-      logger_, "shift_sampling_num must be positive integer. Given parameter: "
-                 << p.shift_sampling_num << std::endl
-                 << "Terminating the program...");
+      node->get_logger().get_child(name()),
+      "shift_sampling_num must be positive integer. Given parameter: "
+        << p.shift_sampling_num << std::endl
+        << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
   if (p.maximum_deceleration < 0.0) {
     RCLCPP_FATAL_STREAM(
-      logger_, "maximum_deceleration cannot be negative value. Given parameter: "
-                 << p.maximum_deceleration << std::endl
-                 << "Terminating the program...");
+      node->get_logger().get_child(name()),
+      "maximum_deceleration cannot be negative value. Given parameter: "
+        << p.maximum_deceleration << std::endl
+        << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
 
@@ -437,7 +440,7 @@ bool GoalPlannerModuleManager::isSimultaneousExecutableAsApprovedModule() const
     return true;
   }
 
-  return enable_simultaneous_execution_as_approved_module_;
+  return config_.enable_simultaneous_execution_as_approved_module;
 }
 
 bool GoalPlannerModuleManager::isSimultaneousExecutableAsCandidateModule() const
@@ -452,7 +455,12 @@ bool GoalPlannerModuleManager::isSimultaneousExecutableAsCandidateModule() const
     return true;
   }
 
-  return enable_simultaneous_execution_as_candidate_module_;
+  return config_.enable_simultaneous_execution_as_candidate_module;
 }
 
 }  // namespace behavior_path_planner
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  behavior_path_planner::GoalPlannerModuleManager,
+  behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -15,9 +15,9 @@
 #include "behavior_path_planner/scene_module/lane_change/interface.hpp"
 
 #include "behavior_path_planner/marker_utils/lane_change/debug.hpp"
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
-#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/lane_change/utils.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
 #include "behavior_path_planner_common/marker_utils/utils.hpp"
 
 #include <tier4_autoware_utils/ros/marker_helper.hpp>

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -143,7 +143,7 @@ void LaneChangeModuleManager::init(rclcpp::Node * node)
 
   // target object
   {
-    std::string ns = "lane_change.target_object.";
+    const std::string ns = "lane_change.target_object.";
     p.object_types_to_check.check_car = getOrDeclareParameter<bool>(*node, ns + "car");
     p.object_types_to_check.check_truck = getOrDeclareParameter<bool>(*node, ns + "truck");
     p.object_types_to_check.check_bus = getOrDeclareParameter<bool>(*node, ns + "bus");
@@ -260,7 +260,7 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
   AvoidanceByLCParameters p{};
   // unique parameters
   {
-    std::string ns = "avoidance_by_lane_change.";
+    const std::string ns = "avoidance_by_lane_change.";
     p.execute_object_longitudinal_margin =
       getOrDeclareParameter<double>(*node, ns + "execute_object_longitudinal_margin");
     p.execute_only_when_lane_change_finish_before_object =
@@ -269,7 +269,7 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
 
   // general params
   {
-    std::string ns = "avoidance.";
+    const std::string ns = "avoidance.";
     p.resample_interval_for_planning =
       getOrDeclareParameter<double>(*node, ns + "resample_interval_for_planning");
     p.resample_interval_for_output =
@@ -323,7 +323,7 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
         getOrDeclareParameter<bool>(*node, ns);
     };
 
-    std::string ns = "avoidance.target_filtering.";
+    const std::string ns = "avoidance.target_filtering.";
     set_target_flag(ObjectClassification::CAR, ns + "target_type.car");
     set_target_flag(ObjectClassification::TRUCK, ns + "target_type.truck");
     set_target_flag(ObjectClassification::TRAILER, ns + "target_type.trailer");
@@ -346,7 +346,7 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
   }
 
   {
-    std::string ns = "avoidance.target_filtering.force_avoidance.";
+    const std::string ns = "avoidance.target_filtering.force_avoidance.";
     p.enable_force_avoidance_for_stopped_vehicle =
       getOrDeclareParameter<bool>(*node, ns + "enable");
     p.threshold_time_force_avoidance_for_stopped_vehicle =
@@ -360,7 +360,7 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
   }
 
   {
-    std::string ns = "avoidance.target_filtering.detection_area.";
+    const std::string ns = "avoidance.target_filtering.detection_area.";
     p.use_static_detection_area = getOrDeclareParameter<bool>(*node, ns + "static");
     p.object_check_min_forward_distance =
       getOrDeclareParameter<double>(*node, ns + "min_forward_distance");
@@ -372,7 +372,7 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
 
   // safety check
   {
-    std::string ns = "avoidance.safety_check.";
+    const std::string ns = "avoidance.safety_check.";
     p.hysteresis_factor_expand_rate =
       getOrDeclareParameter<double>(*node, ns + "hysteresis_factor_expand_rate");
   }

--- a/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
@@ -32,7 +32,7 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
 
   SideShiftParameters p{};
 
-  std::string ns = "side_shift.";
+  const std::string ns = "side_shift.";
   p.min_distance_to_start_shifting =
     node->declare_parameter<double>(ns + "min_distance_to_start_shifting");
   p.time_to_start_shifting = node->declare_parameter<double>(ns + "time_to_start_shifting");
@@ -52,7 +52,7 @@ void SideShiftModuleManager::updateModuleParams(
 
   [[maybe_unused]] auto p = parameters_;
 
-  [[maybe_unused]] std::string ns = "side_shift.";
+  [[maybe_unused]] const std::string ns = "side_shift.";
   // updateParam<bool>(parameters, ns + ..., ...);
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {

--- a/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
@@ -25,20 +25,22 @@
 namespace behavior_path_planner
 {
 
-SideShiftModuleManager::SideShiftModuleManager(
-  rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
-: SceneModuleManagerInterface(node, name, config, {})
+void SideShiftModuleManager::init(rclcpp::Node * node)
 {
+  // init manager interface
+  initInterface(node, {});
+
   SideShiftParameters p{};
 
+  std::string ns = "side_shift.";
   p.min_distance_to_start_shifting =
-    node->declare_parameter<double>(name + ".min_distance_to_start_shifting");
-  p.time_to_start_shifting = node->declare_parameter<double>(name + ".time_to_start_shifting");
-  p.shifting_lateral_jerk = node->declare_parameter<double>(name + ".shifting_lateral_jerk");
-  p.min_shifting_distance = node->declare_parameter<double>(name + ".min_shifting_distance");
-  p.min_shifting_speed = node->declare_parameter<double>(name + ".min_shifting_speed");
-  p.shift_request_time_limit = node->declare_parameter<double>(name + ".shift_request_time_limit");
-  p.publish_debug_marker = node->declare_parameter<bool>(name + ".publish_debug_marker");
+    node->declare_parameter<double>(ns + "min_distance_to_start_shifting");
+  p.time_to_start_shifting = node->declare_parameter<double>(ns + "time_to_start_shifting");
+  p.shifting_lateral_jerk = node->declare_parameter<double>(ns + "shifting_lateral_jerk");
+  p.min_shifting_distance = node->declare_parameter<double>(ns + "min_shifting_distance");
+  p.min_shifting_speed = node->declare_parameter<double>(ns + "min_shifting_speed");
+  p.shift_request_time_limit = node->declare_parameter<double>(ns + "shift_request_time_limit");
+  p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
 }
@@ -59,3 +61,7 @@ void SideShiftModuleManager::updateModuleParams(
 }
 
 }  // namespace behavior_path_planner
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  behavior_path_planner::SideShiftModuleManager, behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -31,7 +31,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
 
   StartPlannerParameters p;
 
-  std::string ns = "start_planner.";
+  const std::string ns = "start_planner.";
 
   p.verbose = node->declare_parameter<bool>(ns + "verbose");
   p.th_arrived_distance = node->declare_parameter<double>(ns + "th_arrived_distance");
@@ -88,7 +88,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
     node->declare_parameter<double>(ns + "ignore_distance_from_lane_end");
   // freespace planner general params
   {
-    std::string ns = "start_planner.freespace_planner.";
+    const std::string ns = "start_planner.freespace_planner.";
     p.enable_freespace_planner = node->declare_parameter<bool>(ns + "enable_freespace_planner");
     p.freespace_planner_algorithm =
       node->declare_parameter<std::string>(ns + "freespace_planner_algorithm");
@@ -115,7 +115,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
   //  freespace planner search config
   {
-    std::string ns = "start_planner.freespace_planner.search_configs.";
+    const std::string ns = "start_planner.freespace_planner.search_configs.";
     p.freespace_planner_common_parameters.theta_size =
       node->declare_parameter<int>(ns + "theta_size");
     p.freespace_planner_common_parameters.angle_goal_range =
@@ -131,13 +131,13 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
   //  freespace planner costmap configs
   {
-    std::string ns = "start_planner.freespace_planner.costmap_configs.";
+    const std::string ns = "start_planner.freespace_planner.costmap_configs.";
     p.freespace_planner_common_parameters.obstacle_threshold =
       node->declare_parameter<int>(ns + "obstacle_threshold");
   }
   //  freespace planner astar
   {
-    std::string ns = "start_planner.freespace_planner.astar.";
+    const std::string ns = "start_planner.freespace_planner.astar.";
     p.astar_parameters.only_behind_solutions =
       node->declare_parameter<bool>(ns + "only_behind_solutions");
     p.astar_parameters.use_back = node->declare_parameter<bool>(ns + "use_back");
@@ -146,7 +146,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
   //   freespace planner rrtstar
   {
-    std::string ns = "start_planner.freespace_planner.rrtstar.";
+    const std::string ns = "start_planner.freespace_planner.rrtstar.";
     p.rrt_star_parameters.enable_update = node->declare_parameter<bool>(ns + "enable_update");
     p.rrt_star_parameters.use_informed_sampling =
       node->declare_parameter<bool>(ns + "use_informed_sampling");
@@ -164,10 +164,10 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
       node->declare_parameter<double>(ns + "stop_condition.maximum_jerk_for_stop");
   }
 
-  std::string base_ns = "start_planner.path_safety_check.";
+  const std::string base_ns = "start_planner.path_safety_check.";
 
   // EgoPredictedPath
-  std::string ego_path_ns = base_ns + "ego_predicted_path.";
+  const std::string ego_path_ns = base_ns + "ego_predicted_path.";
   {
     p.ego_predicted_path_params.min_velocity =
       node->declare_parameter<double>(ego_path_ns + "min_velocity");
@@ -186,7 +186,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // ObjectFilteringParams
-  std::string obj_filter_ns = base_ns + "target_filtering.";
+  const std::string obj_filter_ns = base_ns + "target_filtering.";
   {
     p.objects_filtering_params.safety_check_time_horizon =
       node->declare_parameter<double>(obj_filter_ns + "safety_check_time_horizon");
@@ -211,7 +211,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // ObjectTypesToCheck
-  std::string obj_types_ns = obj_filter_ns + "object_types_to_check.";
+  const std::string obj_types_ns = obj_filter_ns + "object_types_to_check.";
   {
     p.objects_filtering_params.object_types_to_check.check_car =
       node->declare_parameter<bool>(obj_types_ns + "check_car");
@@ -232,7 +232,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // ObjectLaneConfiguration
-  std::string obj_lane_ns = obj_filter_ns + "object_lane_configuration.";
+  const std::string obj_lane_ns = obj_filter_ns + "object_lane_configuration.";
   {
     p.objects_filtering_params.object_lane_configuration.check_current_lane =
       node->declare_parameter<bool>(obj_lane_ns + "check_current_lane");
@@ -247,7 +247,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // SafetyCheckParams
-  std::string safety_check_ns = base_ns + "safety_check_params.";
+  const std::string safety_check_ns = base_ns + "safety_check_params.";
   {
     p.safety_check_params.enable_safety_check =
       node->declare_parameter<bool>(safety_check_ns + "enable_safety_check");
@@ -262,7 +262,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   }
 
   // RSSparams
-  std::string rss_ns = safety_check_ns + "rss_params.";
+  const std::string rss_ns = safety_check_ns + "rss_params.";
   {
     p.safety_check_params.rss_params.rear_vehicle_reaction_time =
       node->declare_parameter<double>(rss_ns + "rear_vehicle_reaction_time");
@@ -296,7 +296,7 @@ void StartPlannerModuleManager::updateModuleParams(
 
   auto & p = parameters_;
 
-  [[maybe_unused]] std::string ns = name_ + ".";
+  [[maybe_unused]] const std::string ns = name_ + ".";
 
   std::for_each(observers_.begin(), observers_.end(), [&](const auto & observer) {
     if (!observer.expired()) {

--- a/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
@@ -48,17 +48,20 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto behavior_path_planner_dir =
     ament_index_cpp::get_package_share_directory("behavior_path_planner");
 
+  std::vector<std::string> module_names;
+  module_names.emplace_back("behavior_path_planner::AvoidanceModuleManager");
+  module_names.emplace_back("behavior_path_planner::DynamicAvoidanceModuleManager");
+  module_names.emplace_back("behavior_path_planner::SideShiftModuleManager");
+  module_names.emplace_back("behavior_path_planner::StartPlannerModuleManager");
+  module_names.emplace_back("behavior_path_planner::GoalPlannerModuleManager");
+  module_names.emplace_back("behavior_path_planner::LaneChangeRightModuleManager");
+  module_names.emplace_back("behavior_path_planner::LaneChangeLeftModuleManager");
+  module_names.emplace_back("behavior_path_planner::ExternalRequestLaneChangeRightModuleManager");
+  module_names.emplace_back("behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager");
+  module_names.emplace_back("behavior_path_planner::AvoidanceByLaneChangeModuleManager");
+
   std::vector<rclcpp::Parameter> params;
-  params.emplace_back("avoidance.enable_module", true);
-  params.emplace_back("avoidance_by_lc.enable_module", true);
-  params.emplace_back("dynamic_avoidance.enable_module", true);
-  params.emplace_back("lane_change_right.enable_module", true);
-  params.emplace_back("lane_change_left.enable_module", true);
-  params.emplace_back("external_request_lane_change_right.enable_module", true);
-  params.emplace_back("external_request_lane_change_left.enable_module", true);
-  params.emplace_back("goal_planner.enable_module", true);
-  params.emplace_back("start_planner.enable_module", true);
-  params.emplace_back("side_shift.enable_module", true);
+  params.emplace_back("launch_modules", module_names);
   node_options.parameter_overrides(params);
 
   test_utils::updateNodeOptions(

--- a/planning/behavior_path_planner_common/CMakeLists.txt
+++ b/planning/behavior_path_planner_common/CMakeLists.txt
@@ -7,8 +7,10 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-ament_auto_add_library(behavior_path_planner_common SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/turn_signal_decider.cpp
+  src/interface/steering_factor_interface.cpp
+  src/interface/scene_module_visitor.cpp
   src/utils/utils.cpp
   src/utils/path_utils.cpp
   src/utils/traffic_light_utils.cpp
@@ -22,37 +24,37 @@ ament_auto_add_library(behavior_path_planner_common SHARED
   src/marker_utils/utils.cpp
 )
 
-target_include_directories(behavior_path_planner_common SYSTEM PUBLIC
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}
 )
 
-target_link_libraries(behavior_path_planner_common
+target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )
 
 if(BUILD_TESTING)
-  ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_utilities
+  ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_utilities
     test/test_drivable_area_expansion.cpp
   )
 
-  target_link_libraries(test_${CMAKE_PROJECT_NAME}_utilities
-    behavior_path_planner_common
+  target_link_libraries(test_${PROJECT_NAME}_utilities
+    ${PROJECT_NAME}
   )
 
-  ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_safety_check
+  ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_safety_check
     test/test_safety_check.cpp
   )
 
-  target_link_libraries(test_${CMAKE_PROJECT_NAME}_safety_check
-    behavior_path_planner_common
+  target_link_libraries(test_${PROJECT_NAME}_safety_check
+    ${PROJECT_NAME}
   )
 
-  ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_turn_signal
+  ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_turn_signal
     test/test_turn_signal.cpp
   )
 
-  target_link_libraries(test_${CMAKE_PROJECT_NAME}_turn_signal
-    behavior_path_planner_common
+  target_link_libraries(test_${PROJECT_NAME}_turn_signal
+    ${PROJECT_NAME}
   )
 endif()
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_INTERFACE_HPP_
-#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_INTERFACE_HPP_
+#ifndef BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_INTERFACE_HPP_
+#define BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_INTERFACE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner_common/data_manager.hpp"
+#include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
 #include "behavior_path_planner_common/marker_utils/utils.hpp"
 #include "behavior_path_planner_common/utils/utils.hpp"
 
-#include <behavior_path_planner/steering_factor_interface.hpp>
+#include <behavior_path_planner_common/interface/steering_factor_interface.hpp>
 #include <behavior_path_planner_common/turn_signal_decider.hpp>
 #include <magic_enum.hpp>
 #include <motion_utils/marker/marker_helper.hpp>
@@ -616,4 +616,4 @@ protected:
 
 }  // namespace behavior_path_planner
 
-#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_INTERFACE_HPP_
+#endif  // BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_INTERFACE_HPP_

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_MANAGER_INTERFACE_HPP_
-#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_MANAGER_INTERFACE_HPP_
+#ifndef BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_MANAGER_INTERFACE_HPP_
+#define BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_MANAGER_INTERFACE_HPP_
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "tier4_autoware_utils/ros/parameter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -326,4 +326,4 @@ protected:
 
 }  // namespace behavior_path_planner
 
-#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_MANAGER_INTERFACE_HPP_
+#endif  // BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_MANAGER_INTERFACE_HPP_

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_visitor.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_VISITOR_HPP_
-#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_VISITOR_HPP_
+#ifndef BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_VISITOR_HPP_
+#define BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_VISITOR_HPP_
 
 #include "tier4_planning_msgs/msg/detail/avoidance_debug_msg_array__struct.hpp"
 
@@ -44,4 +44,4 @@ protected:
 };
 }  // namespace behavior_path_planner
 
-#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_VISITOR_HPP_
+#endif  // BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_VISITOR_HPP_

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/steering_factor_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/steering_factor_interface.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_PATH_PLANNER__STEERING_FACTOR_INTERFACE_HPP_
-#define BEHAVIOR_PATH_PLANNER__STEERING_FACTOR_INTERFACE_HPP_
+#ifndef BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__STEERING_FACTOR_INTERFACE_HPP_
+#define BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__STEERING_FACTOR_INTERFACE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -52,4 +52,4 @@ private:
 
 }  // namespace steering_factor_interface
 
-#endif  // BEHAVIOR_PATH_PLANNER__STEERING_FACTOR_INTERFACE_HPP_
+#endif  // BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__STEERING_FACTOR_INTERFACE_HPP_

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/parameters.hpp
@@ -79,17 +79,6 @@ struct BehaviorPathPlannerParameters
   size_t max_iteration_num{100};
   double traffic_light_signal_timeout{1.0};
 
-  ModuleConfigParameters config_avoidance;
-  ModuleConfigParameters config_avoidance_by_lc;
-  ModuleConfigParameters config_dynamic_avoidance;
-  ModuleConfigParameters config_start_planner;
-  ModuleConfigParameters config_goal_planner;
-  ModuleConfigParameters config_side_shift;
-  ModuleConfigParameters config_lane_change_left;
-  ModuleConfigParameters config_lane_change_right;
-  ModuleConfigParameters config_ext_request_lane_change_left;
-  ModuleConfigParameters config_ext_request_lane_change_right;
-
   double backward_path_length;
   double forward_path_length;
   double backward_length_buffer_for_end_of_lane;

--- a/planning/behavior_path_planner_common/package.xml
+++ b/planning/behavior_path_planner_common/package.xml
@@ -53,8 +53,10 @@
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>
   <depend>object_recognition_utils</depend>
+  <depend>objects_of_interest_marker_interface</depend>
   <depend>rclcpp</depend>
   <depend>route_handler</depend>
+  <depend>rtc_interface</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>

--- a/planning/behavior_path_planner_common/src/interface/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner_common/src/interface/scene_module_visitor.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
+#include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
 
-#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 
 namespace behavior_path_planner
 {

--- a/planning/behavior_path_planner_common/src/interface/steering_factor_interface.cpp
+++ b/planning/behavior_path_planner_common/src/interface/steering_factor_interface.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "behavior_path_planner/steering_factor_interface.hpp"
+#include "behavior_path_planner_common/interface/steering_factor_interface.hpp"
 
 namespace steering_factor_interface
 {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4ff450e</samp>

This pull request refactors the behavior path planner node and its scene modules to use pluginlib for dynamic plugin loading and unloading. It also simplifies the launch and configuration of the node and its modules, and fixes some minor bugs and issues. It modifies several files, including launch files, CMakeLists.txt, header and source files, package.xml, and plugins.xml.

<!-- Write a brief description of this PR. -->

## Tests performed

Confirmed that bpp loaded all scene modules correctly.

```
[INFO] [component_container_mt-29]: process started with pid [145130]                                                                                                                                           
[component_container_mt-29] [INFO 1701737049.463438690] [planning.scenario_planning.lane_driving.behavior_planning.behavior_planning_container]: Load Library: /home/satoshi/pilot-auto/install/behavior_path_planner/lib/libbehavior_path_planner_lib.so
[component_container_mt-29] [INFO 1701737049.570749397] [planning.scenario_planning.lane_driving.behavior_planning.behavior_planning_container]: Found class: rclcpp_components::NodeFactoryTemplate<behavior_path_planner::BehaviorPathPlannerNode>
[component_container_mt-29] [INFO 1701737049.576008845] [planning.scenario_planning.lane_driving.behavior_planning.behavior_planning_container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<behavior_path_planner::BehaviorPathPlannerNode>
[component_container_mt-29] [INFO 1701737049.722422275] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::AvoidanceModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737049.728016083] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::DynamicAvoidanceModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737049.731040344] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::SideShiftModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737049.768085413] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::StartPlannerModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737049.945528895] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::GoalPlannerModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737050.164803561] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::LaneChangeRightModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737050.190003251] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::LaneChangeLeftModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737050.236931556] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::ExternalRequestLaneChangeRightModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737050.411370194] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager' is loaded.
[component_container_mt-29] [INFO 1701737050.600689989] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: The scene plugin 'behavior_path_planner::AvoidanceByLaneChangeModuleManager' is loaded.
```

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/0439c40c-9caf-5f14-88e9-13bebd7fcac2?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
