### PR TITLE
feat(autoware_auto_perception_rviz_plugin): enable to distinguish orientation availability in rviz

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -110,7 +110,7 @@ get_pose_with_covariance_marker_ptr(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_velocity_text_marker_ptr(
   const geometry_msgs::msg::Twist & twist, const geometry_msgs::msg::Point & vis_pos,
-  const std_msgs::msg::ColorRGBA & color_rgba);
+  const std_msgs::msg::ColorRGBA & color_rgba, const bool has_valid_orientation);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_acceleration_text_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -229,11 +229,12 @@ protected:
   template <typename ClassificationContainerT>
   std::optional<Marker::SharedPtr> get_velocity_text_marker_ptr(
     const geometry_msgs::msg::Twist & twist, const geometry_msgs::msg::Point & vis_pos,
-    const ClassificationContainerT & labels) const
+    const ClassificationContainerT & labels, const bool has_valid_orientation = true) const
   {
     if (m_display_velocity_text_property.getBool()) {
       const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
-      return detail::get_velocity_text_marker_ptr(twist, vis_pos, color_rgba);
+      return detail::get_velocity_text_marker_ptr(
+        twist, vis_pos, color_rgba, has_valid_orientation);
     } else {
       return std::nullopt;
     }

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -62,8 +62,13 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
     vel_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x - 0.5;
     vel_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y;
     vel_vis_position.z = object.kinematics.pose_with_covariance.pose.position.z - 0.5;
+
+    bool has_valid_orientation =
+      object.kinematics.orientation_availability !=
+      autoware_auto_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
     auto velocity_text_marker = get_velocity_text_marker_ptr(
-      object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification);
+      object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification,
+      has_valid_orientation);
     if (velocity_text_marker) {
       auto velocity_text_marker_ptr = velocity_text_marker.value();
       velocity_text_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -123,7 +123,7 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
 
 visualization_msgs::msg::Marker::SharedPtr get_velocity_text_marker_ptr(
   const geometry_msgs::msg::Twist & twist, const geometry_msgs::msg::Point & vis_pos,
-  const std_msgs::msg::ColorRGBA & color_rgba)
+  const std_msgs::msg::ColorRGBA & color_rgba, const bool has_valid_orientation)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
@@ -134,7 +134,11 @@ visualization_msgs::msg::Marker::SharedPtr get_velocity_text_marker_ptr(
   double vel = std::sqrt(
     twist.linear.x * twist.linear.x + twist.linear.y * twist.linear.y +
     twist.linear.z * twist.linear.z);
-  marker_ptr->text = std::to_string(static_cast<int>(vel * 3.6)) + std::string("[km/h]");
+  if (has_valid_orientation) {
+    marker_ptr->text = std::to_string(static_cast<int>(vel * 3.6)) + std::string("[km/h]");
+  } else {
+    marker_ptr->text = std::to_string(static_cast<int>(vel * 3.6)) + std::string("*[km/h]*");
+  }
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose.position = vis_pos;
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -87,8 +87,12 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     vel_vis_position.x = uuid_vis_position.x - 0.5;
     vel_vis_position.y = uuid_vis_position.y;
     vel_vis_position.z = uuid_vis_position.z - 0.5;
+    const bool has_valid_orientation =
+      object.kinematics.orientation_availability !=
+      autoware_auto_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
     auto velocity_text_marker = get_velocity_text_marker_ptr(
-      object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification);
+      object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification,
+      has_valid_orientation);
     if (velocity_text_marker) {
       auto velocity_text_marker_ptr = velocity_text_marker.value();
       velocity_text_marker_ptr->header = msg->header;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

copilot:summary

Objects which `orientation_availability` are `Unknown` are going to be displayed with `*` mark in velocity markers. 
![Screenshot from 2023-12-18 20-37-04](https://github.com/autowarefoundation/autoware.universe/assets/20086766/6f936652-8418-4efd-8ea5-4b2f9f7813e7)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
