### PR TITLE
feat(map_loader): use dummy projector when using local coordinates

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_dummy_projector.hpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_dummy_projector.hpp
@@ -23,8 +23,8 @@ namespace lanelet::projection
 class DummyProjector : public Projector
 {
 public:
-  BasicPoint3d forward(const GPSPoint & gps) const override { return {}; }  // NOLINT
-  GPSPoint reverse(const BasicPoint3d & point) const override { return {}; }
+  BasicPoint3d forward(const GPSPoint &) const override { return {}; }  // NOLINT
+  GPSPoint reverse(const BasicPoint3d &) const override { return {}; }
 };
 
 }  // namespace lanelet::projection

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_dummy_projector.hpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_dummy_projector.hpp
@@ -1,0 +1,32 @@
+// Copyright 2023 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_LOADER__LANELET2_DUMMY_PROJECTOR_HPP_
+#define LANELET2_MAP_LOADER__LANELET2_DUMMY_PROJECTOR_HPP_
+
+#include <lanelet2_io/Projection.h>
+
+namespace lanelet::projection
+{
+
+class DummyProjector : public Projector
+{
+public:
+  BasicPoint3d forward(const GPSPoint & gps) const override { return {}; }  // NOLINT
+  GPSPoint reverse(const BasicPoint3d & point) const override { return {}; }
+};
+
+}  // namespace lanelet::projection
+
+#endif  // LANELET2_MAP_LOADER__LANELET2_DUMMY_PROJECTOR_HPP_

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp
@@ -12,21 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANELET2_MAP_LOADER__LANELET2_DUMMY_PROJECTOR_HPP_
-#define LANELET2_MAP_LOADER__LANELET2_DUMMY_PROJECTOR_HPP_
+#ifndef LANELET2_MAP_LOADER__LANELET2_LOCAL_PROJECTOR_HPP_
+#define LANELET2_MAP_LOADER__LANELET2_LOCAL_PROJECTOR_HPP_
 
 #include <lanelet2_io/Projection.h>
 
 namespace lanelet::projection
 {
 
-class DummyProjector : public Projector
+class LocalProjector : public Projector
 {
 public:
-  BasicPoint3d forward(const GPSPoint &) const override { return {}; }  // NOLINT
+  LocalProjector() : Projector(Origin(GPSPoint{})) {}
+
+  BasicPoint3d forward(const GPSPoint & gps) const override  // NOLINT
+  {
+    return BasicPoint3d{0.0, 0.0, gps.ele};
+  }
+
   GPSPoint reverse(const BasicPoint3d &) const override { return {}; }
 };
 
 }  // namespace lanelet::projection
 
-#endif  // LANELET2_MAP_LOADER__LANELET2_DUMMY_PROJECTOR_HPP_
+#endif  // LANELET2_MAP_LOADER__LANELET2_LOCAL_PROJECTOR_HPP_

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp
@@ -30,7 +30,10 @@ public:
     return BasicPoint3d{0.0, 0.0, gps.ele};
   }
 
-  GPSPoint reverse(const BasicPoint3d &) const override { return {}; }
+  GPSPoint reverse(const BasicPoint3d & point) const override
+  {
+    return GPSPoint{0.0, 0.0, point.z()};
+  }
 };
 
 }  // namespace lanelet::projection

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -33,7 +33,7 @@
 
 #include "map_loader/lanelet2_map_loader_node.hpp"
 
-#include "lanelet2_dummy_projector.hpp"
+#include "lanelet2_local_projector.hpp"
 
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <geography_utils/lanelet2_projector.hpp>
@@ -102,7 +102,7 @@ lanelet::LaneletMapPtr Lanelet2MapLoaderNode::load_map(
       return map;
     }
   } else {
-    const lanelet::projection::DummyProjector projector;
+    const lanelet::projection::LocalProjector projector;
     const lanelet::LaneletMapPtr map = lanelet::load(lanelet2_filename, projector, &errors);
 
     // overwrite local_x, local_y

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -33,6 +33,8 @@
 
 #include "map_loader/lanelet2_map_loader_node.hpp"
 
+#include "lanelet2_dummy_projector.hpp"
+
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <geography_utils/lanelet2_projector.hpp>
 #include <lanelet2_extension/io/autoware_osm_parser.hpp>
@@ -100,8 +102,7 @@ lanelet::LaneletMapPtr Lanelet2MapLoaderNode::load_map(
       return map;
     }
   } else {
-    // Use MGRSProjector as parser
-    lanelet::projection::MGRSProjector projector{};
+    const lanelet::projection::DummyProjector projector;
     const lanelet::LaneletMapPtr map = lanelet::load(lanelet2_filename, projector, &errors);
 
     // overwrite local_x, local_y


### PR DESCRIPTION
## Description

Close https://github.com/autowarefoundation/autoware/issues/3427. Use dummy projector when using local coordinates. The dummy projector does no conversion calculations and always returns (0, 0, ele).

## Related links

https://github.com/autowarefoundation/autoware/issues/3427.

## Tests performed

Check if the vehicle can drive autonomously in the simple planning simulator using local coordinate map.
Note: Since the tutorial map also has local coordinates, you can test it by adding the following file.
```yaml
# map_projector_info.yaml
projector_type: local
```

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

MRGS conversion is no longer performed when local projector type is selected.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
