### PR TITLE
fix(dynamic_avoidance): fix drivable area generation during LC

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -143,12 +143,12 @@ public:
     std::optional<MinMaxValue> lat_offset_to_avoid{std::nullopt};
     bool is_collision_left{false};
     bool should_be_avoided{false};
+    std::vector<PathPointWithLaneId> ref_path_points_for_obj_poly;
 
     void update(
       const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
       const bool arg_is_collision_left, const bool arg_should_be_avoided,
       const std::vector<PathPointWithLaneId> & arg_ref_path_points_for_obj_poly)
-      std::vector<PathPointWithLaneId> ref_path_points_for_obj_poly;
     {
       lon_offset_to_avoid = arg_lon_offset_to_avoid;
       lat_offset_to_avoid = arg_lat_offset_to_avoid;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -146,12 +146,15 @@ public:
 
     void update(
       const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
-      const bool arg_is_collision_left, const bool arg_should_be_avoided)
+      const bool arg_is_collision_left, const bool arg_should_be_avoided,
+      const std::vector<PathPointWithLaneId> & arg_ref_path_points_for_obj_poly)
+      std::vector<PathPointWithLaneId> ref_path_points_for_obj_poly;
     {
       lon_offset_to_avoid = arg_lon_offset_to_avoid;
       lat_offset_to_avoid = arg_lat_offset_to_avoid;
       is_collision_left = arg_is_collision_left;
       should_be_avoided = arg_should_be_avoided;
+      ref_path_points_for_obj_poly = arg_ref_path_points_for_obj_poly;
     }
   };
 
@@ -245,11 +248,13 @@ public:
     void updateObject(
       const std::string & uuid, const MinMaxValue & lon_offset_to_avoid,
       const MinMaxValue & lat_offset_to_avoid, const bool is_collision_left,
-      const bool should_be_avoided)
+      const bool should_be_avoided,
+      const std::vector<PathPointWithLaneId> & ref_path_points_for_obj_poly)
     {
       if (object_map_.count(uuid) != 0) {
         object_map_.at(uuid).update(
-          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
+          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided,
+          ref_path_points_for_obj_poly);
       }
     }
 
@@ -307,12 +312,16 @@ private:
 
   bool isLabelTargetObstacle(const uint8_t label) const;
   void updateTargetObjects();
+  void updateRefPathBeforeLaneChange(const std::vector<PathPointWithLaneId> & ego_ref_path_points);
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
     const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
   DecisionWithReason willObjectCutOut(
     const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
     const std::optional<DynamicAvoidanceObject> & prev_object) const;
+  bool willObjectBeOutsideEgoChangingPath(
+    const geometry_msgs::msg::Pose & obj_pose,
+    const autoware_auto_perception_msgs::msg::Shape & obj_shape, const double obj_vel) const;
   bool isObjectFarFromPath(
     const PredictedObject & predicted_object, const double obj_dist_to_path) const;
   double calcTimeToCollision(
@@ -327,14 +336,14 @@ private:
     const PredictedPath & obj_path, const geometry_msgs::msg::Pose & obj_pose,
     const autoware_auto_perception_msgs::msg::Shape & obj_shape) const;
   MinMaxValue calcMinMaxLongitudinalOffsetToAvoid(
-    const std::vector<PathPointWithLaneId> & input_ref_path_points,
+    const std::vector<PathPointWithLaneId> & ref_path_points_for_obj_poly,
     const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
     const PredictedPath & obj_path, const autoware_auto_perception_msgs::msg::Shape & obj_shape,
     const double time_to_collision) const;
   std::optional<MinMaxValue> calcMinMaxLateralOffsetToAvoid(
-    const std::vector<PathPointWithLaneId> & input_ref_path_points, const Polygon2d & obj_points,
-    const double obj_vel, const bool is_collision_left, const double obj_normal_vel,
-    const std::optional<DynamicAvoidanceObject> & prev_object) const;
+    const std::vector<PathPointWithLaneId> & ref_path_points_for_obj_poly,
+    const Polygon2d & obj_points, const double obj_vel, const bool is_collision_left,
+    const double obj_normal_vel, const std::optional<DynamicAvoidanceObject> & prev_object) const;
 
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;
@@ -353,7 +362,8 @@ private:
 
   std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> target_objects_;
   // std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> prev_target_objects_;
-  std::vector<PathPointWithLaneId> prev_input_ref_path_points;
+  std::optional<std::vector<PathPointWithLaneId>> prev_input_ref_path_points_{std::nullopt};
+  std::optional<std::vector<PathPointWithLaneId>> ref_path_before_lane_change_{std::nullopt};
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
 
   TargetObjectsManager target_objects_manager_;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -519,7 +519,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
       object.predicted_paths.begin(), object.predicted_paths.end(),
       [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
 
-    const auto & ref_path_points_for_obj_poly = input_path->points;
+    const auto & ref_path_points_for_obj_poly = input_path.points;
 
     // 2.a. check if object is not to be followed by ego
     const double obj_angle = calcDiffAngleAgainstPath(input_path.points, object.pose);

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -137,7 +137,26 @@ double calcObstacleMaxLength(const autoware_auto_perception_msgs::msg::Shape & s
     return max_length_to_point;
   }
 
-  throw std::logic_error("The shape type is not supported in obstacle_cruise_planner.");
+  throw std::logic_error("The shape type is not supported in dynamic_avoidance.");
+}
+
+double calcObstacleWidth(const autoware_auto_perception_msgs::msg::Shape & shape)
+{
+  if (shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    return shape.dimensions.y;
+  } else if (shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+    return shape.dimensions.x;
+  } else if (shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+    double max_length_to_point = 0.0;
+    for (const auto rel_point : shape.footprint.points) {
+      const double length_to_point = std::hypot(rel_point.x, rel_point.y);
+      if (max_length_to_point < length_to_point) {
+        max_length_to_point = length_to_point;
+      }
+    }
+    return max_length_to_point;
+  }
+  throw std::logic_error("The shape type is not supported in dynamic_avoidance.");
 }
 
 double calcDiffAngleAgainstPath(
@@ -404,6 +423,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
   const auto input_ref_path_points = getPreviousModuleOutput().reference_path.points;
   const auto prev_objects = target_objects_manager_.getValidObjects();
 
+  updateRefPathBeforeLaneChange(input_ref_path_points);
+
   // 1. Rough filtering of target objects
   target_objects_manager_.initialize();
   for (const auto & predicted_object : predicted_objects) {
@@ -498,6 +519,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
       object.predicted_paths.begin(), object.predicted_paths.end(),
       [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
 
+    const auto & ref_path_points_for_obj_poly = input_path->points;
+
     // 2.a. check if object is not to be followed by ego
     const double obj_angle = calcDiffAngleAgainstPath(input_path.points, object.pose);
     const bool is_object_aligned_to_path =
@@ -534,6 +557,17 @@ void DynamicAvoidanceModule::updateTargetObjects()
       printIgnoreReason(obj_uuid.c_str(), will_object_cut_out.reason);
       continue;
     }
+
+    // 2.e. check if the ego will change the lane and the object will be outside the ego's path
+    // const auto will_object_be_outside_ego_changing_path =
+    //   willObjectBeOutsideEgoChangingPath(object.pose, object.shape, object.vel);
+    // if (will_object_be_outside_ego_changing_path) {
+    //   RCLCPP_INFO_EXPRESSION(
+    //     getLogger(), parameters_->enable_debug_info,
+    //     "[DynamicAvoidance] Ignore obstacle (%s) since the object will be outside ego's changing
+    //     path", obj_uuid.c_str());
+    //   continue;
+    // }
 
     // 2.e. check time to collision
     const double time_to_collision =
@@ -590,10 +624,10 @@ void DynamicAvoidanceModule::updateTargetObjects()
     // "ego_path_base"
     const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
     const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
-      input_ref_path_points, object.pose, obj_points, object.vel, obj_path, object.shape,
+      ref_path_points_for_obj_poly, object.pose, obj_points, object.vel, obj_path, object.shape,
       time_to_collision);
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoid(
-      input_ref_path_points, obj_points, object.vel, is_collision_left, object.lat_vel,
+      ref_path_points_for_obj_poly, obj_points, object.vel, is_collision_left, object.lat_vel,
       prev_object);
     if (!lat_offset_to_avoid) {
       RCLCPP_INFO_EXPRESSION(
@@ -606,10 +640,37 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObject(
-      obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided);
+      obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided,
+      ref_path_points_for_obj_poly);
   }
 
-  prev_input_ref_path_points = input_ref_path_points;
+  prev_input_ref_path_points_ = input_ref_path_points;
+}
+
+void DynamicAvoidanceModule::updateRefPathBeforeLaneChange(
+  const std::vector<PathPointWithLaneId> & ego_ref_path_points)
+{
+  if (ref_path_before_lane_change_) {
+    // check if the ego is close enough to the current ref path, meaning that lane change ends.
+    const auto ego_pos = getEgoPose().position;
+    const double dist_to_ref_path =
+      std::abs(motion_utils::calcLateralOffset(ego_ref_path_points, ego_pos));
+
+    constexpr double epsilon_dist_to_ref_path = 0.5;
+    if (dist_to_ref_path < epsilon_dist_to_ref_path) {
+      ref_path_before_lane_change_ = std::nullopt;
+    }
+  } else {
+    // check if the ego is during lane change.
+    if (prev_input_ref_path_points_ && !prev_input_ref_path_points_->empty()) {
+      const double dist_ref_paths = std::abs(motion_utils::calcLateralOffset(
+        ego_ref_path_points, prev_input_ref_path_points_->front().point.pose.position));
+      constexpr double epsilon_ref_paths_diff = 1.0;
+      if (epsilon_ref_paths_diff < dist_ref_paths) {
+        ref_path_before_lane_change_ = *prev_input_ref_path_points_;
+      }
+    }
+  }
 }
 
 [[maybe_unused]] std::optional<std::pair<size_t, size_t>>
@@ -765,6 +826,25 @@ DynamicAvoidanceModule::DecisionWithReason DynamicAvoidanceModule::willObjectCut
   return DecisionWithReason{false};
 }
 
+[[maybe_unused]] bool DynamicAvoidanceModule::willObjectBeOutsideEgoChangingPath(
+  const geometry_msgs::msg::Pose & obj_pose,
+  const autoware_auto_perception_msgs::msg::Shape & obj_shape, const double obj_vel) const
+{
+  if (!ref_path_before_lane_change_ || obj_vel < 0.0) {
+    return false;
+  }
+
+  // Check if object is in the lane before ego's lane change.
+  const double dist_to_ref_path_before_lane_change =
+    std::abs(motion_utils::calcLateralOffset(*ref_path_before_lane_change_, obj_pose.position));
+  const double epsilon_dist_checking_in_lane = calcObstacleWidth(obj_shape);
+  if (epsilon_dist_checking_in_lane < dist_to_ref_path_before_lane_change) {
+    return false;
+  }
+
+  return true;
+}
+
 std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> DynamicAvoidanceModule::getAdjacentLanes(
   const double forward_distance, const double backward_distance) const
 {
@@ -840,13 +920,13 @@ DynamicAvoidanceModule::LatLonOffset DynamicAvoidanceModule::getLateralLongitudi
 }
 
 MinMaxValue DynamicAvoidanceModule::calcMinMaxLongitudinalOffsetToAvoid(
-  const std::vector<PathPointWithLaneId> & input_ref_path_points,
+  const std::vector<PathPointWithLaneId> & ref_path_points_for_obj_poly,
   const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
   const PredictedPath & obj_path, const autoware_auto_perception_msgs::msg::Shape & obj_shape,
   const double time_to_collision) const
 {
   const size_t obj_seg_idx =
-    motion_utils::findNearestSegmentIndex(input_ref_path_points, obj_pose.position);
+    motion_utils::findNearestSegmentIndex(ref_path_points_for_obj_poly, obj_pose.position);
 
   // calculate min/max longitudinal offset from object to path
   const auto obj_lon_offset = [&]() {
@@ -854,7 +934,7 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLongitudinalOffsetToAvoid(
     for (size_t i = 0; i < obj_points.outer().size(); ++i) {
       const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
       const double lon_offset = motion_utils::calcLongitudinalOffsetToSegment(
-        input_ref_path_points, obj_seg_idx, geom_obj_point);
+        ref_path_points_for_obj_poly, obj_seg_idx, geom_obj_point);
       obj_lon_offset_vec.push_back(lon_offset);
     }
 
@@ -930,27 +1010,29 @@ double DynamicAvoidanceModule::calcValidStartLengthToAvoid(
 }
 
 std::optional<MinMaxValue> DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
-  const std::vector<PathPointWithLaneId> & input_ref_path_points, const Polygon2d & obj_points,
-  const double obj_vel, const bool is_collision_left, const double obj_normal_vel,
-  const std::optional<DynamicAvoidanceObject> & prev_object) const
+  const std::vector<PathPointWithLaneId> & ref_path_points_for_obj_poly,
+  const Polygon2d & obj_points, const double obj_vel, const bool is_collision_left,
+  const double obj_normal_vel, const std::optional<DynamicAvoidanceObject> & prev_object) const
 {
+  const bool enable_lowpass_filter = true;
+  /*
   const bool enable_lowpass_filter = [&]() {
-    if (prev_input_ref_path_points.size() < 2) {
+    if (!prev_ref_path_points_for_obj_poly_ || prev_ref_path_points_for_obj_poly_->size() < 2) {
       return true;
     }
     const size_t prev_front_seg_idx = motion_utils::findNearestSegmentIndex(
-      prev_input_ref_path_points, input_ref_path_points.front().point.pose.position);
-    constexpr double min_lane_change_path_lat_offset = 1.0;
-    if (
-      motion_utils::calcLateralOffset(
-        prev_input_ref_path_points, input_ref_path_points.front().point.pose.position,
-        prev_front_seg_idx) < min_lane_change_path_lat_offset) {
-      return true;
+      *prev_ref_path_points_for_obj_poly_,
+  ref_path_points_for_obj_poly.front().point.pose.position); constexpr double
+  min_lane_change_path_lat_offset = 1.0; if ( motion_utils::calcLateralOffset(
+        *prev_ref_path_points_for_obj_poly_,
+  ref_path_points_for_obj_poly.front().point.pose.position, prev_front_seg_idx) <
+  min_lane_change_path_lat_offset) { return true;
     }
     // NOTE: When the input reference path laterally changes, the low-pass filter is disabled not to
     // shift the obstacle polygon suddenly.
     return false;
   }();
+  */
 
   // calculate min/max lateral offset from object to path
   const auto obj_lat_abs_offset = [&]() {
@@ -958,9 +1040,9 @@ std::optional<MinMaxValue> DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoi
     for (size_t i = 0; i < obj_points.outer().size(); ++i) {
       const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
       const size_t obj_point_seg_idx =
-        motion_utils::findNearestSegmentIndex(input_ref_path_points, geom_obj_point);
-      const double obj_point_lat_offset =
-        motion_utils::calcLateralOffset(input_ref_path_points, geom_obj_point, obj_point_seg_idx);
+        motion_utils::findNearestSegmentIndex(ref_path_points_for_obj_poly, geom_obj_point);
+      const double obj_point_lat_offset = motion_utils::calcLateralOffset(
+        ref_path_points_for_obj_poly, geom_obj_point, obj_point_seg_idx);
       obj_lat_abs_offset_vec.push_back(obj_point_lat_offset);
     }
     return getMinMaxValues(obj_lat_abs_offset_vec);
@@ -1027,19 +1109,19 @@ DynamicAvoidanceModule::calcEgoPathBasedDynamicObstaclePolygon(
     return std::nullopt;
   }
 
-  auto input_ref_path_points = getPreviousModuleOutput().reference_path.points;
+  auto ref_path_points_for_obj_poly = object.ref_path_points_for_obj_poly;
 
   const size_t obj_seg_idx =
-    motion_utils::findNearestSegmentIndex(input_ref_path_points, object.pose.position);
+    motion_utils::findNearestSegmentIndex(ref_path_points_for_obj_poly, object.pose.position);
   const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
 
   const auto lon_bound_start_idx_opt = motion_utils::insertTargetPoint(
-    obj_seg_idx, object.lon_offset_to_avoid->min_value, input_ref_path_points);
+    obj_seg_idx, object.lon_offset_to_avoid->min_value, ref_path_points_for_obj_poly);
   const size_t updated_obj_seg_idx =
     (lon_bound_start_idx_opt && lon_bound_start_idx_opt.value() <= obj_seg_idx) ? obj_seg_idx + 1
                                                                                 : obj_seg_idx;
   const auto lon_bound_end_idx_opt = motion_utils::insertTargetPoint(
-    updated_obj_seg_idx, object.lon_offset_to_avoid->max_value, input_ref_path_points);
+    updated_obj_seg_idx, object.lon_offset_to_avoid->max_value, ref_path_points_for_obj_poly);
 
   if (!lon_bound_start_idx_opt && !lon_bound_end_idx_opt) {
     // NOTE: The obstacle is longitudinally out of the ego's trajectory.
@@ -1049,20 +1131,20 @@ DynamicAvoidanceModule::calcEgoPathBasedDynamicObstaclePolygon(
     lon_bound_start_idx_opt ? lon_bound_start_idx_opt.value() : static_cast<size_t>(0);
   const size_t lon_bound_end_idx = lon_bound_end_idx_opt
                                      ? lon_bound_end_idx_opt.value()
-                                     : static_cast<size_t>(input_ref_path_points.size() - 1);
+                                     : static_cast<size_t>(ref_path_points_for_obj_poly.size() - 1);
 
   // create inner/outer bound points
   std::vector<geometry_msgs::msg::Point> obj_inner_bound_points;
   std::vector<geometry_msgs::msg::Point> obj_outer_bound_points;
   for (size_t i = lon_bound_start_idx; i <= lon_bound_end_idx; ++i) {
-    obj_inner_bound_points.push_back(
-      tier4_autoware_utils::calcOffsetPose(
-        input_ref_path_points.at(i).point.pose, 0.0, object.lat_offset_to_avoid->min_value, 0.0)
-        .position);
-    obj_outer_bound_points.push_back(
-      tier4_autoware_utils::calcOffsetPose(
-        input_ref_path_points.at(i).point.pose, 0.0, object.lat_offset_to_avoid->max_value, 0.0)
-        .position);
+    obj_inner_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
+                                       ref_path_points_for_obj_poly.at(i).point.pose, 0.0,
+                                       object.lat_offset_to_avoid->min_value, 0.0)
+                                       .position);
+    obj_outer_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
+                                       ref_path_points_for_obj_poly.at(i).point.pose, 0.0,
+                                       object.lat_offset_to_avoid->max_value, 0.0)
+                                       .position);
   }
 
   // create obj_polygon from inner/outer bound points


### PR DESCRIPTION
## Description

When creating an object polygon to extract from the drivable area, the previous module's path instead of its reference path is used to avoid the following too large extraction.

![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/d66f9999-97c5-4f85-a991-2263cce20016)


NOTE: prev_input_ref_path_points_ and ref_path_before_lane_change_ are not used.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
