### PR TITLE
feat(dynamic_avoidance): apply ego's lateral acc/jerk constraints to object polygon

### DIFF
--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -59,6 +59,10 @@
         max_time_for_object_lat_shift: 0.0 # [s]
         lpf_gain_for_lat_avoid_to_offset: 0.9 # [-]
 
+        max_ego_lat_acc: 0.3        # [m/ss]
+        max_ego_lat_jerk: 0.3       # [m/sss]
+        delay_time_ego_shift: 1.0   # [s]
+
         # for same directional object
         overtaking_object:
           max_time_to_collision: 40.0 # [s]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -35,6 +35,25 @@
 #include <utility>
 #include <vector>
 
+namespace
+{
+template <typename T>
+bool isInVector(const T & val, const std::vector<T> & vec)
+{
+  return std::find(vec.begin(), vec.end(), val) != vec.end();
+}
+
+template <typename T, typename S>
+std::vector<T> getAllKeys(const std::unordered_map<T, S> & map)
+{
+  std::vector<T> keys;
+  for (const auto & pair : map) {
+    keys.push_back(pair.first);
+  }
+  return keys;
+}
+}  // namespace
+
 namespace behavior_path_planner
 {
 using autoware_auto_perception_msgs::msg::PredictedPath;
@@ -97,6 +116,10 @@ struct DynamicAvoidanceParameters
   double max_time_for_lat_shift{0.0};
   double lpf_gain_for_lat_avoid_to_offset{0.0};
 
+  double max_ego_lat_acc{0.0};
+  double max_ego_lat_jerk{0.0};
+  double delay_time_ego_shift{0.0};
+
   double max_time_to_collision_overtaking_object{0.0};
   double start_duration_to_avoid_overtaking_object{0.0};
   double end_duration_to_avoid_overtaking_object{0.0};
@@ -113,6 +136,11 @@ struct TimeWhileCollision
   double time_to_end_collision;
 };
 
+struct LatFeasiblePaths
+{
+  std::vector<geometry_msgs::msg::Point> left_path;
+  std::vector<geometry_msgs::msg::Point> right_path;
+};
 class DynamicAvoidanceModule : public SceneModuleInterface
 {
 public:
@@ -151,6 +179,7 @@ public:
     bool is_collision_left{false};
     bool should_be_avoided{false};
     std::vector<PathPointWithLaneId> ref_path_points_for_obj_poly;
+    LatFeasiblePaths ego_lat_feasible_paths;
 
     void update(
       const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
@@ -172,14 +201,18 @@ public:
     {
     }
     int max_count_{0};
-    int min_count_{0};
+    int min_count_{0};  // TODO(murooka): The sign needs to be opposite?
 
     void initialize() { current_uuids_.clear(); }
     void updateObject(const std::string & uuid, const DynamicAvoidanceObject & object)
     {
       // add/update object
       if (object_map_.count(uuid) != 0) {
+        const auto prev_object = object_map_.at(uuid);
         object_map_.at(uuid) = object;
+        // TODO(murooka) refactor this. Counter can be moved to DynamicObject,
+        //               and TargetObjectsManager can be removed.
+        object_map_.at(uuid).ego_lat_feasible_paths = prev_object.ego_lat_feasible_paths;
       } else {
         object_map_.emplace(uuid, object);
       }
@@ -195,14 +228,12 @@ public:
       current_uuids_.push_back(uuid);
     }
 
-    void finalize()
+    void finalize(const LatFeasiblePaths & ego_lat_feasible_paths)
     {
       // decrease counter for not updated uuids
       std::vector<std::string> not_updated_uuids;
       for (const auto & object : object_map_) {
-        if (
-          std::find(current_uuids_.begin(), current_uuids_.end(), object.first) ==
-          current_uuids_.end()) {
+        if (!isInVector(object.first, current_uuids_)) {
           not_updated_uuids.push_back(object.first);
         }
       }
@@ -214,45 +245,47 @@ public:
         }
       }
 
-      // remove objects whose counter is lower than threshold
-      std::vector<std::string> obsolete_uuids;
+      // update valid object uuids and its variable
       for (const auto & counter : counter_map_) {
-        if (counter.second < min_count_) {
-          obsolete_uuids.push_back(counter.first);
+        if (!isInVector(counter.first, valid_object_uuids_) && max_count_ <= counter.second) {
+          valid_object_uuids_.push_back(counter.first);
+          object_map_.at(counter.first).ego_lat_feasible_paths = ego_lat_feasible_paths;
+          std::cerr << counter.first << std::endl;
         }
       }
-      for (const auto & obsolete_uuid : obsolete_uuids) {
-        counter_map_.erase(obsolete_uuid);
-        object_map_.erase(obsolete_uuid);
+      valid_object_uuids_.erase(
+        std::remove_if(
+          valid_object_uuids_.begin(), valid_object_uuids_.end(),
+          [&](const auto & uuid) {
+            return counter_map_.count(uuid) == 0 || counter_map_.at(uuid) < max_count_;
+          }),
+        valid_object_uuids_.end());
+
+      // remove objects whose counter is lower than threshold
+      const auto counter_map_keys = getAllKeys(counter_map_);
+      for (const auto & key : counter_map_keys) {
+        if (counter_map_.at(key) < min_count_) {
+          counter_map_.erase(key);
+          object_map_.erase(key);
+        }
       }
     }
     std::vector<DynamicAvoidanceObject> getValidObjects() const
     {
-      std::vector<DynamicAvoidanceObject> objects;
-      for (const auto & object : object_map_) {
-        if (counter_map_.count(object.first) != 0) {
-          if (max_count_ <= counter_map_.at(object.first)) {
-            objects.push_back(object.second);
-          }
+      std::vector<DynamicAvoidanceObject> valid_objects;
+      for (const auto & valid_object_uuid : valid_object_uuids_) {
+        if (object_map_.count(valid_object_uuid) == 0) {
+          std::cerr
+            << "[DynamicAvoidance] Internal calculation has an error when getting valid objects."
+            << std::endl;
+          continue;
         }
+        valid_objects.push_back(object_map_.at(valid_object_uuid));
       }
-      return objects;
+
+      return valid_objects;
     }
-    std::optional<DynamicAvoidanceObject> getValidObject(const std::string & uuid) const
-    {
-      // add/update object
-      if (counter_map_.count(uuid) == 0) {
-        return std::nullopt;
-      }
-      if (counter_map_.at(uuid) < max_count_) {
-        return std::nullopt;
-      }
-      if (object_map_.count(uuid) == 0) {
-        return std::nullopt;
-      }
-      return object_map_.at(uuid);
-    }
-    void updateObject(
+    void updateObjectVariables(
       const std::string & uuid, const MinMaxValue & lon_offset_to_avoid,
       const MinMaxValue & lat_offset_to_avoid, const bool is_collision_left,
       const bool should_be_avoided,
@@ -269,6 +302,7 @@ public:
     // NOTE: positive is for meeting entry condition, and negative is for exiting.
     std::unordered_map<std::string, int> counter_map_;
     std::unordered_map<std::string, DynamicAvoidanceObject> object_map_;
+    std::vector<std::string> valid_object_uuids_{};
   };
 
   struct DecisionWithReason
@@ -319,6 +353,8 @@ private:
 
   bool isLabelTargetObstacle(const uint8_t label) const;
   void updateTargetObjects();
+  LatFeasiblePaths generateLateralFeasiblePaths(
+    const geometry_msgs::msg::Pose & ego_pose, const double ego_vel) const;
   void updateRefPathBeforeLaneChange(const std::vector<PathPointWithLaneId> & ego_ref_path_points);
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -250,7 +250,6 @@ public:
         if (!isInVector(counter.first, valid_object_uuids_) && max_count_ <= counter.second) {
           valid_object_uuids_.push_back(counter.first);
           object_map_.at(counter.first).ego_lat_feasible_paths = ego_lat_feasible_paths;
-          std::cerr << counter.first << std::endl;
         }
       }
       valid_object_uuids_.erase(

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -262,6 +262,35 @@ double calcDistanceToSegment(
     first_to_second * first_to_target.dot(first_to_second) / std::pow(first_to_second.norm(), 2);
   return (Eigen::Vector2d{p1.x, p1.y} - p2_nearest).norm();
 }
+
+std::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectLines(
+  const std::vector<geometry_msgs::msg::Pose> & source_line,
+  const std::vector<geometry_msgs::msg::Point> & target_line)
+{
+  for (int source_seg_idx = 0; source_seg_idx < static_cast<int>(source_line.size()) - 1;
+       ++source_seg_idx) {
+    for (int target_seg_idx = 0; target_seg_idx < static_cast<int>(target_line.size()) - 1;
+         ++target_seg_idx) {
+      const auto intersect_point = tier4_autoware_utils::intersect(
+        source_line.at(source_seg_idx).position, source_line.at(source_seg_idx + 1).position,
+        target_line.at(target_seg_idx), target_line.at(target_seg_idx + 1));
+      if (intersect_point) {
+        return std::make_pair(source_seg_idx, *intersect_point);
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::vector<geometry_msgs::msg::Point> convertToPoints(
+  const std::vector<geometry_msgs::msg::Pose> & poses)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  for (const auto & pose : poses) {
+    points.push_back(pose.position);
+  }
+  return points;
+}
 }  // namespace
 
 DynamicAvoidanceModule::DynamicAvoidanceModule(
@@ -310,6 +339,9 @@ bool DynamicAvoidanceModule::isExecutionReady() const
 
 void DynamicAvoidanceModule::updateData()
 {
+  info_marker_.markers.clear();
+  debug_marker_.markers.clear();
+
   // calculate target objects
   updateTargetObjects();
 
@@ -329,9 +361,6 @@ bool DynamicAvoidanceModule::canTransitSuccessState()
 
 BehaviorModuleOutput DynamicAvoidanceModule::plan()
 {
-  info_marker_.markers.clear();
-  debug_marker_.markers.clear();
-
   const auto & input_path = getPreviousModuleOutput().path;
 
   // create obstacles to avoid (= extract from the drivable area)
@@ -425,6 +454,10 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
   updateRefPathBeforeLaneChange(input_ref_path_points);
 
+  const auto & ego_pose = getEgoPose();
+  const double ego_vel = getEgoSpeed();
+  const auto ego_lat_feasible_paths = generateLateralFeasiblePaths(ego_pose, ego_vel);
+
   // 1. Rough filtering of target objects
   target_objects_manager_.initialize();
   for (const auto & predicted_object : predicted_objects) {
@@ -509,7 +542,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
       latest_time_inside_ego_path);
     target_objects_manager_.updateObject(obj_uuid, target_object);
   }
-  target_objects_manager_.finalize();
+  target_objects_manager_.finalize(ego_lat_feasible_paths);
 
   // 2. Precise filtering of target objects and check if they should be avoided
   for (const auto & object : target_objects_manager_.getValidObjects()) {
@@ -580,18 +613,24 @@ void DynamicAvoidanceModule::updateTargetObjects()
          parameters_->max_time_to_collision_overtaking_object < time_to_collision) ||
         (object.vel <= 0 &&
          parameters_->max_time_to_collision_oncoming_object < time_to_collision)) {
+        const auto time_to_collision_str = time_to_collision == std::numeric_limits<double>::max()
+                                             ? "infinity"
+                                             : std::to_string(time_to_collision);
         RCLCPP_INFO_EXPRESSION(
           getLogger(), parameters_->enable_debug_info,
-          "[DynamicAvoidance] Ignore obstacle (%s) since time to collision (%f) is large.",
-          obj_uuid.c_str(), time_to_collision);
+          "[DynamicAvoidance] Ignore obstacle (%s) since time to collision (%s) is large.",
+          obj_uuid.c_str(), time_to_collision_str.c_str());
         continue;
       }
       if (time_to_collision < -parameters_->duration_to_hold_avoidance_overtaking_object) {
+        const auto time_to_collision_str = time_to_collision == std::numeric_limits<double>::max()
+                                             ? "infinity"
+                                             : std::to_string(time_to_collision);
         RCLCPP_INFO_EXPRESSION(
           getLogger(), parameters_->enable_debug_info,
-          "[DynamicAvoidance] Ignore obstacle (%s) since time to collision (%f) is a small "
+          "[DynamicAvoidance] Ignore obstacle (%s) since time to collision (%s) is a small "
           "negative value.",
-          obj_uuid.c_str(), time_to_collision);
+          obj_uuid.c_str(), time_to_collision_str.c_str());
         continue;
       }
     }
@@ -611,7 +650,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
     const double signed_dist_ego_to_obj = [&]() {
       const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(input_path.points);
       const double lon_offset_ego_to_obj = motion_utils::calcSignedArcLength(
-        input_path.points, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx);
+        input_path.points, ego_pose.position, ego_seg_idx, lat_lon_offset.nearest_idx);
       if (0 < lon_offset_ego_to_obj) {
         return std::max(
           0.0, lon_offset_ego_to_obj - planner_data_->parameters.front_overhang +
@@ -649,12 +688,48 @@ void DynamicAvoidanceModule::updateTargetObjects()
     }
 
     const bool should_be_avoided = true;
-    target_objects_manager_.updateObject(
+    target_objects_manager_.updateObjectVariables(
       obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided,
       ref_path_points_for_obj_poly);
   }
 
   prev_input_ref_path_points_ = input_ref_path_points;
+}
+
+LatFeasiblePaths DynamicAvoidanceModule::generateLateralFeasiblePaths(
+  const geometry_msgs::msg::Pose & ego_pose, const double ego_vel) const
+{
+  const double lat_acc = parameters_->max_ego_lat_acc;
+  const double lat_jerk = parameters_->max_ego_lat_jerk;
+  const double delay_time = parameters_->delay_time_ego_shift;
+
+  LatFeasiblePaths ego_lat_feasible_paths;
+  for (double t = 0; t < 10.0; t += 1.0) {
+    const double feasible_lat_offset = lat_acc * std::pow(std::max(t - delay_time, 0.0), 2) / 2.0 +
+                                       lat_jerk * std::pow(std::max(t - delay_time, 0.0), 3) / 6.0 -
+                                       planner_data_->parameters.vehicle_width / 2.0;
+    const double x = t * ego_vel;
+    const double y = feasible_lat_offset;
+
+    const auto feasible_left_bound_point =
+      tier4_autoware_utils::calcOffsetPose(ego_pose, x, -y, 0.0).position;
+    ego_lat_feasible_paths.left_path.push_back(feasible_left_bound_point);
+
+    const auto feasible_right_bound_point =
+      tier4_autoware_utils::calcOffsetPose(ego_pose, x, y, 0.0).position;
+    ego_lat_feasible_paths.right_path.push_back(feasible_right_bound_point);
+  }
+
+  appendMarkerArray(
+    marker_utils::createPointsMarkerArray(
+      ego_lat_feasible_paths.left_path, "ego_lat_feasible_left_path", 0, 0.6, 0.9, 0.9),
+    &debug_marker_);
+  appendMarkerArray(
+    marker_utils::createPointsMarkerArray(
+      ego_lat_feasible_paths.right_path, "ego_lat_feasible_right_path", 0, 0.6, 0.9, 0.9),
+    &debug_marker_);
+
+  return ego_lat_feasible_paths;
 }
 
 void DynamicAvoidanceModule::updateRefPathBeforeLaneChange(
@@ -1251,31 +1326,74 @@ DynamicAvoidanceModule::calcEgoPathBasedDynamicObstaclePolygon(
                                      ? lon_bound_end_idx_opt.value()
                                      : static_cast<size_t>(ref_path_points_for_obj_poly.size() - 1);
 
-  // create inner/outer bound points
-  std::vector<geometry_msgs::msg::Point> obj_inner_bound_points;
-  std::vector<geometry_msgs::msg::Point> obj_outer_bound_points;
+  // create inner bound points
+  std::vector<geometry_msgs::msg::Pose> obj_inner_bound_poses;
   for (size_t i = lon_bound_start_idx; i <= lon_bound_end_idx; ++i) {
-    obj_inner_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
-                                       ref_path_points_for_obj_poly.at(i).point.pose, 0.0,
-                                       object.lat_offset_to_avoid->min_value, 0.0)
-                                       .position);
-    obj_outer_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
-                                       ref_path_points_for_obj_poly.at(i).point.pose, 0.0,
-                                       object.lat_offset_to_avoid->max_value, 0.0)
-                                       .position);
+    // NOTE: object.lat_offset_to_avoid->min_value is not the minimum value but the inner value.
+    obj_inner_bound_poses.push_back(tier4_autoware_utils::calcOffsetPose(
+      ref_path_points_for_obj_poly.at(i).point.pose, 0.0, object.lat_offset_to_avoid->min_value,
+      0.0));
+  }
+
+  // calculate start index laterally feasible for ego to shift considering maximum lateral jerk and
+  // acceleration
+  const auto obj_inner_bound_start_idx = [&]() -> std::optional<size_t> {
+    const auto & ego_lat_feasible_path = object.is_collision_left
+                                           ? object.ego_lat_feasible_paths.left_path
+                                           : object.ego_lat_feasible_paths.right_path;
+    const auto intersect_result = intersectLines(obj_inner_bound_poses, ego_lat_feasible_path);
+
+    // Check if the object polygon intersects with the ego_lat_feasible_path.
+    if (intersect_result) {
+      const auto & [bound_seg_idx, intersect_point] = *intersect_result;
+      const double lon_offset = tier4_autoware_utils::calcDistance2d(
+        obj_inner_bound_poses.at(bound_seg_idx), intersect_point);
+
+      const auto obj_inner_bound_start_idx_opt =
+        motion_utils::insertTargetPoint(bound_seg_idx, lon_offset, obj_inner_bound_poses);
+      if (obj_inner_bound_start_idx_opt) {
+        return *obj_inner_bound_start_idx_opt;
+      }
+    }
+
+    // Check if the object polygon is fully outside the ego_lat_feasible_path.
+    const double obj_poly_lat_offset = motion_utils::calcLateralOffset(
+      ego_lat_feasible_path, obj_inner_bound_poses.front().position);
+    if (
+      (!object.is_collision_left && 0 < obj_poly_lat_offset) ||
+      (object.is_collision_left && obj_poly_lat_offset < 0)) {
+      return std::nullopt;
+    }
+
+    return 0;
+  }();
+  if (!obj_inner_bound_start_idx) {
+    return std::nullopt;
+  }
+
+  // calculate feasible inner/outer bound points
+  const auto feasible_obj_inner_bound_poses = std::vector<geometry_msgs::msg::Pose>(
+    obj_inner_bound_poses.begin() + *obj_inner_bound_start_idx, obj_inner_bound_poses.end());
+  const auto feasible_obj_inner_bound_points = convertToPoints(feasible_obj_inner_bound_poses);
+  std::vector<geometry_msgs::msg::Point> feasible_obj_outer_bound_points;
+  for (const auto & feasible_obj_inner_bound_pose : feasible_obj_inner_bound_poses) {
+    feasible_obj_outer_bound_points.push_back(
+      tier4_autoware_utils::calcOffsetPose(
+        feasible_obj_inner_bound_pose, 0.0,
+        object.lat_offset_to_avoid->max_value - object.lat_offset_to_avoid->min_value, 0.0)
+        .position);
   }
 
   // create obj_polygon from inner/outer bound points
   tier4_autoware_utils::Polygon2d obj_poly;
-  for (const auto & bound_point : obj_inner_bound_points) {
-    const auto obj_poly_point = tier4_autoware_utils::Point2d(bound_point.x, bound_point.y);
-    obj_poly.outer().push_back(obj_poly_point);
-  }
-  std::reverse(obj_outer_bound_points.begin(), obj_outer_bound_points.end());
-  for (const auto & bound_point : obj_outer_bound_points) {
-    const auto obj_poly_point = tier4_autoware_utils::Point2d(bound_point.x, bound_point.y);
-    obj_poly.outer().push_back(obj_poly_point);
-  }
+  const auto add_points_to_obj_poly = [&](const auto & bound_points) {
+    for (const auto & bound_point : bound_points) {
+      obj_poly.outer().push_back(tier4_autoware_utils::Point2d(bound_point.x, bound_point.y));
+    }
+  };
+  add_points_to_obj_poly(feasible_obj_inner_bound_points);
+  std::reverse(feasible_obj_outer_bound_points.begin(), feasible_obj_outer_bound_points.end());
+  add_points_to_obj_poly(feasible_obj_outer_bound_points);
 
   boost::geometry::correct(obj_poly);
   return obj_poly;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -720,11 +720,11 @@ LatFeasiblePaths DynamicAvoidanceModule::generateLateralFeasiblePaths(
     ego_lat_feasible_paths.right_path.push_back(feasible_right_bound_point);
   }
 
-  appendMarkerArray(
+  tier4_autoware_utils::appendMarkerArray(
     marker_utils::createPointsMarkerArray(
       ego_lat_feasible_paths.left_path, "ego_lat_feasible_left_path", 0, 0.6, 0.9, 0.9),
     &debug_marker_);
-  appendMarkerArray(
+  tier4_autoware_utils::appendMarkerArray(
     marker_utils::createPointsMarkerArray(
       ego_lat_feasible_paths.right_path, "ego_lat_feasible_right_path", 0, 0.6, 0.9, 0.9),
     &debug_marker_);

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -117,6 +117,10 @@ void DynamicAvoidanceModuleManager::init(rclcpp::Node * node)
     p.lpf_gain_for_lat_avoid_to_offset =
       node->declare_parameter<double>(ns + "lpf_gain_for_lat_avoid_to_offset");
 
+    p.max_ego_lat_acc = node->declare_parameter<double>(ns + "max_ego_lat_acc");
+    p.max_ego_lat_jerk = node->declare_parameter<double>(ns + "max_ego_lat_jerk");
+    p.delay_time_ego_shift = node->declare_parameter<double>(ns + "delay_time_ego_shift");
+
     p.max_time_to_collision_overtaking_object =
       node->declare_parameter<double>(ns + "overtaking_object.max_time_to_collision");
     p.start_duration_to_avoid_overtaking_object =
@@ -232,6 +236,10 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
       parameters, ns + "max_time_for_object_lat_shift", p->max_time_for_lat_shift);
     updateParam<double>(
       parameters, ns + "lpf_gain_for_lat_avoid_to_offset", p->lpf_gain_for_lat_avoid_to_offset);
+
+    updateParam<double>(parameters, ns + "max_ego_lat_acc", p->max_ego_lat_acc);
+    updateParam<double>(parameters, ns + "max_ego_lat_jerk", p->max_ego_lat_jerk);
+    updateParam<double>(parameters, ns + "delay_time_ego_shift", p->delay_time_ego_shift);
 
     updateParam<double>(
       parameters, ns + "overtaking_object.max_time_to_collision",

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/marker_utils/utils.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/marker_utils/utils.hpp
@@ -66,6 +66,10 @@ MarkerArray createFootprintMarkerArray(
   const Pose & base_link_pose, const vehicle_info_util::VehicleInfo vehicle_info,
   const std::string && ns, const int32_t & id, const float & r, const float & g, const float & b);
 
+MarkerArray createPointsMarkerArray(
+  const std::vector<Point> points, const std::string & ns, const int32_t id, const float r,
+  const float g, const float b);
+
 MarkerArray createPoseMarkerArray(
   const Pose & pose, std::string && ns, const int32_t & id, const float & r, const float & g,
   const float & b);

--- a/planning/behavior_path_planner_common/src/marker_utils/utils.cpp
+++ b/planning/behavior_path_planner_common/src/marker_utils/utils.cpp
@@ -74,7 +74,23 @@ MarkerArray createFootprintMarkerArray(
   MarkerArray marker_array;
 
   addFootprintMarker(marker, base_link_pose, vehicle_info);
+  msg.markers.push_back(marker);
+  return msg;
+}
 
+MarkerArray createPointsMarkerArray(
+  const std::vector<Point> points, const std::string & ns, const int32_t id, const float r,
+  const float g, const float b)
+{
+  auto marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, id, Marker::LINE_STRIP,
+    createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.999));
+
+  for (const auto & point : points) {
+    marker.points.push_back(point);
+  }
+
+  MarkerArray msg;
   msg.markers.push_back(marker);
   return msg;
 }


### PR DESCRIPTION
## Description

In order to suppress sudden steering by the change of the drivable area just in front of the ego, the feasible ego's path considering lateral acc/jerk is calculated, and the object polygon to be removed from the drivable area is limited to this feasible path.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
