### PR TITLE
feat(mission_planner): print reroute info

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -444,6 +444,7 @@ void MissionPlanner::on_set_mrm_route(
       res->status.success = false;
     }
     change_state(RouteState::Message::SET);
+    RCLCPP_INFO(get_logger(), "Route is successfully changed with the modified goal");
     return;
   }
 
@@ -452,6 +453,7 @@ void MissionPlanner::on_set_mrm_route(
     change_mrm_route(new_route);
     change_state(RouteState::Message::SET);
     res->status.success = true;
+    RCLCPP_INFO(get_logger(), "MRM route is successfully changed with the modified goal");
     return;
   }
 
@@ -537,6 +539,8 @@ void MissionPlanner::on_clear_mrm_route(
 
 void MissionPlanner::on_modified_goal(const ModifiedGoal::Message::ConstSharedPtr msg)
 {
+  RCLCPP_INFO(get_logger(), "Received modified goal.");
+
   if (state_.state != RouteState::Message::SET) {
     RCLCPP_ERROR(get_logger(), "The route hasn't set yet. Cannot reroute.");
     return;
@@ -572,6 +576,7 @@ void MissionPlanner::on_modified_goal(const ModifiedGoal::Message::ConstSharedPt
 
     change_mrm_route(new_route);
     change_state(RouteState::Message::SET);
+    RCLCPP_INFO(get_logger(), "Changed the MRM route with the modified goal");
     return;
   }
 
@@ -593,6 +598,7 @@ void MissionPlanner::on_modified_goal(const ModifiedGoal::Message::ConstSharedPt
 
     change_route(new_route);
     change_state(RouteState::Message::SET);
+    RCLCPP_INFO(get_logger(), "Changed the route with the modified goal");
     return;
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

just add print like chore

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
