### PR TITLE
fix(start_planner): refine shift pull out path to start pose

### DIFF
--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -46,6 +46,10 @@ public:
   double calcBeforeShiftedArcLength(
     const PathWithLaneId & path, const double target_after_arc_length, const double dr);
 
+  bool refineShiftedPathToStartPose(
+    ShiftedPath & shifted_path, const Pose & start_pose, const Pose & end_pose,
+    const double longitudinal_acc, const double lateral_acc);
+
   std::shared_ptr<LaneDepartureChecker> lane_departure_checker_;
 
 private:

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -166,7 +166,7 @@ bool ShiftPullOut::refineShiftedPathToStartPose(
   constexpr size_t MAX_ITERATION = 100;
 
   // Lambda to check if change is above tolerance
-  auto is_whithin_tolerance =
+  auto is_within_tolerance =
     [](const auto & prev_val, const auto & current_val, const auto & tolerance) {
       return std::abs(current_val - prev_val) < tolerance;
     };
@@ -194,7 +194,7 @@ bool ShiftPullOut::refineShiftedPathToStartPose(
       return false;
     }
 
-    if (is_whithin_tolerance(
+    if (is_within_tolerance(
           lateral_offset,
           motion_utils::calcLateralOffset(shifted_path.path.points, start_pose.position),
           TOLERANCE)) {

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -158,6 +158,58 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
   return std::nullopt;
 }
 
+bool ShiftPullOut::refineShiftedPathToStartPose(
+  ShiftedPath & shifted_path, const Pose & start_pose, const Pose & end_pose,
+  const double longitudinal_acc, const double lateral_acc)
+{
+  constexpr double TOLERANCE = 0.01;
+  constexpr size_t MAX_ITERATION = 100;
+
+  // Lambda to check if change is above tolerance
+  auto is_whithin_tolerance =
+    [](const auto & prev_val, const auto & current_val, const auto & tolerance) {
+      return std::abs(current_val - prev_val) < tolerance;
+    };
+
+  size_t iteration = 0;
+  while (iteration < MAX_ITERATION) {
+    const double lateral_offset =
+      motion_utils::calcLateralOffset(shifted_path.path.points, start_pose.position);
+
+    PathShifter path_shifter;
+    path_shifter.setPath(shifted_path.path);
+    ShiftLine shift_line{};
+    shift_line.start = start_pose;
+    shift_line.end = end_pose;
+    shift_line.end_shift_length = lateral_offset;
+    path_shifter.addShiftLine(shift_line);
+    path_shifter.setVelocity(0.0);
+    path_shifter.setLongitudinalAcceleration(longitudinal_acc);
+    path_shifter.setLateralAccelerationLimit(lateral_acc);
+
+    if (!path_shifter.generate(&shifted_path, false)) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("ShiftPullOut:refineShiftedPathToStartPose()"),
+        "Failed to generate shifted path");
+      return false;
+    }
+
+    if (is_whithin_tolerance(
+          lateral_offset,
+          motion_utils::calcLateralOffset(shifted_path.path.points, start_pose.position),
+          TOLERANCE)) {
+      return true;
+    }
+
+    iteration++;
+  }
+
+  RCLCPP_WARN(
+    rclcpp::get_logger("ShiftPullOut:refineShiftedPathToStartPose()"),
+    "Failed to converge lateral offset until max iteration");
+  return false;
+}
+
 std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & road_lanes,
   const Pose & start_pose, const Pose & goal_pose)
@@ -303,6 +355,8 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     if (!path_shifter.generate(&shifted_path, offset_back)) {
       continue;
     }
+    refineShiftedPathToStartPose(
+      shifted_path, start_pose, *shift_end_pose_ptr, longitudinal_acc, lateral_acc);
 
     // set velocity
     const size_t pull_out_end_idx =


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

 refine shift pull out path to start pose


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/e26ba7e3-fd54-4a29-8f72-a04c121825c8)


after

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/b5cb5d2d-03a8-48fe-aba0-2893390fed9f)


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/760b51ff-4a7e-42bf-8967-6e766c6ce7d8)

evaluator_description: fix/shift_pull_out_start
2023/12/14 https://evaluation.tier4.jp/evaluation/reports/e8673ccf-7003-5fbb-a379-7c7c6f8cabe8/?project_id=prd_jt



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
