### PR TITLE
fix(ndt_scan_matcher): fixed oscillation in ndt_scan_matcher

### DIFF
--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -125,6 +125,7 @@ private:
     const double score, const double score_threshold, const std::string & score_name);
   bool validate_converged_param(
     const double & transform_probability, const double & nearest_voxel_transformation_likelihood);
+  static int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array);
 
   std::array<double, 36> estimate_covariance(
     const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
@@ -195,8 +196,6 @@ private:
   double lidar_topic_timeout_sec_;
   double initial_pose_timeout_sec_;
   double initial_pose_distance_tolerance_m_;
-  float inversion_vector_threshold_;
-  float oscillation_threshold_;
   bool use_cov_estimation_;
   std::vector<Eigen::Vector2d> initial_pose_offset_model_;
   std::array<double, 36> output_pose_covariance_;


### PR DESCRIPTION
## Description

This PR addresses a issue related to oscillation detection in the ndt_scan_matcher.

### Context
The execution time of the ndt_scan_matcher is proportional to the number of iterations. In the current [ndt_omp implementation](https://github.com/tier4/ndt_omp/blob/03f63ed7d3f9bf54bebf254060a1d70eb62308f3/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp#L907-L914), since line search is disabled, ndt_scan_matcher sometimes experiences oscillations, leading to a high number of iterations. Monitoring for oscillation can be beneficial when ndt_scan_matcher performance slows down.

### Changes
* Fixed a bug where the vector was not normalized in the calculation of oscillation.
* Fixed to add output the oscillation count in `/diagnostics`.

## Tests performed

It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

Additionally, for a internal rosbag known to cause oscillations, it was observed that the oscillation count is accurately reported in `/diagnostics` and is correlated with execution time. Below is the resulting plot.

![oscillation](https://github.com/autowarefoundation/autoware.universe/assets/28504069/b75c35b9-116b-430d-a988-7df38e568eb1)

## Effects on system behavior

There are no effects on system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
