### PR TITLE
feat(start_planner): visualize refined start pose and start pose candidates with idx

### DIFF
--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/marker_utils/utils.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/marker_utils/utils.hpp
@@ -18,6 +18,8 @@
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 #include "behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
 
+#include <vehicle_info_util/vehicle_info.hpp>
+
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_path.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
@@ -55,6 +57,14 @@ inline int64_t bitShift(int64_t original_id)
 {
   return original_id << (sizeof(int32_t) * 8 / 2);
 }
+
+void addFootprintMarker(
+  visualization_msgs::msg::Marker & marker, const geometry_msgs::msg::Pose & pose,
+  const vehicle_info_util::VehicleInfo & vehicle_info);
+
+MarkerArray createFootprintMarkerArray(
+  const Pose & base_link_pose, const vehicle_info_util::VehicleInfo vehicle_info,
+  const std::string && ns, const int32_t & id, const float & r, const float & g, const float & b);
 
 MarkerArray createPoseMarkerArray(
   const Pose & pose, std::string && ns, const int32_t & id, const float & r, const float & g,

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/parking_departure/common_module_data.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/parking_departure/common_module_data.hpp
@@ -38,6 +38,9 @@ struct StartGoalPlannerData
   std::vector<PoseWithVelocityStamped> ego_predicted_path;
   // collision check debug map
   CollisionCheckDebugMap collision_check;
+
+  Pose refined_start_pose;
+  std::vector<Pose> start_pose_candidates;
 };
 
 }  // namespace behavior_path_planner


### PR DESCRIPTION
## Description
visualize refined start pose
![Screenshot from 2023-12-27 23-35-29](https://github.com/autowarefoundation/autoware.universe/assets/32741405/4b4a9256-1e34-4d3f-a4d4-9c081f3f6aef)

and start pose candidates with idx
![Screenshot from 2023-12-27 23-35-16](https://github.com/autowarefoundation/autoware.universe/assets/32741405/debf8e82-5506-4936-819f-76516d573b7a)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
