### PR TITLE
feat(component_state_monitor): monitor traffic light recognition output

### DIFF
--- a/system/component_state_monitor/config/topics.yaml
+++ b/system/component_state_monitor/config/topics.yaml
@@ -89,6 +89,19 @@
     error_rate: 1.0
     timeout: 1.0
 
+- module: perception
+  mode: [online, logging_simulation]
+  type: autonomous
+  args:
+    node_name_suffix: traffic_light_recognition_traffic_signals
+    topic: /perception/traffic_light_recognition/traffic_signals
+    topic_type: autoware_perception_msgs/msg/TrafficSignalArray
+    best_effort: false
+    transient_local: false
+    warn_rate: 5.0
+    error_rate: 1.0
+    timeout: 1.0
+
 - module: planning
   mode: [online, logging_simulation, planning_simulation]
   type: autonomous


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I propose adding a topic monitor for the output of the traffic light recognition system. This is necessary because, in the current implementation of Autoware, the vehicle continues to operate as normal even when traffic signal messages are not received. Implementing this monitor could enhance safety by ensuring appropriate responses to traffic signal status.

PR for the launch:
- https://github.com/autowarefoundation/autoware_launch/pull/720


Related links
- [TIER IV INTERNAL](https://star4.slack.com/archives/C03S84LDJGG/p1701751131170859?thread_ts=1701412549.186139&cid=C03S84LDJGG)
- [TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT1-3997)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Run logging simulator and confirmed hazard status is published properly.


Terminal1
Run logging simulator.
```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/data/map/sample-map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```

Terminal2
Play sample rosbag in https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/
```
ros2 bag play sample-rosbag/ -r 0.2 -s sqlite3
```

Terminal3
Confirm the hazard status is published.

```
ros2 topic echo /system/emergency/hazard_status | grep traffic_signals -A17 -B1
--
  - level: "\x02"
    name: '/autoware/perception/node_alive_monitoring/topic_status/topic_state_monitor_traffic_light_recognition_traffic_signals: perceptio...'
    message: Error
    hardware_id: topic_state_monitor
    values:
    - key: topic
      value: /perception/traffic_light_recognition/traffic_signals
    - key: status
      value: Timeout
    - key: warn_rate
      value: 5.00 [Hz]
    - key: error_rate
      value: 1.00 [Hz]
    - key: timeout
      value: 1.00 [s]
    - key: measured_rate
      value: 49.34 [Hz]
    - key: now
      value: 1585897275.00 [s]
    - key: last_message_time
      value: 1585897269.75 [s]
---
```

https://github.com/autowarefoundation/autoware.universe/assets/11865769/da7cb9c3-fa4d-4e8f-8e97-d84d48cbc269


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

If traffic signal messages are not received or its topic rate is decreased, the vehicle will enter the emergency state.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
