### PR TITLE
refactor(start_planner): change return type for plan()

### DIFF
--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/freespace_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/freespace_pull_out.hpp
@@ -40,7 +40,7 @@ public:
 
   PlannerType getPlannerType() override { return PlannerType::FREESPACE; }
 
-  std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & end_pose) override;
+  std::vector<PullOutPath> plan(const Pose & start_pose, const Pose & end_pose) override;
 
 protected:
   std::unique_ptr<AbstractPlanningAlgorithm> planner_;

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -29,7 +29,7 @@ public:
   explicit GeometricPullOut(rclcpp::Node & node, const StartPlannerParameters & parameters);
 
   PlannerType getPlannerType() override { return PlannerType::GEOMETRIC; };
-  std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
+  std::vector<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   GeometricParallelParking planner_;
   ParallelParkingParameters parallel_parking_parameters_;

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -56,7 +56,7 @@ public:
   }
 
   virtual PlannerType getPlannerType() = 0;
-  virtual std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
+  virtual std::vector<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
 
 protected:
   std::shared_ptr<const PlannerData> planner_data_;

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -37,7 +37,7 @@ public:
     std::shared_ptr<LaneDepartureChecker> & lane_departure_checker);
 
   PlannerType getPlannerType() override { return PlannerType::SHIFT; };
-  std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
+  std::vector<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   std::vector<PullOutPath> calcPullOutPaths(
     const RouteHandler & route_handler, const lanelet::ConstLanelets & road_lanes,

--- a/planning/behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -26,6 +26,7 @@
 
 namespace behavior_path_planner
 {
+
 FreespacePullOut::FreespacePullOut(
   rclcpp::Node & node, const StartPlannerParameters & parameters,
   const vehicle_info_util::VehicleInfo & vehicle_info)
@@ -45,7 +46,7 @@ FreespacePullOut::FreespacePullOut(
   }
 }
 
-std::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const Pose & end_pose)
+std::vector<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const Pose & end_pose)
 {
   const auto & route_handler = planner_data_->route_handler;
   const double backward_path_length = planner_data_->parameters.backward_path_length;
@@ -53,8 +54,7 @@ std::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const
 
   planner_->setMap(*planner_data_->costmap);
 
-  const bool found_path = planner_->makePlan(start_pose, end_pose);
-  if (!found_path) {
+  if (!planner_->makePlan(start_pose, end_pose)) {
     return {};
   }
 
@@ -112,6 +112,9 @@ std::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const
   pull_out_path.start_pose = start_pose;
   pull_out_path.end_pose = end_pose;
 
-  return pull_out_path;
+  std::vector<PullOutPath> pull_out_path_candidates;
+  pull_out_path_candidates.push_back(pull_out_path);
+
+  return pull_out_path_candidates;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -37,7 +37,7 @@ GeometricPullOut::GeometricPullOut(rclcpp::Node & node, const StartPlannerParame
   planner_.setParameters(parallel_parking_parameters_);
 }
 
-std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const Pose & goal_pose)
+std::vector<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const Pose & goal_pose)
 {
   PullOutPath output;
 
@@ -55,9 +55,8 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
   planner_.setTurningRadius(
     planner_data_->parameters, parallel_parking_parameters_.pull_out_max_steer_angle);
   planner_.setPlannerData(planner_data_);
-  const bool found_valid_path =
-    planner_.planPullOut(start_pose, goal_pose, road_lanes, pull_out_lanes, left_side_start);
-  if (!found_valid_path) {
+
+  if (!planner_.planPullOut(start_pose, goal_pose, road_lanes, pull_out_lanes, left_side_start)) {
     return {};
   }
 
@@ -120,7 +119,9 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
 
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
+  std::vector<PullOutPath> pull_out_path_candidates;
+  pull_out_path_candidates.push_back(output);
 
-  return output;
+  return pull_out_path_candidates;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -631,13 +631,11 @@ bool StartPlannerModule::findPullOutPath(
   const auto pull_out_path = planner->plan(pull_out_start_pose, goal_pose);
 
   // If no path is found, return false
-  if (!pull_out_path) {
-    return false;
-  }
+  if (pull_out_path.empty()) return false;
 
   // If driving forward, update status with the current path and return true
   if (is_driving_forward) {
-    updateStatusWithCurrentPath(*pull_out_path, pull_out_start_pose, planner->getPlannerType());
+    updateStatusWithCurrentPath(pull_out_path.at(0), pull_out_start_pose, planner->getPlannerType());
     return true;
   }
 
@@ -648,11 +646,11 @@ bool StartPlannerModule::findPullOutPath(
   const auto next_pull_out_path = planner->plan(next_pull_out_start_pose, goal_pose);
 
   // If no next path is found, return false
-  if (!next_pull_out_path) return false;
+  if (next_pull_out_path.empty()) return false;
 
   // Update status with the next path and return true
   updateStatusWithNextPath(
-    *next_pull_out_path, next_pull_out_start_pose, planner->getPlannerType());
+    next_pull_out_path.at(0), next_pull_out_start_pose, planner->getPlannerType());
   return true;
 }
 
@@ -1234,12 +1232,12 @@ bool StartPlannerModule::planFreespacePath()
     freespace_planner_->setPlannerData(planner_data_);
     auto freespace_path = freespace_planner_->plan(current_pose, end_pose);
 
-    if (!freespace_path) {
+    if (freespace_path.empty()) {
       continue;
     }
 
     const std::lock_guard<std::mutex> lock(mutex_);
-    status_.pull_out_path = *freespace_path;
+    status_.pull_out_path = freespace_path.at(0);
     status_.pull_out_start_pose = current_pose;
     status_.planner_type = freespace_planner_->getPlannerType();
     status_.found_pull_out_path = true;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -635,7 +635,8 @@ bool StartPlannerModule::findPullOutPath(
 
   // If driving forward, update status with the current path and return true
   if (is_driving_forward) {
-    updateStatusWithCurrentPath(pull_out_path.at(0), pull_out_start_pose, planner->getPlannerType());
+    updateStatusWithCurrentPath(
+      pull_out_path.at(0), pull_out_start_pose, planner->getPlannerType());
     return true;
   }
 


### PR DESCRIPTION
## Description

To execute collision check outside of plan().
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cd44827</samp>

This pull request modifies the `plan` methods of the pull-out planners and their base interface to return multiple pull-out path candidates instead of a single optional one. This enables the vehicle to choose the best pull-out path based on the traffic situation and the costmap. The changes affect the files `freespace_pull_out.cpp`, `geometric_pull_out.cpp`, `shift_pull_out.cpp`, `start_planner_module.cpp`, and their corresponding header files.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
