### PR TITLE
refactor(ar_tag_based_localizer): refactor pub/sub and so on

### DIFF
--- a/launch/tier4_localization_launch/launch/pose_twist_estimator/ar_tag_based_localizer.launch.xml
+++ b/launch/tier4_localization_launch/launch/pose_twist_estimator/ar_tag_based_localizer.launch.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0"?>
 <launch>
   <group>
-    <push-ros-namespace namespace="ar_tag_based_localizer"/>
-    <group>
-      <include file="$(find-pkg-share ar_tag_based_localizer)/launch/ar_tag_based_localizer.launch.xml">
-        <arg name="input_lanelet2_map" value="/map/vector_map"/>
-        <arg name="input_image" value="/sensing/camera/traffic_light/image_raw"/>
-        <arg name="input_camera_info" value="/sensing/camera/traffic_light/camera_info"/>
-        <arg name="input_ekf_pose" value="/localization/pose_twist_fusion_filter/biased_pose_with_covariance"/>
-        <arg name="output_image" value="/localization/pose_estimator/ar_tag_detected_image"/>
-        <arg name="output_pose_with_covariance" value="/localization/pose_estimator/pose_with_covariance"/>
-        <arg name="param_file" value="$(find-pkg-share ar_tag_based_localizer)/config/ar_tag_based_localizer.param.yaml"/>
-      </include>
-    </group>
+    <include file="$(find-pkg-share ar_tag_based_localizer)/launch/ar_tag_based_localizer.launch.xml">
+      <arg name="input_lanelet2_map" value="/map/vector_map"/>
+      <arg name="input_image" value="/sensing/camera/traffic_light/image_raw"/>
+      <arg name="input_camera_info" value="/sensing/camera/traffic_light/camera_info"/>
+      <arg name="input_ekf_pose" value="/localization/pose_twist_fusion_filter/biased_pose_with_covariance"/>
+      <arg name="output_pose_with_covariance" value="/localization/pose_estimator/pose_with_covariance"/>
+      <arg name="param_file" value="$(find-pkg-share ar_tag_based_localizer)/config/ar_tag_based_localizer.param.yaml"/>
+    </include>
   </group>
 </launch>

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/launch/ar_tag_based_localizer.launch.xml
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/launch/ar_tag_based_localizer.launch.xml
@@ -8,8 +8,11 @@
   <arg name="input_camera_info" default="~/input/camera_info"/>
   <arg name="input_ekf_pose" default="~/input/ekf_pose"/>
 
-  <arg name="output_image" default="~/debug/result"/>
   <arg name="output_pose_with_covariance" default="~/output/pose_with_covariance"/>
+
+  <arg name="debug_image" default="~/debug/image"/>
+  <arg name="debug_mapped_tag" default="~/debug/mapped_tag"/>
+  <arg name="debug_detected_tag" default="~/debug/detected_tag"/>
 
   <node pkg="ar_tag_based_localizer" exec="ar_tag_based_localizer" name="$(var node_name)" output="log">
     <remap from="~/input/lanelet2_map" to="$(var input_lanelet2_map)"/>
@@ -17,8 +20,11 @@
     <remap from="~/input/camera_info" to="$(var input_camera_info)"/>
     <remap from="~/input/ekf_pose" to="$(var input_ekf_pose)"/>
 
-    <remap from="~/debug/result" to="$(var output_image)"/>
     <remap from="~/output/pose_with_covariance" to="$(var output_pose_with_covariance)"/>
+
+    <remap from="~/debug/image" to="$(var debug_image)"/>
+    <remap from="~/debug/mapped_tag" to="$(var debug_mapped_tag)"/>
+    <remap from="~/debug/detected_tag" to="$(var debug_detected_tag)"/>
 
     <param from="$(var param_file)"/>
   </node>

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/package.xml
@@ -17,7 +17,6 @@
   <depend>aruco</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>image_transport</depend>
   <depend>landmark_manager</depend>
   <depend>lanelet2_extension</depend>
   <depend>localization_util</depend>

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/src/ar_tag_based_localizer.hpp
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/src/ar_tag_based_localizer.hpp
@@ -48,11 +48,12 @@
 #include "landmark_manager/landmark_manager.hpp"
 #include "localization_util/smart_pose_buffer.hpp"
 
-#include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
@@ -82,7 +83,6 @@ class ArTagBasedLocalizer : public rclcpp::Node
 
 public:
   explicit ArTagBasedLocalizer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
-  bool setup();
 
 private:
   void map_bin_callback(const HADMapBin::ConstSharedPtr & msg);
@@ -104,9 +104,6 @@ private:
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
-  // image transport
-  std::unique_ptr<image_transport::ImageTransport> it_;
-
   // Subscribers
   rclcpp::Subscription<HADMapBin>::SharedPtr map_bin_sub_;
   rclcpp::Subscription<Image>::SharedPtr image_sub_;
@@ -114,10 +111,10 @@ private:
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr ekf_pose_sub_;
 
   // Publishers
-  rclcpp::Publisher<MarkerArray>::SharedPtr marker_pub_;
-  rclcpp::Publisher<PoseArray>::SharedPtr pose_array_pub_;
-  image_transport::Publisher image_pub_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pose_pub_;
+  rclcpp::Publisher<Image>::SharedPtr image_pub_;
+  rclcpp::Publisher<PoseArray>::SharedPtr detected_tag_pose_pub_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr mapped_tag_pose_pub_;
   rclcpp::Publisher<DiagnosticArray>::SharedPtr diag_pub_;
 
   // Others

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/src/main.cpp
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/src/main.cpp
@@ -48,7 +48,6 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   std::shared_ptr<ArTagBasedLocalizer> ptr = std::make_shared<ArTagBasedLocalizer>();
-  ptr->setup();
   rclcpp::spin(ptr);
   rclcpp::shutdown();
 }

--- a/localization/landmark_based_localizer/ar_tag_based_localizer/test/test.cpp
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/test/test.cpp
@@ -55,7 +55,8 @@ protected:
 
 TEST_F(TestArTagBasedLocalizer, test_setup)  // NOLINT
 {
-  EXPECT_TRUE(node_->setup());
+  // Check if the constructor finishes successfully
+  EXPECT_TRUE(true);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Refactored `ar_tag_based_localizer`.

 * Changed launch nest
   * Before `/localization/pose_estimator/ar_tag_based_localizer/ar_tag_based_localizer`
   * After `/localization/pose_estimator/ar_tag_based_localizer`
   * Previously, `landmark_parser` was running as a node, so it was necessary to create a namespace and launch nodes within it, but that is no longer the case.
 * Fixed launch.xml to remap correctly
 * Removed `image_transport`
   * it has allowed to remove setup function also
 * Fixed the code of the qos variable (the contents remain unchanged)
 * Fixed cam_info_callback
 * Fixed test

## Tests performed

It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

## Effects on system behavior

There are no effects on system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
