### PR TITLE
fix(behavior, launch): fix launch error

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -95,9 +95,7 @@
     value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::AvoidanceByLaneChangeModuleManager, '&quot;)"
     if="$(var launch_avoidance_by_lane_change_module)"
   />
-  <let name="behavior_path_planner_launch_modules" value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + ']'&quot;)"/>
-
-  <let name="behavior_path_planner_launch_modules" value="['null']" if="$(eval &quot;'$(var behavior_path_planner_launch_modules)' == '[]'&quot;)"/>
+  <let name="behavior_path_planner_launch_modules" value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'END]'&quot;)"/>
 
   <!-- assemble launch config for behavior velocity planner -->
   <arg name="behavior_velocity_planner_launch_modules" default="["/>
@@ -176,9 +174,7 @@
     value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + 'behavior_velocity_planner::NoDrivableLaneModulePlugin, '&quot;)"
     if="$(var launch_no_drivable_lane_module)"
   />
-  <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + ']'&quot;)"/>
-
-  <let name="behavior_velocity_planner_launch_modules" value="['null']" if="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' == '[]'&quot;)"/>
+  <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + 'END]'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="screen">
     <composable_node pkg="behavior_path_planner" plugin="behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -43,6 +43,8 @@
   <arg name="launch_out_of_lane_module" default="true"/>
   <arg name="launch_no_drivable_lane_module" default="true"/>
 
+  <arg name="launch_module_list_end" default="&quot;&quot;]"/>
+
   <!-- assemble launch config for behavior path planner -->
   <arg name="behavior_path_planner_launch_modules" default="["/>
   <let
@@ -95,7 +97,7 @@
     value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::AvoidanceByLaneChangeModuleManager, '&quot;)"
     if="$(var launch_avoidance_by_lane_change_module)"
   />
-  <let name="behavior_path_planner_launch_modules" value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'END]'&quot;)"/>
+  <let name="behavior_path_planner_launch_modules" value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
   <!-- assemble launch config for behavior velocity planner -->
   <arg name="behavior_velocity_planner_launch_modules" default="["/>
@@ -174,7 +176,7 @@
     value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + 'behavior_velocity_planner::NoDrivableLaneModulePlugin, '&quot;)"
     if="$(var launch_no_drivable_lane_module)"
   />
-  <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + 'END]'&quot;)"/>
+  <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="screen">
     <composable_node pkg="behavior_path_planner" plugin="behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -97,6 +97,8 @@
   />
   <let name="behavior_path_planner_launch_modules" value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + ']'&quot;)"/>
 
+  <let name="behavior_path_planner_launch_modules" value="['null']" if="$(eval &quot;'$(var behavior_path_planner_launch_modules)' == '[]'&quot;)"/>
+
   <!-- assemble launch config for behavior velocity planner -->
   <arg name="behavior_velocity_planner_launch_modules" default="["/>
   <let
@@ -175,6 +177,8 @@
     if="$(var launch_no_drivable_lane_module)"
   />
   <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + ']'&quot;)"/>
+
+  <let name="behavior_velocity_planner_launch_modules" value="['null']" if="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' == '[]'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="screen">
     <composable_node pkg="behavior_path_planner" plugin="behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -135,6 +135,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     planner_manager_ = std::make_shared<PlannerManager>(*this, p.max_iteration_num, p.verbose);
 
     for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
+      // workaround: Since ROS 2 can't get empty list, launcher set ['null'] on the parameter.
       if (name == "null") {
         RCLCPP_INFO(get_logger(), "No modules are registered.");
         break;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -135,9 +135,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     planner_manager_ = std::make_shared<PlannerManager>(*this, p.max_iteration_num, p.verbose);
 
     for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
-      // workaround: Since ROS 2 can't get empty list, launcher set ['null'] on the parameter.
-      if (name == "null") {
-        RCLCPP_INFO(get_logger(), "No modules are registered.");
+      // workaround: Since ROS 2 can't get empty list, launcher set ['END'] on the parameter.
+      if (name == "END") {
         break;
       }
       planner_manager_->launchScenePlugin(*this, name);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -135,8 +135,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     planner_manager_ = std::make_shared<PlannerManager>(*this, p.max_iteration_num, p.verbose);
 
     for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
-      // workaround: Since ROS 2 can't get empty list, launcher set ['END'] on the parameter.
-      if (name == "END") {
+      // workaround: Since ROS 2 can't get empty list, launcher set [''] on the parameter.
+      if (name == "") {
         break;
       }
       planner_manager_->launchScenePlugin(*this, name);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -135,6 +135,10 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     planner_manager_ = std::make_shared<PlannerManager>(*this, p.max_iteration_num, p.verbose);
 
     for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
+      if (name == "null") {
+        RCLCPP_INFO(get_logger(), "No modules are registered.");
+        break;
+      }
       planner_manager_->launchScenePlugin(*this, name);
     }
 

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -147,9 +147,8 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   // Initialize PlannerManager
   for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
-    // workaround: Since ROS 2 can't get empty list, launcher set ['END'] on the parameter.
-    if (name == "END") {
-      RCLCPP_INFO(get_logger(), "No modules are registered.");
+    // workaround: Since ROS 2 can't get empty list, launcher set [''] on the parameter.
+    if (name == "") {
       break;
     }
     planner_manager_.launchScenePlugin(*this, name);

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -147,6 +147,10 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   // Initialize PlannerManager
   for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
+    if (name == "null") {
+      RCLCPP_INFO(get_logger(), "No modules are registered.");
+      break;
+    }
     planner_manager_.launchScenePlugin(*this, name);
   }
 

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -147,6 +147,7 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   // Initialize PlannerManager
   for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
+    // workaround: Since ROS 2 can't get empty list, launcher set ['null'] on the parameter.
     if (name == "null") {
       RCLCPP_INFO(get_logger(), "No modules are registered.");
       break;

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -147,8 +147,8 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   // Initialize PlannerManager
   for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
-    // workaround: Since ROS 2 can't get empty list, launcher set ['null'] on the parameter.
-    if (name == "null") {
+    // workaround: Since ROS 2 can't get empty list, launcher set ['END'] on the parameter.
+    if (name == "END") {
       RCLCPP_INFO(get_logger(), "No modules are registered.");
       break;
     }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0274073</samp>

This pull request fixes a parameter handling issue in the behavior path planner and the behavior velocity planner nodes. It adds a condition to check if the module name is `””` and skips loading it, to prevent errors with ROS 2.

FIx following error:

```
[component_container_mt-10] [ERROR] [1702012466.731917489] [planning.scenario_planning.lane_driving.behavior_planning.behavior_planning_container]: Component constructor threw an exception: parameter 'launch_modules' has invalid type: Wrong parameter type, parameter {launch_modules} is of type {string_array}, setting it to {byte_array} is not allowed.
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim (disable all scene modules)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
