### PR TITLE
feat(start_planner): visualize stop line for safety check feature

### DIFF
--- a/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -798,7 +798,7 @@ void GoalPlannerModule::setStopPathFromCurrentPath(BehaviorModuleOutput & output
     auto current_path = thread_safe_data_.get_pull_over_path()->getCurrentPath();
     const auto stop_path =
       behavior_path_planner::utils::parking_departure::generateFeasibleStopPath(
-        current_path, planner_data_, *stop_pose_, parameters_->maximum_deceleration_for_stop,
+        current_path, planner_data_, stop_pose_, parameters_->maximum_deceleration_for_stop,
         parameters_->maximum_jerk_for_stop);
     if (stop_path) {
       output.path = *stop_path;

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/parking_departure/utils.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/parking_departure/utils.hpp
@@ -70,7 +70,7 @@ std::pair<double, double> getPairsTerminalVelocityAndAccel(
 
 std::optional<PathWithLaneId> generateFeasibleStopPath(
   PathWithLaneId & current_path, std::shared_ptr<const PlannerData> planner_data,
-  geometry_msgs::msg::Pose & stop_pose, const double maximum_deceleration,
+  std::optional<geometry_msgs::msg::Pose> & stop_pose, const double maximum_deceleration,
   const double maximum_jerk);
 
 /**

--- a/planning/behavior_path_planner_common/src/utils/parking_departure/utils.cpp
+++ b/planning/behavior_path_planner_common/src/utils/parking_departure/utils.cpp
@@ -126,7 +126,7 @@ std::pair<double, double> getPairsTerminalVelocityAndAccel(
 
 std::optional<PathWithLaneId> generateFeasibleStopPath(
   PathWithLaneId & current_path, std::shared_ptr<const PlannerData> planner_data,
-  geometry_msgs::msg::Pose & stop_pose, const double maximum_deceleration,
+  std::optional<geometry_msgs::msg::Pose> & stop_pose, const double maximum_deceleration,
   const double maximum_jerk)
 {
   if (current_path.points.empty()) {

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -68,7 +68,7 @@ struct PullOutStatus
   Pose pull_out_start_pose{};
   bool prev_is_safe_dynamic_objects{false};
   std::shared_ptr<PathWithLaneId> prev_stop_path_after_approval{nullptr};
-  bool has_stop_point{false};
+  std::optional<Pose> stop_pose{std::nullopt};
 
   PullOutStatus() {}
 };

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -371,11 +371,11 @@ BehaviorModuleOutput StartPlannerModule::plan()
       incrementPathIndex();
     }
 
-    if (!status_.is_safe_dynamic_objects && !isWaitingApproval() && !status_.has_stop_point) {
+    if (!status_.is_safe_dynamic_objects && !isWaitingApproval() && !status_.stop_pose) {
       auto current_path = getCurrentPath();
       const auto stop_path =
         behavior_path_planner::utils::parking_departure::generateFeasibleStopPath(
-          current_path, planner_data_, *stop_pose_, parameters_->maximum_deceleration_for_stop,
+          current_path, planner_data_, stop_pose_, parameters_->maximum_deceleration_for_stop,
           parameters_->maximum_jerk_for_stop);
 
       // Insert stop point in the path if needed
@@ -384,17 +384,18 @@ BehaviorModuleOutput StartPlannerModule::plan()
           getLogger(), *clock_, 5000, "Insert stop point in the path because of dynamic objects");
         path = *stop_path;
         status_.prev_stop_path_after_approval = std::make_shared<PathWithLaneId>(path);
-        status_.has_stop_point = true;
+        status_.stop_pose = stop_pose_;
       } else {
         path = current_path;
       }
-    } else if (!isWaitingApproval() && status_.has_stop_point) {
+    } else if (!isWaitingApproval() && status_.stop_pose) {
       // Delete stop point if conditions are met
       if (status_.is_safe_dynamic_objects && isStopped()) {
-        status_.has_stop_point = false;
+        status_.stop_pose = std::nullopt;
         path = getCurrentPath();
       }
       path = *status_.prev_stop_path_after_approval;
+      stop_pose_ = status_.stop_pose;
     } else {
       path = getCurrentPath();
     }
@@ -1389,7 +1390,7 @@ void StartPlannerModule::logPullOutStatus(rclcpp::Logger::Level log_level) const
     status_.prev_is_safe_dynamic_objects ? "true" : "false");
   logFunc("  Driving Forward: %s", status_.driving_forward ? "true" : "false");
   logFunc("  Backward Driving Complete: %s", status_.backward_driving_complete ? "true" : "false");
-  logFunc("  Has Stop Point: %s", status_.has_stop_point ? "true" : "false");
+  logFunc("  Has Stop Pose: %s", status_.stop_pose ? "true" : "false");
 
   logFunc("[Module State]");
   logFunc("  isActivated: %s", isActivated() ? "true" : "false");


### PR DESCRIPTION
## Description

visualize stop line when module inserts stop line in the path

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

confirmed with psim
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/11d5f8c7-c589-4362-a18b-4280f6f0fd9b)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
