### PR TITLE
docs(pid_longitudinal_controller): add the explanation of STOPPED Parameter

### DIFF
--- a/control/pid_longitudinal_controller/README.md
+++ b/control/pid_longitudinal_controller/README.md
@@ -241,6 +241,10 @@ If the ego is still running, strong acceleration (`strong_stop_acc`) to stop rig
 
 ### STOPPED Parameter
 
+The `STOPPED` state assumes that the vehicle is completely stopped with the brakes fully applied.
+Therefore, `stopped_acc` should be set to a value that allows the vehicle to apply the strongest possible brake.
+If `stopped_acc` is not sufficiently low, there is a possibility of sliding down on steep slopes.
+
 | Name         | Type   | Description                                  | Default value |
 | :----------- | :----- | :------------------------------------------- | :------------ |
 | stopped_vel  | double | target velocity in STOPPED state [m/s]       | 0.0           |


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I have updated the documentation to provide a more comprehensive explanation of the parameter associated with the `STOPPED` state, aiming to enhance clarity and understanding for users.

Related: link:
[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QW0GU6P7/p1702956736838629?thread_ts=1702946228.311829&cid=C03QW0GU6P7)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

None.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
