### PR TITLE
fix(start_planner): check safety only when waiting approval

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -146,6 +146,8 @@ void StartPlannerModule::updateData()
 
   if (requiresDynamicObjectsCollisionDetection()) {
     status_.is_safe_dynamic_objects = !hasCollisionWithDynamicObjects();
+  } else {
+    status_.is_safe_dynamic_objects = true;
   }
 }
 
@@ -279,7 +281,7 @@ bool StartPlannerModule::isExecutionReady() const
     is_safe = false;
   }
 
-  if (requiresDynamicObjectsCollisionDetection()) {
+  if (requiresDynamicObjectsCollisionDetection() && isWaitingApproval()) {
     is_safe = !hasCollisionWithDynamicObjects();
   }
 


### PR DESCRIPTION
## Description

Fix PR for the [PR](https://github.com/autowarefoundation/autoware.universe/pull/5747)

1. The `updateData()` function now sets `status_.is_safe_dynamic_objects` to true when `requiresDynamicObjectsCollisionDetection()` returns false.

2. The `isExecutionReady()` function now checks for dynamic object collisions only if `requiresDynamicObjectsCollisionDetection()` returns true and `isWaitingApproval()` also returns true. This change ensures that dynamic object collision detection is performed only when necessary and approval is pending.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/6159e56f-ed70-548b-8e49-d66e2c33eb2a?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
