### PR TITLE
feat(intersection): disable stuck detection against private lane

### DIFF
--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -23,8 +23,7 @@
         stuck_vehicle_velocity_threshold: 0.833
         # enable_front_car_decel_prediction: false
         # assumed_front_car_decel: 1.0
-        timeout_private_area: 3.0
-        enable_private_area_stuck_disregard: false
+        disable_against_private_lane: true
 
       yield_stuck:
         turn_direction:

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -74,10 +74,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".stuck_vehicle.stuck_vehicle_detect_dist");
   ip.stuck_vehicle.stuck_vehicle_velocity_threshold =
     getOrDeclareParameter<double>(node, ns + ".stuck_vehicle.stuck_vehicle_velocity_threshold");
-  ip.stuck_vehicle.timeout_private_area =
-    getOrDeclareParameter<double>(node, ns + ".stuck_vehicle.timeout_private_area");
-  ip.stuck_vehicle.enable_private_area_stuck_disregard =
-    getOrDeclareParameter<bool>(node, ns + ".stuck_vehicle.enable_private_area_stuck_disregard");
+  ip.stuck_vehicle.disable_against_private_lane =
+    getOrDeclareParameter<bool>(node, ns + ".stuck_vehicle.disable_against_private_lane");
 
   ip.yield_stuck.turn_direction.left =
     getOrDeclareParameter<bool>(node, ns + ".yield_stuck.turn_direction.left");
@@ -201,7 +199,6 @@ void IntersectionModuleManager::launchNewModules(
     }
 
     const std::string location = ll.attributeOr("location", "else");
-    const bool is_private_area = (location.compare("private") == 0);
     const auto associative_ids =
       planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
     bool has_traffic_light = false;
@@ -213,7 +210,7 @@ void IntersectionModuleManager::launchNewModules(
     }
     const auto new_module = std::make_shared<IntersectionModule>(
       module_id, lane_id, planner_data_, intersection_param_, associative_ids, turn_direction,
-      has_traffic_light, enable_occlusion_detection, is_private_area, node_,
+      has_traffic_light, enable_occlusion_detection, node_,
       logger_.get_child("intersection_module"), clock_);
     generateUUID(module_id);
     /* set RTC status as non_occluded status initially */

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -74,8 +74,7 @@ public:
       bool use_stuck_stopline;
       double stuck_vehicle_detect_dist;
       double stuck_vehicle_velocity_threshold;
-      double timeout_private_area;
-      bool enable_private_area_stuck_disregard;
+      bool disable_against_private_lane;
     } stuck_vehicle;
 
     struct YieldStuck
@@ -263,8 +262,8 @@ public:
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
     const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
     const std::string & turn_direction, const bool has_traffic_light,
-    const bool enable_occlusion_detection, const bool is_private_area, rclcpp::Node & node,
-    const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
+    const bool enable_occlusion_detection, rclcpp::Node & node, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -313,9 +312,6 @@ private:
   // for pseudo-collision detection when ego just entered intersection on green light and upcoming
   // vehicles are very slow
   std::optional<rclcpp::Time> initial_green_light_observed_time_{std::nullopt};
-
-  // for stuck vehicle detection
-  const bool is_private_area_;
 
   // for RTC
   const UUID occlusion_uuid_;


### PR DESCRIPTION
## Description

disable stuck vehicle detection against private lane

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/744

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### before

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/21eecfc6-0aac-4c81-a709-7b33c629b07a)

### after

![Screenshot from 2023-12-19 14-03-39](https://github.com/autowarefoundation/autoware.universe/assets/28677420/9086e698-f196-46ac-b1c2-8f6e715b463c)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.\

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
