### PR TITLE
feat(pid_longitudinal_controller): change the condition from emergency to stopped

### DIFF
--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -646,10 +646,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
   // in EMERGENCY state
   if (m_control_state == ControlState::EMERGENCY) {
+    if (stopped_condition) {
+      return changeState(ControlState::STOPPED);
+    }
+
     if (!emergency_condition) {
-      if (stopped_condition) {
-        return changeState(ControlState::STOPPED);
-      }
       if (!is_under_control) {
         // NOTE: On manual driving, no need stopping to exit the emergency.
         return changeState(ControlState::DRIVE);


### PR DESCRIPTION
## Description
When the ego exceeds the goal position, the longitudinal controller does the emergency stop.
Even after the ego stops, the control state in the longitudinal controller is still emergency and showing the following unnecessary message.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/03e12be9-43ec-4d79-a204-17b2fda5dd7e)

This PR changes the condition from the emergency to the stopped.
In the emergency state, when the ego successfully stopped, the state will be changed to the stopped.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
