### PR TITLE
fix(landmark_manager): changed to a shared library

### DIFF
--- a/localization/landmark_based_localizer/landmark_manager/CMakeLists.txt
+++ b/localization/landmark_based_localizer/landmark_manager/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-ament_auto_add_library(landmark_manager
+ament_auto_add_library(landmark_manager SHARED
   src/landmark_manager.cpp
 )
 


### PR DESCRIPTION
## Description

Changed `landmark_manager` to a shared library

It is just a mistake that I did not make it a shared library until now.

## Tests performed

It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

## Effects on system behavior

`landmark_manager` will work as a shared library.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
