### PR TITLE
feat(obstacle_cruise_planner): add jerk and acc limits for slow-down

### DIFF
--- a/planning/obstacle_cruise_planner/config/default_common.param.yaml
+++ b/planning/obstacle_cruise_planner/config/default_common.param.yaml
@@ -7,6 +7,10 @@
       min_jerk: -1.0        # min jerk [m/sss]
       max_jerk: 1.0         # max jerk [m/sss]
 
+    slow_down:
+      min_acc: -1.0         # min slowdown deceleration [m/ss]
+      min_jerk: -1.0        # min slowdown jerk [m/sss]
+
     # constraints to be observed
     limit:
       min_acc: -2.5         # min deceleration limit [m/ss]

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -166,6 +166,8 @@ struct LongitudinalInfo
     limit_min_accel = node.declare_parameter<double>("limit.min_acc");
     limit_max_jerk = node.declare_parameter<double>("limit.max_jerk");
     limit_min_jerk = node.declare_parameter<double>("limit.min_jerk");
+    slow_down_min_accel = node.declare_parameter<double>("slow_down.min_acc");
+    slow_down_min_jerk = node.declare_parameter<double>("slow_down.min_jerk");
 
     idling_time = node.declare_parameter<double>("common.idling_time");
     min_ego_accel_for_rss = node.declare_parameter<double>("common.min_ego_accel_for_rss");
@@ -191,6 +193,9 @@ struct LongitudinalInfo
     tier4_autoware_utils::updateParam<double>(parameters, "limit.min_accel", limit_min_accel);
     tier4_autoware_utils::updateParam<double>(parameters, "limit.max_jerk", limit_max_jerk);
     tier4_autoware_utils::updateParam<double>(parameters, "limit.min_jerk", limit_min_jerk);
+    tier4_autoware_utils::updateParam<double>(
+      parameters, "slow_down.min_accel", slow_down_min_accel);
+    tier4_autoware_utils::updateParam<double>(parameters, "slow_down.min_jerk", slow_down_min_jerk);
 
     tier4_autoware_utils::updateParam<double>(parameters, "common.idling_time", idling_time);
     tier4_autoware_utils::updateParam<double>(
@@ -214,6 +219,8 @@ struct LongitudinalInfo
   double min_accel;
   double max_jerk;
   double min_jerk;
+  double slow_down_min_jerk;
+  double slow_down_min_accel;
   double limit_max_accel;
   double limit_min_accel;
   double limit_max_jerk;

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -790,8 +790,8 @@ PlannerInterface::calculateDistanceToSlowDownWithConstraints(
       }
       // TODO(murooka) Calculate more precisely. Final acceleration should be zero.
       const double min_feasible_slow_down_vel = calcDecelerationVelocityFromDistanceToTarget(
-        longitudinal_info_.min_jerk, longitudinal_info_.min_accel, planner_data.ego_acc,
-        planner_data.ego_vel, deceleration_dist);
+        longitudinal_info_.slow_down_min_jerk, longitudinal_info_.slow_down_min_accel,
+        planner_data.ego_acc, planner_data.ego_vel, deceleration_dist);
       return min_feasible_slow_down_vel;
     }();
     if (prev_output) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f95a0b7</samp>

This pull request adds new parameters and variables for the slow down mode of the obstacle cruise planner. The slow down mode is used to avoid collisions with obstacles by smoothly reducing the ego vehicle speed. The new parameters and variables allow tuning the minimum deceleration and jerk values for the slow down mode.

Usually, the min_jerk and min_acc values are tuned to low values for a comfortable driving experience. However, if said values are too low, it is possible that the cruise_planner's slow down cannot be used when the vehicle is travelling at highers speeds (the slow down requires a bigger jerk and/or acceleration limit). This PR adds parameters to customize the minimum jerk and acc used specifically for slow down.
## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-4637)

## Tests performed

Simulations on PSim to check the effect of the changes.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
Requires this PR(launch) to be merged as well: https://github.com/autowarefoundation/autoware_launch/pull/726

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
Added a min_acc and min_jerk parameter for obstacle_cruise_planner slow_down 

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
