### PR TITLE
refactor(avoidance): use drivable bound to calculate road shoulder distance

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -401,6 +401,9 @@ struct ObjectData  // avoidance target
 
   // lateral avoid margin
   std::optional<double> avoid_margin{std::nullopt};
+
+  // the nearest bound point (use in road shoulder distance calculation)
+  std::optional<Point> nearest_bound_point{std::nullopt};
 };
 using ObjectDataArray = std::vector<ObjectData>;
 

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/debug.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/debug.hpp
@@ -59,13 +59,6 @@ MarkerArray createTargetObjectsMarkerArray(const ObjectDataArray & objects, cons
 
 MarkerArray createOtherObjectsMarkerArray(const ObjectDataArray & objects, const std::string & ns);
 
-MarkerArray makeOverhangToRoadShoulderMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
-
-MarkerArray createOverhangFurthestLineStringMarkerArray(
-  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float & r,
-  const float & g, const float & b);
-
 MarkerArray createDebugMarkerArray(
   const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug);
 }  // namespace marker_utils::avoidance_marker

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/utils.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/utils.hpp
@@ -135,13 +135,6 @@ double getRoadShoulderDistance(
   const std::shared_ptr<const PlannerData> & planner_data,
   const std::shared_ptr<AvoidanceParameters> & parameters);
 
-double extendToRoadShoulderDistanceWithPolygon(
-  const std::shared_ptr<route_handler::RouteHandler> & rh,
-  const lanelet::ConstLineString3d & target_line, const double to_road_shoulder_distance,
-  const lanelet::ConstLanelet & overhang_lanelet, const geometry_msgs::msg::Point & overhang_pos,
-  const lanelet::BasicPoint3d & overhang_basic_pose, const bool use_hatched_road_markings,
-  const bool use_intersection_areas);
-
 void fillAdditionalInfoFromPoint(const AvoidancePlanningData & data, AvoidLineArray & lines);
 
 void fillAdditionalInfoFromLongitudinal(const AvoidancePlanningData & data, AvoidLine & line);

--- a/planning/behavior_path_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_avoidance_module/src/debug.cpp
@@ -109,6 +109,42 @@ MarkerArray createObjectPolygonMarkerArray(const ObjectDataArray & objects, std:
   return msg;
 }
 
+MarkerArray createToDrivableBoundDistance(const ObjectDataArray & objects, std::string && ns)
+{
+  MarkerArray msg;
+
+  for (const auto & object : objects) {
+    if (!object.nearest_bound_point.has_value()) {
+      continue;
+    }
+
+    {
+      auto marker = createDefaultMarker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::LINE_STRIP,
+        createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(1.0, 0.0, 0.42, 0.999));
+
+      marker.points.push_back(object.overhang_pose.position);
+      marker.points.push_back(object.nearest_bound_point.value());
+      marker.id = uuidToInt32(object.object.object_id);
+      msg.markers.push_back(marker);
+    }
+
+    {
+      auto marker = createDefaultMarker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::TEXT_VIEW_FACING,
+        createMarkerScale(0.5, 0.5, 0.5), createMarkerColor(1.0, 1.0, 0.0, 1.0));
+
+      marker.pose.position = object.nearest_bound_point.value();
+      std::ostringstream string_stream;
+      string_stream << object.to_road_shoulder_distance << "[m]";
+      marker.text = string_stream.str();
+      msg.markers.push_back(marker);
+    }
+  }
+
+  return msg;
+}
+
 MarkerArray createObjectInfoMarkerArray(const ObjectDataArray & objects, std::string && ns)
 {
   MarkerArray msg;
@@ -166,6 +202,7 @@ MarkerArray avoidableObjectsMarkerArray(const ObjectDataArray & objects, std::st
 
   appendMarkerArray(createObjectInfoMarkerArray(objects, ns + "_info"), &msg);
   appendMarkerArray(createObjectPolygonMarkerArray(objects, ns + "_envelope_polygon"), &msg);
+  appendMarkerArray(createToDrivableBoundDistance(objects, ns + "_to_drivable_bound"), &msg);
 
   return msg;
 }
@@ -183,6 +220,7 @@ MarkerArray unAvoidableObjectsMarkerArray(const ObjectDataArray & objects, std::
 
   appendMarkerArray(createObjectInfoMarkerArray(objects, ns + "_info"), &msg);
   appendMarkerArray(createObjectPolygonMarkerArray(objects, ns + "_envelope_polygon"), &msg);
+  appendMarkerArray(createToDrivableBoundDistance(objects, ns + "_to_drivable_bound"), &msg);
 
   return msg;
 }
@@ -418,58 +456,37 @@ MarkerArray createOtherObjectsMarkerArray(const ObjectDataArray & objects, const
   return msg;
 }
 
-MarkerArray makeOverhangToRoadShoulderMarkerArray(
-  const ObjectDataArray & objects, std::string && ns)
-{
-  auto marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::TEXT_VIEW_FACING,
-    createMarkerScale(1.0, 1.0, 1.0), createMarkerColor(1.0, 1.0, 0.0, 1.0));
-
-  int32_t i{0};
-  MarkerArray msg;
-  for (const auto & object : objects) {
-    marker.id = ++i;
-    marker.pose = object.overhang_pose;
-    std::ostringstream string_stream;
-    string_stream << "(to_road_shoulder_distance = " << object.to_road_shoulder_distance << " [m])";
-    marker.text = string_stream.str();
-    msg.markers.push_back(marker);
-  }
-
-  return msg;
-}
-
-MarkerArray createOverhangFurthestLineStringMarkerArray(
-  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float & r,
-  const float & g, const float & b)
+MarkerArray createDrivableBounds(
+  const AvoidancePlanningData & data, std::string && ns, const float & r, const float & g,
+  const float & b)
 {
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
   MarkerArray msg;
 
-  for (const auto & linestring : linestrings) {
-    const auto id = static_cast<int>(linestring.id());
+  // right bound
+  {
     auto marker = createDefaultMarker(
-      "map", current_time, ns, id, Marker::LINE_STRIP, createMarkerScale(0.4, 0.0, 0.0),
+      "map", current_time, ns + "_right", 0L, Marker::LINE_STRIP, createMarkerScale(0.4, 0.0, 0.0),
       createMarkerColor(r, g, b, 0.999));
 
-    marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-    for (const auto & p : linestring.basicLineString()) {
+    for (const auto & p : data.right_bound) {
       marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
     }
-    msg.markers.push_back(marker);
 
-    Marker marker_linestring_id = createDefaultMarker(
-      "map", current_time, "linestring_id", id, Marker::TEXT_VIEW_FACING,
-      createMarkerScale(1.5, 1.5, 1.5), createMarkerColor(1.0, 1.0, 1.0, 0.8));
-    Pose text_id_pose;
-    text_id_pose.position.x = linestring.front().x();
-    text_id_pose.position.y = linestring.front().y();
-    text_id_pose.position.z = linestring.front().z();
-    marker_linestring_id.pose = text_id_pose;
-    std::ostringstream ss;
-    ss << "(ID : " << id << ") ";
-    marker_linestring_id.text = ss.str();
-    msg.markers.push_back(marker_linestring_id);
+    msg.markers.push_back(marker);
+  }
+
+  // left bound
+  {
+    auto marker = createDefaultMarker(
+      "map", current_time, ns + "_left", 0L, Marker::LINE_STRIP, createMarkerScale(0.4, 0.0, 0.0),
+      createMarkerColor(r, g, b, 0.999));
+
+    for (const auto & p : data.left_bound) {
+      marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
+    }
+
+    msg.markers.push_back(marker);
   }
 
   return msg;
@@ -593,8 +610,7 @@ MarkerArray createDebugMarkerArray(
     add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
     add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
     add(createPolygonMarkerArray(debug.detection_area, "detection_area", 0L, 0.16, 1.0, 0.69, 0.1));
-    add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
-    add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
+    add(createDrivableBounds(data, "drivable_bound", 1.0, 0.0, 0.42));
   }
 
   return msg;

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -1348,76 +1348,60 @@ void compensateDetectionLost(
 double getRoadShoulderDistance(
   ObjectData & object, const AvoidancePlanningData & data,
   const std::shared_ptr<const PlannerData> & planner_data,
-  const std::shared_ptr<AvoidanceParameters> & parameters)
+  [[maybe_unused]] const std::shared_ptr<AvoidanceParameters> & parameters)
 {
   using lanelet::utils::to2D;
+  using tier4_autoware_utils::Point2d;
 
   const auto & object_pose = object.object.kinematics.initial_pose_with_covariance.pose;
   const auto object_closest_index =
-    findNearestIndex(data.reference_path_rough.points, object_pose.position);
-  const auto object_closest_pose =
-    data.reference_path_rough.points.at(object_closest_index).point.pose;
+    findNearestIndex(data.reference_path.points, object_pose.position);
+  const auto object_closest_pose = data.reference_path.points.at(object_closest_index).point.pose;
 
   const auto rh = planner_data->route_handler;
   if (!rh->getClosestLaneletWithinRoute(object_closest_pose, &object.overhang_lanelet)) {
     return 0.0;
   }
 
-  double road_shoulder_distance = std::numeric_limits<double>::max();
+  const auto centerline_pose =
+    lanelet::utils::getClosestCenterPose(object.overhang_lanelet, object_pose.position);
+  const auto & p1_object = object.overhang_pose.position;
+  const auto p_tmp =
+    geometry_msgs::build<Pose>().position(p1_object).orientation(centerline_pose.orientation);
+  const auto p2_object =
+    calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? 100.0 : -100.0), 0.0).position;
 
-  const bool get_left = isOnRight(object) && parameters->use_adjacent_lane;
-  const bool get_right = !isOnRight(object) && parameters->use_adjacent_lane;
-  const bool get_opposite = parameters->use_opposite_lane;
+  // TODO(Satoshi OTA): check if the basic point is on right or left of bound.
+  const auto bound = isOnRight(object) ? data.left_bound : data.right_bound;
 
-  lanelet::BasicPoint3d p_overhang(
-    object.overhang_pose.position.x, object.overhang_pose.position.y,
-    object.overhang_pose.position.z);
+  std::vector<Point> intersects;
+  for (size_t i = 1; i < bound.size(); i++) {
+    const auto p1_bound =
+      geometry_msgs::build<Point>().x(bound[i - 1].x()).y(bound[i - 1].y()).z(bound[i - 1].z());
+    const auto p2_bound =
+      geometry_msgs::build<Point>().x(bound[i].x()).y(bound[i].y()).z(bound[i].z());
 
-  lanelet::ConstLineString3d target_line{};
+    const auto opt_intersect =
+      tier4_autoware_utils::intersect(p1_object, p2_object, p1_bound, p2_bound);
 
-  const auto update_road_to_shoulder_distance = [&](const auto & target_lanelet) {
-    const auto lines =
-      rh->getFurthestLinestring(target_lanelet, get_right, get_left, get_opposite, true);
-    const auto & line = isOnRight(object) ? lines.back() : lines.front();
-    const auto d = boost::geometry::distance(object.envelope_poly, to2D(line.basicLineString()));
-    if (d < road_shoulder_distance) {
-      road_shoulder_distance = d;
-      target_line = line;
+    if (!opt_intersect) {
+      continue;
     }
-  };
 
-  // current lanelet
-  {
-    update_road_to_shoulder_distance(object.overhang_lanelet);
-
-    road_shoulder_distance = extendToRoadShoulderDistanceWithPolygon(
-      rh, target_line, road_shoulder_distance, object.overhang_lanelet,
-      object.overhang_pose.position, p_overhang, parameters->use_hatched_road_markings,
-      parameters->use_intersection_areas);
+    intersects.push_back(opt_intersect.value());
   }
 
-  // previous lanelet
-  lanelet::ConstLanelets previous_lanelet{};
-  if (rh->getPreviousLaneletsWithinRoute(object.overhang_lanelet, &previous_lanelet)) {
-    update_road_to_shoulder_distance(previous_lanelet.front());
-
-    road_shoulder_distance = extendToRoadShoulderDistanceWithPolygon(
-      rh, target_line, road_shoulder_distance, previous_lanelet.front(),
-      object.overhang_pose.position, p_overhang, parameters->use_hatched_road_markings,
-      parameters->use_intersection_areas);
+  if (intersects.empty()) {
+    return 0.0;
   }
 
-  // next lanelet
-  lanelet::ConstLanelet next_lanelet{};
-  if (rh->getNextLaneletWithinRoute(object.overhang_lanelet, &next_lanelet)) {
-    update_road_to_shoulder_distance(next_lanelet);
+  std::sort(intersects.begin(), intersects.end(), [&p1_object](const auto & a, const auto & b) {
+    return calcDistance2d(p1_object, a) < calcDistance2d(p1_object, b);
+  });
 
-    road_shoulder_distance = extendToRoadShoulderDistanceWithPolygon(
-      rh, target_line, road_shoulder_distance, next_lanelet, object.overhang_pose.position,
-      p_overhang, parameters->use_hatched_road_markings, parameters->use_intersection_areas);
-  }
+  object.nearest_bound_point = intersects.front();
 
-  return road_shoulder_distance;
+  return calcDistance2d(p1_object, object.nearest_bound_point.value());
 }
 
 void filterTargetObjects(
@@ -1463,93 +1447,6 @@ void filterTargetObjects(
 
     push_target_object(o);
   }
-}
-
-double extendToRoadShoulderDistanceWithPolygon(
-  const std::shared_ptr<route_handler::RouteHandler> & rh,
-  const lanelet::ConstLineString3d & target_line, const double to_road_shoulder_distance,
-  const lanelet::ConstLanelet & overhang_lanelet, const geometry_msgs::msg::Point & overhang_pos,
-  const lanelet::BasicPoint3d & overhang_basic_pose, const bool use_hatched_road_markings,
-  const bool use_intersection_areas)
-{
-  // get expandable polygons for avoidance (e.g. hatched road markings)
-  std::vector<lanelet::Polygon3d> expandable_polygons;
-
-  const auto exist_polygon = [&](const auto & candidate_polygon) {
-    return std::any_of(
-      expandable_polygons.begin(), expandable_polygons.end(),
-      [&](const auto & polygon) { return polygon.id() == candidate_polygon.id(); });
-  };
-
-  if (use_hatched_road_markings) {
-    for (const auto & point : target_line) {
-      const auto new_polygon_candidate =
-        utils::getPolygonByPoint(rh, point, "hatched_road_markings");
-
-      if (!!new_polygon_candidate && !exist_polygon(*new_polygon_candidate)) {
-        expandable_polygons.push_back(*new_polygon_candidate);
-      }
-    }
-  }
-
-  if (use_intersection_areas) {
-    const std::string area_id_str = overhang_lanelet.attributeOr("intersection_area", "else");
-
-    if (area_id_str != "else") {
-      expandable_polygons.push_back(
-        rh->getLaneletMapPtr()->polygonLayer.get(std::atoi(area_id_str.c_str())));
-    }
-  }
-
-  if (expandable_polygons.empty()) {
-    return to_road_shoulder_distance;
-  }
-
-  // calculate point laterally offset from overhang position to calculate intersection with
-  // polygon
-  Point lat_offset_overhang_pos;
-  {
-    auto arc_coordinates = lanelet::geometry::toArcCoordinates(
-      lanelet::utils::to2D(target_line), lanelet::utils::to2D(overhang_basic_pose));
-    arc_coordinates.distance = 0.0;
-    const auto closest_target_line_point =
-      lanelet::geometry::fromArcCoordinates(target_line, arc_coordinates);
-
-    const double ratio = 100.0 / to_road_shoulder_distance;
-    lat_offset_overhang_pos.x =
-      closest_target_line_point.x() + (closest_target_line_point.x() - overhang_pos.x) * ratio;
-    lat_offset_overhang_pos.y =
-      closest_target_line_point.y() + (closest_target_line_point.y() - overhang_pos.y) * ratio;
-  }
-
-  // update to_road_shoulder_distance with valid expandable polygon
-  double updated_to_road_shoulder_distance = to_road_shoulder_distance;
-  for (const auto & polygon : expandable_polygons) {
-    std::vector<double> intersect_dist_vec;
-    for (size_t i = 0; i < polygon.size(); ++i) {
-      const auto polygon_current_point =
-        geometry_msgs::build<Point>().x(polygon[i].x()).y(polygon[i].y()).z(0.0);
-      const auto polygon_next_point = geometry_msgs::build<Point>()
-                                        .x(polygon[(i + 1) % polygon.size()].x())
-                                        .y(polygon[(i + 1) % polygon.size()].y())
-                                        .z(0.0);
-
-      const auto intersect_pos = tier4_autoware_utils::intersect(
-        overhang_pos, lat_offset_overhang_pos, polygon_current_point, polygon_next_point);
-      if (intersect_pos) {
-        intersect_dist_vec.push_back(calcDistance2d(*intersect_pos, overhang_pos));
-      }
-    }
-
-    if (intersect_dist_vec.empty()) {
-      continue;
-    }
-
-    std::sort(intersect_dist_vec.begin(), intersect_dist_vec.end());
-    updated_to_road_shoulder_distance =
-      std::max(updated_to_road_shoulder_distance, intersect_dist_vec.back());
-  }
-  return updated_to_road_shoulder_distance;
 }
 
 AvoidLine fillAdditionalInfo(const AvoidancePlanningData & data, const AvoidLine & line)


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b779b30</samp>

This pull request updates the behavior path avoidance module to use the drivable bound distance instead of the road shoulder distance for calculating and visualizing the clearance from the objects on the road. It adds code to generate and store the drivable bounds for each lane, and modifies the debug functions to create new markers for them. It also refactors and removes some unused or outdated functions and variables.

---

Previously, avoidance module use unique function to find drivable bound when it calculate between overhang point and drivable bound. But there are actually some functions to calculate drivable bound from lanelet info for drivable area generation.

In this PR, I removed avoidance unique function and re-use common util functions to calculate distance to drivable bound.

![Screenshot from 2023-12-08 09-38-17](https://github.com/autowarefoundation/autoware.universe/assets/44889564/d9ba975d-cca6-41aa-af6d-bd1701f54baf)

<!-- Write a brief description of this PR. -->

| default | don't use opposite lane | don't use intersection area | don't use hatched road marking |
| ---- | ---- | ---- | ---- |
| ![Screenshot from 2023-12-08 09-38-17](https://github.com/autowarefoundation/autoware.universe/assets/44889564/7a0aa284-f563-413c-86b0-d9e58ce7a4e0) | ![Screenshot from 2023-12-08 09-43-17](https://github.com/autowarefoundation/autoware.universe/assets/44889564/d53c0140-8c04-427f-b5af-161ee13d9165) | ![Screenshot from 2023-12-08 09-45-41](https://github.com/autowarefoundation/autoware.universe/assets/44889564/1ba87d76-5c45-4884-bae6-937990d41ad2) | ![Screenshot from 2023-12-08 09-46-34](https://github.com/autowarefoundation/autoware.universe/assets/44889564/c35b5468-4685-4203-af54-e949c76bbfb4) |

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/d4e08655-b325-5235-9cd7-0bed6411b990?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
