### PR TITLE
chore(behavior_velocity_planner): use DEBUG for launching modules

### DIFF
--- a/planning/behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -174,7 +174,7 @@ void SceneModuleManagerInterface::deleteExpiredModules(
 void SceneModuleManagerInterface::registerModule(
   const std::shared_ptr<SceneModuleInterface> & scene_module)
 {
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     logger_, "register task: module = %s, id = %lu", getModuleName(), scene_module->getModuleId());
   registered_module_id_set_.emplace(scene_module->getModuleId());
   scene_modules_.insert(scene_module);
@@ -183,7 +183,7 @@ void SceneModuleManagerInterface::registerModule(
 void SceneModuleManagerInterface::unregisterModule(
   const std::shared_ptr<SceneModuleInterface> & scene_module)
 {
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     logger_, "unregister task: module = %s, id = %lu", getModuleName(),
     scene_module->getModuleId());
   registered_module_id_set_.erase(scene_module->getModuleId());


### PR DESCRIPTION
## Description

When launching behavior_velocity_planner's modules, the following message to register the new modules is shown, which is for developers but makes the terminal messy.
```
[component_container_mt-29] [INFO 1702873200.701397039] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = crosswalk, id = 1595 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.703595298] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = crosswalk, id = 1598 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.707912157] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = crosswalk, id = 1596 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.724486464] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = traffic_light, id = 1114 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.724625789] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = traffic_light, id = 1128 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.729213898] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = intersection, id = 1128 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.732657760] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = intersection, id = 1114 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.748576996] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = blind_spot, id = 1128 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.768965304] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = run_out, id = 0 (registerModule():177)
[component_container_mt-29] [INFO 1702873200.773928139] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner]: register task: module = out_of_lane, id = 0 (registerModule():177)
```

This PR makes it to use DEBUG instead of INFO
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
