### PR TITLE
refactor(map_projection_loader): make important part a library

### DIFF
--- a/map/map_projection_loader/include/map_projection_loader/map_projection_loader.hpp
+++ b/map/map_projection_loader/include/map_projection_loader/map_projection_loader.hpp
@@ -23,6 +23,8 @@
 #include <string>
 
 tier4_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string & filename);
+tier4_map_msgs::msg::MapProjectorInfo load_map_projector_info(
+  const std::string & filename, const std::string & lanelet2_map_filename, bool use_yaml_file);
 
 class MapProjectionLoader : public rclcpp::Node
 {

--- a/map/map_projection_loader/include/map_projection_loader/map_projection_loader.hpp
+++ b/map/map_projection_loader/include/map_projection_loader/map_projection_loader.hpp
@@ -24,7 +24,7 @@
 
 tier4_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string & filename);
 tier4_map_msgs::msg::MapProjectorInfo load_map_projector_info(
-  const std::string & filename, const std::string & lanelet2_map_filename, bool use_yaml_file);
+  const std::string & yaml_filename, const std::string & lanelet2_map_filename);
 
 class MapProjectionLoader : public rclcpp::Node
 {

--- a/map/map_projection_loader/src/map_projection_loader.cpp
+++ b/map/map_projection_loader/src/map_projection_loader.cpp
@@ -64,10 +64,13 @@ tier4_map_msgs::msg::MapProjectorInfo load_map_projector_info(
     msg = load_info_from_yaml(yaml_filename);
   } else {
     std::cout << "Load " << lanelet2_map_filename << std::endl;
-    std::cout << "DEPRECATED WARNING: Loading map projection info from lanelet2 map may soon be deleted. "
-      "Please use map_projector_info.yaml instead. For more info, visit "
-      "https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_projection_loader/"
-      "README.md" << std::endl;
+    std::cout
+      << "DEPRECATED WARNING: Loading map projection info from lanelet2 map may soon be deleted. "
+         "Please use map_projector_info.yaml instead. For more info, visit "
+         "https://github.com/autowarefoundation/autoware.universe/blob/main/map/"
+         "map_projection_loader/"
+         "README.md"
+      << std::endl;
     msg = load_info_from_lanelet2_map(lanelet2_map_filename);
   }
   return msg;
@@ -79,9 +82,9 @@ MapProjectionLoader::MapProjectionLoader() : Node("map_projection_loader")
   std::string lanelet2_map_filename = this->declare_parameter<std::string>("lanelet2_map_path");
   std::ifstream file(yaml_filename);
 
-  tier4_map_msgs::msg::MapProjectorInfo msg = load_map_projector_info(
-    yaml_filename, lanelet2_map_filename, file.is_open());
-  
+  tier4_map_msgs::msg::MapProjectorInfo msg =
+    load_map_projector_info(yaml_filename, lanelet2_map_filename, file.is_open());
+
   // Publish the message
   const auto adaptor = component_interface_utils::NodeAdaptor(this);
   adaptor.init_pub(publisher_);

--- a/map/map_projection_loader/src/map_projection_loader.cpp
+++ b/map/map_projection_loader/src/map_projection_loader.cpp
@@ -78,11 +78,11 @@ tier4_map_msgs::msg::MapProjectorInfo load_map_projector_info(
 
 MapProjectionLoader::MapProjectionLoader() : Node("map_projection_loader")
 {
-  std::string yaml_filename = this->declare_parameter<std::string>("map_projector_info_path");
-  std::string lanelet2_map_filename = this->declare_parameter<std::string>("lanelet2_map_path");
+  const std::string yaml_filename = this->declare_parameter<std::string>("map_projector_info_path");
+  const std::string lanelet2_map_filename = this->declare_parameter<std::string>("lanelet2_map_path");
   std::ifstream file(yaml_filename);
 
-  tier4_map_msgs::msg::MapProjectorInfo msg =
+  const tier4_map_msgs::msg::MapProjectorInfo msg =
     load_map_projector_info(yaml_filename, lanelet2_map_filename, file.is_open());
 
   // Publish the message

--- a/map/map_projection_loader/src/map_projection_loader.cpp
+++ b/map/map_projection_loader/src/map_projection_loader.cpp
@@ -20,8 +20,8 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 
 tier4_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string & filename)
 {
@@ -75,8 +75,9 @@ tier4_map_msgs::msg::MapProjectorInfo load_map_projector_info(
       << std::endl;
     msg = load_info_from_lanelet2_map(lanelet2_map_filename);
   } else {
-    throw std::runtime_error("No map projector info files found. Please provide either "
-                             "map_projector_info.yaml or lanelet2_map.osm");
+    throw std::runtime_error(
+      "No map projector info files found. Please provide either "
+      "map_projector_info.yaml or lanelet2_map.osm");
   }
   return msg;
 }
@@ -84,7 +85,8 @@ tier4_map_msgs::msg::MapProjectorInfo load_map_projector_info(
 MapProjectionLoader::MapProjectionLoader() : Node("map_projection_loader")
 {
   const std::string yaml_filename = this->declare_parameter<std::string>("map_projector_info_path");
-  const std::string lanelet2_map_filename = this->declare_parameter<std::string>("lanelet2_map_path");
+  const std::string lanelet2_map_filename =
+    this->declare_parameter<std::string>("lanelet2_map_path");
 
   const tier4_map_msgs::msg::MapProjectorInfo msg =
     load_map_projector_info(yaml_filename, lanelet2_map_filename);


### PR DESCRIPTION
## Description
I would like to make the part where the `map_projector_info` object is created an independent library so that not only this node but also other nodes can use this.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- Launch logging_simulator and confirmed that localization works fine with sample rosbag and map
- Colcon test passes

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
No effects expected

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
