### PR TITLE
feat(system_error_monitor): aggregate control validator diagnostics

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml
@@ -68,6 +68,12 @@
                   contains: [": control_state"]
                   timeout: 1.0
 
+                control_validator:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: control_validator
+                  contains: [": control_validation_max_distance_deviation"]
+                  timeout: 1.0
+
         external_control:
           type: diagnostic_aggregator/AnalyzerGroup
           path: external_control


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

add missing control.param.ymal update for https://github.com/autowarefoundation/autoware.universe/pull/4549



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

https://github.com/autowarefoundation/autoware.universe/assets/39142679/726fa0ed-ad44-4fed-aeb6-652394a1f6c2

system_error_monitor.param.yaml
```
        /autoware/control/autonomous_driving/performance_monitoring/control_validator: { sf_at: "none", lf_at: "warn", spf_at: "error"}
```

vehicle cmd gate
```
    use_emergency_handling: true
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
