### PR TITLE
perf(planning_debug_tools): improve calculation time of perception_reproducer

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -84,9 +84,14 @@ class PerceptionReproducer(PerceptionReplayerCommon):
 
         # copy the messages
         self.stopwatch.tic("message deepcopy")
-        msgs = pickle.loads(pickle.dumps(msgs_orig))  # this is x5 faster than deepcopy
-        objects_msg = msgs[0]
-        traffic_signals_msg = msgs[1]
+        if self.args.detected_object:
+            msgs = pickle.loads(pickle.dumps(msgs_orig))  # this is x5 faster than deepcopy
+            objects_msg = msgs[0]
+            traffic_signals_msg = msgs[1]
+        else:
+            # NOTE: No need to deepcopy since only timestamp will be changed and it will be changed every time correctly.
+            objects_msg = msgs_orig[0]
+            traffic_signals_msg = msgs_orig[1]
         self.stopwatch.toc("message deepcopy")
 
         self.stopwatch.tic("transform and publish")


### PR DESCRIPTION
## Description

Since the type of `PredictedObjects` is too large and copying the predicted objects is too heavy, the hertz of the perception_reproducer is sometimes less than 10, resulting in the published objects disappearing on Rviz.

This PR improved the calculation time of perception_reproducer when using `predicted object` mode.
Total time is
- Before this PR: 50 - 80ms (sometimes 100 - 200ms and the objects disappear)
- After this PR: 15 - 25ms

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
