### PR TITLE
feat(dynamic_avoidance): always launch the module when requested

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
@@ -44,6 +44,8 @@ public:
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
+  bool isAlwaysExecutableModule() const override;
+
 private:
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
 };

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -255,6 +255,11 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
     if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
+
+bool DynamicAvoidanceModuleManager::isAlwaysExecutableModule() const
+{
+  return true;
+}
 }  // namespace behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>


### PR DESCRIPTION
## Description

Without the PR, the dynamic avoidance did not become the IDLE state when the avoidance module is WAITING_APPROVAL.
This PR makes the dynamic avoidance always IDLE when requested by using the isAlwaysExecutableModule function.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
