### PR TITLE
fix(avoidance): update logic to calculate centerline distance

### DIFF
--- a/planning/behavior_path_avoidance_by_lane_change_module/package.xml
+++ b/planning/behavior_path_avoidance_by_lane_change_module/package.xml
@@ -22,6 +22,7 @@
   <depend>behavior_path_lane_change_module</depend>
   <depend>behavior_path_planner</depend>
   <depend>behavior_path_planner_common</depend>
+  <depend>lanelet2_extension</depend>
   <depend>motion_utils</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -52,6 +52,8 @@ using geometry_msgs::msg::TransformStamped;
 
 using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 
+using route_handler::Direction;
+
 struct ObjectParameter
 {
   bool is_avoidance_target{false};
@@ -327,14 +329,14 @@ struct ObjectData  // avoidance target
 {
   ObjectData() = default;
   ObjectData(const PredictedObject & obj, double lat, double lon, double len, double overhang)
-  : object(obj), lateral(lat), longitudinal(lon), length(len), overhang_dist(overhang)
+  : object(obj), to_centerline(lat), longitudinal(lon), length(len), overhang_dist(overhang)
   {
   }
 
   PredictedObject object;
 
   // lateral position of the CoM, in Frenet coordinate from ego-pose
-  double lateral;
+  double to_centerline;
 
   // longitudinal position of the CoM, in Frenet coordinate from ego-pose
   double longitudinal;
@@ -395,6 +397,9 @@ struct ObjectData  // avoidance target
 
   // is within intersection area
   bool is_within_intersection{false};
+
+  // object direction.
+  Direction direction{Direction::NONE};
 
   // unavoidable reason
   std::string reason{""};
@@ -566,8 +571,6 @@ struct ShiftLineData
  */
 struct DebugData
 {
-  std::shared_ptr<lanelet::ConstLanelets> current_lanelets;
-
   geometry_msgs::msg::Polygon detection_area;
 
   lanelet::ConstLineStrings3d bounds;

--- a/planning/behavior_path_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_avoidance_module/src/debug.cpp
@@ -16,6 +16,7 @@
 
 #include "behavior_path_planner_common/utils/utils.hpp"
 
+#include <lanelet2_extension/visualization/visualization.hpp>
 #include <magic_enum.hpp>
 #include <tier4_autoware_utils/ros/uuid_helper.hpp>
 
@@ -160,7 +161,7 @@ MarkerArray createObjectInfoMarkerArray(const ObjectDataArray & objects, std::st
       std::ostringstream string_stream;
       string_stream << std::fixed << std::setprecision(2) << std::boolalpha;
       string_stream << "ratio:" << object.shiftable_ratio << " [-]\n"
-                    << "lateral:" << object.lateral << " [m]\n"
+                    << "lateral:" << object.to_centerline << " [m]\n"
                     << "necessity:" << object.avoid_required << " [-]\n"
                     << "stoppable:" << object.is_stoppable << " [-]\n"
                     << "stop_factor:" << object.to_stop_factor_distance << " [m]\n"
@@ -495,6 +496,8 @@ MarkerArray createDrivableBounds(
 MarkerArray createDebugMarkerArray(
   const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug)
 {
+  using behavior_path_planner::utils::transformToLanelets;
+  using lanelet::visualization::laneletsAsTriangleMarkerArray;
   using marker_utils::createLaneletsAreaMarkerArray;
   using marker_utils::createObjectsMarkerArray;
   using marker_utils::createPathMarkerArray;
@@ -608,9 +611,13 @@ MarkerArray createDebugMarkerArray(
   // misc
   {
     add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
-    add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
     add(createPolygonMarkerArray(debug.detection_area, "detection_area", 0L, 0.16, 1.0, 0.69, 0.1));
     add(createDrivableBounds(data, "drivable_bound", 1.0, 0.0, 0.42));
+    add(laneletsAsTriangleMarkerArray(
+      "drivable_lanes", transformToLanelets(data.drivable_lanes),
+      createMarkerColor(0.16, 1.0, 0.69, 0.2)));
+    add(laneletsAsTriangleMarkerArray(
+      "current_lanes", data.current_lanelets, createMarkerColor(1.0, 1.0, 1.0, 0.2)));
   }
 
   return msg;

--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -328,14 +328,12 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
 
   // debug
   {
-    debug.current_lanelets = std::make_shared<lanelet::ConstLanelets>(data.current_lanelets);
-
     std::vector<AvoidanceDebugMsg> debug_info_array;
     const auto append = [&](const auto & o) {
       AvoidanceDebugMsg debug_info;
       debug_info.object_id = toHexString(o.object.object_id);
       debug_info.longitudinal_distance = o.longitudinal;
-      debug_info.lateral_distance_from_centerline = o.lateral;
+      debug_info.lateral_distance_from_centerline = o.to_centerline;
       debug_info.allow_avoidance = o.reason == "";
       debug_info.failed_reason = o.reason;
       debug_info_array.push_back(debug_info);
@@ -380,7 +378,11 @@ ObjectData AvoidanceModule::createObjectData(
   utils::avoidance::fillObjectMovingTime(object_data, stopped_objects_, parameters_);
 
   // Calc lateral deviation from path to target object.
-  object_data.lateral = calcLateralDeviation(object_closest_pose, object_pose.position);
+  object_data.to_centerline =
+    lanelet::utils::getArcCoordinates(data.current_lanelets, object_pose).distance;
+  object_data.direction = calcLateralDeviation(object_closest_pose, object_pose.position) > 0.0
+                            ? Direction::LEFT
+                            : Direction::RIGHT;
 
   // Find the footprint point closest to the path, set to object_data.overhang_distance.
   object_data.overhang_dist = utils::avoidance::calcEnvelopeOverhangDistance(

--- a/planning/behavior_path_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_avoidance_module/test/test_utils.cpp
@@ -25,7 +25,7 @@ using behavior_path_planner::utils::avoidance::isSameDirectionShift;
 TEST(BehaviorPathPlanningAvoidanceUtilsTest, shiftLengthDirectionTest)
 {
   ObjectData right_obj;
-  right_obj.to_centerline = -0.3;
+  right_obj.direction = route_handler::Direction::RIGHT;
   const double negative_shift_length = -1.0;
   const double positive_shift_length = 1.0;
 
@@ -33,11 +33,7 @@ TEST(BehaviorPathPlanningAvoidanceUtilsTest, shiftLengthDirectionTest)
   ASSERT_FALSE(isSameDirectionShift(isOnRight(right_obj), positive_shift_length));
 
   ObjectData left_obj;
-  left_obj.to_centerline = 0.3;
+  left_obj.direction = route_handler::Direction::LEFT;
   ASSERT_TRUE(isSameDirectionShift(isOnRight(left_obj), positive_shift_length));
   ASSERT_FALSE(isSameDirectionShift(isOnRight(left_obj), negative_shift_length));
-
-  const double zero_shift_length = 0.0;
-  ASSERT_TRUE(isSameDirectionShift(isOnRight(left_obj), zero_shift_length));
-  ASSERT_FALSE(isSameDirectionShift(isOnRight(right_obj), zero_shift_length));
 }

--- a/planning/behavior_path_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_avoidance_module/test/test_utils.cpp
@@ -25,7 +25,7 @@ using behavior_path_planner::utils::avoidance::isSameDirectionShift;
 TEST(BehaviorPathPlanningAvoidanceUtilsTest, shiftLengthDirectionTest)
 {
   ObjectData right_obj;
-  right_obj.lateral = -0.3;
+  right_obj.to_centerline = -0.3;
   const double negative_shift_length = -1.0;
   const double positive_shift_length = 1.0;
 
@@ -33,7 +33,7 @@ TEST(BehaviorPathPlanningAvoidanceUtilsTest, shiftLengthDirectionTest)
   ASSERT_FALSE(isSameDirectionShift(isOnRight(right_obj), positive_shift_length));
 
   ObjectData left_obj;
-  left_obj.lateral = 0.3;
+  left_obj.to_centerline = 0.3;
   ASSERT_TRUE(isSameDirectionShift(isOnRight(left_obj), positive_shift_length));
   ASSERT_FALSE(isSameDirectionShift(isOnRight(left_obj), negative_shift_length));
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fbdb015</samp>

This pull request improves the behavior_path_avoidance_module and the behavior_path_avoidance_by_lane_change_module by using the lanelet2_extension utilities, updating the object data structure, and adding more debug information. It also updates the test case and the package dependency to reflect the changes. These changes aim to enhance the detection and avoidance of objects on the path by using the centerline of the lanelets as a reference and adjusting the forward detection range.

---

**We assumed that most of all vehicles which are near centerline of the lane are NOT parked vehicle.**

Previously, avoidance module calculated distance between object and ego's dynamic path to judge whether the object is parked vehicle based on above assumption. But I think we should calculate and use distance from **static centerline which is made from ego's driving lanelets**.

```c++
  object_data.to_centerline =
    lanelet::utils::getArcCoordinates(data.current_lanelets, object_pose).distance;

...

  // Object is on center line -> ignore.
  if (std::abs(object.to_centerline) < parameters->threshold_distance_object_is_on_center) {
    object.reason = AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE;
    return false;
  }
```

![Screenshot from 2023-12-18 13-03-02](https://github.com/autowarefoundation/autoware.universe/assets/44889564/fd296ec8-8dc3-4ed3-8805-5c5f13d73d46)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/2960b5cc-13dd-5f07-86c7-c4ab99c7f155?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
