### PR TITLE
feat: add pose_instability_detector to diagnostic_aggregator

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -30,6 +30,12 @@
               contains: ["localization: localization_error_monitor"]
               timeout: 1.0
 
+            localization_stability:
+              type: diagnostic_aggregator/GenericAnalyzer
+              path: localization_stability
+              contains: ["localization: pose_instability_detector"]
+              timeout: 1.0
+
             # This diagnostic should ideally be avoided in terms of Fault Tree Analysis (FTA) compatibility.
             # However, we may need this since the localization accuracy is still not reliable enough and may produce
             # false positives. Thus, NOTE that this diagnostic should be removed in the future when the localization accuracy


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/5439
Add pose_instability_detector to diagnostic_aggregator.
We haven't added the diagnostics to the system_error_monitor yet, so Autoware's behavior remains unchanged. ( Even if there's an error in diagnostics, Autoware won't switch to Emergency mode. )

<!-- Write a brief description of this PR. -->

## Tests performed

Confirmed that there are no errors in Psim.
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
