### PR TITLE
refactor(freespace_planning_algorithm): boost optional to std

### DIFF
--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/rrtstar_core.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/rrtstar_core.hpp
@@ -17,16 +17,13 @@
 
 #include "freespace_planning_algorithms/reeds_shepp.hpp"
 
-#include <boost/optional.hpp>
-
 #include <tf2/utils.h>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
-#include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <random>
 #include <string>
 #include <vector>
@@ -96,9 +93,9 @@ using NodeWeakPtr = std::weak_ptr<Node>;
 struct Node
 {
   Pose pose;
-  boost::optional<double> cost_from_start = boost::none;
-  boost::optional<double> cost_to_goal = boost::none;
-  boost::optional<double> cost_to_parent = boost::none;
+  std::optional<double> cost_from_start = std::nullopt;
+  std::optional<double> cost_to_goal = std::nullopt;
+  std::optional<double> cost_to_parent = std::nullopt;
   NodeWeakPtr parent = NodeWeakPtr();
   std::vector<NodeSharedPtr> childs = std::vector<NodeSharedPtr>();
 

--- a/planning/freespace_planning_algorithms/src/rrtstar_core.cpp
+++ b/planning/freespace_planning_algorithms/src/rrtstar_core.cpp
@@ -135,7 +135,7 @@ RRTStar::RRTStar(
   is_informed_(is_informed),
   cspace_(cspace)
 {
-  node_goal_ = std::make_shared<Node>(Node{x_goal, boost::none, 0.0});
+  node_goal_ = std::make_shared<Node>(Node{x_goal, std::nullopt, 0.0});
   node_start_ = std::make_shared<Node>(Node{x_start, 0.0});
   nodes_.push_back(node_start_);
 }
@@ -375,7 +375,7 @@ NodeSharedPtr RRTStar::addNewNode(const Pose & pose, NodeSharedPtr node_parent)
   const double cost_to_parent = cspace_.distance(pose, node_parent->pose);
   const double cost_from_start = *(node_parent->cost_from_start) + cost_to_parent;
   auto node_new =
-    std::make_shared<Node>(Node{pose, cost_from_start, boost::none, cost_to_parent, node_parent});
+    std::make_shared<Node>(Node{pose, cost_from_start, std::nullopt, cost_to_parent, node_parent});
   nodes_.push_back(node_new);
   node_parent->childs.push_back(node_new);
   return node_new;
@@ -431,7 +431,7 @@ void RRTStar::reconnect(const NodeSharedPtr & node_new, const NodeSharedPtr & no
   const auto node_reconnect_parent = node_reconnect->getParent();
   node_reconnect_parent->deleteChild(node_reconnect);
   node_reconnect->parent = std::weak_ptr<Node>();
-  node_reconnect->cost_to_parent = boost::none;
+  node_reconnect->cost_to_parent = std::nullopt;
 
   // Current state:
   // node_new_parent -> node_new -> #nil


### PR DESCRIPTION
## Description

replace boost optional to std optional

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
