### PR TITLE
refactor(bpp): remove virtual qualifier

### DIFF
--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/interface.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/interface.hpp
@@ -67,7 +67,10 @@ public:
 
   bool isExecutionReady() const override;
 
-  bool isRootLaneletToBeUpdated() const override { return current_state_ == ModuleStatus::SUCCESS; }
+  bool isRootLaneletToBeUpdated() const override
+  {
+    return getCurrentStatus() == ModuleStatus::SUCCESS;
+  }
 
   void updateData() override;
 

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -64,7 +64,7 @@ void LaneChangeInterface::processOnExit()
 
 bool LaneChangeInterface::isExecutionRequested() const
 {
-  if (current_state_ == ModuleStatus::RUNNING) {
+  if (getCurrentStatus() == ModuleStatus::RUNNING) {
     return true;
   }
 
@@ -359,7 +359,7 @@ MarkerArray LaneChangeInterface::getModuleVirtualWall()
     return marker;
   }
 
-  if (isWaitingApproval() || current_state_ != ModuleStatus::RUNNING) {
+  if (isWaitingApproval() || getCurrentStatus() != ModuleStatus::RUNNING) {
     return marker;
   }
   const auto & start_pose = module_type_->getLaneChangePath().info.lane_changing_start;

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -112,21 +112,6 @@ public:
   virtual void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const = 0;
 
   /**
-   * @brief Set the current_state_ based on updateState output.
-   */
-  virtual void updateCurrentState()
-  {
-    const auto print = [this](const auto & from, const auto & to) {
-      RCLCPP_DEBUG(
-        getLogger(), "[%s] Transit from %s to %s.", name_.c_str(), from.data(), to.data());
-    };
-
-    const auto & from = current_state_;
-    current_state_ = updateState();
-    print(magic_enum::enum_name(from), magic_enum::enum_name(current_state_));
-  }
-
-  /**
    * @brief Return true if the module has request for execution (not necessarily feasible)
    */
   virtual bool isExecutionRequested() const = 0;
@@ -157,6 +142,21 @@ public:
   {
     updateData();
     return isWaitingApproval() ? planWaitingApproval() : plan();
+  }
+
+  /**
+   * @brief Set the current_state_ based on updateState output.
+   */
+  void updateCurrentState()
+  {
+    const auto print = [this](const auto & from, const auto & to) {
+      RCLCPP_DEBUG(
+        getLogger(), "[%s] Transit from %s to %s.", name_.c_str(), from.data(), to.data());
+    };
+
+    const auto & from = current_state_;
+    current_state_ = updateState();
+    print(magic_enum::enum_name(from), magic_enum::enum_name(current_state_));
   }
 
   /**
@@ -362,7 +362,83 @@ private:
     return existApprovedRequest();
   }
 
+  /**
+   * @brief Return SUCCESS if plan is not needed or plan is successfully finished,
+   *        FAILURE if plan has failed, RUNNING if plan is on going.
+   *        These condition is to be implemented in each modules.
+   */
+  ModuleStatus updateState()
+  {
+    auto log_debug_throttled = [&](std::string_view message) -> void {
+      RCLCPP_WARN(getLogger(), "%s", message.data());
+    };
+    if (current_state_ == ModuleStatus::IDLE) {
+      if (canTransitIdleToRunningState()) {
+        log_debug_throttled("transiting from IDLE to RUNNING");
+        return ModuleStatus::RUNNING;
+      }
+
+      log_debug_throttled("transiting from IDLE to IDLE");
+      return ModuleStatus::IDLE;
+    }
+
+    if (current_state_ == ModuleStatus::RUNNING) {
+      if (canTransitSuccessState()) {
+        log_debug_throttled("transiting from RUNNING to SUCCESS");
+        return ModuleStatus::SUCCESS;
+      }
+
+      if (canTransitFailureState()) {
+        log_debug_throttled("transiting from RUNNING to FAILURE");
+        return ModuleStatus::FAILURE;
+      }
+
+      if (canTransitWaitingApprovalState()) {
+        log_debug_throttled("transiting from RUNNING to WAITING_APPROVAL");
+        return ModuleStatus::WAITING_APPROVAL;
+      }
+
+      log_debug_throttled("transiting from RUNNING to RUNNING");
+      return ModuleStatus::RUNNING;
+    }
+
+    if (current_state_ == ModuleStatus::WAITING_APPROVAL) {
+      if (canTransitSuccessState()) {
+        log_debug_throttled("transiting from WAITING_APPROVAL to SUCCESS");
+        return ModuleStatus::SUCCESS;
+      }
+
+      if (canTransitFailureState()) {
+        log_debug_throttled("transiting from WAITING_APPROVAL to FAILURE");
+        return ModuleStatus::FAILURE;
+      }
+
+      if (canTransitWaitingApprovalToRunningState()) {
+        log_debug_throttled("transiting from WAITING_APPROVAL to RUNNING");
+        return ModuleStatus::RUNNING;
+      }
+
+      log_debug_throttled("transiting from WAITING_APPROVAL to WAITING APPROVAL");
+      return ModuleStatus::WAITING_APPROVAL;
+    }
+
+    if (current_state_ == ModuleStatus::SUCCESS) {
+      log_debug_throttled("already SUCCESS");
+      return ModuleStatus::SUCCESS;
+    }
+
+    if (current_state_ == ModuleStatus::FAILURE) {
+      log_debug_throttled("already FAILURE");
+      return ModuleStatus::FAILURE;
+    }
+
+    log_debug_throttled("already IDLE");
+    return ModuleStatus::IDLE;
+  }
+
   std::string name_;
+
+  ModuleStatus current_state_{ModuleStatus::IDLE};
 
   BehaviorModuleOutput previous_module_output_;
 
@@ -440,80 +516,6 @@ protected:
         ptr->insertObjectData(obj_pose, obj_shape, color_name);
       }
     }
-  }
-
-  /**
-   * @brief Return SUCCESS if plan is not needed or plan is successfully finished,
-   *        FAILURE if plan has failed, RUNNING if plan is on going.
-   *        These condition is to be implemented in each modules.
-   */
-  virtual ModuleStatus updateState()
-  {
-    auto log_debug_throttled = [&](std::string_view message) -> void {
-      RCLCPP_WARN(getLogger(), "%s", message.data());
-    };
-    if (current_state_ == ModuleStatus::IDLE) {
-      if (canTransitIdleToRunningState()) {
-        log_debug_throttled("transiting from IDLE to RUNNING");
-        return ModuleStatus::RUNNING;
-      }
-
-      log_debug_throttled("transiting from IDLE to IDLE");
-      return ModuleStatus::IDLE;
-    }
-
-    if (current_state_ == ModuleStatus::RUNNING) {
-      if (canTransitSuccessState()) {
-        log_debug_throttled("transiting from RUNNING to SUCCESS");
-        return ModuleStatus::SUCCESS;
-      }
-
-      if (canTransitFailureState()) {
-        log_debug_throttled("transiting from RUNNING to FAILURE");
-        return ModuleStatus::FAILURE;
-      }
-
-      if (canTransitWaitingApprovalState()) {
-        log_debug_throttled("transiting from RUNNING to WAITING_APPROVAL");
-        return ModuleStatus::WAITING_APPROVAL;
-      }
-
-      log_debug_throttled("transiting from RUNNING to RUNNING");
-      return ModuleStatus::RUNNING;
-    }
-
-    if (current_state_ == ModuleStatus::WAITING_APPROVAL) {
-      if (canTransitSuccessState()) {
-        log_debug_throttled("transiting from WAITING_APPROVAL to SUCCESS");
-        return ModuleStatus::SUCCESS;
-      }
-
-      if (canTransitFailureState()) {
-        log_debug_throttled("transiting from WAITING_APPROVAL to FAILURE");
-        return ModuleStatus::FAILURE;
-      }
-
-      if (canTransitWaitingApprovalToRunningState()) {
-        log_debug_throttled("transiting from WAITING_APPROVAL to RUNNING");
-        return ModuleStatus::RUNNING;
-      }
-
-      log_debug_throttled("transiting from WAITING_APPROVAL to WAITING APPROVAL");
-      return ModuleStatus::WAITING_APPROVAL;
-    }
-
-    if (current_state_ == ModuleStatus::SUCCESS) {
-      log_debug_throttled("already SUCCESS");
-      return ModuleStatus::SUCCESS;
-    }
-
-    if (current_state_ == ModuleStatus::FAILURE) {
-      log_debug_throttled("already FAILURE");
-      return ModuleStatus::FAILURE;
-    }
-
-    log_debug_throttled("already IDLE");
-    return ModuleStatus::IDLE;
   }
 
   /**
@@ -609,8 +611,6 @@ protected:
 
   PlanResult path_candidate_;
   PlanResult path_reference_;
-
-  ModuleStatus current_state_{ModuleStatus::IDLE};
 
   std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map_;
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -370,7 +370,7 @@ private:
   ModuleStatus updateState()
   {
     auto log_debug_throttled = [&](std::string_view message) -> void {
-      RCLCPP_WARN(getLogger(), "%s", message.data());
+      RCLCPP_DEBUG(getLogger(), "%s", message.data());
     };
     if (current_state_ == ModuleStatus::IDLE) {
       if (canTransitIdleToRunningState()) {


### PR DESCRIPTION
## Description

Hide `updateCurrentState()` as private function. Inherit class only can override state transit conditions, and interface decides next state based on them.

This PR contains following modifications.

- remove `virtual` qualifier from `updateState()`
- remove `virtual` qualifier from `updateCurrentState()`
- move `current_state_` to private

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
