### PR TITLE
fix(avoidance): fix invalid optional access

### DIFF
--- a/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp
@@ -966,6 +966,7 @@ AvoidLineArray ShiftLineGenerator::addReturnShiftLine(
   AvoidLineArray ret = shift_lines;
 
   constexpr double ep = 1.0e-3;
+  constexpr double RETURN_SHIFT_THRESHOLD = 0.1;
   const bool has_candidate_point = !ret.empty();
   const bool has_registered_point = last_.has_value();
 
@@ -977,14 +978,15 @@ AvoidLineArray ShiftLineGenerator::addReturnShiftLine(
     return ret;
   }
 
-  // If the return-to-center shift points are already registered, do nothing.
-  if (!has_registered_point && std::fabs(base_offset_) < ep) {
-    return ret;
-  }
-
-  constexpr double RETURN_SHIFT_THRESHOLD = 0.1;
-  if (std::abs(last_.value().end_shift_length) < RETURN_SHIFT_THRESHOLD) {
-    return ret;
+  if (last_.has_value()) {
+    if (std::abs(last_.value().end_shift_length) < RETURN_SHIFT_THRESHOLD) {
+      return ret;
+    }
+  } else {
+    // If the return-to-center shift points are already registered, do nothing.
+    if (std::abs(base_offset_) < ep) {
+      return ret;
+    }
   }
 
   // From here, the return-to-center is not registered. But perhaps the candidate is


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29517fd</samp>

Improved return-to-center shift line generation in `behavior_path_avoidance_module`. Added a threshold and adjusted the shift point condition to reduce redundant or invalid shift lines.

---

Fix following error:

```
#9  0x00007f6f607109cd in std::__throw_bad_optional_access () at /usr/include/c++/11/optional:102                                                                                                               
#10 0x00007f6f60714366 in std::optional<behavior_path_planner::ShiftLine>::value() const & (this=0x7f6f406cd200)                                                                                                
    at /usr/include/c++/11/optional:948                                                                 
#11 behavior_path_planner::utils::avoidance::ShiftLineGenerator::addReturnShiftLine (this=0x7f6f406cd1d0, shift_lines=..., data=...,                                                                            
    debug=...) at /home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp:986                                                                       
#12 0x00007f6f607fee0f in behavior_path_planner::utils::avoidance::ShiftLineGenerator::applyPreProcess (this=0x7f6f406cd1d0,                                                                                    
    outlines=..., data=..., debug=...)                                                                  
    at /home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp:397                                                                                  
#13 0x00007f6f607fef68 in behavior_path_planner::utils::avoidance::ShiftLineGenerator::update (this=this@entry=0x7f6f406cd1d0, data=...,                                                                        
    debug=...) at /home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp:110                                                                       
#14 0x00007f6f60728dd4 in behavior_path_planner::AvoidanceModule::updateData (this=0x7f6f406ccd50)                                                                                                              
    at /home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_avoidance_module/src/scene.cpp:1196                                                                                                
#15 0x00007f6f6072b288 in behavior_path_planner::SceneModuleInterface::run (this=0x7f6f406ccd50)                                                                                                                
    at /home/satoshi/pilot-auto/install/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp:158
#16 0x00007f6f61d045f7 in behavior_path_planner::PlannerManager::run (this=this@entry=0x7f6f4c110b60,                                                                                                           
    module_ptr=std::shared_ptr<behavior_path_planner::SceneModuleInterface> (use count 4, weak count 1) = {...},                                                                                                
    planner_data=std::shared_ptr<behavior_path_planner::PlannerData> (use count 21, weak count 0) = {...}, previous_module_output=...)                                                                          
    at /home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp:280 
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
