### PR TITLE
refactor(surround_obstacle_checker): boost::optional to std:optional

### DIFF
--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -31,13 +31,12 @@
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <boost/optional/optional.hpp>
-
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -93,13 +92,13 @@ private:
 
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
-  boost::optional<Obstacle> getNearestObstacle() const;
+  std::optional<Obstacle> getNearestObstacle() const;
 
-  boost::optional<Obstacle> getNearestObstacleByPointCloud() const;
+  std::optional<Obstacle> getNearestObstacleByPointCloud() const;
 
-  boost::optional<Obstacle> getNearestObstacleByDynamicObject() const;
+  std::optional<Obstacle> getNearestObstacleByDynamicObject() const;
 
-  boost::optional<geometry_msgs::msg::TransformStamped> getTransform(
+  std::optional<geometry_msgs::msg::TransformStamped> getTransform(
     const std::string & source, const std::string & target, const rclcpp::Time & stamp,
     double duration_sec) const;
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at db9c2f6</samp>

This pull request replaces `boost::optional` types with `std::optional` types in the `SurroundObstacleCheckerNode` class and its header file. This is part of a code modernization and dependency reduction effort.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
