### PR TITLE
chore(map_loader): visualize crosswalk id

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -225,6 +225,9 @@ void Lanelet2MapVisualizationNode::onMapBin(
     &map_marker_array,
     lanelet::visualization::generateLaneletIdMarker(road_lanelets, cl_lanelet_id));
   insertMarkerArray(
+    &map_marker_array, lanelet::visualization::generateLaneletIdMarker(
+                         crosswalk_lanelets, cl_lanelet_id, "crosswalk_lanelet_id"));
+  insertMarkerArray(
     &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
                          "shoulder_road_lanelets", shoulder_lanelets, cl_shoulder));
   insertMarkerArray(


### PR DESCRIPTION
## Description

Add crosswalk_id visualization.
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/16c82c7d-8980-4ec0-97b8-9e4fde7f7c3a)


This must be merged after https://github.com/autowarefoundation/autoware_common/pull/220.


<!-- Write a brief description of this PR. -->

## Tests performed

run psim and see the crosswalk id visualized

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
