### PR TITLE
fix(avoidance): add missing param declaration

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
@@ -207,6 +207,8 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
       getOrDeclareParameter<double>(*node, ns + "max_velocity");
     p.ego_predicted_path_params.acceleration =
       getOrDeclareParameter<double>(*node, "avoidance.constraints.longitudinal.max_acceleration");
+    p.ego_predicted_path_params.time_horizon_for_front_object =
+      getOrDeclareParameter<double>(*node, ns + "time_horizon_for_front_object");
     p.ego_predicted_path_params.time_horizon_for_rear_object =
       getOrDeclareParameter<double>(*node, ns + "time_horizon_for_rear_object");
     p.ego_predicted_path_params.time_resolution =


### PR DESCRIPTION
## Description

Following param declaration was removed accidentally. Fixed it in this PR.

```c++
    p.ego_predicted_path_params.time_horizon_for_front_object =
      getOrDeclareParameter<double>(*node, ns + "time_horizon_for_front_object");
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
