### PR TITLE
fix(obstacle_avoidance_planner): suppress the osqp error about upper/lower bounds

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1423,8 +1423,11 @@ MPTOptimizer::ConstraintMatrix MPTOptimizer::calcConstraintMatrix(
   for (const size_t i : fixed_points_indices) {
     A.block(A_rows_end, D_x * i, D_x, D_x) = Eigen::MatrixXd::Identity(D_x, D_x);
 
-    lb.segment(A_rows_end, D_x) = ref_points.at(i).fixed_kinematic_state->toEigenVector();
-    ub.segment(A_rows_end, D_x) = ref_points.at(i).fixed_kinematic_state->toEigenVector();
+    const Eigen::VectorXd epsilon_vec = Eigen::VectorXd::Constant(D_x, 1e-9);
+    lb.segment(A_rows_end, D_x) =
+      ref_points.at(i).fixed_kinematic_state->toEigenVector() - epsilon_vec;
+    ub.segment(A_rows_end, D_x) =
+      ref_points.at(i).fixed_kinematic_state->toEigenVector() + epsilon_vec;
 
     A_rows_end += D_x;
   }

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1423,6 +1423,8 @@ MPTOptimizer::ConstraintMatrix MPTOptimizer::calcConstraintMatrix(
   for (const size_t i : fixed_points_indices) {
     A.block(A_rows_end, D_x * i, D_x, D_x) = Eigen::MatrixXd::Identity(D_x, D_x);
 
+    // NOTE: Without this, "ERROR in osqp_update_lower_bound: upper bound must be greater than
+    //       or equal to lower bound" is shown somehow especially when reaching the goal.
     const Eigen::VectorXd epsilon_vec = Eigen::VectorXd::Constant(D_x, 1e-9);
     lb.segment(A_rows_end, D_x) =
       ref_points.at(i).fixed_kinematic_state->toEigenVector() - epsilon_vec;


### PR DESCRIPTION
## Description

The current Autoware sometimes shows `ERROR in osqp_update_lower_bound: upper bound must be greater than or equal to lower bound` a lot from the obstacle_avoidance_planner, mainly around reaching the goal.
I checked those values by printing them, but nothing was wrong.

When I added this PR's change, which looks unnecessary though, the error disappeared.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
