### PR TITLE
refactor(lane_change): standardizing lane change logger name

### DIFF
--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -38,9 +38,13 @@ Planning:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance
 
-  behavior_path_planner_lane_change:
+  behavior_path_avoidance_by_lane_change:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
-      logger_name: lane_change
+      logger_name: lane_change.AVOIDANCE_BY_LANE_CHANGE
+
+  behavior_path_lane_change:
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+      logger_name: lane_change.NORMAL
 
   behavior_velocity_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/base_class.hpp
@@ -265,7 +265,7 @@ protected:
   mutable double object_debug_lifetime_{0.0};
   mutable StopWatch<std::chrono::milliseconds> stop_watch_;
 
-  rclcpp::Logger logger_ = rclcpp::get_logger("lane_change");
+  rclcpp::Logger logger_ = utils::lane_change::getLogger(getModuleTypeStr());
   mutable rclcpp::Clock clock_{RCL_ROS_TIME};
 };
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
@@ -20,6 +20,7 @@
 #include "behavior_path_planner_common/parameters.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 #include "behavior_path_planner_common/utils/utils.hpp"
+#include "rclcpp/logger.hpp"
 
 #include <route_handler/route_handler.hpp>
 
@@ -207,5 +208,17 @@ lanelet::ConstLanelets generateExpandedLanelets(
   const lanelet::ConstLanelets & lanes, const Direction direction, const double left_offset,
   const double right_offset);
 
+/**
+ * @brief Retrieves a logger instance for a specific lane change type.
+ *
+ * This function provides a specialized logger for different types of lane change.
+ *
+ * @param type A string representing the type of lane change operation. This could be
+ *             a specific maneuver or condition related to lane changing, such as
+ *             'avoidance_by_lane_change', 'normal', 'external_request'.
+ *
+ * @return rclcpp::Logger The logger instance configured for the specified lane change type.
+ */
+rclcpp::Logger getLogger(const std::string & type);
 }  // namespace behavior_path_planner::utils::lane_change
 #endif  // BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -44,6 +44,7 @@ LaneChangeInterface::LaneChangeInterface(
   prev_approved_path_{std::make_unique<PathWithLaneId>()}
 {
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, name);
+  logger_ = utils::lane_change::getLogger(module_type_->getModuleTypeStr());
 }
 
 void LaneChangeInterface::processOnEntry()
@@ -78,8 +79,7 @@ bool LaneChangeInterface::isExecutionReady() const
 ModuleStatus LaneChangeInterface::updateState()
 {
   auto log_warn_throttled = [&](const std::string & message) -> void {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      getLogger().get_child(module_type_->getModuleTypeStr()), *clock_, 5000, message);
+    RCLCPP_WARN_STREAM_THROTTLE(getLogger(), *clock_, 5000, message);
   };
 
   if (module_type_->specialExpiredCheck()) {
@@ -111,8 +111,7 @@ ModuleStatus LaneChangeInterface::updateState()
 
   if (module_type_->isEgoOnPreparePhase() && module_type_->isStoppedAtRedTrafficLight()) {
     RCLCPP_WARN_STREAM_THROTTLE(
-      getLogger().get_child(module_type_->getModuleTypeStr()), *clock_, 5000,
-      "Ego stopped at traffic light. Canceling lane change");
+      getLogger(), *clock_, 5000, "Ego stopped at traffic light. Canceling lane change");
     module_type_->toCancelState();
     return isWaitingApproval() ? ModuleStatus::RUNNING : ModuleStatus::SUCCESS;
   }

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -997,12 +997,7 @@ PathWithLaneId NormalLaneChange::getTargetSegment(
         std::min(dist_from_start, dist_from_end), s_start + std::numeric_limits<double>::epsilon());
     });
 
-  RCLCPP_DEBUG(
-    rclcpp::get_logger("behavior_path_planner")
-      .get_child("lane_change")
-      .get_child("util")
-      .get_child("getTargetSegment"),
-    "start: %f, end: %f", s_start, s_end);
+  RCLCPP_DEBUG(logger_, "in %s start: %f, end: %f", __func__, s_start, s_end);
 
   PathWithLaneId target_segment = route_handler.getCenterLinePath(target_lanes, s_start, s_end);
   for (auto & point : target_segment.points) {

--- a/planning/behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1159,4 +1159,9 @@ lanelet::ConstLanelets generateExpandedLanelets(
   const auto right_extend_offset = (direction == Direction::RIGHT) ? -right_offset : 0.0;
   return lanelet::utils::getExpandedLanelets(lanes, left_extend_offset, right_extend_offset);
 }
+
+rclcpp::Logger getLogger(const std::string & type)
+{
+  return rclcpp::get_logger("lane_change").get_child(type);
+}
 }  // namespace behavior_path_planner::utils::lane_change

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -362,8 +362,6 @@ private:
 
   std::string name_;
 
-  rclcpp::Logger logger_;
-
   BehaviorModuleOutput previous_module_output_;
 
   StopReason stop_reason_;
@@ -580,6 +578,8 @@ protected:
   {
     return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
   }
+
+  rclcpp::Logger logger_;
 
   rclcpp::Clock::SharedPtr clock_;
 


### PR DESCRIPTION
## Description

copilot:summary

standardizing lane change logger name for better debugging experience in lane change module.

![image](https://github.com/autowarefoundation/autoware.universe/assets/93502286/d6a9a560-c676-44a8-a449-5be362fc3ed2)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
