### PR TITLE
fix(surround_obstacle_checker): remove the virtual wall from the node

### DIFF
--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/debug_marker.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/debug_marker.hpp
@@ -71,7 +71,6 @@ public:
     const double back_distance);
 
 private:
-  rclcpp::Publisher<MarkerArray>::SharedPtr debug_virtual_wall_pub_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;
   rclcpp::Publisher<StopReasonArray>::SharedPtr stop_reason_pub_;
   rclcpp::Publisher<VelocityFactorArray>::SharedPtr velocity_factor_pub_;
@@ -89,7 +88,6 @@ private:
   double surround_check_hysteresis_distance_;
   geometry_msgs::msg::Pose self_pose_;
 
-  MarkerArray makeVirtualWallMarker();
   MarkerArray makeVisualizationMarker();
   StopReasonArray makeStopReasonArray();
   VelocityFactorArray makeVelocityFactorArray();

--- a/planning/surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/surround_obstacle_checker/src/debug_marker.cpp
@@ -15,7 +15,6 @@
 #include "surround_obstacle_checker/debug_marker.hpp"
 
 #include <motion_utils/marker/marker_helper.hpp>
-#include <motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 #ifdef ROS_DISTRO_GALACTIC
@@ -52,7 +51,6 @@ Polygon2d createSelfPolygon(
 }
 }  // namespace
 
-using motion_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
@@ -76,8 +74,6 @@ SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
   self_pose_(self_pose),
   clock_(clock)
 {
-  debug_virtual_wall_pub_ =
-    node.create_publisher<visualization_msgs::msg::MarkerArray>("~/virtual_wall", 1);
   debug_viz_pub_ = node.create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/marker", 1);
   stop_reason_pub_ = node.create_publisher<StopReasonArray>("~/output/stop_reasons", 1);
   velocity_factor_pub_ =
@@ -141,10 +137,6 @@ void SurroundObstacleCheckerDebugNode::publishFootprints()
 
 void SurroundObstacleCheckerDebugNode::publish()
 {
-  /* publish virtual_wall marker for rviz */
-  const auto virtual_wall_msg = makeVirtualWallMarker();
-  debug_virtual_wall_pub_->publish(virtual_wall_msg);
-
   /* publish debug marker for rviz */
   const auto visualization_msg = makeVisualizationMarker();
   debug_viz_pub_->publish(visualization_msg);
@@ -158,21 +150,6 @@ void SurroundObstacleCheckerDebugNode::publish()
   /* reset variables */
   stop_pose_ptr_ = nullptr;
   stop_obstacle_point_ptr_ = nullptr;
-}
-
-MarkerArray SurroundObstacleCheckerDebugNode::makeVirtualWallMarker()
-{
-  MarkerArray msg;
-  rclcpp::Time current_time = this->clock_->now();
-
-  // visualize stop line
-  if (stop_pose_ptr_ != nullptr) {
-    const auto p = calcOffsetPose(*stop_pose_ptr_, base_link2front_, 0.0, 0.0);
-    const auto markers = createStopVirtualWallMarker(p, "surround obstacle", current_time, 0);
-    appendMarkerArray(markers, &msg);
-  }
-
-  return msg;
 }
 
 MarkerArray SurroundObstacleCheckerDebugNode::makeVisualizationMarker()


### PR DESCRIPTION
## Description

By the following PR, a stop virtual wall by the external velocity limit is published from the motion_velocity_smoother for MRM comfortable stop.
https://github.com/autowarefoundation/autoware.universe/pull/5555

The surround obstacle checker, which uses the external velocity limit to stop the ego, internally publishes the stop virtual wall, resulting in the duplicated walls.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/705b7f25-390a-4b58-8ee5-9a1323e30d08)

This PR removes the publisher of the wall in the surround obstacle checker.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
