### PR TITLE
refactor(motion_utils): apply clang-tidy result

### DIFF
--- a/common/motion_utils/include/motion_utils/marker/virtual_wall_marker_creator.hpp
+++ b/common/motion_utils/include/motion_utils/marker/virtual_wall_marker_creator.hpp
@@ -20,9 +20,11 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 namespace motion_utils
 {
 
@@ -38,7 +40,7 @@ struct VirtualWall
   double longitudinal_offset{};
   bool is_driving_forward{true};
 };
-typedef std::vector<VirtualWall> VirtualWalls;
+using VirtualWalls = std::vector<VirtualWall>;
 
 /// @brief class to manage the creation of virtual wall markers
 /// @details creates both ADD and DELETE markers
@@ -55,8 +57,8 @@ class VirtualWallMarkerCreator
     const rclcpp::Time & now, const int32_t id, const double longitudinal_offset,
     const std::string & ns_prefix, const bool is_driving_forward)>;
 
-  VirtualWalls virtual_walls;
-  std::unordered_map<std::string, MarkerCount> marker_count_per_namespace;
+  VirtualWalls virtual_walls_;
+  std::unordered_map<std::string, MarkerCount> marker_count_per_namespace_;
 
   /// @brief internal cleanup: clear the stored markers and remove unused namespace from the map
   void cleanup();

--- a/common/motion_utils/include/motion_utils/resample/resample.hpp
+++ b/common/motion_utils/include/motion_utils/resample/resample.hpp
@@ -15,13 +15,10 @@
 #ifndef MOTION_UTILS__RESAMPLE__RESAMPLE_HPP_
 #define MOTION_UTILS__RESAMPLE__RESAMPLE_HPP_
 
-#include "autoware_auto_planning_msgs/msg/path.hpp"
-#include "autoware_auto_planning_msgs/msg/path_with_lane_id.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/path__struct.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/path_with_lane_id__struct.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/trajectory__struct.hpp"
 
-#include <algorithm>
-#include <limits>
-#include <stdexcept>
 #include <vector>
 
 namespace motion_utils
@@ -187,7 +184,8 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
 autoware_auto_planning_msgs::msg::Path resamplePath(
   const autoware_auto_planning_msgs::msg::Path & input_path, const double resample_interval,
   const bool use_akima_spline_for_xy = false, const bool use_lerp_for_z = true,
-  const bool use_zero_order_hold_for_v = true, const bool resample_input_path_stop_point = true);
+  const bool use_zero_order_hold_for_twist = true,
+  const bool resample_input_path_stop_point = true);
 
 /**
  * @brief A resampling function for a trajectory. Note that in a default setting, position xy are

--- a/common/motion_utils/include/motion_utils/resample/resample_utils.hpp
+++ b/common/motion_utils/include/motion_utils/resample/resample_utils.hpp
@@ -23,26 +23,19 @@
 
 namespace resample_utils
 {
-constexpr double CLOSE_S_THRESHOLD = 1e-6;
+constexpr double close_s_threshold = 1e-6;
 
 template <class T>
 bool validate_size(const T & points)
 {
-  if (points.size() < 2) {
-    return false;
-  }
-  return true;
+  return points.size() >= 2;
 }
 
 template <class T>
 bool validate_resampling_range(const T & points, const std::vector<double> & resampling_intervals)
 {
   const double points_length = motion_utils::calcArcLength(points);
-  if (points_length < resampling_intervals.back()) {
-    return false;
-  }
-
-  return true;
+  return points_length >= resampling_intervals.back();
 }
 
 template <class T>
@@ -52,7 +45,7 @@ bool validate_points_duplication(const T & points)
     const auto & curr_pt = tier4_autoware_utils::getPoint(points.at(i));
     const auto & next_pt = tier4_autoware_utils::getPoint(points.at(i + 1));
     const double ds = tier4_autoware_utils::calcDistance2d(curr_pt, next_pt);
-    if (ds < CLOSE_S_THRESHOLD) {
+    if (ds < close_s_threshold) {
       return false;
     }
   }
@@ -67,7 +60,8 @@ bool validate_arguments(const T & input_points, const std::vector<double> & resa
   if (!validate_size(input_points)) {
     std::cerr << "The number of input points is less than 2" << std::endl;
     return false;
-  } else if (!validate_size(resampling_intervals)) {
+  }
+  if (!validate_size(resampling_intervals)) {
     std::cerr << "The number of resampling intervals is less than 2" << std::endl;
     return false;
   }

--- a/common/motion_utils/include/motion_utils/trajectory/interpolation.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/interpolation.hpp
@@ -16,16 +16,12 @@
 #define MOTION_UTILS__TRAJECTORY__INTERPOLATION_HPP_
 
 #include "tier4_autoware_utils/geometry/geometry.hpp"
-#include "tier4_autoware_utils/math/constants.hpp"
 
-#include "autoware_auto_planning_msgs/msg/path_with_lane_id.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/path_with_lane_id__struct.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/trajectory__struct.hpp"
 
 #include <algorithm>
 #include <limits>
-#include <optional>
-#include <stdexcept>
-#include <vector>
 
 namespace motion_utils
 {

--- a/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
@@ -15,7 +15,7 @@
 #ifndef MOTION_UTILS__TRAJECTORY__PATH_WITH_LANE_ID_HPP_
 #define MOTION_UTILS__TRAJECTORY__PATH_WITH_LANE_ID_HPP_
 
-#include "autoware_auto_planning_msgs/msg/path_with_lane_id.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/path_with_lane_id__struct.hpp"
 #include <geometry_msgs/msg/point.hpp>
 
 #include <optional>

--- a/common/motion_utils/include/motion_utils/trajectory/tmp_conversion.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/tmp_conversion.hpp
@@ -15,8 +15,8 @@
 #ifndef MOTION_UTILS__TRAJECTORY__TMP_CONVERSION_HPP_
 #define MOTION_UTILS__TRAJECTORY__TMP_CONVERSION_HPP_
 
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/trajectory__struct.hpp"
+#include "autoware_auto_planning_msgs/msg/detail/trajectory_point__struct.hpp"
 
 #include <vector>
 

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -130,11 +130,11 @@ std::optional<bool> isDrivingForwardWithTwist(const T & points_with_twist)
   if (points_with_twist.size() == 1) {
     if (0.0 < tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.front())) {
       return true;
-    } else if (0.0 > tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.front())) {
-      return false;
-    } else {
-      return std::nullopt;
     }
+    if (0.0 > tier4_autoware_utils::getLongitudinalVelocity(points_with_twist.front())) {
+      return false;
+    }
+    return std::nullopt;
   }
 
   return isDrivingForward(points_with_twist);
@@ -401,12 +401,12 @@ double calcLongitudinalOffsetToSegment(
   const bool throw_exception = false)
 {
   if (seg_idx >= points.size() - 1) {
-    const std::out_of_range e("Segment index is invalid.");
+    const auto error_message{"Segment index is invalid."};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::out_of_range(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return std::nan("");
   }
 
@@ -424,12 +424,12 @@ double calcLongitudinalOffsetToSegment(
   }
 
   if (seg_idx >= overlap_removed_points.size() - 1) {
-    const std::runtime_error e("Same points are given.");
+    const auto error_message{"Same points are given."};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::runtime_error(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return std::nan("");
   }
 
@@ -581,12 +581,12 @@ double calcLateralOffset(
   }
 
   if (overlap_removed_points.size() == 1) {
-    const std::runtime_error e("Same points are given.");
+    const auto error_message{"Same points are given."};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::runtime_error(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return std::nan("");
   }
 
@@ -643,12 +643,12 @@ double calcLateralOffset(
   }
 
   if (overlap_removed_points.size() == 1) {
-    const std::runtime_error e("Same points are given.");
+    const auto error_message{"Same points are given."};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::runtime_error(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return std::nan("");
   }
 
@@ -968,7 +968,7 @@ std::vector<std::pair<double, double>> calcCurvatureAndArcLength(const T & point
 {
   // Note that arclength is for the segment, not the sum.
   std::vector<std::pair<double, double>> curvature_arc_length_vec;
-  curvature_arc_length_vec.push_back(std::pair(0.0, 0.0));
+  curvature_arc_length_vec.emplace_back(0.0, 0.0);
   for (size_t i = 1; i < points.size() - 1; ++i) {
     const auto p1 = tier4_autoware_utils::getPoint(points.at(i - 1));
     const auto p2 = tier4_autoware_utils::getPoint(points.at(i));
@@ -976,9 +976,9 @@ std::vector<std::pair<double, double>> calcCurvatureAndArcLength(const T & point
     const double curvature = tier4_autoware_utils::calcCurvature(p1, p2, p3);
     const double arc_length = tier4_autoware_utils::calcDistance2d(points.at(i - 1), points.at(i)) +
                               tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
-    curvature_arc_length_vec.push_back(std::pair(curvature, arc_length));
+    curvature_arc_length_vec.emplace_back(curvature, arc_length);
   }
-  curvature_arc_length_vec.push_back(std::pair(0.0, 0.0));
+  curvature_arc_length_vec.emplace_back(0.0, 0.0);
 
   return curvature_arc_length_vec;
 }
@@ -1046,12 +1046,12 @@ std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   }
 
   if (points.size() - 1 < src_idx) {
-    const auto e = std::out_of_range("Invalid source index");
+    const auto error_message{"Invalid source index"};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::out_of_range(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return {};
   }
 
@@ -1171,12 +1171,12 @@ std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   }
 
   if (points.size() - 1 < src_idx) {
-    const auto e = std::out_of_range("Invalid source index");
+    const auto error_message{"Invalid source index"};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::out_of_range(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return {};
   }
 
@@ -2041,9 +2041,8 @@ size_t findFirstNearestIndexWithSoftConstraints(
       if (squared_dist_threshold < squared_dist || yaw_threshold < std::abs(yaw)) {
         if (is_within_constraints) {
           break;
-        } else {
-          continue;
         }
+        continue;
       }
 
       if (min_squared_dist <= squared_dist) {
@@ -2073,9 +2072,8 @@ size_t findFirstNearestIndexWithSoftConstraints(
       if (squared_dist_threshold < squared_dist) {
         if (is_within_constraints) {
           break;
-        } else {
-          continue;
         }
+        continue;
       }
 
       if (min_squared_dist <= squared_dist) {
@@ -2386,12 +2384,12 @@ double calcYawDeviation(
   }
 
   if (overlap_removed_points.size() <= 1) {
-    const std::runtime_error e("points size is less than 2");
+    const auto error_message{"points size is less than 2"};
     tier4_autoware_utils::print_backtrace();
     if (throw_exception) {
-      throw e;
+      throw std::runtime_error(error_message);
     }
-    std::cerr << e.what() << std::endl;
+    std::cerr << error_message << std::endl;
     return 0.0;
   }
 

--- a/common/motion_utils/include/motion_utils/vehicle/vehicle_state_checker.hpp
+++ b/common/motion_utils/include/motion_utils/vehicle/vehicle_state_checker.hpp
@@ -22,7 +22,6 @@
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <deque>
-#include <memory>
 
 namespace motion_utils
 {

--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -262,7 +262,8 @@ std::optional<double> calcDecelDistWithJerkAndAccConstraints(
   if (t_during_min_acc > epsilon) {
     return calcDecelDistPlanType1(
       current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec, t_during_min_acc);
-  } else if (is_decel_needed || current_acc > epsilon) {
+  }
+  if (is_decel_needed || current_acc > epsilon) {
     return calcDecelDistPlanType2(current_vel, target_vel, current_acc, jerk_acc, jerk_dec);
   }
 

--- a/common/motion_utils/src/marker/marker_helper.cpp
+++ b/common/motion_utils/src/marker/marker_helper.cpp
@@ -14,14 +14,12 @@
 
 #include "motion_utils/marker/marker_helper.hpp"
 
-#include "motion_utils/resample/resample_utils.hpp"
 #include "tier4_autoware_utils/ros/marker_helper.hpp"
+
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <functional>
-
-using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createDeletedDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -14,15 +14,12 @@
 
 #include "motion_utils/resample/resample.hpp"
 
-#include "interpolation/interpolation_utils.hpp"
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "interpolation/zero_order_hold.hpp"
 #include "motion_utils/resample/resample_utils.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
-#include "tier4_autoware_utils/geometry/pose_deviation.hpp"
-#include "tier4_autoware_utils/math/constants.hpp"
 
 namespace motion_utils
 {

--- a/common/motion_utils/src/trajectory/interpolation.cpp
+++ b/common/motion_utils/src/trajectory/interpolation.cpp
@@ -15,8 +15,6 @@
 #include "motion_utils/trajectory/interpolation.hpp"
 
 #include "interpolation/linear_interpolation.hpp"
-#include "interpolation/zero_order_hold.hpp"
-#include "motion_utils/trajectory/path_with_lane_id.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 
 using autoware_auto_planning_msgs::msg::PathPointWithLaneId;
@@ -34,7 +32,8 @@ TrajectoryPoint calcInterpolatedPoint(
     TrajectoryPoint interpolated_point{};
     interpolated_point.pose = target_pose;
     return interpolated_point;
-  } else if (trajectory.points.size() == 1) {
+  }
+  if (trajectory.points.size() == 1) {
     return trajectory.points.front();
   }
 
@@ -101,7 +100,8 @@ PathPointWithLaneId calcInterpolatedPoint(
     PathPointWithLaneId interpolated_point{};
     interpolated_point.point.pose = target_pose;
     return interpolated_point;
-  } else if (path.points.size() == 1) {
+  }
+  if (path.points.size() == 1) {
     return path.points.front();
   }
 

--- a/common/motion_utils/src/trajectory/tmp_conversion.cpp
+++ b/common/motion_utils/src/trajectory/tmp_conversion.cpp
@@ -14,9 +14,6 @@
 
 #include "motion_utils/trajectory/tmp_conversion.hpp"
 
-#include "tier4_autoware_utils/geometry/geometry.hpp"
-#include "tier4_autoware_utils/geometry/pose_deviation.hpp"
-
 #include <algorithm>
 
 namespace motion_utils


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29e9f44</samp>

This pull request improves the code quality, readability, and consistency of the `motion_utils` package, by refactoring, simplifying, and fixing some parts of the header and source files. It also updates the header include conventions to follow the ROS 2 style and the `detail` subdirectory for message struct headers.

### Additional note

What are the things that is not fixed
1. Function case: not going to fix camelCase to snake_case
2. Narrowing conversion
3. Unincluded header due to extern template being used.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
