### PR TITLE
feat(start_planner): add surround moving obstacle check

### DIFF
--- a/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
+++ b/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
@@ -138,6 +138,20 @@
           backward_path_length: 30.0
           forward_path_length: 100.0
 
+      surround_moving_obstacle_check:
+          search_radius: 10.0
+          th_moving_obstacle_velocity: 1.0
+          # ObjectTypesToCheck
+          object_types_to_check:
+            check_car: true
+            check_truck: true
+            check_bus: true
+            check_trailer: true
+            check_bicycle: true
+            check_motorcycle: true
+            check_pedestrian: true
+            check_unknown: false
+
       # debug
       debug:
         print_debug_info: false

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -137,6 +137,17 @@ private:
   void initializeSafetyCheckParameters();
 
   bool requiresDynamicObjectsCollisionDetection() const;
+
+  /**
+   * @brief Check if there are no moving objects around within a certain radius.
+   *
+   * This function filters the dynamic objects within a certain radius and then filters them by
+   * their velocity. If there are no moving objects around, it returns true. Otherwise, it returns
+   * false.
+   *
+   * @return True if there are no moving objects around. False otherwise.
+   */
+  bool noMovingObjectsAround() const;
   bool receivedNewRoute() const;
 
   bool isModuleRunning() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -93,6 +93,12 @@ struct StartPlannerParameters
   utils::path_safety_checker::ObjectsFilteringParams objects_filtering_params{};
   utils::path_safety_checker::SafetyCheckParams safety_check_params{};
 
+  // surround moving obstacle check
+  double search_radius{0.0};
+  double th_moving_obstacle_velocity{0.0};
+  behavior_path_planner::utils::path_safety_checker::ObjectTypesToCheck
+    surround_moving_obstacles_type_to_check{};
+
   bool print_debug_info{false};
 };
 

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -273,6 +273,35 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
       node->declare_parameter<double>(rss_ns + "longitudinal_velocity_delta_time");
   }
 
+  // surround moving obstacle check
+  std::string surround_moving_obstacle_check_ns = ns + "surround_moving_obstacle_check.";
+  {
+    p.search_radius =
+      node->declare_parameter<double>(surround_moving_obstacle_check_ns + "search_radius");
+    p.th_moving_obstacle_velocity = node->declare_parameter<double>(
+      surround_moving_obstacle_check_ns + "th_moving_obstacle_velocity");
+    // ObjectTypesToCheck
+    std::string obj_types_ns = surround_moving_obstacle_check_ns + "object_types_to_check.";
+    {
+      p.surround_moving_obstacles_type_to_check.check_car =
+        node->declare_parameter<bool>(obj_types_ns + "check_car");
+      p.surround_moving_obstacles_type_to_check.check_truck =
+        node->declare_parameter<bool>(obj_types_ns + "check_truck");
+      p.surround_moving_obstacles_type_to_check.check_bus =
+        node->declare_parameter<bool>(obj_types_ns + "check_bus");
+      p.surround_moving_obstacles_type_to_check.check_trailer =
+        node->declare_parameter<bool>(obj_types_ns + "check_trailer");
+      p.surround_moving_obstacles_type_to_check.check_unknown =
+        node->declare_parameter<bool>(obj_types_ns + "check_unknown");
+      p.surround_moving_obstacles_type_to_check.check_bicycle =
+        node->declare_parameter<bool>(obj_types_ns + "check_bicycle");
+      p.surround_moving_obstacles_type_to_check.check_motorcycle =
+        node->declare_parameter<bool>(obj_types_ns + "check_motorcycle");
+      p.surround_moving_obstacles_type_to_check.check_pedestrian =
+        node->declare_parameter<bool>(obj_types_ns + "check_pedestrian");
+    }
+  }
+
   // debug
   std::string debug_ns = ns + "debug.";
   {

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -179,6 +179,21 @@ bool StartPlannerModule::requiresDynamicObjectsCollisionDetection() const
   return parameters_->safety_check_params.enable_safety_check && status_.driving_forward;
 }
 
+bool StartPlannerModule::noMovingObjectsAround() const
+{
+  auto dynamic_objects = *(planner_data_->dynamic_object);
+  utils::path_safety_checker::filterObjectsWithinRadius(
+    dynamic_objects, planner_data_->self_odometry->pose.pose.position, parameters_->search_radius);
+  utils::path_safety_checker::filterObjectsByClass(
+    dynamic_objects, parameters_->surround_moving_obstacles_type_to_check);
+  const auto filtered_objects = utils::path_safety_checker::filterObjectsByVelocity(
+    dynamic_objects, parameters_->th_moving_obstacle_velocity, false);
+  if (!filtered_objects.objects.empty()) {
+    DEBUG_PRINT("Moving objects exist in the safety check area");
+  }
+  return filtered_objects.objects.empty();
+}
+
 bool StartPlannerModule::hasCollisionWithDynamicObjects() const
 {
   // TODO(Sugahara): update path, params for predicted path and so on in this function to avoid
@@ -274,9 +289,14 @@ bool StartPlannerModule::isExecutionReady() const
 
   // Evaluate safety. The situation is not safe if any of the following conditions are met:
   // 1. pull out path has not been found
-  // 2. waiting for approval and there is a collision with dynamic objects
+  // 2. there is a moving objects around ego
+  // 3. waiting for approval and there is a collision with dynamic objects
   if (!status_.found_pull_out_path) {
     is_safe = false;
+  }
+
+  if (isWaitingApproval()) {
+    is_safe = noMovingObjectsAround();
   }
 
   if (requiresDynamicObjectsCollisionDetection()) {

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -146,6 +146,8 @@ void StartPlannerModule::updateData()
 
   if (requiresDynamicObjectsCollisionDetection()) {
     status_.is_safe_dynamic_objects = !hasCollisionWithDynamicObjects();
+  } else {
+    status_.is_safe_dynamic_objects = true;
   }
 }
 
@@ -286,24 +288,23 @@ bool StartPlannerModule::isStopped()
 bool StartPlannerModule::isExecutionReady() const
 {
   bool is_safe = true;
-
   // Evaluate safety. The situation is not safe if any of the following conditions are met:
   // 1. pull out path has not been found
   // 2. there is a moving objects around ego
   // 3. waiting for approval and there is a collision with dynamic objects
   if (!status_.found_pull_out_path) {
     is_safe = false;
+  } else if (isWaitingApproval()) {
+    if (!noMovingObjectsAround()) {
+      is_safe = false;
+    } else if (requiresDynamicObjectsCollisionDetection() && hasCollisionWithDynamicObjects()) {
+      is_safe = false;
+    }
   }
 
-  if (isWaitingApproval()) {
-    is_safe = noMovingObjectsAround();
+  if (!is_safe) {
+    stop_pose_ = planner_data_->self_odometry->pose.pose;
   }
-
-  if (requiresDynamicObjectsCollisionDetection()) {
-    is_safe = !hasCollisionWithDynamicObjects();
-  }
-
-  if (!is_safe) stop_pose_ = planner_data_->self_odometry->pose.pose;
 
   return is_safe;
 }

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
@@ -135,6 +135,19 @@ void filterObjectsByPosition(
   const double backward_distance);
 
 /**
+ * @brief Filter objects based on their distance from a reference point.
+ *
+ * This function filters out objects that are outside a specified radius from a reference point.
+ *
+ * @param objects The predicted objects to filter.
+ * @param reference_point The reference point (e.g., current pose of the ego vehicle).
+ * @param search_radius The radius within which to retain objects.
+ */
+void filterObjectsWithinRadius(
+  PredictedObjects & objects, const geometry_msgs::msg::Point & reference_point,
+  const double search_radius);
+
+/**
  * @brief Filters the provided objects based on their classification.
  *
  * @param objects The predicted objects to be filtered.

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -45,11 +45,10 @@ bool position_filter(
   return (backward_distance < dist_ego_to_obj && dist_ego_to_obj < forward_distance);
 }
 
-bool position_filter(
-  const PredictedObject & object, const geometry_msgs::msg::Point & reference_point,
+bool is_within_circle(
+  const geometry_msgs::msg::Point & object_pos, const geometry_msgs::msg::Point & reference_point,
   const double search_radius)
 {
-  const auto & object_pos = object.kinematics.initial_pose_with_covariance.pose.position;
   const double dist =
     std::hypot(reference_point.x - object_pos.x, reference_point.y - object_pos.y);
   return dist < search_radius;
@@ -143,7 +142,8 @@ void filterObjectsWithinRadius(
   const double search_radius)
 {
   const auto filter = [&](const auto & object) {
-    return filter::position_filter(object, reference_point, search_radius);
+    return filter::is_within_circle(
+      object.kinematics.initial_pose_with_covariance.pose.position, reference_point, search_radius);
   };
 
   filterObjects(objects, filter);

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -44,6 +44,16 @@ bool position_filter(
 
   return (backward_distance < dist_ego_to_obj && dist_ego_to_obj < forward_distance);
 }
+
+bool position_filter(
+  const PredictedObject & object, const geometry_msgs::msg::Point & reference_point,
+  const double search_radius)
+{
+  const auto & object_pos = object.kinematics.initial_pose_with_covariance.pose.position;
+  const double dist =
+    std::hypot(reference_point.x - object_pos.x, reference_point.y - object_pos.y);
+  return dist < search_radius;
+}
 }  // namespace behavior_path_planner::utils::path_safety_checker::filter
 
 namespace behavior_path_planner::utils::path_safety_checker
@@ -123,6 +133,17 @@ void filterObjectsByPosition(
   const auto filter = [&](const auto & object) {
     return filter::position_filter(
       object, path_points, current_pose, forward_distance, -backward_distance);
+  };
+
+  filterObjects(objects, filter);
+}
+
+void filterObjectsWithinRadius(
+  PredictedObjects & objects, const geometry_msgs::msg::Point & reference_point,
+  const double search_radius)
+{
+  const auto filter = [&](const auto & object) {
+    return filter::position_filter(object, reference_point, search_radius);
   };
 
   filterObjects(objects, filter);


### PR DESCRIPTION
## Description

**This [PR](https://github.com/autowarefoundation/autoware_launch/pull/723) should be merged first!!!**

This commit introduces a new feature in the start_planner module for checking surrounding moving obstacles.
- It adds parameters to specify the search radius and threshold velocity for moving obstacles, along with flags to indicate which types of objects should be checked.
- The `noMovingObjectsAround` function has been added to filter dynamic objects within a certain radius based on their velocity.
  - If no moving objects are detected, the function returns true; otherwise, it returns false.
- This feature enhances the safety of the start_planner by ensuring that the path can't be approved while surrond moving obstacles exist.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

confirmed with psim that safe status becomes false 
※safety check against dynamic object is disabled in the scene
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/416c7c62-6bca-4859-ae6c-cc836ff1382b)

- [x] [PASS TIERIV INTERNAL SCEANRIOS](https://evaluation.tier4.jp/evaluation/reports/f4f1d596-2618-5b14-a477-13d6af39f626?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
