### PR TITLE
refactor(occlusion_spot): boost::optional to std::optional

### DIFF
--- a/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
@@ -123,7 +123,7 @@ bool isCollisionFree(
   return true;
 }
 
-boost::optional<Polygon2d> generateOcclusionPolygon(
+std::optional<Polygon2d> generateOcclusionPolygon(
   const Polygon2d & occupancy_poly, const Point2d & origin, const Point2d & min_theta_pos,
   const Point2d & max_theta_pos, const double ray_max_length = 100.0)
 {
@@ -157,7 +157,7 @@ boost::optional<Polygon2d> generateOcclusionPolygon(
     occlusion_poly.outer().emplace_back(max_intersections.front());
   }
   //! case outside detection area
-  if (occlusion_poly.outer().size() == 2) return boost::none;
+  if (occlusion_poly.outer().size() == 2) return std::nullopt;
   boost::geometry::correct(occlusion_poly);
   Polygon2d hull_poly;
   boost::geometry::convex_hull(occlusion_poly, hull_poly);
@@ -200,7 +200,7 @@ std::pair<size_t, size_t> calcEdgePoint(const Polygon2d & foot_print, const Poin
   return std::make_pair(min_idx, max_idx);
 }
 
-boost::optional<Polygon2d> generateOccupiedPolygon(
+std::optional<Polygon2d> generateOccupiedPolygon(
   const Polygon2d & occupancy_poly, const Polygon2d & foot_print, const Point & position)
 {
   Point2d origin = {position.x, position.y};
@@ -275,9 +275,9 @@ void generateOccupiedImage(
     for (const auto & foot_print : moving_vehicle_foot_prints) {
       // calculate occlusion polygon from moving vehicle
       const auto polys = generateOccupiedPolygon(occupancy_poly, foot_print, scan_origin);
-      if (polys == boost::none) continue;
+      if (polys == std::nullopt) continue;
       // transform to cv point and stuck it to cv polygon
-      for (const auto & p : polys.get().outer()) {
+      for (const auto & p : polys.value().outer()) {
         const Point transformed_geom_pt = transformFromMap2Grid(geom_tf_map2grid, p);
         cv_polygon.emplace_back(
           toCVPoint(transformed_geom_pt, width, height, occupancy_grid.info.resolution));

--- a/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.hpp
@@ -99,7 +99,7 @@ void findOcclusionSpots(
 bool isCollisionFree(
   const grid_map::GridMap & grid, const grid_map::Position & p1, const grid_map::Position & p2,
   const double radius);
-boost::optional<Polygon2d> generateOccupiedPolygon(
+std::optional<Polygon2d> generateOccupiedPolygon(
   const Polygon2d & occupancy_poly, const Polygons2d & stuck_vehicle_foot_prints,
   const Polygons2d & moving_vehicle_foot_prints, const Point & position);
 //!< @brief generate occupied polygon from foot print

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -406,11 +406,11 @@ bool generatePossibleCollisionsFromGridMap(
     const auto pc = generateOneNotableCollisionFromOcclusionSpot(
       grid, occlusion_spot_positions, offset_from_start_to_ego, base_point, path_lanelet, param,
       debug_data);
-    if (pc == boost::none) continue;
-    const double lateral_distance = std::abs(pc.get().arc_lane_dist_at_collision.distance);
+    if (pc) continue;
+    const double lateral_distance = std::abs(pc.value().arc_lane_dist_at_collision.distance);
     if (lateral_distance > distance_lower_bound) continue;
     distance_lower_bound = lateral_distance;
-    possible_collisions.emplace_back(pc.get());
+    possible_collisions.emplace_back(pc.value());
   }
   return !possible_collisions.empty();
 }
@@ -423,7 +423,7 @@ bool isBlockedByPartition(const LineString2d & direction, const BasicPolygons2d 
   return false;
 }
 
-boost::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
+std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
   const grid_map::GridMap & grid, const std::vector<grid_map::Position> & occlusion_spot_positions,
   const double offset_from_start_to_ego, const Point2d base_point,
   const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, DebugData & debug_data)
@@ -473,7 +473,7 @@ boost::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionS
     has_collision = true;
   }
   if (has_collision) return candidate;
-  return boost::none;
+  return std::nullopt;
 }
 
 }  // namespace occlusion_spot_utils

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -30,8 +30,6 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
-#include <boost/optional.hpp>
-
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LaneletMap.h>
 #include <tf2/utils.h>
@@ -67,7 +65,7 @@ using lanelet::ConstLineString2d;
 using lanelet::LaneletMapPtr;
 using lanelet::geometry::fromArcCoordinates;
 using lanelet::geometry::toArcCoordinates;
-using DetectionAreaIdx = boost::optional<std::pair<double, double>>;
+using DetectionAreaIdx = std::optional<std::pair<double, double>>;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
 
 namespace occlusion_spot_utils
@@ -240,7 +238,7 @@ void calcSlowDownPointsForPossibleCollision(
   const int closest_idx, const PathWithLaneId & path, const double offset,
   std::vector<PossibleCollisionInfo> & possible_collisions);
 //!< @brief convert a set of occlusion spots found on detection_area slice
-boost::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
+std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
   const grid_map::GridMap & grid, const std::vector<grid_map::Position> & occlusion_spot_positions,
   const double offset_from_start_to_ego, const Point2d base_point,
   const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, DebugData & debug_data);


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 56a7913</samp>

Replaced `boost::optional` with `std::optional` in the `behavior_velocity_occlusion_spot_module` to reduce dependency on Boost and use standard C++17 features. This affects the functions and types related to occlusion and occupancy polygons in `grid_utils.cpp`, `grid_utils.hpp`, `occlusion_spot_utils.cpp`, and `occlusion_spot_utils.hpp`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
