### PR TITLE
feat(map_based_prediction): prediction with acc constraints

### DIFF
--- a/perception/map_based_prediction/README.md
+++ b/perception/map_based_prediction/README.md
@@ -66,7 +66,7 @@ Lane change logics is illustrated in the figure below.An example of how to tune 
 
 ### Tuning lane change detection logic
 
-Currently we provide two parameters to tune lane change detection:
+Currently we provide three parameters to tune lane change detection:
 
 - `dist_threshold_to_bound_`: maximum distance from lane boundary allowed for lane changing vehicle
 - `time_threshold_to_bound_`: maximum time allowed for lane change vehicle to reach the boundary
@@ -123,6 +123,24 @@ See paper [2] for more details.
 #### Tuning lateral path shape
 
 `lateral_control_time_horizon` parameter supports the tuning of the lateral path shape. This parameter is used to calculate the time to reach the reference path. The smaller the value, the more the path will be generated to reach the reference path quickly. (Mostly the center of the lane.)
+
+#### Pruning predicted paths with lateral acceleration constraint
+
+It is possible to apply a maximum lateral acceleration constraint to generated vehicle paths. This check verifies if it is possible for the vehicle to perform the predicted path without surpassing a lateral acceleration threshold `max_lateral_accel` when taking a curve. If it is not possible, it checks if the vehicle can slow down on time to take the curve with a deceleration of `min_acceleration_before_curve` and comply with the constraint. If that is also not possible, the path is eliminated.
+
+Currently we provide three parameters to tune the lateral acceleration constraint:
+
+- `check_lateral_acceleration_constraints_`: to enable the constraint check.
+- `max_lateral_accel_`: max acceptable lateral acceleration for predicted paths (absolute value).
+- `min_acceleration_before_curve_`: the minimum acceleration the vehicle would theoretically use to slow down before a curve is taken (must be negative).
+
+You can change these parameters in rosparam in the table below.
+
+| param name                                | default value  |
+| ----------------------------------------- | -------------- |
+| `check_lateral_acceleration_constraints_` | `false` [bool] |
+| `max_lateral_accel`                       | `2.0` [m/s^2]  |
+| `min_acceleration_before_curve`           | `-2.0` [m/s^2] |
 
 ### Path prediction for crosswalk users
 

--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -13,6 +13,9 @@
     sigma_yaw_angle_deg: 5.0 #[angle degree]
     object_buffer_time_length: 2.0 #[s]
     history_time_length: 1.0 #[s]
+    check_lateral_acceleration_constraints: false # whether to check if the predicted path complies with lateral acceleration constraints
+    max_lateral_accel: 2.0 # [m/ss] max acceptable lateral acceleration for predicted vehicle paths
+    min_acceleration_before_curve: -2.0 # [m/ss] min acceleration a vehicle might take to decelerate before a curve
     # parameter for shoulder lane prediction
     prediction_time_horizon_rate_for_validate_shoulder_lane_length: 0.8
 

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -357,16 +357,6 @@ private:
       const double distance_to_slow_down =
         current_speed * t + 0.5 * min_acceleration_before_curve_ * std::pow(t, 2);
 
-      std::cerr << "current_speed > v_curvature_max  checking if deceleration is possible\n";
-      std::cerr << "Current path index " << i << "\n";
-      std::cerr << "Decel time " << t << "\n";
-      std::cerr << "Decel distance " << distance_to_slow_down << "\n";
-      std::cerr << "Arc length " << arc_length << "\n";
-      std::cerr << "yaw_rate " << yaw_rate << "\n";
-      std::cerr << "current_speed " << current_speed << "\n";
-      std::cerr << "v_curvature_max " << v_curvature_max << "\n";
-      bool c = distance_to_slow_down > arc_length;
-      std::cerr << "Check is " << c << "\n";
       if (distance_to_slow_down > arc_length) return false;
     }
     return true;

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -171,9 +171,8 @@ private:
   bool consider_only_routable_neighbours_;
   double reference_path_resolution_;
 
+  bool check_lateral_acceleration_constraints_;
   double max_lateral_accel_;
-  double deceleration_distance_before_curve_;
-  double deceleration_distance_after_curve_;
   double min_acceleration_before_curve_;
 
   // Stop watch

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -335,7 +335,6 @@ private:
       static_cast<size_t>(std::round(deceleration_distance_after_curve_ / points_interval));
     const double max_lateral_accel_abs = std::fabs(max_lateral_accel_);
 
-    double min_curv_thing = 0.0;
     for (size_t i = 0; i < trajectory.size(); ++i) {
       double curvature = 0.0;
       const size_t start = i > after_decel_index ? i - after_decel_index : 0;

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -346,14 +346,12 @@ private:
       }
       double v_curvature_max = std::sqrt(max_lateral_accel_abs / std::max(curvature, 1.0E-5));
       // v_curvature_max = std::max(v_curvature_max, min_curve_velocity);
-      min_curv_thing = std::min(v_curvature_max, min_curv_thing);
       if (trajectory.at(i).longitudinal_velocity_mps > v_curvature_max) {
         std::cerr << "False Min curvature thing " << min_curv_thing << "\n";
         std::cerr << "Velocity " << trajectory.at(i).longitudinal_velocity_mps << "\n";
         return false;
       }
     }
-    std::cerr << "True Min curvature thing " << min_curv_thing << "\n";
     std::cerr << "Velocity " << trajectory.back().longitudinal_velocity_mps << "\n";
 
     return true;

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -16,11 +16,13 @@
 #define MAP_BASED_PREDICTION__MAP_BASED_PREDICTION_NODE_HPP_
 
 #include "map_based_prediction/path_generator.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/transform_listener.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
+#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
@@ -34,6 +36,7 @@
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
 
+#include <algorithm>
 #include <deque>
 #include <memory>
 #include <string>
@@ -99,8 +102,111 @@ using autoware_auto_perception_msgs::msg::PredictedPath;
 using autoware_auto_perception_msgs::msg::TrackedObject;
 using autoware_auto_perception_msgs::msg::TrackedObjectKinematics;
 using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using tier4_autoware_utils::StopWatch;
 using tier4_debug_msgs::msg::StringStamped;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+
+inline std::vector<double> calcTrajectoryCurvatureFrom3Points(
+  const TrajectoryPoints & trajectory, size_t idx_dist)
+{
+  using tier4_autoware_utils::calcCurvature;
+  using tier4_autoware_utils::getPoint;
+
+  if (trajectory.size() < 3) {
+    const std::vector<double> k_arr(trajectory.size(), 0.0);
+    return k_arr;
+  }
+
+  // if the idx size is not enough, change the idx_dist
+  const auto max_idx_dist = static_cast<size_t>(std::floor((trajectory.size() - 1) / 2.0));
+  idx_dist = std::max(1ul, std::min(idx_dist, max_idx_dist));
+
+  if (idx_dist < 1) {
+    throw std::logic_error("idx_dist less than 1 is not expected");
+  }
+
+  // calculate curvature by circle fitting from three points
+  std::vector<double> k_arr(trajectory.size(), 0.0);
+
+  for (size_t i = 1; i + 1 < trajectory.size(); i++) {
+    double curvature = 0.0;
+    const auto p0 = getPoint(trajectory.at(i - std::min(idx_dist, i)));
+    const auto p1 = getPoint(trajectory.at(i));
+    const auto p2 = getPoint(trajectory.at(i + std::min(idx_dist, trajectory.size() - 1 - i)));
+    try {
+      curvature = calcCurvature(p0, p1, p2);
+    } catch (std::exception const & e) {
+      // ...code that handles the error...
+      RCLCPP_WARN(
+        rclcpp::get_logger("motion_velocity_smoother").get_child("trajectory_utils"), "%s",
+        e.what());
+      if (i > 1) {
+        curvature = k_arr.at(i - 1);  // previous curvature
+      } else {
+        curvature = 0.0;
+      }
+    }
+    k_arr.at(i) = curvature;
+  }
+  // copy curvatures for the last and first points;
+  k_arr.at(0) = k_arr.at(1);
+  k_arr.back() = k_arr.at((trajectory.size() - 2));
+
+  return k_arr;
+}
+
+inline TrajectoryPoints toTrajectoryPoints(const PredictedPath & path, const double velocity)
+{
+  TrajectoryPoints out_trajectory;
+  std::for_each(path.path.begin(), path.path.end(), [&out_trajectory, velocity](const auto & pose) {
+    TrajectoryPoint p;
+    p.pose = pose;
+    p.longitudinal_velocity_mps = velocity;
+    out_trajectory.push_back(p);
+  });
+  return out_trajectory;
+};
+
+inline bool isAccelerationConstraintsSatisfied(
+  const TrajectoryPoints & trajectory [[maybe_unused]], const double points_interval = 1.0)
+{
+  if (trajectory.size() < 3) return false;
+  constexpr double curvature_calculation_distance = 5.0;
+  const size_t idx_dist = static_cast<size_t>(
+    std::max(static_cast<int>((curvature_calculation_distance) / points_interval), 1));
+  // Calculate curvature assuming the trajectory points interval is constant
+  const auto curvature_v = calcTrajectoryCurvatureFrom3Points(trajectory, idx_dist);
+
+  constexpr double max_lateral_accel = 1.0;
+  // constexpr double min_curve_velocity = 3.5;
+  constexpr double deceleration_distance_before_curve = 3.5;
+  constexpr double deceleration_distance_after_curve = 2.0;
+
+  //  Decrease speed according to lateral G
+  const size_t before_decel_index =
+    static_cast<size_t>(std::round(deceleration_distance_before_curve / points_interval));
+  const size_t after_decel_index =
+    static_cast<size_t>(std::round(deceleration_distance_after_curve / points_interval));
+  const double max_lateral_accel_abs = std::fabs(max_lateral_accel);
+
+  for (size_t i = 0; i < trajectory.size(); ++i) {
+    double curvature = 0.0;
+    const size_t start = i > after_decel_index ? i - after_decel_index : 0;
+    const size_t end = std::min(trajectory.size(), i + before_decel_index + 1);
+    for (size_t j = start; j < end; ++j) {
+      if (j >= curvature_v.size()) return true;
+      curvature = std::max(curvature, std::fabs(curvature_v.at(j)));
+    }
+    double v_curvature_max = std::sqrt(max_lateral_accel_abs / std::max(curvature, 1.0E-5));
+    // v_curvature_max = std::max(v_curvature_max, min_curve_velocity);
+
+    if (trajectory.at(i).longitudinal_velocity_mps > v_curvature_max) {
+      return false;
+    }
+  }
+  return true;
+};
 
 class MapBasedPredictionNode : public rclcpp::Node
 {

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -316,7 +316,7 @@ private:
     return out_trajectory;
   };
 
-  inline bool isAccelerationConstraintsSatisfied(
+  inline bool isLateralAccelerationConstraintSatisfied(
     const TrajectoryPoints & trajectory [[maybe_unused]], const double delta_time)
   {
     if (trajectory.size() < 3) return true;

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -347,7 +347,6 @@ private:
       double v_curvature_max = std::sqrt(max_lateral_accel_abs / std::max(curvature, 1.0E-5));
       // v_curvature_max = std::max(v_curvature_max, min_curve_velocity);
       if (trajectory.at(i).longitudinal_velocity_mps > v_curvature_max) {
-        std::cerr << "False Min curvature thing " << min_curv_thing << "\n";
         std::cerr << "Velocity " << trajectory.at(i).longitudinal_velocity_mps << "\n";
         return false;
       }

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -253,6 +253,8 @@ private:
     const TrackedObject & object, const LaneletData & current_lanelet_data,
     const double object_detected_time);
 
+  // NOTE: This function is copied from the motion_velocity_smoother package.
+  // TODO(someone): Consolidate functions and move them to a common
   inline std::vector<double> calcTrajectoryCurvatureFrom3Points(
     const TrajectoryPoints & trajectory, size_t idx_dist)
   {
@@ -284,9 +286,7 @@ private:
         curvature = calcCurvature(p0, p1, p2);
       } catch (std::exception const & e) {
         // ...code that handles the error...
-        RCLCPP_WARN(
-          rclcpp::get_logger("motion_velocity_smoother").get_child("trajectory_utils"), "%s",
-          e.what());
+        RCLCPP_WARN(rclcpp::get_logger("map_based_prediction"), "%s", e.what());
         if (i > 1) {
           curvature = k_arr.at(i - 1);  // previous curvature
         } else {
@@ -337,10 +337,10 @@ private:
       tf2::convert(next_pose.orientation, q_next);
       double delta_theta = q_current.angleShortestPath(q_next);
       // Handle wrap-around
-      if (delta_theta > 3.14159) {
-        delta_theta -= 2.0 * 3.14159;
-      } else if (delta_theta < -3.14159) {
-        delta_theta += 2.0 * 3.14159;
+      if (delta_theta > M_PI) {
+        delta_theta -= 2.0 * M_PI;
+      } else if (delta_theta < -M_PI) {
+        delta_theta += 2.0 * M_PI;
       }
 
       const double yaw_rate = std::max(delta_theta / delta_time, 1.0E-5);

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1002,7 +1002,6 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         // Check lat. acceleration constraints
 
         std::vector<PredictedPath> predicted_paths;
-        int count = 0;
         for (const auto & ref_path : ref_paths) {
           PredictedPath predicted_path = path_generator_->generatePathForOnLaneVehicle(
             yaw_fixed_transformed_object, ref_path.path);

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1033,7 +1033,9 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
             std::max(static_cast<int>((curvature_calculation_distance) / points_interval), 1));
           const auto curvature_v =
             calcTrajectoryCurvatureFrom3Points(trajectory_with_const_velocity, idx_dist);
-          if (curvature_v.empty()) continue;
+          if (curvature_v.empty()) {
+            continue;
+          }
           const auto curvature_avg =
             std::accumulate(curvature_v.begin(), curvature_v.end(), 0.0) / curvature_v.size();
           if (curvature_avg < min_avg_curvature) {

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -999,8 +999,6 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
           replaceObjectYawWithLaneletsYaw(current_lanelets, yaw_fixed_transformed_object);
         }
         // Generate Predicted Path
-        // Check lat. acceleration constraints
-
         std::vector<PredictedPath> predicted_paths;
         for (const auto & ref_path : ref_paths) {
           PredictedPath predicted_path = path_generator_->generatePathForOnLaneVehicle(
@@ -1008,10 +1006,10 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
           if (predicted_path.path.empty()) {
             continue;
           }
-
+          // Check lat. acceleration constraints
           const auto trajectory_with_const_velocity =
             toTrajectoryPoints(predicted_path, abs_obj_speed);
-          if (!isAccelerationConstraintsSatisfied(
+          if (!isLateralAccelerationConstraintSatisfied(
                 trajectory_with_const_velocity, prediction_sampling_time_interval_)) {
             continue;
           }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1003,9 +1003,7 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         for (const auto & ref_path : ref_paths) {
           PredictedPath predicted_path = path_generator_->generatePathForOnLaneVehicle(
             yaw_fixed_transformed_object, ref_path.path);
-          if (predicted_path.path.empty()) {
-            continue;
-          }
+          if (predicted_path.path.empty()) continue;
 
           if (!check_lateral_acceleration_constraints_) {
             predicted_path.confidence = ref_path.probability;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1000,37 +1000,26 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         }
         // Generate Predicted Path
         // Check lat. acceleration constraints
-        std::cerr << "---------- Object " << tier4_autoware_utils::toHexString(object.object_id)
-                  << "---------\n";
-        std::cerr << "Object speed " << abs_obj_speed << "\n";
+
         std::vector<PredictedPath> predicted_paths;
         int count = 0;
         for (const auto & ref_path : ref_paths) {
-          std::cerr << "---------------Path # -------------" << count << "\n";
           PredictedPath predicted_path = path_generator_->generatePathForOnLaneVehicle(
             yaw_fixed_transformed_object, ref_path.path);
           if (predicted_path.path.empty()) {
             continue;
           }
-          std::cerr << "path prob " << predicted_path.confidence << "\n";
 
-          // if (ref_path.maneuver != Maneuver::LANE_FOLLOW) {
           const auto trajectory_with_const_velocity =
             toTrajectoryPoints(predicted_path, abs_obj_speed);
           if (!isAccelerationConstraintsSatisfied(
                 trajectory_with_const_velocity, prediction_sampling_time_interval_)) {
-            std::cerr << "Path eliminated by Lat acc constraints\n";
-            std::cerr << "---------------Path # -------------" << count++ << "\n";
             continue;
           }
-          // }
 
           predicted_path.confidence = ref_path.probability;
           predicted_paths.push_back(predicted_path);
-          std::cerr << "---------------Path # -------------" << count++ << "\n";
         }
-        std::cerr << "---------- Object " << tier4_autoware_utils::toHexString(object.object_id)
-                  << "---------\n";
 
         // Normalize Path Confidence and output the predicted object
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -746,6 +746,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
     declare_parameter<double>("deceleration_distance_before_curve");
   deceleration_distance_after_curve_ =
     declare_parameter<double>("deceleration_distance_after_curve");
+  min_acceleration_before_curve_ = declare_parameter<double>("min_acceleration_before_curve");
 
   {  // lane change detection
     lane_change_detection_method_ = declare_parameter<std::string>("lane_change_detection.method");
@@ -810,11 +811,7 @@ rcl_interfaces::msg::SetParametersResult MapBasedPredictionNode::onParam(
   updateParam(
     parameters, "deceleration_distance_before_curve", deceleration_distance_before_curve_);
   updateParam(parameters, "deceleration_distance_after_curve", deceleration_distance_after_curve_);
-
-  std::cerr << "Params updated! \n";
-  std::cerr << "max_lateral_accel" << max_lateral_accel_ << "\n";
-  std::cerr << "deceleration_distance_before_curve" << deceleration_distance_before_curve_ << "\n";
-  std::cerr << "deceleration_distance_after_curve" << deceleration_distance_after_curve_ << "\n";
+  updateParam(parameters, "min_acceleration_before_curve", min_acceleration_before_curve_);
 
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -978,6 +978,14 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
           if (predicted_path.path.empty()) {
             continue;
           }
+
+          // Check lat. acceleration constraints
+          if (ref_path.maneuver != Maneuver::LANE_FOLLOW) {
+            const auto trajectory_with_const_velocity =
+              toTrajectoryPoints(predicted_path, abs_obj_speed);
+            if (!isAccelerationConstraintsSatisfied(trajectory_with_const_velocity)) continue;
+          }
+
           predicted_path.confidence = ref_path.probability;
           predicted_paths.push_back(predicted_path);
         }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1004,27 +1004,33 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
                   << "---------\n";
         std::cerr << "Object speed " << abs_obj_speed << "\n";
         std::vector<PredictedPath> predicted_paths;
+        int count = 0;
         for (const auto & ref_path : ref_paths) {
+          std::cerr << "---------------Path # -------------" << count << "\n";
           PredictedPath predicted_path = path_generator_->generatePathForOnLaneVehicle(
             yaw_fixed_transformed_object, ref_path.path);
           if (predicted_path.path.empty()) {
             continue;
           }
+          std::cerr << "path prob " << predicted_path.confidence << "\n";
 
           // if (ref_path.maneuver != Maneuver::LANE_FOLLOW) {
           const auto trajectory_with_const_velocity =
             toTrajectoryPoints(predicted_path, abs_obj_speed);
-          if (!isAccelerationConstraintsSatisfied(trajectory_with_const_velocity)) {
+          if (!isAccelerationConstraintsSatisfied(
+                trajectory_with_const_velocity, prediction_sampling_time_interval_)) {
             std::cerr << "Path eliminated by Lat acc constraints\n";
+            std::cerr << "---------------Path # -------------" << count++ << "\n";
             continue;
           }
           // }
-          std::cerr << "---------- Object " << tier4_autoware_utils::toHexString(object.object_id)
-                    << "---------\n";
 
           predicted_path.confidence = ref_path.probability;
           predicted_paths.push_back(predicted_path);
+          std::cerr << "---------------Path # -------------" << count++ << "\n";
         }
+        std::cerr << "---------- Object " << tier4_autoware_utils::toHexString(object.object_id)
+                  << "---------\n";
 
         // Normalize Path Confidence and output the predicted object
 


### PR DESCRIPTION
## Description

Implement a lateral acceleration-based pruning mechanism to eliminate unfeasible vehicle paths. See link for more details: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~7120207d8589d164d74a6d8162863204d3efe2/pages/2977566225/Map+based+prediction+with+lateral+acceleration+constraints)

Also, added the possibility of updating parameters in real time (only used for the parameters added by this PR). 

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~7120207d8589d164d74a6d8162863204d3efe2/pages/2977566225/Map+based+prediction+with+lateral+acceleration+constraints)

## Tests performed

PSim with different vehicle speeds and Evaluator tests (I did not find degradation caused by this PR.
): [TIER IV INTERNAL LINK]( https://evaluation.tier4.jp/evaluation/reports/4b9c1ce4-30bf-5bbb-ae97-f559144ba701?project_id=prd_jt)
Example video:

The paths to turn right or left dissappear then the vehicle is close t\because it cannot realistically slow down on time to turn.

https://github.com/autowarefoundation/autoware.universe/assets/25967964/e66e806b-719e-4155-9c00-156438fc9c65


## Notes for reviewers

Requires these changes to launch: https://github.com/autowarefoundation/autoware_launch/pull/759

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Eliminates predicted paths (for vehicles) that are unfeasible because they would generate large lateral accelerations

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
