### PR TITLE
feat(perception_rviz_plugin): tracked object option to filter by is_stationary flag

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -120,7 +120,7 @@ get_acceleration_text_marker_ptr(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_twist_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance);
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_predicted_path_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -91,6 +91,7 @@ public:
       "Visualization Type", "Normal", "Simplicity of the polygon to display object.", this);
     m_simple_visualize_mode_property->addOption("Normal", 0);
     m_simple_visualize_mode_property->addOption("Simple", 1);
+
     // iterate over default values to create and initialize the properties.
     for (const auto & map_property_it : detail::kDefaultObjectPropertyValues) {
       const auto & class_property_values = map_property_it.second;
@@ -254,10 +255,11 @@ protected:
 
   std::optional<Marker::SharedPtr> get_twist_marker_ptr(
     const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance) const
+    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+    const double & line_width) const
   {
     if (m_display_twist_property.getBool()) {
-      return detail::get_twist_marker_ptr(pose_with_covariance, twist_with_covariance);
+      return detail::get_twist_marker_ptr(pose_with_covariance, twist_with_covariance, line_width);
     } else {
       return std::nullopt;
     }

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/tracked_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/tracked_objects_display.hpp
@@ -50,7 +50,7 @@ protected:
     return m_select_object_dynamics_property->getOptionInt();
   }
 
-  bool isObjectToShow(const uint showing_dynamic_status, const TrackedObject & object);
+  static bool is_object_to_show(const uint showing_dynamic_status, const TrackedObject & object);
 
 private:
   // Property to choose object dynamics to visualize

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/tracked_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/tracked_objects_display.hpp
@@ -39,11 +39,23 @@ class AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC TrackedObjectsDisplay
   Q_OBJECT
 
 public:
+  using TrackedObject = autoware_auto_perception_msgs::msg::TrackedObject;
   using TrackedObjects = autoware_auto_perception_msgs::msg::TrackedObjects;
 
   TrackedObjectsDisplay();
 
+protected:
+  uint get_object_dynamics_to_visualize()
+  {
+    return m_select_object_dynamics_property->getOptionInt();
+  }
+
+  bool isObjectToShow(const uint showing_dynamic_status, const TrackedObject & object);
+
 private:
+  // Property to choose object dynamics to visualize
+  rviz_common::properties::EnumProperty * m_select_object_dynamics_property;
+
   void processMessage(TrackedObjects::ConstSharedPtr msg) override;
 
   boost::uuids::uuid to_boost_uuid(const unique_identifier_msgs::msg::UUID & uuid_msg)

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -73,7 +73,8 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
 
     // Get marker for twist
     auto twist_marker = get_twist_marker_ptr(
-      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width());
     if (twist_marker) {
       auto twist_marker_ptr = twist_marker.value();
       twist_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -56,7 +56,7 @@ visualization_msgs::msg::Marker::SharedPtr get_path_confidence_marker_ptr(
   marker_ptr->type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   marker_ptr->ns = std::string("path confidence");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->scale.x = 0.5;
   marker_ptr->scale.y = 0.5;
   marker_ptr->scale.z = 0.5;
@@ -77,7 +77,7 @@ visualization_msgs::msg::Marker::SharedPtr get_predicted_path_marker_ptr(
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_ptr->ns = std::string("path");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->pose = initPose();
   marker_ptr->color = predicted_path_color;
   marker_ptr->color.a = 0.6;
@@ -91,12 +91,12 @@ visualization_msgs::msg::Marker::SharedPtr get_predicted_path_marker_ptr(
 
 visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance)
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_ptr->ns = std::string("twist");
-  marker_ptr->scale.x = 0.03;
+  marker_ptr->scale.x = line_width;
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = pose_with_covariance.pose;
 
@@ -112,7 +112,7 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
   pt_e.z = twist_with_covariance.twist.linear.z;
   marker_ptr->points.push_back(pt_e);
 
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color.a = 0.999;
   marker_ptr->color.r = 1.0;
   marker_ptr->color.g = 0.0;
@@ -137,7 +137,7 @@ visualization_msgs::msg::Marker::SharedPtr get_velocity_text_marker_ptr(
   marker_ptr->text = std::to_string(static_cast<int>(vel * 3.6)) + std::string("[km/h]");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose.position = vis_pos;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color = color_rgba;
   return marker_ptr;
 }
@@ -158,7 +158,7 @@ visualization_msgs::msg::Marker::SharedPtr get_acceleration_text_marker_ptr(
   marker_ptr->text = getRoundedDoubleString(acc) + std::string("[m/s^2]");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose.position = vis_pos;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color = color_rgba;
   return marker_ptr;
 }
@@ -202,7 +202,7 @@ visualization_msgs::msg::Marker::SharedPtr get_pose_with_covariance_marker_ptr(
   point.y = e2.y() * sigma2;
   point.z = 0;
   marker_ptr->points.push_back(point);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color.a = 0.999;
   marker_ptr->color.r = 1.0;
   marker_ptr->color.g = 1.0;
@@ -237,7 +237,7 @@ visualization_msgs::msg::Marker::SharedPtr get_label_marker_ptr(
   marker_ptr->text = label;
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = marker_ptr->pose = to_pose(centroid, orientation);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color = color_rgba;
   return marker_ptr;
 }
@@ -267,7 +267,7 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
 
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = to_pose(centroid, orientation);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->scale.x = line_width;
   marker_ptr->color = color_rgba;
 
@@ -299,7 +299,7 @@ visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
 
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = to_pose(centroid, orientation);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->scale.x = line_width;
   marker_ptr->color = color_rgba;
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -154,7 +154,7 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     // Get marker for twist
     auto twist_marker = get_twist_marker_ptr(
       object.kinematics.initial_pose_with_covariance,
-      object.kinematics.initial_twist_with_covariance);
+      object.kinematics.initial_twist_with_covariance, get_line_width());
     if (twist_marker) {
       auto twist_marker_ptr = twist_marker.value();
       twist_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -26,6 +26,23 @@ namespace object_detection
 {
 TrackedObjectsDisplay::TrackedObjectsDisplay() : ObjectPolygonDisplayBase("tracks")
 {
+  // Option for selective visualization by object dynamics
+  m_select_object_dynamics_property = new rviz_common::properties::EnumProperty(
+    "Dynamic Status", "All", "Selectively visualize objects by its dynamic status.", this);
+  m_select_object_dynamics_property->addOption("Dynamic", 0);
+  m_select_object_dynamics_property->addOption("Static", 1);
+  m_select_object_dynamics_property->addOption("All", 2);
+}
+
+bool TrackedObjectsDisplay::isObjectToShow(
+  const uint showing_dynamic_status, const TrackedObject & object)
+{
+  if (showing_dynamic_status == 0 && object.kinematics.is_stationary) {
+    return false;  // Show only moving objects
+  } else if (showing_dynamic_status == 1 && !object.kinematics.is_stationary) {
+    return false;  // Show only stationary objects
+  }
+  return true;
 }
 
 void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
@@ -33,12 +50,15 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
   clear_markers();
   update_id_map(msg);
 
+  const auto showing_dynamic_status = get_object_dynamics_to_visualize();
   for (const auto & object : msg->objects) {
+    // Filter by object dynamic status
+    if (!isObjectToShow(showing_dynamic_status, object)) continue;
+    const auto line_width = get_line_width();
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.pose_with_covariance.pose.position,
-      object.kinematics.pose_with_covariance.pose.orientation, object.classification,
-      get_line_width());
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification, line_width);
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;
@@ -113,7 +133,7 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for twist
     auto twist_marker = get_twist_marker_ptr(
-      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance, line_width);
     if (twist_marker) {
       auto twist_marker_ptr = twist_marker.value();
       twist_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -34,12 +34,13 @@ TrackedObjectsDisplay::TrackedObjectsDisplay() : ObjectPolygonDisplayBase("track
   m_select_object_dynamics_property->addOption("All", 2);
 }
 
-bool TrackedObjectsDisplay::isObjectToShow(
+bool TrackedObjectsDisplay::is_object_to_show(
   const uint showing_dynamic_status, const TrackedObject & object)
 {
   if (showing_dynamic_status == 0 && object.kinematics.is_stationary) {
     return false;  // Show only moving objects
-  } else if (showing_dynamic_status == 1 && !object.kinematics.is_stationary) {
+  }
+  if (showing_dynamic_status == 1 && !object.kinematics.is_stationary) {
     return false;  // Show only stationary objects
   }
   return true;
@@ -53,7 +54,7 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
   const auto showing_dynamic_status = get_object_dynamics_to_visualize();
   for (const auto & object : msg->objects) {
     // Filter by object dynamic status
-    if (!isObjectToShow(showing_dynamic_status, object)) continue;
+    if (!is_object_to_show(showing_dynamic_status, object)) continue;
     const auto line_width = get_line_width();
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(


### PR DESCRIPTION
## Description

related PR: https://github.com/autowarefoundation/autoware.universe/pull/5823 implementation of 'is_stationary' flag on radar tracking objects

feat (autoware_auto_perception_rviz_plugin): In the tracked objects plugin, visualizing object dynamic status can be chosen.


## Tests performed

Simulations of sensing and perception modules were performed under a tier4 deployment, and the messages were selectively visualized by the Rviz plugin.

https://github.com/autowarefoundation/autoware.universe/assets/42434141/3f187061-a96e-4ea6-8949-df2f433821f3


## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
