### PR TITLE
fix(dynamic_avoidance): deal with reference path changing by LC

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -330,14 +330,14 @@ private:
     const PredictedPath & obj_path, const geometry_msgs::msg::Pose & obj_pose,
     const autoware_auto_perception_msgs::msg::Shape & obj_shape) const;
   MinMaxValue calcMinMaxLongitudinalOffsetToAvoid(
-    const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
+    const std::vector<PathPointWithLaneId> & input_ref_path_points,
     const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
     const PredictedPath & obj_path, const autoware_auto_perception_msgs::msg::Shape & obj_shape,
     const double time_to_collision) const;
   std::optional<MinMaxValue> calcMinMaxLateralOffsetToAvoid(
-    const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
-    const Polygon2d & obj_points, const double obj_vel, const bool is_collision_left,
-    const double obj_normal_vel, const std::optional<DynamicAvoidanceObject> & prev_object) const;
+    const std::vector<PathPointWithLaneId> & input_ref_path_points, const Polygon2d & obj_points,
+    const double obj_vel, const bool is_collision_left, const double obj_normal_vel,
+    const std::optional<DynamicAvoidanceObject> & prev_object) const;
 
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;
@@ -356,6 +356,7 @@ private:
 
   std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> target_objects_;
   // std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> prev_target_objects_;
+  std::vector<PathPointWithLaneId> prev_input_ref_path_points;
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
 
   TargetObjectsManager target_objects_manager_;


### PR DESCRIPTION
## Description

In the dynamic_avoidance module, the object's polygon removed from the drivable area is created along the previous module's reference path in the behavior_path_planner.
However, when the LC starts to run with the dynamic avoidance, since the LC changes the reference path suddenly, the object polygon's lateral position will be wrong due to the low-pass filter to the distance between the polygon and the reference path.

This PR fixes the issue.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

dynamic avoidance with LC can be achieved.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
