### PR TITLE
fix(avoidance): fix missing parent ids

### DIFF
--- a/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_avoidance_module/src/shift_line_generator.cpp
@@ -931,6 +931,9 @@ void ShiftLineGenerator::applySimilarGradFilter(
       combine, input.at(i).end_shift_length, input.at(i).end, input.at(i).end_idx,
       input.at(i).end_longitudinal);
 
+    combine.parent_ids =
+      utils::avoidance::concatParentIds(base_line.parent_ids, input.at(i).parent_ids);
+
     combine_buffer.push_back(input.at(i));
 
     const auto violates = [&]() {

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -756,11 +756,21 @@ size_t findPathIndexFromArclength(
 std::vector<UUID> concatParentIds(const std::vector<UUID> & ids1, const std::vector<UUID> & ids2)
 {
   std::vector<UUID> ret;
-  for (const auto id2 : ids2) {
-    if (std::any_of(ids1.begin(), ids1.end(), [&id2](const auto & id1) { return id1 == id2; })) {
+
+  for (const auto & id : ids1) {
+    if (std::any_of(
+          ret.begin(), ret.end(), [&id](const auto & exist_id) { return exist_id == id; })) {
       continue;
     }
-    ret.push_back(id2);
+    ret.push_back(id);
+  }
+
+  for (const auto & id : ids2) {
+    if (std::any_of(
+          ret.begin(), ret.end(), [&id](const auto & exist_id) { return exist_id == id; })) {
+      continue;
+    }
+    ret.push_back(id);
   }
 
   return ret;


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43f5930</samp>

This pull request adds and improves the functionality of the `ShiftLineGenerator` class, which generates shifted lines that avoid obstacles and respect the lane boundaries. It assigns the `parent_ids` field of the combined lines in `shift_line_generator.cpp` and optimizes the `concatParentIds` function in `utils.cpp`.

Related Ticket: https://tier4.atlassian.net/browse/RT1-4532

Fix following error:

```
[component_container_mt-29] [ERROR 1700802888.493218325] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance] registerRawShiftLines(): avoid line for path_shifter must have parent_id.:(L887)
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
