### PR TITLE
feat(geography_utils): add mgrs code in projector

### DIFF
--- a/common/geography_utils/src/lanelet2_projector.cpp
+++ b/common/geography_utils/src/lanelet2_projector.cpp
@@ -34,6 +34,7 @@ std::unique_ptr<lanelet::Projector> get_lanelet2_projector(const MapProjectorInf
 
   } else if (projector_info.projector_type == MapProjectorInfo::MGRS) {
     lanelet::projection::MGRSProjector projector{};
+    projector.setMGRSCode(projector_info.mgrs_grid);
     return std::make_unique<lanelet::projection::MGRSProjector>(projector);
 
   } else if (projector_info.projector_type == MapProjectorInfo::TRANSVERSE_MERCATOR) {


### PR DESCRIPTION
## Description

Without this PR, when handling the MGRS projector created by `geography_utils::get_lanelet2_projector`, the following error occurred.
https://github.com/autowarefoundation/autoware_common/blob/6bbda6513206ea968f76f310a4bf2847bff3a583/tmp/lanelet2_extension/lib/mgrs_projector.cpp#L82-L83
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Run static_centerline_optimizer's script
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
