### PR TITLE
fix(behavior_path_planner_common): added a guard of obstacle polygon points

### DIFF
--- a/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -1089,13 +1089,17 @@ void extractObstaclesFromDrivableArea(
   std::vector<std::vector<PolygonPoint>> right_polygons;
   std::vector<std::vector<PolygonPoint>> left_polygons;
   for (const auto & obstacle : obstacles) {
+    if (obstacle.poly.outer().empty()) {
+      continue;
+    }
+
     const auto & obj_pos = obstacle.pose.position;
 
     // get edge points of the object
     const size_t nearest_path_idx =
       motion_utils::findNearestIndex(path.points, obj_pos);  // to get z for object polygon
     std::vector<Point> edge_points;
-    for (size_t i = 0; i < obstacle.poly.outer().size() - 1;
+    for (size_t i = 0; i < static_cast<int>(obstacle.poly.outer().size()) - 1;
          ++i) {  // NOTE: There is a duplicated points
       edge_points.push_back(tier4_autoware_utils::createPoint(
         obstacle.poly.outer().at(i).x(), obstacle.poly.outer().at(i).y(),

--- a/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -1099,7 +1099,7 @@ void extractObstaclesFromDrivableArea(
     const size_t nearest_path_idx =
       motion_utils::findNearestIndex(path.points, obj_pos);  // to get z for object polygon
     std::vector<Point> edge_points;
-    for (size_t i = 0; i < static_cast<int>(obstacle.poly.outer().size()) - 1;
+    for (int i = 0; i < static_cast<int>(obstacle.poly.outer().size()) - 1;
          ++i) {  // NOTE: There is a duplicated points
       edge_points.push_back(tier4_autoware_utils::createPoint(
         obstacle.poly.outer().at(i).x(), obstacle.poly.outer().at(i).y(),


### PR DESCRIPTION
## Description

Added a guard of obstacle polygon points' size so that the behavior path planner node will not die.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
