### PR TITLE
fix(obstacle_stop_planner): change the nearest_collision_point calculation place

### DIFF
--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -107,15 +107,31 @@ struct ObstacleWithDetectionTime
 
 struct PredictedObjectWithDetectionTime
 {
-  explicit PredictedObjectWithDetectionTime(
-    const rclcpp::Time & t, geometry_msgs::msg::Point & p, PredictedObject obj)
-  : detection_time(t), point(p), object(std::move(obj))
+  explicit PredictedObjectWithDetectionTime(const rclcpp::Time & t, PredictedObject obj)
+  : detection_time(t), object(std::move(obj))
   {
   }
 
   rclcpp::Time detection_time;
-  geometry_msgs::msg::Point point;
   PredictedObject object;
+};
+
+struct IntersectedPredictedObject
+{
+  explicit IntersectedPredictedObject(
+    const rclcpp::Time & t, PredictedObject obj, const Polygon2d obj_polygon,
+    const Polygon2d ego_polygon)
+  : detection_time(t),
+    object(std::move(obj)),
+    object_polygon{obj_polygon},
+    vehicle_polygon{ego_polygon}
+  {
+  }
+
+  rclcpp::Time detection_time;
+  PredictedObject object;
+  Polygon2d object_polygon;
+  Polygon2d vehicle_polygon;
 };
 
 class ObstacleStopPlannerNode : public rclcpp::Node
@@ -272,6 +288,19 @@ private:
 
       itr++;
     }
+  }
+
+  void addPredictedObstacleToHistory(const PredictedObject & obj, const rclcpp::Time & now)
+  {
+    for (auto itr = predicted_object_history_.begin(); itr != predicted_object_history_.end();) {
+      if (obj.object_id.uuid == itr->object.object_id.uuid) {
+        // Erase the itr from the vector
+        itr = predicted_object_history_.erase(itr);
+      } else {
+        ++itr;
+      }
+    }
+    predicted_object_history_.emplace_back(now, obj);
   }
 
   PointCloud::Ptr getOldPointCloudPtr() const


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR closes following issues:
https://github.com/autowarefoundation/autoware.universe/issues/5449
https://github.com/autowarefoundation/autoware.universe/issues/6007

The purpose of this PR is fixing logical bug. 
At first for loop [here](https://github.com/autowarefoundation/autoware.universe/blob/65bb40985f8c9e488f30d467e13a3cfff9333f28/planning/obstacle_stop_planner/src/node.cpp#L603), it searches collision on trajectory by looking into predicted objects. If there is a collision object, it finds the nearest point of the object (by looking both intersected points and corner points [here](https://github.com/autowarefoundation/autoware.universe/blob/65bb40985f8c9e488f30d467e13a3cfff9333f28/planning/obstacle_stop_planner/src/node.cpp#L805-L830)), and it pushes predicted object, time, and nearest point into predicted_object_history_.

At the second for loop [here](https://github.com/autowarefoundation/autoware.universe/blob/65bb40985f8c9e488f30d467e13a3cfff9333f28/planning/obstacle_stop_planner/src/node.cpp#L854), it searches the nearest collision object in predicted_object_history_ vector. It looks for the pre-calculated nearest point inside the trajectory footprint or not. It is the mistake.
If the nearest point we found in the first loop is an intersected point, bg::intersect might not be true in the second loop, it is a logical mistake.

In this issue (https://github.com/autowarefoundation/autoware.universe/issues/6007) we realized if the use_predicted_objects is true, obstacle_stop_planner may react too late to obstacle. 

To solve this problem, we made structural change on `searchPredictedObject` function. We changed the nearest_collision_point calculation place to the second loop.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
Tested in PSim by using reaction_analyzer tool. (https://github.com/brkay54/autoware.universe/tree/feat/reaction-measure-tool/tools/reaction_analyzer)

**Reaction Times before the PR:**
![withoutpr-list](https://github.com/autowarefoundation/autoware.universe/assets/45468306/454b80bc-bfb7-4532-ba74-db582fddf511)
![without-pr-stat](https://github.com/autowarefoundation/autoware.universe/assets/45468306/b0ad7bfd-1200-4521-919a-348a5192d073)

**Reaction Times after the PR:**
![withpr-list](https://github.com/autowarefoundation/autoware.universe/assets/45468306/22401981-0cba-4e73-ac35-29a19d96d183)
![withpr-stat](https://github.com/autowarefoundation/autoware.universe/assets/45468306/70083561-d955-4d5a-9437-c3982777d699)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
You can use the [reaction_analyzer](https://github.com/brkay54/autoware.universe/tree/feat/reaction-measure-tool/tools/reaction_analyzer) tool to check the reaction times of the node. Please refer README for the usage.


## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
-

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Decreases the reaction delay of the obstacle_stop_planner when use_predicted_objects is true.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
