### PR TITLE
fix(avoidance): don't ignore objects on straight lane in intersection

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -635,12 +635,7 @@ bool isSatisfiedWithVehicleCondition(
     return true;
   }
 
-  // Object is on center line -> ignore.
-  if (std::abs(object.to_centerline) < parameters->threshold_distance_object_is_on_center) {
-    object.reason = AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE;
-    return false;
-  }
-
+  // check vehicle shift ratio
   lanelet::BasicPoint2d object_centroid(object.centroid.x(), object.centroid.y());
   const auto on_ego_driving_lane =
     within(object_centroid, object.overhang_lanelet.polygon2d().basicPolygon());
@@ -651,6 +646,12 @@ bool isSatisfiedWithVehicleCondition(
       object.reason = AvoidanceDebugFactor::NOT_PARKING_OBJECT;
       return false;
     }
+  }
+
+  // Object is on center line -> ignore.
+  if (std::abs(object.to_centerline) < parameters->threshold_distance_object_is_on_center) {
+    object.reason = AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE;
+    return false;
   }
 
   if (object.is_within_intersection) {

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -635,12 +635,6 @@ bool isSatisfiedWithVehicleCondition(
     return true;
   }
 
-  // always ignore all merging objects.
-  if (object.behavior == ObjectData::Behavior::MERGING) {
-    object.reason = "MergingToEgoLane";
-    return false;
-  }
-
   // Object is on center line -> ignore.
   if (std::abs(object.to_centerline) < parameters->threshold_distance_object_is_on_center) {
     object.reason = AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE;
@@ -659,17 +653,20 @@ bool isSatisfiedWithVehicleCondition(
     }
   }
 
-  if (!object.is_within_intersection) {
-    return true;
+  if (object.is_within_intersection) {
+    std::string turn_direction = object.overhang_lanelet.attributeOr("turn_direction", "else");
+    if (turn_direction == "straight") {
+      return true;
+    }
+
+    if (object.behavior == ObjectData::Behavior::NONE) {
+      object.reason = "ParallelToEgoLane";
+      return false;
+    }
   }
 
-  std::string turn_direction = object.overhang_lanelet.attributeOr("turn_direction", "else");
-  if (turn_direction == "straight") {
-    return true;
-  }
-
-  if (object.behavior == ObjectData::Behavior::NONE) {
-    object.reason = "ParallelToEgoLane";
+  if (object.behavior == ObjectData::Behavior::MERGING) {
+    object.reason = "MergingToEgoLane";
     return false;
   }
 


### PR DESCRIPTION
## Description

Basically, it is able to filter objects that should be avoid with high confidence if the ego goes straight in intersection because the lane infomation defined in HDMap is relatively accurate. On the other hand, it is more difficult to filter avoidance target objects based on right/left turning lane since sometimes thier lane bounds are not painted on ground in real world. Additionally, there are vehicles turn left and merge to ego lane, and ego vehicle doesn't have to avoid them.

Then, avoidance module uses some filtering condition (e.g. objects merging to ego lane are ignored.) for objects on right/left lane in order not to output unnecessary avoidance path.

But I found those condition applied for objects on straight lane unintentionally and caused scenario fails as follow.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/7e4110ab-7096-4078-872e-6889a591ac49

In this PR, I fixed this issue and confirmed that avoidance module could output path expectedly.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
https://github.com/autowarefoundation/autoware.universe/assets/44889564/fc7c6fc7-c3e5-432b-b92f-3de943552692

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/70a5aeac-e075-526c-833d-3111e49eab6f?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve avoidance module behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
