### PR TITLE
fix(avoidance): check far objects during shifting

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
@@ -185,6 +185,10 @@ public:
       return parameters_->object_check_max_forward_distance;
     }
 
+    if (isShifted()) {
+      return parameters_->object_check_max_forward_distance;
+    }
+
     const auto max_shift_length = std::max(
       std::abs(parameters_->max_right_shift_length), std::abs(parameters_->max_left_shift_length));
     const auto dynamic_distance = PathShifter::calcLongitudinalDistFromJerk(

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
@@ -58,6 +58,8 @@ public:
 
   double getEgoSpeed() const { return std::abs(data_->self_odometry->twist.twist.linear.x); }
 
+  geometry_msgs::msg::Pose getEgoPose() const { return data_->self_odometry->pose.pose; }
+
   size_t getConstraintsMapIndex(const double velocity, const std::vector<double> & values) const
   {
     const auto itr = std::find_if(
@@ -185,14 +187,20 @@ public:
       return parameters_->object_check_max_forward_distance;
     }
 
-    if (isShifted()) {
+    const auto & route_handler = data_->route_handler;
+
+    lanelet::ConstLanelet closest_lane;
+    if (!route_handler->getClosestLaneletWithinRoute(getEgoPose(), &closest_lane)) {
       return parameters_->object_check_max_forward_distance;
     }
 
+    const auto limit = route_handler->getTrafficRulesPtr()->speedLimit(closest_lane);
+    const auto speed = isShifted() ? limit.speedLimit.value() : getEgoSpeed();
+
     const auto max_shift_length = std::max(
       std::abs(parameters_->max_right_shift_length), std::abs(parameters_->max_left_shift_length));
-    const auto dynamic_distance = PathShifter::calcLongitudinalDistFromJerk(
-      max_shift_length, getLateralMinJerkLimit(), getEgoSpeed());
+    const auto dynamic_distance =
+      PathShifter::calcLongitudinalDistFromJerk(max_shift_length, getLateralMinJerkLimit(), speed);
 
     return std::clamp(
       1.5 * dynamic_distance + getNominalPrepareDistance(),


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c12bae9</samp>

Added a condition to `helper.hpp` to limit obstacle detection range when the vehicle is shifted. This improves the performance of the behavior path avoidance module.

Previously, avoidance behavior was unnatural and wavy. SInce detection area longitudinal distance is based on current ego speed, if the vehicle drives low speed avoidance module doesn't generate far objects. Then, avoidance module doesn't update return path until the vehicle gets closer.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/f1093dad-cfef-45c2-b77d-889b1c2b4284

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

https://github.com/autowarefoundation/autoware.universe/assets/44889564/590d770c-104c-4717-8f21-3c469eeba036

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
