### PR TITLE
refactor(lane_change): move lane change param

### DIFF
--- a/planning/behavior_path_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -62,8 +62,6 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
                    behavior_path_planner_dir + "/config/behavior_path_planner.param.yaml",
                    behavior_path_planner_dir + "/config/drivable_area_expansion.param.yaml",
                    behavior_path_planner_dir + "/config/scene_module_manager.param.yaml",
-                   ament_index_cpp::get_package_share_directory("behavior_path_planner") +
-                     "/config/lane_change/lane_change.param.yaml",
                    ament_index_cpp::get_package_share_directory("behavior_path_avoidance_module") +
                      "/config/avoidance.param.yaml"});
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -54,17 +54,21 @@ using tier4_autoware_utils::Polygon2d;
 double calcLaneChangeResampleInterval(
   const double lane_changing_length, const double lane_changing_velocity);
 
+double calcMinimumLaneChangeLength(
+  const LaneChangeParameters & lane_change_parameters, const std::vector<double> & shift_intervals,
+  const double length_to_intersection = 0.0);
+
 double calcMaximumLaneChangeLength(
-  const double current_velocity, const BehaviorPathPlannerParameters & common_param,
+  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
   const std::vector<double> & shift_intervals, const double max_acc);
 
 double calcMinimumAcceleration(
   const double current_velocity, const double min_longitudinal_acc,
-  const BehaviorPathPlannerParameters & params);
+  const LaneChangeParameters & lane_change_parameters);
 
 double calcMaximumAcceleration(
   const double current_velocity, const double current_max_velocity,
-  const double max_longitudinal_acc, const BehaviorPathPlannerParameters & params);
+  const double max_longitudinal_acc, const LaneChangeParameters & lane_change_parameters);
 
 double calcLaneChangingAcceleration(
   const double initial_lane_changing_velocity, const double max_path_velocity,
@@ -130,7 +134,7 @@ double getLateralShift(const LaneChangePath & path);
 bool hasEnoughLengthToLaneChangeAfterAbort(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const Pose & curent_pose, const double abort_return_dist,
-  const BehaviorPathPlannerParameters & common_param, const Direction direction);
+  const LaneChangeParameters & lane_change_parameters, const Direction direction);
 
 lanelet::ConstLanelets getBackwardLanelets(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
@@ -150,7 +154,8 @@ std::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(
 
 std::vector<PoseWithVelocityStamped> convertToPredictedPath(
   const LaneChangePath & lane_change_path, const Twist & vehicle_twist, const Pose & pose,
-  const BehaviorPathPlannerParameters & common_parameters, const double resolution);
+  const BehaviorPathPlannerParameters & common_parameters,
+  const LaneChangeParameters & lane_change_parameters, const double resolution);
 
 bool isParkedObject(
   const PathWithLaneId & path, const RouteHandler & route_handler,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -238,39 +238,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.min_acc = declare_parameter<double>("normal.min_acc");
   p.max_acc = declare_parameter<double>("normal.max_acc");
 
-  // lane change parameters
-  p.backward_length_buffer_for_end_of_lane =
-    declare_parameter<double>("lane_change.backward_length_buffer_for_end_of_lane");
-  p.backward_length_buffer_for_blocking_object =
-    declare_parameter<double>("lane_change.backward_length_buffer_for_blocking_object");
-  p.lane_changing_lateral_jerk =
-    declare_parameter<double>("lane_change.lane_changing_lateral_jerk");
-  p.lane_change_prepare_duration = declare_parameter<double>("lane_change.prepare_duration");
-  p.minimum_lane_changing_velocity =
-    declare_parameter<double>("lane_change.minimum_lane_changing_velocity");
-  p.minimum_lane_changing_velocity =
-    std::min(p.minimum_lane_changing_velocity, p.max_acc * p.lane_change_prepare_duration);
-  p.lane_change_finish_judge_buffer =
-    declare_parameter<double>("lane_change.lane_change_finish_judge_buffer");
-
-  // lateral acceleration map for lane change
-  const auto lateral_acc_velocity =
-    declare_parameter<std::vector<double>>("lane_change.lateral_acceleration.velocity");
-  const auto min_lateral_acc =
-    declare_parameter<std::vector<double>>("lane_change.lateral_acceleration.min_values");
-  const auto max_lateral_acc =
-    declare_parameter<std::vector<double>>("lane_change.lateral_acceleration.max_values");
-  if (
-    lateral_acc_velocity.size() != min_lateral_acc.size() ||
-    lateral_acc_velocity.size() != max_lateral_acc.size()) {
-    RCLCPP_ERROR(get_logger(), "Lane change lateral acceleration map has invalid size.");
-    exit(EXIT_FAILURE);
-  }
-  for (size_t i = 0; i < lateral_acc_velocity.size(); ++i) {
-    p.lane_change_lat_acc_map.add(
-      lateral_acc_velocity.at(i), min_lateral_acc.at(i), max_lateral_acc.at(i));
-  }
-
   p.backward_length_buffer_for_end_of_pull_over =
     declare_parameter<double>("backward_length_buffer_for_end_of_pull_over");
   p.backward_length_buffer_for_end_of_pull_out =
@@ -297,10 +264,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
   p.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
 
-  if (p.backward_length_buffer_for_end_of_lane < 1.0) {
-    RCLCPP_WARN_STREAM(
-      get_logger(), "Lane change buffer must be more than 1 meter. Modifying the buffer.");
-  }
   return p;
 }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -148,8 +148,7 @@ ModuleStatus LaneChangeInterface::updateState()
     return ModuleStatus::RUNNING;
   }
 
-  const auto & common_parameters = module_type_->getCommonParam();
-  const auto threshold = common_parameters.backward_length_buffer_for_end_of_lane;
+  const auto threshold = module_type_->getLaneChangeParam().backward_length_buffer_for_end_of_lane;
   const auto status = module_type_->getLaneChangeStatus();
   if (module_type_->isNearEndOfCurrentLanes(status.current_lanes, status.target_lanes, threshold)) {
     log_warn_throttled("Lane change path is unsafe but near end of lane. Continue lane change.");
@@ -432,8 +431,8 @@ TurnSignalInfo LaneChangeInterface::getCurrentTurnSignalInfo(
   const auto & common_parameter = module_type_->getCommonParam();
   const auto shift_intervals =
     route_handler->getLateralIntervalsToPreferredLane(current_lanes.back());
-  const double next_lane_change_buffer = utils::calcMinimumLaneChangeLength(
-    common_parameter, shift_intervals, common_parameter.backward_length_buffer_for_end_of_lane);
+  const double next_lane_change_buffer =
+    utils::lane_change::calcMinimumLaneChangeLength(lane_change_param, shift_intervals);
   const double & nearest_dist_threshold = common_parameter.ego_nearest_dist_threshold;
   const double & nearest_yaw_threshold = common_parameter.ego_nearest_yaw_threshold;
   const double & base_to_front = common_parameter.base_link2front;

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -67,17 +67,43 @@ double calcLaneChangeResampleInterval(
     lane_changing_length / min_resampling_points, lane_changing_velocity * resampling_dt);
 }
 
+double calcMinimumLaneChangeLength(
+  const LaneChangeParameters & lane_change_parameters, const std::vector<double> & shift_intervals,
+  const double length_to_intersection)
+{
+  if (shift_intervals.empty()) {
+    return 0.0;
+  }
+
+  const double & vel = lane_change_parameters.minimum_lane_changing_velocity;
+  const auto lat_acc = lane_change_parameters.lane_change_lat_acc_map.find(vel);
+  const double & max_lateral_acc = lat_acc.second;
+  const double & lateral_jerk = lane_change_parameters.lane_changing_lateral_jerk;
+  const double & finish_judge_buffer = lane_change_parameters.lane_change_finish_judge_buffer;
+  const double & backward_buffer = lane_change_parameters.backward_length_buffer_for_end_of_lane;
+
+  double accumulated_length = length_to_intersection;
+  for (const auto & shift_interval : shift_intervals) {
+    const double t =
+      PathShifter::calcShiftTimeFromJerk(shift_interval, lateral_jerk, max_lateral_acc);
+    accumulated_length += vel * t + finish_judge_buffer;
+  }
+  accumulated_length += backward_buffer * (shift_intervals.size() - 1.0);
+
+  return accumulated_length;
+}
+
 double calcMaximumLaneChangeLength(
-  const double current_velocity, const BehaviorPathPlannerParameters & common_param,
+  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
   const std::vector<double> & shift_intervals, const double max_acc)
 {
   if (shift_intervals.empty()) {
     return 0.0;
   }
 
-  const double & finish_judge_buffer = common_param.lane_change_finish_judge_buffer;
-  const double & lateral_jerk = common_param.lane_changing_lateral_jerk;
-  const double & t_prepare = common_param.lane_change_prepare_duration;
+  const double & finish_judge_buffer = lane_change_parameters.lane_change_finish_judge_buffer;
+  const double & lateral_jerk = lane_change_parameters.lane_changing_lateral_jerk;
+  const double & t_prepare = lane_change_parameters.lane_change_prepare_duration;
 
   double vel = current_velocity;
   double accumulated_length = 0.0;
@@ -87,7 +113,7 @@ double calcMaximumLaneChangeLength(
     vel = vel + max_acc * t_prepare;
 
     // lane changing section
-    const auto lat_acc = common_param.lane_change_lat_acc_map.find(vel);
+    const auto lat_acc = lane_change_parameters.lane_change_lat_acc_map.find(vel);
     const double t_lane_changing =
       PathShifter::calcShiftTimeFromJerk(shift_interval, lateral_jerk, lat_acc.second);
     const double lane_changing_length =
@@ -97,26 +123,26 @@ double calcMaximumLaneChangeLength(
     vel = vel + max_acc * t_lane_changing;
   }
   accumulated_length +=
-    common_param.backward_length_buffer_for_end_of_lane * (shift_intervals.size() - 1.0);
+    lane_change_parameters.backward_length_buffer_for_end_of_lane * (shift_intervals.size() - 1.0);
 
   return accumulated_length;
 }
 
 double calcMinimumAcceleration(
   const double current_velocity, const double min_longitudinal_acc,
-  const BehaviorPathPlannerParameters & params)
+  const LaneChangeParameters & lane_change_parameters)
 {
-  const double min_lane_changing_velocity = params.minimum_lane_changing_velocity;
-  const double prepare_duration = params.lane_change_prepare_duration;
+  const double min_lane_changing_velocity = lane_change_parameters.minimum_lane_changing_velocity;
+  const double prepare_duration = lane_change_parameters.lane_change_prepare_duration;
   const double acc = (min_lane_changing_velocity - current_velocity) / prepare_duration;
   return std::clamp(acc, -std::abs(min_longitudinal_acc), -std::numeric_limits<double>::epsilon());
 }
 
 double calcMaximumAcceleration(
   const double current_velocity, const double current_max_velocity,
-  const double max_longitudinal_acc, const BehaviorPathPlannerParameters & params)
+  const double max_longitudinal_acc, const LaneChangeParameters & lane_change_parameters)
 {
-  const double prepare_duration = params.lane_change_prepare_duration;
+  const double prepare_duration = lane_change_parameters.lane_change_prepare_duration;
   const double acc = (current_max_velocity - current_velocity) / prepare_duration;
   return std::clamp(acc, 0.0, max_longitudinal_acc);
 }
@@ -601,12 +627,12 @@ double getLateralShift(const LaneChangePath & path)
 bool hasEnoughLengthToLaneChangeAfterAbort(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const Pose & current_pose, const double abort_return_dist,
-  const BehaviorPathPlannerParameters & common_param, const Direction direction)
+  const LaneChangeParameters & lane_change_parameters, const Direction direction)
 {
   const auto shift_intervals =
     route_handler.getLateralIntervalsToPreferredLane(current_lanes.back(), direction);
-  const double minimum_lane_change_length = utils::calcMinimumLaneChangeLength(
-    common_param, shift_intervals, common_param.backward_length_buffer_for_end_of_lane);
+  const double minimum_lane_change_length =
+    calcMinimumLaneChangeLength(lane_change_parameters, shift_intervals);
   const auto abort_plus_lane_change_length = abort_return_dist + minimum_lane_change_length;
   if (abort_plus_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     return false;
@@ -765,7 +791,8 @@ std::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(
 
 std::vector<PoseWithVelocityStamped> convertToPredictedPath(
   const LaneChangePath & lane_change_path, const Twist & vehicle_twist, const Pose & vehicle_pose,
-  const BehaviorPathPlannerParameters & common_parameters, const double resolution)
+  const BehaviorPathPlannerParameters & common_parameters,
+  const LaneChangeParameters & lane_change_parameters, const double resolution)
 {
   if (lane_change_path.path.points.empty()) {
     return {};
@@ -776,7 +803,8 @@ std::vector<PoseWithVelocityStamped> convertToPredictedPath(
   const auto lane_changing_acc = lane_change_path.info.longitudinal_acceleration.lane_changing;
   const auto duration = lane_change_path.info.duration.sum();
   const auto prepare_time = lane_change_path.info.duration.prepare;
-  const auto & minimum_lane_changing_velocity = common_parameters.minimum_lane_changing_velocity;
+  const auto & minimum_lane_changing_velocity =
+    lane_change_parameters.minimum_lane_changing_velocity;
 
   const auto nearest_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     path.points, vehicle_pose, common_parameters.ego_nearest_dist_threshold,
@@ -1065,7 +1093,8 @@ std::optional<lanelet::BasicPolygon2d> createPolygon(
 }
 
 ExtendedPredictedObject transform(
-  const PredictedObject & object, const BehaviorPathPlannerParameters & common_parameters,
+  const PredictedObject & object,
+  [[maybe_unused]] const BehaviorPathPlannerParameters & common_parameters,
   const LaneChangeParameters & lane_change_parameters)
 {
   ExtendedPredictedObject extended_object;
@@ -1078,7 +1107,7 @@ ExtendedPredictedObject transform(
   const auto & time_resolution = lane_change_parameters.prediction_time_resolution;
   const auto & check_at_prepare_phase =
     lane_change_parameters.enable_prepare_segment_collision_check;
-  const auto & prepare_duration = common_parameters.lane_change_prepare_duration;
+  const auto & prepare_duration = lane_change_parameters.lane_change_prepare_duration;
   const auto & velocity_threshold =
     lane_change_parameters.prepare_segment_ignore_object_velocity_thresh;
   const auto start_time = check_at_prepare_phase ? 0.0 : prepare_duration;

--- a/planning/behavior_path_planner/test/test_lane_change_utils.cpp
+++ b/planning/behavior_path_planner/test/test_lane_change_utils.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "behavior_path_planner/utils/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp"
 
 #include <tier4_autoware_utils/geometry/geometry.hpp>
@@ -41,7 +42,7 @@ TEST(BehaviorPathPlanningLaneChangeUtilsTest, projectCurrentPoseToTarget)
 
 TEST(BehaviorPathPlanningLaneChangeUtilsTest, TESTLateralAccelerationMap)
 {
-  LateralAccelerationMap lat_acc_map;
+  behavior_path_planner::LateralAccelerationMap lat_acc_map;
   lat_acc_map.add(0.0, 0.2, 0.315);
   lat_acc_map.add(3.0, 0.2, 0.315);
   lat_acc_map.add(5.0, 0.2, 0.315);

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/parameters.hpp
@@ -15,7 +15,6 @@
 #ifndef BEHAVIOR_PATH_PLANNER_COMMON__PARAMETERS_HPP_
 #define BEHAVIOR_PATH_PLANNER_COMMON__PARAMETERS_HPP_
 
-#include <interpolation/linear_interpolation.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <utility>
@@ -32,47 +31,6 @@ struct ModuleConfigParameters
   uint8_t max_module_size{0};
 };
 
-struct LateralAccelerationMap
-{
-  std::vector<double> base_vel;
-  std::vector<double> base_min_acc;
-  std::vector<double> base_max_acc;
-
-  void add(const double velocity, const double min_acc, const double max_acc)
-  {
-    if (base_vel.size() != base_min_acc.size() || base_vel.size() != base_max_acc.size()) {
-      return;
-    }
-
-    size_t idx = 0;
-    for (size_t i = 0; i < base_vel.size(); ++i) {
-      if (velocity < base_vel.at(i)) {
-        break;
-      }
-      idx = i + 1;
-    }
-
-    base_vel.insert(base_vel.begin() + idx, velocity);
-    base_min_acc.insert(base_min_acc.begin() + idx, min_acc);
-    base_max_acc.insert(base_max_acc.begin() + idx, max_acc);
-  }
-
-  std::pair<double, double> find(const double velocity) const
-  {
-    if (!base_vel.empty() && velocity < base_vel.front()) {
-      return std::make_pair(base_min_acc.front(), base_max_acc.front());
-    }
-    if (!base_vel.empty() && velocity > base_vel.back()) {
-      return std::make_pair(base_min_acc.back(), base_max_acc.back());
-    }
-
-    const double min_acc = interpolation::lerp(base_vel, base_min_acc, velocity);
-    const double max_acc = interpolation::lerp(base_vel, base_max_acc, velocity);
-
-    return std::make_pair(min_acc, max_acc);
-  }
-};
-
 struct BehaviorPathPlannerParameters
 {
   bool verbose;
@@ -81,21 +39,12 @@ struct BehaviorPathPlannerParameters
 
   double backward_path_length;
   double forward_path_length;
-  double backward_length_buffer_for_end_of_lane;
-  double backward_length_buffer_for_blocking_object;
   double backward_length_buffer_for_end_of_pull_over;
   double backward_length_buffer_for_end_of_pull_out;
 
   // common parameters
   double min_acc;
   double max_acc;
-
-  // lane change parameters
-  double lane_changing_lateral_jerk{0.5};
-  double minimum_lane_changing_velocity{5.6};
-  double lane_change_prepare_duration{4.0};
-  double lane_change_finish_judge_buffer{3.0};
-  LateralAccelerationMap lane_change_lat_acc_map;
 
   double minimum_pull_over_length;
   double minimum_pull_out_length;

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/utils.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/utils.hpp
@@ -333,10 +333,6 @@ lanelet::ConstLanelets calcLaneAroundPose(
 
 bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_threshold);
 
-double calcMinimumLaneChangeLength(
-  const BehaviorPathPlannerParameters & common_param, const std::vector<double> & shift_intervals,
-  const double backward_buffer, const double length_to_intersection = 0.0);
-
 lanelet::ConstLanelets getLaneletsFromPath(
   const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
 

--- a/planning/behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner_common/src/utils/utils.cpp
@@ -1515,31 +1515,6 @@ bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_thre
   return true;
 }
 
-double calcMinimumLaneChangeLength(
-  const BehaviorPathPlannerParameters & common_param, const std::vector<double> & shift_intervals,
-  const double backward_buffer, const double length_to_intersection)
-{
-  if (shift_intervals.empty()) {
-    return 0.0;
-  }
-
-  const double & vel = common_param.minimum_lane_changing_velocity;
-  const auto lat_acc = common_param.lane_change_lat_acc_map.find(vel);
-  const double & max_lateral_acc = lat_acc.second;
-  const double & lateral_jerk = common_param.lane_changing_lateral_jerk;
-  const double & finish_judge_buffer = common_param.lane_change_finish_judge_buffer;
-
-  double accumulated_length = length_to_intersection;
-  for (const auto & shift_interval : shift_intervals) {
-    const double t =
-      PathShifter::calcShiftTimeFromJerk(shift_interval, lateral_jerk, max_lateral_acc);
-    accumulated_length += vel * t + finish_judge_buffer;
-  }
-  accumulated_length += backward_buffer * (shift_intervals.size() - 1.0);
-
-  return accumulated_length;
-}
-
 lanelet::ConstLanelets getLaneletsFromPath(
   const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler)
 {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9cec5ad</samp>

This pull request refactors the behavior path planner code to improve the handling of lane change parameters. It introduces a new `LaneChangeParameters` struct and a `lane_change` namespace that contain the lane change specific data and logic. It simplifies the function signatures and reduces the code duplication by passing a `LaneChangeParameters` object instead of a `BehaviorPathPlannerParameters` object where appropriate. It also updates the test code and the node parameter server to use the new data structures and namespaces.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/88d26f50-428d-5cde-a600-679c18100f80?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
