### PR TITLE
feat(simple_planning_simulator): add mesurent_steer_bias

### DIFF
--- a/simulator/simple_planning_simulator/README.md
+++ b/simulator/simple_planning_simulator/README.md
@@ -51,6 +51,7 @@ The purpose of this simulator is for the integration test of planning and contro
 | vel_noise_stddev      | double | Standard deviation for longitudinal velocity noise                                                                                         | 0.0                  |
 | angvel_noise_stddev   | double | Standard deviation for angular velocity noise                                                                                              | 0.0                  |
 | steer_noise_stddev    | double | Standard deviation for steering angle noise                                                                                                | 0.0001               |
+| measurement_steer_bias | double | Measurement bias for steering angle                                                                                                       | 0.0                  |
 
 ### Vehicle Model Parameters
 

--- a/simulator/simple_planning_simulator/README.md
+++ b/simulator/simple_planning_simulator/README.md
@@ -40,18 +40,18 @@ The purpose of this simulator is for the integration test of planning and contro
 
 ### Common Parameters
 
-| Name                  | Type   | Description                                                                                                                                | Default value        |
-| :-------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------- | :------------------- |
-| simulated_frame_id    | string | set to the child_frame_id in output tf                                                                                                     | "base_link"          |
-| origin_frame_id       | string | set to the frame_id in output tf                                                                                                           | "odom"               |
-| initialize_source     | string | If "ORIGIN", the initial pose is set at (0,0,0). If "INITIAL_POSE_TOPIC", node will wait until the `input/initialpose` topic is published. | "INITIAL_POSE_TOPIC" |
-| add_measurement_noise | bool   | If true, the Gaussian noise is added to the simulated results.                                                                             | true                 |
-| pos_noise_stddev      | double | Standard deviation for position noise                                                                                                      | 0.01                 |
-| rpy_noise_stddev      | double | Standard deviation for Euler angle noise                                                                                                   | 0.0001               |
-| vel_noise_stddev      | double | Standard deviation for longitudinal velocity noise                                                                                         | 0.0                  |
-| angvel_noise_stddev   | double | Standard deviation for angular velocity noise                                                                                              | 0.0                  |
-| steer_noise_stddev    | double | Standard deviation for steering angle noise                                                                                                | 0.0001               |
-| measurement_steer_bias | double | Measurement bias for steering angle                                                                                                       | 0.0                  |
+| Name                   | Type   | Description                                                                                                                                | Default value        |
+| :--------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------- | :------------------- |
+| simulated_frame_id     | string | set to the child_frame_id in output tf                                                                                                     | "base_link"          |
+| origin_frame_id        | string | set to the frame_id in output tf                                                                                                           | "odom"               |
+| initialize_source      | string | If "ORIGIN", the initial pose is set at (0,0,0). If "INITIAL_POSE_TOPIC", node will wait until the `input/initialpose` topic is published. | "INITIAL_POSE_TOPIC" |
+| add_measurement_noise  | bool   | If true, the Gaussian noise is added to the simulated results.                                                                             | true                 |
+| pos_noise_stddev       | double | Standard deviation for position noise                                                                                                      | 0.01                 |
+| rpy_noise_stddev       | double | Standard deviation for Euler angle noise                                                                                                   | 0.0001               |
+| vel_noise_stddev       | double | Standard deviation for longitudinal velocity noise                                                                                         | 0.0                  |
+| angvel_noise_stddev    | double | Standard deviation for angular velocity noise                                                                                              | 0.0                  |
+| steer_noise_stddev     | double | Standard deviation for steering angle noise                                                                                                | 0.0001               |
+| measurement_steer_bias | double | Measurement bias for steering angle                                                                                                        | 0.0                  |
 
 ### Vehicle Model Parameters
 

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -195,6 +195,9 @@ private:
   bool is_initialized_ = false;         //!< @brief flag to check the initial position is set
   bool add_measurement_noise_ = false;  //!< @brief flag to add measurement noise
 
+  /* measurement bias */
+  double measurement_steer_bias_ = 0.0;  //!< @brief measurement bias for steering measurement
+
   DeltaTime delta_time_{};  //!< @brief to calculate delta time
 
   MeasurementNoiseGenerator measurement_noise_{};  //!< @brief for measurement noise

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -102,6 +102,7 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
   simulated_frame_id_ = declare_parameter("simulated_frame_id", "base_link");
   origin_frame_id_ = declare_parameter("origin_frame_id", "odom");
   add_measurement_noise_ = declare_parameter("add_measurement_noise", false);
+  measurement_steer_bias_ = declare_parameter("measurement_steer_bias", 0.0);
   simulate_motion_ = declare_parameter<bool>("initial_engage_state");
   enable_road_slope_simulation_ = declare_parameter("enable_road_slope_simulation", false);
 
@@ -380,6 +381,9 @@ void SimplePlanningSimulator::on_timer()
   if (add_measurement_noise_) {
     add_measurement_noise(current_odometry_, current_velocity_, current_steer_);
   }
+
+  // add measurement bias
+  current_steer_.steering_tire_angle += measurement_steer_bias_;
 
   // add estimate covariance
   {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

add mesurent_steer_bias. the default value is 0.0




## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


mesurent_steer_bias : 1.0

https://github.com/autowarefoundation/autoware.universe/assets/39142679/05e17e02-05fb-41c2-9c8c-a6688d0f1219



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
