### PR TITLE
feat(diagnostic_graph_aggregator): change default publish rate

### DIFF
--- a/system/diagnostic_graph_aggregator/config/default.param.yaml
+++ b/system/diagnostic_graph_aggregator/config/default.param.yaml
@@ -2,6 +2,6 @@
   ros__parameters:
     use_operation_mode_availability: true
     use_debug_mode: false
-    rate: 1.0
+    rate: 10.0
     input_qos_depth: 1000
     graph_qos_depth: 1


### PR DESCRIPTION
## Description

Change default publish rate of diagnostic_graph_aggregator.

## Related links

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C0657FNJ5EG/p1702535324810249)

## Tests performed

None

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

`/diagnostics_graph` topic is publihed at 10 Hz.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
