### PR TITLE
fix(run_out): do not insert stop point when stopped in Object method

### DIFF
--- a/planning/behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.cpp
@@ -584,14 +584,23 @@ std::optional<geometry_msgs::msg::Pose> RunOutModule::calcStopPoint(
   // vehicle have to decelerate if there is not enough distance with deceleration_jerk
   const bool deceleration_needed =
     *stop_dist > dist_to_collision - planner_param_.run_out.stop_margin;
-  // avoid acceleration when ego is decelerating
-  // TODO(Tomohito Ando): replace with more appropriate method
-  constexpr float epsilon = 1.0e-2;
-  constexpr float stopping_vel_mps = 2.5 / 3.6;
-  const bool is_stopping = current_vel < stopping_vel_mps && current_acc < epsilon;
-  if (!deceleration_needed && !is_stopping) {
+  const auto & detection_method = planner_param_.run_out.detection_method;
+
+  if (!deceleration_needed && detection_method == "Object") {
     debug_ptr_->setAccelReason(RunOutDebug::AccelReason::LOW_JERK);
     return {};
+  }
+
+  // If the detection method assumes running out, avoid acceleration when the ego is decelerating.
+  // TODO(Tomohito Ando): replace with more appropriate way
+  if (!deceleration_needed && detection_method != "Object") {
+    constexpr float epsilon = 1.0e-2;
+    constexpr float stopping_vel_mps = 2.5 / 3.6;
+    const bool is_stopping = current_vel < stopping_vel_mps && current_acc < epsilon;
+    if (!is_stopping) {
+      debug_ptr_->setAccelReason(RunOutDebug::AccelReason::LOW_JERK);
+      return {};
+    }
   }
 
   // calculate the stop point for base link


### PR DESCRIPTION
## Description

In the current implementation, the run-out module inserts a stop point when the ego vehicle is stationary. This is to prevent the stop decision from oscillating. This approach is particularly necessary for methods that assume pedestrians running out (`Point`s or `ObjectWithoutPath`), as these methods continuously detect objects. However, I believe this feature has a minimal impact when the method is set to `Object`. Therefore, I have disabled this feature for the `Object` method.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Simple planning simulator

### Before
Stop point is inserted when the ego has stopped.

https://github.com/autowarefoundation/autoware.universe/assets/11865769/4ff1b27d-c487-47e8-9af9-25e0a3469da3

### After

https://github.com/autowarefoundation/autoware.universe/assets/11865769/c6bc296b-38a1-4771-84b2-5fc463410bf4



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
