### PR TITLE
fix(AEB): ego to object distance calculation logic with predicted path

### DIFF
--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -358,25 +358,29 @@ bool AEB::hasCollision(
   const double current_v, const Path & ego_path, const std::vector<ObjectData> & objects)
 {
   // calculate RSS
-  const auto current_p = tier4_autoware_utils::createPoint(0.0, 0.0, 0.0);
+  const auto current_p = tier4_autoware_utils::createPoint(
+    ego_path[0].position.x, ego_path[0].position.y, ego_path[0].position.z);
   const double & t = t_response_;
   for (const auto & obj : objects) {
     const double & obj_v = obj.velocity;
     const double rss_dist = current_v * t + (current_v * current_v) / (2 * std::fabs(a_ego_min_)) -
                             obj_v * obj_v / (2 * std::fabs(a_obj_min_)) + longitudinal_offset_;
-    const double dist_ego_to_object =
-      motion_utils::calcSignedArcLength(ego_path, current_p, obj.position) -
-      vehicle_info_.max_longitudinal_offset_m;
-    if (dist_ego_to_object < rss_dist) {
-      // collision happens
-      ObjectData collision_data = obj;
-      collision_data.rss = rss_dist;
-      collision_data.distance_to_object = dist_ego_to_object;
-      collision_data_keeper_.update(collision_data);
-      return true;
+
+    // check the object is front the ego or not
+    if ((obj.position.x - ego_path[0].position.x) > 0) {
+      const double dist_ego_to_object =
+        motion_utils::calcSignedArcLength(ego_path, current_p, obj.position) -
+        vehicle_info_.max_longitudinal_offset_m;
+      if (dist_ego_to_object < rss_dist) {
+        // collision happens
+        ObjectData collision_data = obj;
+        collision_data.rss = rss_dist;
+        collision_data.distance_to_object = dist_ego_to_object;
+        collision_data_keeper_.update(collision_data);
+        return true;
+      }
     }
   }
-
   return false;
 }
 


### PR DESCRIPTION
## Description

Fixes #5931

This PR fixes the calculation of ego to object distance. 

At the following `motion_utils::calcSignedArcLength` function:

https://github.com/autowarefoundation/autoware.universe/blob/f63ad331dabd1b979c14b8f6d20a20ecc5dec8c2/control/autonomous_emergency_braking/src/node.cpp#L367-L368

For instance, the predicted trajectory points of 'ego_path' have a size of 50, with only 15 predicted points provided. Consequently, the remaining 35 points have coordinates x: 0, y: 0, z: 0. As we've set 'current_p' to x: 0, y: 0, z: 0, the distance calculation becomes impossible. To resolve this issue, we need to utilize 'current_p' as the first index of 'ego_path' for calculating the distance between the ego and the object.

https://github.com/autowarefoundation/autoware.universe/blob/f63ad331dabd1b979c14b8f6d20a20ecc5dec8c2/control/autonomous_emergency_braking/src/node.cpp#L361

## Related links

- #5931
## Tests performed

### Planning Sim
(Only `use_predicted_trajectory` is set as true)

https://github.com/autowarefoundation/autoware.universe/assets/56237550/7b0a0ce0-06ff-44fb-a3d9-4136d3638a10

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
