### PR TITLE
feat(mission_planner): restrict enable_correct_goal_pose to poses within lanelets

### DIFF
--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -111,7 +111,8 @@ geometry_msgs::msg::Pose get_closest_centerline_pose(
   vehicle_info_util::VehicleInfo vehicle_info)
 {
   lanelet::Lanelet closest_lanelet;
-  if (!lanelet::utils::query::getClosestLaneletWithConstrains(road_lanelets, point, &closest_lanelet, 0.0)) {
+  if (!lanelet::utils::query::getClosestLaneletWithConstrains(
+        road_lanelets, point, &closest_lanelet, 0.0)) {
     // point is not on any lanelet.
     return point;
   }

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -111,7 +111,10 @@ geometry_msgs::msg::Pose get_closest_centerline_pose(
   vehicle_info_util::VehicleInfo vehicle_info)
 {
   lanelet::Lanelet closest_lanelet;
-  lanelet::utils::query::getClosestLanelet(road_lanelets, point, &closest_lanelet);
+  if (!lanelet::utils::query::getClosestLaneletWithConstrains(road_lanelets, point, &closest_lanelet, 0.0)) {
+    // point is not on any lanelet.
+    return point;
+  }
 
   const auto refined_center_line = lanelet::utils::generateFineCenterline(closest_lanelet, 1.0);
   closest_lanelet.setCenterline(refined_center_line);


### PR DESCRIPTION
fixes #5881

## Description

<!-- Write a brief description of this PR. -->

when `enable_correct_goal_pose` is set to true, only goal poses within lanelets are modified.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

[Screencast from 12-15-2023 04_26_37 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/18645627/a655bee3-16b8-47bc-9432-3ab9d2b68814)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
