### PR TITLE
fix(localization_util): fixed rejection criteria of SmartPoseBuffer::interpolate

### DIFF
--- a/localization/localization_util/src/smart_pose_buffer.cpp
+++ b/localization/localization_util/src/smart_pose_buffer.cpp
@@ -39,9 +39,15 @@ std::optional<SmartPoseBuffer::InterpolateResult> SmartPoseBuffer::interpolate(
     const rclcpp::Time time_first = pose_buffer_.front()->header.stamp;
     const rclcpp::Time time_last = pose_buffer_.back()->header.stamp;
 
-    if (target_ros_time < time_first || time_last < target_ros_time) {
+    if (target_ros_time < time_first) {
       return std::nullopt;
     }
+
+    // [time_last < target_ros_time] is acceptable here.
+    // It is possible that the target_ros_time (often sensor timestamp) is newer than the latest
+    // timestamp of buffered pose (often EKF).
+    // However, if the timestamp difference is too large,
+    // it will later be rejected by validate_time_stamp_difference.
 
     // get the nearest poses
     result.old_pose = *pose_buffer_.front();


### PR DESCRIPTION
## Description

Fixed rejection criteria of `SmartPoseBuffer::interpolate`.

See comments in changed code.

## Tests performed

It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

## Effects on system behavior

There are no effects on system behavior for basic vehicles.

In environments where LiDAR is lightweight, such as AWSIM, SmartPoseBuffer::interpolate are less likely to fail.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
