### PR TITLE
fix(ekf_localizer): correct the initialization of accumulated_delay_times to obtain accurate computation of delay_time

### DIFF
--- a/localization/ekf_localizer/src/ekf_module.cpp
+++ b/localization/ekf_localizer/src/ekf_module.cpp
@@ -167,10 +167,10 @@ void EKFModule::accumulate_delay_time(const double dt)
     accumulated_delay_times_.begin(), accumulated_delay_times_.end() - 1,
     accumulated_delay_times_.end());
 
-  // Add the new delay time to all elements.
+  // Add a new element (=0) and, and add delay time to the previous elements.
   accumulated_delay_times_.front() = 0.0;
-  for (auto & delay_time : accumulated_delay_times_) {
-    delay_time += dt;
+  for (size_t i = 1; i < accumulated_delay_times_.size(); ++i) {
+    accumulated_delay_times_[i] += dt;
   }
 }
 


### PR DESCRIPTION
## Description

[In the recent PR of ekf localizer](https://github.com/autowarefoundation/autoware.universe/pull/5691), a new variable `accumulated_delay_times_` have been introduced so that the calculation of `delay_step` in `updateMeasurementPose/Twist()` will not be distorted when the timer callback has unintended time periods. 

However, the initialization of thefirst element of `accumulated_delay_times_` was `ekf_dt` seconds large while it should zero, which leads to a computation error of `delay_step` that will be one step earlier. 

This PR should fix that.

## Tests performed

Tested and worked well in the [rosbag replay simulation tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).
Also, tested with TIER IV internal rosbags too.

## Effects on system behavior

A few millimeters of localization error proportional to the twist will be relieved.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
