### PR TITLE
fix(behavior_path_planner): change getLaneletSequence function parameter for large scale lanelet2

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -428,7 +428,7 @@ BehaviorModuleOutput PlannerManager::getReferencePath(
     std::max(p.backward_path_length, p.backward_path_length + extra_margin);
 
   const auto lanelet_sequence = route_handler->getLaneletSequence(
-    root_lanelet_.value(), pose, backward_length, std::numeric_limits<double>::max());
+    root_lanelet_.value(), pose, backward_length, p.forward_path_length);
 
   lanelet::ConstLanelet closest_lane{};
   if (lanelet::utils::query::getClosestLaneletWithConstrains(


### PR DESCRIPTION
## Description

When we use current planning pipeline with large scale lanelet2 maps, we investigate some time consumption. You can check following discussion:

- https://github.com/orgs/autowarefoundation/discussions/4075 

When we use `std::numeric_limits<double>::max()` as a parameter, it takes all forward path it waste a lot of time. Using normal numbers reduce time consumption.

## Tests performed

This is the video before change:
- https://youtu.be/yrFhXr40rXY
This is the video after changes:
- https://youtu.be/Y0hLWt1O9J8
You can see, the time consumption is reducing with this change

## Effects on system behavior

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
