### PR TITLE
chore(component_interface_utils): set log level of debug printing to DEBUG

### DIFF
--- a/common/component_interface_utils/include/component_interface_utils/rclcpp/interface.hpp
+++ b/common/component_interface_utils/include/component_interface_utils/rclcpp/interface.hpp
@@ -52,7 +52,7 @@ struct NodeInterface
        {ServiceLog::CLIENT_RESPONSE, "client exit"},
        {ServiceLog::ERROR_UNREADY, "client unready"},
        {ServiceLog::ERROR_TIMEOUT, "client timeout"}});
-    RCLCPP_INFO_STREAM(node->get_logger(), type_text.at(type) << ": " << name);
+    RCLCPP_DEBUG_STREAM(node->get_logger(), type_text.at(type) << ": " << name);
 
     ServiceLog msg;
     msg.stamp = node->now();


### PR DESCRIPTION
## Description


Currently, when
- the ego pose is set
- the Autoware is engaged
- the ego arrives the goal
- etc,
the following multiple debug printing is shown by component_interface_utils, which is not necessary for daily use.
```
[component_container_mt-35] [INFO 1702834054.891762811] [default_ad_api.node.routing]: server call: /api/routing/clear_route (log():55)
[component_container_mt-35] [INFO 1702834054.892185041] [default_ad_api.node.routing]: client call: /planning/mission_planning/clear_route (log():55)
[component_container_mt-35] [INFO 1702834054.892788913] [default_ad_api.node.routing]: client exit: /planning/mission_planning/clear_route (log():55)
[component_container_mt-35] [INFO 1702834054.892814293] [default_ad_api.node.routing]: server exit: /api/routing/clear_route (log():55)
[component_container-24] [INFO 1702834054.892408732] [planning.mission_planning.mission_planner]: server call: /planning/mission_planning/clear_route (log():55)
[component_container-24] [INFO 1702834054.892547344] [planning.mission_planning.mission_planner]: server exit: /planning/mission_planning/clear_route (log():55)
[routing_adaptor-38] [INFO 1702834054.893230405] [default_ad_api.helpers.routing_adaptor]: client exit: /api/routing/clear_route (log():55)
[routing_adaptor-38] [INFO 1702834055.090843387] [default_ad_api.helpers.routing_adaptor]: client call: /api/routing/set_route_points (log():55)
[component_container_mt-35] [INFO 1702834055.091650248] [default_ad_api.node.routing]: server call: /api/routing/set_route_points (log():55)
[component_container_mt-35] [INFO 1702834055.092060048] [default_ad_api.node.routing]: client call: /planning/mission_planning/set_route_points (log():55)
```
This PR set its log level from INFO to DEBUG.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
