### PR TITLE
chore: set log level of debug printing in rviz plugin to DEBUG

### DIFF
--- a/common/tier4_api_utils/include/tier4_api_utils/rclcpp/client.hpp
+++ b/common/tier4_api_utils/include/tier4_api_utils/rclcpp/client.hpp
@@ -41,20 +41,20 @@ public:
     const typename ServiceT::Request::SharedPtr & request,
     const std::chrono::nanoseconds & timeout = std::chrono::seconds(2))
   {
-    RCLCPP_INFO(logger_, "client request");
+    RCLCPP_DEBUG(logger_, "client request");
 
     if (!client_->service_is_ready()) {
-      RCLCPP_INFO(logger_, "client available");
+      RCLCPP_DEBUG(logger_, "client available");
       return {response_error("Internal service is not available."), nullptr};
     }
 
     auto future = client_->async_send_request(request);
     if (future.wait_for(timeout) != std::future_status::ready) {
-      RCLCPP_INFO(logger_, "client timeout");
+      RCLCPP_DEBUG(logger_, "client timeout");
       return {response_error("Internal service has timed out."), nullptr};
     }
 
-    RCLCPP_INFO(logger_, "client response");
+    RCLCPP_DEBUG(logger_, "client response");
     return {response_success(), future.get()};
   }
 

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -263,9 +263,9 @@ void ManualController::onClickEnableButton()
   {
     auto req = std::make_shared<EngageSrv::Request>();
     req->engage = true;
-    RCLCPP_INFO(raw_node_->get_logger(), "client request");
+    RCLCPP_DEBUG(raw_node_->get_logger(), "client request");
     if (!client_engage_->service_is_ready()) {
-      RCLCPP_INFO(raw_node_->get_logger(), "client is unavailable");
+      RCLCPP_DEBUG(raw_node_->get_logger(), "client is unavailable");
       return;
     }
     client_engage_->async_send_request(

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -171,15 +171,15 @@ protected:
   {
     auto req = std::make_shared<typename T::Request>();
 
-    RCLCPP_INFO(raw_node_->get_logger(), "client request");
+    RCLCPP_DEBUG(raw_node_->get_logger(), "client request");
 
     if (!client->service_is_ready()) {
-      RCLCPP_INFO(raw_node_->get_logger(), "client is unavailable");
+      RCLCPP_DEBUG(raw_node_->get_logger(), "client is unavailable");
       return;
     }
 
     client->async_send_request(req, [this](typename rclcpp::Client<T>::SharedFuture result) {
-      RCLCPP_INFO(
+      RCLCPP_DEBUG(
         raw_node_->get_logger(), "Status: %d, %s", result.get()->status.code,
         result.get()->status.message.c_str());
     });


### PR DESCRIPTION
## Description

Some packages in common/ (e.g. rviz plugins to connect with the Autoware) show the debug printing as follows when using ROS2 service, which is not necessary for daily use.
```
client request
Status 0,
```
This PR sets its log level from INFO to DEBUG.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
