### PR TITLE
refactor(traffic_light_module): boost::optional to std::optional

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_traffic_light_module/package.xml
@@ -24,7 +24,6 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libboost-dev</depend>
   <depend>motion_utils</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/planning/behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/debug.cpp
@@ -26,8 +26,6 @@
 
 namespace behavior_velocity_planner
 {
-using tier4_autoware_utils::appendMarkerArray;
-
 visualization_msgs::msg::MarkerArray TrafficLightModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;

--- a/planning/behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.cpp
@@ -23,7 +23,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <unordered_map>
 #include <utility>
 namespace behavior_velocity_planner
 {

--- a/planning/behavior_velocity_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.hpp
@@ -26,6 +26,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 
 namespace behavior_velocity_planner
 {
@@ -57,7 +58,7 @@ private:
   // Debug
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficSignal>::SharedPtr pub_tl_state_;
 
-  boost::optional<int> first_ref_stop_path_point_index_;
+  std::optional<int> first_ref_stop_path_point_index_;
 };
 
 class TrafficLightModulePlugin : public PluginWrapper<TrafficLightModuleManager>

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -19,7 +19,6 @@
 
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
-#include <boost/optional.hpp>  // To be replaced by std::optional in C++17
 
 #include <tf2/utils.h>
 
@@ -31,9 +30,7 @@
 
 #include <algorithm>
 #include <limits>
-#include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace behavior_velocity_planner
@@ -52,14 +49,14 @@ bool getBackwardPointFromBasePoint(
   return true;
 }
 
-boost::optional<Point2d> findNearestCollisionPoint(
+std::optional<Point2d> findNearestCollisionPoint(
   const LineString2d & line1, const LineString2d & line2, const Point2d & origin)
 {
   std::vector<Point2d> collision_points;
   bg::intersection(line1, line2, collision_points);
 
   if (collision_points.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // check nearest collision point

--- a/planning/behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.hpp
@@ -17,7 +17,6 @@
 
 #include <memory>
 #include <optional>
-#include <string>
 #include <tuple>
 #include <vector>
 
@@ -81,7 +80,7 @@ public:
 
   inline State getTrafficLightModuleState() const { return state_; }
 
-  inline boost::optional<int> getFirstRefStopPathPointIndex() const
+  inline std::optional<int> getFirstRefStopPathPointIndex() const
   {
     return first_ref_stop_path_point_index_;
   }
@@ -130,9 +129,9 @@ private:
   // prevent stop chattering
   std::unique_ptr<Time> stop_signal_received_time_ptr_{};
 
-  boost::optional<int> first_ref_stop_path_point_index_;
+  std::optional<int> first_ref_stop_path_point_index_;
 
-  boost::optional<Time> traffic_signal_stamp_;
+  std::optional<Time> traffic_signal_stamp_;
 
   // Traffic Light State
   TrafficSignal looking_tl_state_;


### PR DESCRIPTION
## Description

Replace `boost::optional` to `std::optional` in traffic_light module.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
