### PR TITLE
fix(traffic_light): stop if the traffic light signal timed out

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/README.md
+++ b/planning/behavior_velocity_traffic_light_module/README.md
@@ -19,13 +19,13 @@ This module is activated when there is traffic light in ego lane.
 
 1. Obtains a traffic light mapped to the route and a stop line correspond to the traffic light from a map information.
 
-- If a corresponding traffic light signal have never been found, it treats as a signal to pass.
+   - If a corresponding traffic light signal have never been found, it treats as a signal to pass.
 
-- If a corresponding traffic light signal is found but timed out, it treats as a signal to stop.
+   - If a corresponding traffic light signal is found but timed out, it treats as a signal to stop.
 
 2. Uses the highest reliability one of the traffic light recognition result and if the color of that was not green or corresponding arrow signal, generates a stop point.
 
-- If an elapsed time to receive stop signal is less than `stop_time_hysteresis`, it treats as a signal to pass. This feature is to prevent chattering.
+   - If an elapsed time to receive stop signal is less than `stop_time_hysteresis`, it treats as a signal to pass. This feature is to prevent chattering.
 
 3. When vehicle current velocity is
 

--- a/planning/behavior_velocity_traffic_light_module/README.md
+++ b/planning/behavior_velocity_traffic_light_module/README.md
@@ -19,7 +19,13 @@ This module is activated when there is traffic light in ego lane.
 
 1. Obtains a traffic light mapped to the route and a stop line correspond to the traffic light from a map information.
 
-2. Uses the highest reliability one of the traffic light recognition result and if the color of that was red, generates a stop point.
+- If a corresponding traffic light signal have never been found, it treats as a signal to pass.
+
+- If a corresponding traffic light signal is found but timed out, it treats as a signal to stop.
+
+2. Uses the highest reliability one of the traffic light recognition result and if the color of that was not green or corresponding arrow signal, generates a stop point.
+
+- If an elapsed time to receive stop signal is less than `stop_time_hysteresis`, it treats as a signal to pass. This feature is to prevent chattering.
 
 3. When vehicle current velocity is
 
@@ -63,12 +69,13 @@ This module is activated when there is traffic light in ego lane.
 
 #### Module Parameters
 
-| Parameter            | Type   | Description                                     |
-| -------------------- | ------ | ----------------------------------------------- |
-| `stop_margin`        | double | [m] margin before stop point                    |
-| `tl_state_timeout`   | double | [s] time out for detected traffic light result. |
-| `yellow_lamp_period` | double | [s] time for yellow lamp                        |
-| `enable_pass_judge`  | bool   | [-] whether to use pass judge                   |
+| Parameter              | Type   | Description                                                          |
+| ---------------------- | ------ | -------------------------------------------------------------------- |
+| `stop_margin`          | double | [m] margin before stop point                                         |
+| `tl_state_timeout`     | double | [s] time out for detected traffic light result.                      |
+| `stop_time_hysteresis` | double | [s] time threshold to decide stop planning for chattering prevention |
+| `yellow_lamp_period`   | double | [s] time for yellow lamp                                             |
+| `enable_pass_judge`    | bool   | [-] whether to use pass judge                                        |
 
 #### Flowchart
 
@@ -91,7 +98,7 @@ if (state is APPROACH) then (yes)
     :change state to GO_OUT;
     stop
   elseif (no stop signal) then (yes)
-    :change previous state to STOP;
+    :change previous state to PASS;
     stop
   elseif (not pass through) then (yes)
     :insert stop pose;

--- a/planning/behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
+++ b/planning/behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
@@ -3,6 +3,7 @@
     traffic_light:
       stop_margin: 0.0
       tl_state_timeout: 1.0
+      stop_time_hysteresis: 0.1
       yellow_lamp_period: 2.75
       enable_pass_judge: true
       enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval

--- a/planning/behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.cpp
@@ -38,6 +38,8 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
   const std::string ns(getModuleName());
   planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
   planner_param_.tl_state_timeout = getOrDeclareParameter<double>(node, ns + ".tl_state_timeout");
+  planner_param_.stop_time_hysteresis =
+    getOrDeclareParameter<double>(node, ns + ".stop_time_hysteresis");
   planner_param_.enable_pass_judge = getOrDeclareParameter<bool>(node, ns + ".enable_pass_judge");
   planner_param_.yellow_lamp_period =
     getOrDeclareParameter<double>(node, ns + ".yellow_lamp_period");


### PR DESCRIPTION
## Description

Before this change, traffic light module plans PASS if the traffic light signal is timed out.
In this PR, I changed the behavior of traffic light module as following:

1. If a corresponding traffic light signal have never been found, it treats as a signal to pass.
2. If a corresponding traffic light signal is found but timed out, it treats as a signal to stop.

Furthermore, in this PR, I add the parameter to prevent chattering.

Please merge following PR before merge this PR
https://github.com/autowarefoundation/autoware_launch/pull/727

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

[TIER IV INTERNAL TEST](https://evaluation.tier4.jp/evaluation/reports/fcd51dca-0400-592f-b86b-052475e126f4?project_id=prd_jt)

Before:

[Screencast from 2023年12月08日 17時08分51秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/10190493/52d3f1b7-9549-4b17-a2c9-d814de8d42bf)

After:

[Screencast from 2023年12月08日 17時03分53秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/10190493/ead174e2-5a57-4fe3-b387-c819792378a4)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

`stop_time_hysteresis` is added as a parameter.

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

The vehicle stops if the traffic light signal is timed out.

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
