### PR TITLE
fix(avoidance): unintentional path cut

### DIFF
--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -233,8 +233,8 @@ void AvoidanceModule::fillFundamentalData(AvoidancePlanningData & data, DebugDat
     });
 
   // calc drivable bound
-  const auto shorten_lanes =
-    utils::cutOverlappedLanes(*getPreviousModuleOutput().path, data.drivable_lanes);
+  auto tmp_path = *getPreviousModuleOutput().path;
+  const auto shorten_lanes = utils::cutOverlappedLanes(tmp_path, data.drivable_lanes);
   data.left_bound = toLineString3d(utils::calcBound(
     planner_data_->route_handler, shorten_lanes, parameters_->use_hatched_road_markings,
     parameters_->use_intersection_areas, true));

--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -220,7 +220,7 @@ void AvoidanceModule::fillFundamentalData(AvoidancePlanningData & data, DebugDat
 
   // lanelet info
   data.current_lanelets = utils::avoidance::getCurrentLanesFromPath(
-    *getPreviousModuleOutput().reference_path, planner_data_);
+    getPreviousModuleOutput().reference_path, planner_data_);
 
   data.extend_lanelets =
     utils::avoidance::getExtendLanes(data.current_lanelets, getEgoPose(), planner_data_);
@@ -233,7 +233,7 @@ void AvoidanceModule::fillFundamentalData(AvoidancePlanningData & data, DebugDat
     });
 
   // calc drivable bound
-  auto tmp_path = *getPreviousModuleOutput().path;
+  auto tmp_path = getPreviousModuleOutput().path;
   const auto shorten_lanes = utils::cutOverlappedLanes(tmp_path, data.drivable_lanes);
   data.left_bound = toLineString3d(utils::calcBound(
     planner_data_->route_handler, shorten_lanes, parameters_->use_hatched_road_markings,
@@ -244,9 +244,9 @@ void AvoidanceModule::fillFundamentalData(AvoidancePlanningData & data, DebugDat
 
   // reference path
   if (isDrivingSameLane(helper_->getPreviousDrivingLanes(), data.current_lanelets)) {
-    data.reference_path_rough = extendBackwardLength(*getPreviousModuleOutput().path);
+    data.reference_path_rough = extendBackwardLength(getPreviousModuleOutput().path);
   } else {
-    data.reference_path_rough = *getPreviousModuleOutput().path;
+    data.reference_path_rough = getPreviousModuleOutput().path;
     RCLCPP_WARN(getLogger(), "Previous module lane is updated. Don't use latest reference path.");
   }
 
@@ -910,17 +910,17 @@ BehaviorModuleOutput AvoidanceModule::plan()
   }
 
   if (isDrivingSameLane(helper_->getPreviousDrivingLanes(), data.current_lanelets)) {
-    output.path = std::make_shared<PathWithLaneId>(spline_shift_path.path);
+    output.path = spline_shift_path.path;
   } else {
     output.path = getPreviousModuleOutput().path;
     RCLCPP_WARN(getLogger(), "Previous module lane is updated. Do nothing.");
   }
 
   output.reference_path = getPreviousModuleOutput().reference_path;
-  path_reference_ = getPreviousModuleOutput().reference_path;
+  path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
-  const size_t ego_idx = planner_data_->findEgoIndex(output.path->points);
-  utils::clipPathLength(*output.path, ego_idx, planner_data_->parameters);
+  const size_t ego_idx = planner_data_->findEgoIndex(output.path.points);
+  utils::clipPathLength(output.path, ego_idx, planner_data_->parameters);
 
   // Drivable area generation.
   {
@@ -995,7 +995,7 @@ BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
   }
 
   path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
-  path_reference_ = getPreviousModuleOutput().reference_path;
+  path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
   return out;
 }
@@ -1169,11 +1169,11 @@ void AvoidanceModule::updateData()
   helper_->setData(planner_data_);
 
   if (!helper_->isInitialized()) {
-    helper_->setPreviousSplineShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
-    helper_->setPreviousLinearShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
-    helper_->setPreviousReferencePath(*getPreviousModuleOutput().path);
+    helper_->setPreviousSplineShiftPath(toShiftedPath(getPreviousModuleOutput().path));
+    helper_->setPreviousLinearShiftPath(toShiftedPath(getPreviousModuleOutput().path));
+    helper_->setPreviousReferencePath(getPreviousModuleOutput().path);
     helper_->setPreviousDrivingLanes(utils::avoidance::getCurrentLanesFromPath(
-      *getPreviousModuleOutput().reference_path, planner_data_));
+      getPreviousModuleOutput().reference_path, planner_data_));
   }
 
   debug_data_ = DebugData();

--- a/planning/behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
+++ b/planning/behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
@@ -33,9 +33,8 @@ BehaviorModuleOutput DefaultFixedGoalPlanner::plan(
   BehaviorModuleOutput output =
     // use planner previous module reference path
     getPreviousModuleOutput();
-  const PathWithLaneId smoothed_path =
-    modifyPathForSmoothGoalConnection(*(output.path), planner_data);
-  output.path = std::make_shared<PathWithLaneId>(smoothed_path);
+  const PathWithLaneId smoothed_path = modifyPathForSmoothGoalConnection(output.path, planner_data);
+  output.path = smoothed_path;
   output.reference_path = getPreviousModuleOutput().reference_path;
   return output;
 }

--- a/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -282,7 +282,7 @@ void GoalPlannerModule::updateData()
 
   resetPathCandidate();
   resetPathReference();
-  path_reference_ = getPreviousModuleOutput().reference_path;
+  path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
   updateOccupancyGrid();
 
@@ -761,7 +761,7 @@ void GoalPlannerModule::setOutput(BehaviorModuleOutput & output) const
     // because it takes time for the trajectory to be reflected
     auto current_path = thread_safe_data_.get_pull_over_path()->getCurrentPath();
     keepStoppedWithCurrentPath(current_path);
-    output.path = std::make_shared<PathWithLaneId>(current_path);
+    output.path = current_path;
   }
 
   setModifiedGoal(output);
@@ -777,14 +777,14 @@ void GoalPlannerModule::setStopPath(BehaviorModuleOutput & output) const
 {
   if (prev_data_.found_path || !prev_data_.stop_path) {
     // safe -> not_safe or no prev_stop_path: generate new stop_path
-    output.path = std::make_shared<PathWithLaneId>(generateStopPath());
+    output.path = generateStopPath();
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 5000, "Not found safe pull_over path, generate stop path");
   } else {
     // not_safe -> not_safe: use previous stop path
-    output.path = prev_data_.stop_path;
+    output.path = *prev_data_.stop_path;
     // stop_pose_ is removed in manager every loop, so need to set every loop.
-    stop_pose_ = utils::getFirstStopPoseFromPath(*output.path);
+    stop_pose_ = utils::getFirstStopPoseFromPath(output.path);
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 5000, "Not found safe pull_over path, use previous stop path");
   }
@@ -800,20 +800,19 @@ void GoalPlannerModule::setStopPathFromCurrentPath(BehaviorModuleOutput & output
         current_path, planner_data_, *stop_pose_, parameters_->maximum_deceleration_for_stop,
         parameters_->maximum_jerk_for_stop);
     if (stop_path) {
-      output.path = std::make_shared<PathWithLaneId>(*stop_path);
+      output.path = *stop_path;
       RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "Collision detected, generate stop path");
     } else {
-      output.path =
-        std::make_shared<PathWithLaneId>(thread_safe_data_.get_pull_over_path()->getCurrentPath());
+      output.path = thread_safe_data_.get_pull_over_path()->getCurrentPath();
       RCLCPP_WARN_THROTTLE(
         getLogger(), *clock_, 5000,
         "Collision detected, no feasible stop path found, cannot stop.");
     }
   } else {
     // not_safe safe(no feasible stop path found) -> not_safe: use previous stop path
-    output.path = prev_data_.stop_path_after_approval;
+    output.path = *prev_data_.stop_path_after_approval;
     // stop_pose_ is removed in manager every loop, so need to set every loop.
-    stop_pose_ = utils::getFirstStopPoseFromPath(*output.path);
+    stop_pose_ = utils::getFirstStopPoseFromPath(output.path);
     RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "Collision detected, use previous stop path");
   }
 }
@@ -826,7 +825,7 @@ void GoalPlannerModule::setDrivableAreaInfo(BehaviorModuleOutput & output) const
       planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
   } else {
     const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
-      *output.path, generateDrivableLanes(), planner_data_->drivable_area_expansion_parameters);
+      output.path, generateDrivableLanes(), planner_data_->drivable_area_expansion_parameters);
 
     DrivableAreaInfo current_drivable_area_info;
     current_drivable_area_info.drivable_lanes = target_drivable_lanes;
@@ -853,9 +852,9 @@ void GoalPlannerModule::setTurnSignalInfo(BehaviorModuleOutput & output) const
 {
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
   const auto new_signal = calcTurnSignalInfo();
-  const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path->points);
+  const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
   output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
-    *output.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
+    output.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
     planner_data_->parameters.ego_nearest_dist_threshold,
     planner_data_->parameters.ego_nearest_yaw_threshold);
 }
@@ -942,11 +941,11 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsCandidate()
   BehaviorModuleOutput output{};
   const BehaviorModuleOutput pull_over_output = planPullOverAsOutput();
   output.modified_goal = pull_over_output.modified_goal;
-  output.path = std::make_shared<PathWithLaneId>(generateStopPath());
+  output.path = generateStopPath();
   output.reference_path = getPreviousModuleOutput().reference_path;
 
   const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
-    *output.path, generateDrivableLanes(), planner_data_->drivable_area_expansion_parameters);
+    output.path, generateDrivableLanes(), planner_data_->drivable_area_expansion_parameters);
 
   DrivableAreaInfo current_drivable_area_info{};
   current_drivable_area_info.drivable_lanes = target_drivable_lanes;
@@ -1054,7 +1053,7 @@ void GoalPlannerModule::postProcess()
 void GoalPlannerModule::updatePreviousData(const BehaviorModuleOutput & output)
 {
   if (prev_data_.found_path || !prev_data_.stop_path) {
-    prev_data_.stop_path = output.path;
+    prev_data_.stop_path = std::make_shared<PathWithLaneId>(output.path);
   }
 
   // for the next loop setOutput().
@@ -1086,7 +1085,7 @@ void GoalPlannerModule::updatePreviousData(const BehaviorModuleOutput & output)
   if (!isActivated() || (!is_safe && prev_data_.stop_path_after_approval)) {
     return;
   }
-  auto stop_path = std::make_shared<PathWithLaneId>(*output.path);
+  auto stop_path = std::make_shared<PathWithLaneId>(output.path);
   for (auto & point : stop_path->points) {
     point.point.longitudinal_velocity_mps = 0.0;
   }

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/base_class.hpp
@@ -107,14 +107,13 @@ public:
   virtual bool specialExpiredCheck() const { return false; }
 
   virtual void setPreviousModulePaths(
-    const std::shared_ptr<PathWithLaneId> & prev_module_reference_path,
-    const std::shared_ptr<PathWithLaneId> & prev_module_path)
+    const PathWithLaneId & prev_module_reference_path, const PathWithLaneId & prev_module_path)
   {
-    if (prev_module_reference_path) {
-      prev_module_reference_path_ = *prev_module_reference_path;
+    if (!prev_module_reference_path.points.empty()) {
+      prev_module_reference_path_ = prev_module_reference_path;
     }
-    if (prev_module_path) {
-      prev_module_path_ = *prev_module_path;
+    if (!prev_module_path.points.empty()) {
+      prev_module_path_ = prev_module_path;
     }
   };
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -738,7 +738,8 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(
 {
   // TODO(Horibe) do some error handling when path is not available.
 
-  auto path = output.path ? output.path : planner_data->prev_output_path;
+  auto path = !output.path.points.empty() ? std::make_shared<PathWithLaneId>(output.path)
+                                          : planner_data->prev_output_path;
   path->header = planner_data->route_handler->getRouteHeader();
   path->header.stamp = this->now();
 

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -198,7 +198,7 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
 void PlannerManager::generateCombinedDrivableArea(
   BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & data) const
 {
-  if (!output.path || output.path->points.empty()) {
+  if (output.path.points.empty()) {
     RCLCPP_ERROR_STREAM(logger_, "[generateCombinedDrivableArea] Output path is empty!");
     return;
   }
@@ -206,20 +206,20 @@ void PlannerManager::generateCombinedDrivableArea(
   const auto & di = output.drivable_area_info;
   constexpr double epsilon = 1e-3;
 
-  const auto is_driving_forward_opt = motion_utils::isDrivingForward(output.path->points);
+  const auto is_driving_forward_opt = motion_utils::isDrivingForward(output.path.points);
   const bool is_driving_forward = is_driving_forward_opt ? *is_driving_forward_opt : true;
 
   if (epsilon < std::abs(di.drivable_margin)) {
     // for single free space pull over
     utils::generateDrivableArea(
-      *output.path, data->parameters.vehicle_length, di.drivable_margin, is_driving_forward);
+      output.path, data->parameters.vehicle_length, di.drivable_margin, is_driving_forward);
   } else if (di.is_already_expanded) {
     // for single side shift
     utils::generateDrivableArea(
-      *output.path, di.drivable_lanes, false, false, data->parameters.vehicle_length, data,
+      output.path, di.drivable_lanes, false, false, data->parameters.vehicle_length, data,
       is_driving_forward);
   } else {
-    const auto shorten_lanes = utils::cutOverlappedLanes(*output.path, di.drivable_lanes);
+    const auto shorten_lanes = utils::cutOverlappedLanes(output.path, di.drivable_lanes);
 
     const auto & dp = data->drivable_area_expansion_parameters;
     const auto expanded_lanes = utils::expandLanelets(
@@ -228,19 +228,19 @@ void PlannerManager::generateCombinedDrivableArea(
 
     // for other modules where multiple modules may be launched
     utils::generateDrivableArea(
-      *output.path, expanded_lanes, di.enable_expanding_hatched_road_markings,
+      output.path, expanded_lanes, di.enable_expanding_hatched_road_markings,
       di.enable_expanding_intersection_areas, data->parameters.vehicle_length, data,
       is_driving_forward);
   }
 
   // extract obstacles from drivable area
-  utils::extractObstaclesFromDrivableArea(*output.path, di.obstacles);
+  utils::extractObstaclesFromDrivableArea(output.path, di.obstacles);
 }
 
 std::vector<SceneModulePtr> PlannerManager::getRequestModules(
   const BehaviorModuleOutput & previous_module_output) const
 {
-  if (!previous_module_output.path) {
+  if (previous_module_output.path.points.empty()) {
     RCLCPP_ERROR_STREAM(
       logger_, "Current module output is null. Skip candidate module check."
                  << "\n      - Approved  module list: " << getNames(approved_module_ptrs_)

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/data_manager.hpp
@@ -119,10 +119,10 @@ struct BehaviorModuleOutput
   BehaviorModuleOutput() = default;
 
   // path planed by module
-  PlanResult path{};
+  PathWithLaneId path{};
 
   // reference path planed by module
-  PlanResult reference_path{};
+  PathWithLaneId reference_path{};
 
   TurnSignalInfo turn_signal_info{};
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -405,7 +405,7 @@ protected:
   virtual BehaviorModuleOutput planWaitingApproval()
   {
     path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
-    path_reference_ = getPreviousModuleOutput().reference_path;
+    path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
     return getPreviousModuleOutput();
   }

--- a/planning/behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_utils.cpp
@@ -642,8 +642,8 @@ BehaviorModuleOutput getReferencePath(
     dp.drivable_area_types_to_skip);
 
   BehaviorModuleOutput output;
-  output.path = std::make_shared<PathWithLaneId>(reference_path);
-  output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
+  output.path = reference_path;
+  output.reference_path = reference_path;
   output.drivable_area_info.drivable_lanes = drivable_lanes;
 
   return output;
@@ -692,8 +692,8 @@ BehaviorModuleOutput createGoalAroundPath(const std::shared_ptr<const PlannerDat
     point.point.longitudinal_velocity_mps = 0.0;
   }
 
-  output.path = std::make_shared<PathWithLaneId>(reference_path);
-  output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
+  output.path = reference_path;
+  output.reference_path = reference_path;
   output.drivable_area_info.drivable_lanes = drivable_lanes;
 
   return output;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -402,11 +402,11 @@ BehaviorModuleOutput StartPlannerModule::plan()
     path = status_.backward_path;
   }
 
-  output.path = std::make_shared<PathWithLaneId>(path);
+  output.path = path;
   output.reference_path = getPreviousModuleOutput().reference_path;
   output.turn_signal_info = calcTurnSignalInfo();
   path_candidate_ = std::make_shared<PathWithLaneId>(getFullPath());
-  path_reference_ = getPreviousModuleOutput().reference_path;
+  path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
   setDrivableAreaInfo(output);
 
@@ -512,11 +512,11 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
     p.point.longitudinal_velocity_mps = 0.0;
   }
 
-  output.path = std::make_shared<PathWithLaneId>(stop_path);
+  output.path = stop_path;
   output.reference_path = getPreviousModuleOutput().reference_path;
   output.turn_signal_info = calcTurnSignalInfo();
   path_candidate_ = std::make_shared<PathWithLaneId>(getFullPath());
-  path_reference_ = getPreviousModuleOutput().reference_path;
+  path_reference_ = std::make_unique<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
   setDrivableAreaInfo(output);
 
@@ -1182,7 +1182,7 @@ BehaviorModuleOutput StartPlannerModule::generateStopOutput()
 {
   BehaviorModuleOutput output;
   const PathWithLaneId stop_path = generateStopPath();
-  output.path = std::make_shared<PathWithLaneId>(stop_path);
+  output.path = stop_path;
 
   setDrivableAreaInfo(output);
 
@@ -1201,7 +1201,7 @@ BehaviorModuleOutput StartPlannerModule::generateStopOutput()
   }
 
   path_candidate_ = std::make_shared<PathWithLaneId>(stop_path);
-  path_reference_ = getPreviousModuleOutput().reference_path;
+  path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
   return output;
 }
@@ -1258,7 +1258,7 @@ void StartPlannerModule::setDrivableAreaInfo(BehaviorModuleOutput & output) cons
       planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
   } else {
     const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
-      *output.path, generateDrivableLanes(*output.path),
+      output.path, generateDrivableLanes(output.path),
       planner_data_->drivable_area_expansion_parameters);
 
     DrivableAreaInfo current_drivable_area_info;


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7df9214</samp>

Fix path shortening bug in `behavior_path_avoidance_module` by creating a temporary copy of the path before cutting overlapping lanes. This prevents modifying the original path from the previous module output.

---

Previously, avoidance module changed input path unintentionally even when the module was **NOT** running.

```c++
 const auto shorten_lanes =
    utils::cutOverlappedLanes(*getPreviousModuleOutput().path, data.drivable_lanes);
```

In this PR, I use copied variable.

```c++
  auto tmp_path = *getPreviousModuleOutput().path;
  const auto shorten_lanes = utils::cutOverlappedLanes(tmp_path, data.drivable_lanes);
```

Additionally, I use `PathWithLaneId` instead of `PathWithLaneId::SharedPtr` in `BehaviorModuleOutput` struct in order to prevent this kind of bugs.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/50de8382-488e-497e-8ea7-8a18823f7cbc

<!-- Write a brief description of this PR. -->

## Tests performed

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/91143de7-fbb5-5005-ad90-00c4ccb266e7?project_id=prd_jt)

```
webauto ci scenario run --project-id prd_jt --scenario-id 380415ee-f507-4676-8a15-e1eff8f7d4c7 --scenario-version-id 1
```
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

https://github.com/autowarefoundation/autoware.universe/assets/44889564/cb75248c-9ae6-4a92-87ff-f97a6963df84


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Bug fix.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
