### PR TITLE
fix(goal_planner): fix checkOriginalGoalIsInShoulder

### DIFF
--- a/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -476,10 +476,6 @@ private:
   void onTimer();
   void onFreespaceParkingTimer();
 
-  // flag for the interface which do not support `allow_goal_modification`
-  // when the goal is in `road_shoulder`, always allow goal modification.
-  bool checkOriginalGoalIsInShoulder() const;
-
   // steering factor
   void updateSteeringFactor(
     const std::array<Pose, 2> & pose, const std::array<double, 2> distance, const uint16_t type);

--- a/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -2036,21 +2036,6 @@ void GoalPlannerModule::printParkingPositionError() const
     distance_from_real_shoulder);
 }
 
-bool GoalPlannerModule::checkOriginalGoalIsInShoulder() const
-{
-  const auto & route_handler = planner_data_->route_handler;
-  const Pose goal_pose = route_handler->getOriginalGoalPose();
-
-  const lanelet::ConstLanelets pull_over_lanes = goal_planner_utils::getPullOverLanes(
-    *(route_handler), left_side_parking_, parameters_->backward_goal_search_length,
-    parameters_->forward_goal_search_length);
-  lanelet::ConstLanelet target_lane{};
-  lanelet::utils::query::getClosestLanelet(pull_over_lanes, goal_pose, &target_lane);
-
-  return route_handler->isShoulderLanelet(target_lane) &&
-         lanelet::utils::isInLanelet(goal_pose, target_lane, 0.1);
-}
-
 bool GoalPlannerModule::needPathUpdate(const double path_update_duration) const
 {
   return !isOnModifiedGoal() && hasEnoughTimePassedSincePathUpdate(path_update_duration);

--- a/planning/behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_goal_planner_module/src/util.cpp
@@ -203,7 +203,7 @@ bool isAllowedGoalModification(const std::shared_ptr<RouteHandler> & route_handl
 
 bool checkOriginalGoalIsInShoulder(const std::shared_ptr<RouteHandler> & route_handler)
 {
-  const Pose & goal_pose = route_handler->getGoalPose();
+  const Pose & goal_pose = route_handler->getOriginalGoalPose();
   const auto shoulder_lanes = route_handler->getShoulderLanelets();
 
   lanelet::ConstLanelet closest_shoulder_lane{};


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


check**Original**GoalIsInShoulder must check **original** goal pose
and remove unused methods.


this fix https://github.com/autowarefoundation/autoware.universe/pull/5533#issuecomment-1834013029

before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/3014881d-459e-45b0-964d-2a009739c672)


after

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/f18bc1cb-052a-4de4-bb2d-991e1081767d)



tier4 internal ticket
https://tier4.atlassian.net/browse/RT1-4666

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

evaluator_description: fix/check_goal_is_in_shoulder
2023/12/11 https://evaluation.tier4.jp/evaluation/reports/11a68df2-9b57-500e-b5f2-56c687c126ea/?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
