### PR TITLE
fix(dynamic_avoidance): fix which side to avoid

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -456,7 +456,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
     }
 
     // 1.c. check if object is not crossing ego's path
-    const double obj_angle = calcDiffAngleBetweenPaths(input_path.points, obj_path);
+    const double obj_angle = calcDiffAngleAgainstPath(input_path.points, obj_pose);
     const double max_crossing_object_angle = 0.0 <= obj_tangent_vel
                                                ? parameters_->max_overtaking_crossing_object_angle
                                                : parameters_->max_oncoming_crossing_object_angle;
@@ -592,10 +592,15 @@ void DynamicAvoidanceModule::updateTargetObjects()
     }
 
     // 2.f. calculate which side object will be against ego's path
-    const auto future_obj_pose =
-      object_recognition_utils::calcInterpolatedPose(obj_path, time_to_collision);
-    const bool is_collision_left =
-      future_obj_pose ? isLeft(input_path.points, future_obj_pose->position) : is_object_left;
+    const bool is_collision_left = [&]() {
+      if (0.0 < object.vel) {
+        return is_object_left;
+      }
+      const auto future_obj_pose =
+        object_recognition_utils::calcInterpolatedPose(obj_path, time_to_collision);
+      return future_obj_pose ? isLeft(input_path.points, future_obj_pose->position)
+                             : is_object_left;
+    }();
 
     // 2.g. check if the ego is not ahead of the object.
     const double signed_dist_ego_to_obj = [&]() {

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -172,7 +172,7 @@ double calcDiffAngleAgainstPath(
   return diff_yaw;
 }
 
-double calcDiffAngleBetweenPaths(
+[[maybe_unused]] double calcDiffAngleBetweenPaths(
   const std::vector<PathPointWithLaneId> & path_points, const PredictedPath & predicted_path)
 {
   const size_t nearest_idx =


### PR DESCRIPTION
## Description

Changed the logic about which side to avoid
- When the target object velocity is the same direction as the ego
    - Check if the current object position is left or right against the ego's path
- When the target object velocity is NOT the same direction as the ego
    - Check if the object position in the near future is left or right against the ego's path
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
