### PR TITLE
feat(joy_controller): add xbox one joy mapping

### DIFF
--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -105,5 +105,5 @@
 | Clear Emergency Stop | Menu                  |
 | Autoware Engage      | X                     |
 | Autoware Disengage   | Y                     |
-| Vehicle Engage       | Left Trigger          |
-| Vehicle Disengage    | Right Trigger         |
+| Vehicle Engage       | Left Stick Button     |
+| Vehicle Disengage    | Right Stick Button    |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -86,7 +86,7 @@
 | Vehicle Engage       | △                          |
 | Vehicle Disengage    | △                          |
 
-## XONE Joystick Key Map
+## XBOX Joystick Key Map
 
 | Action               | Button                |
 | -------------------- | --------------------- |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -85,3 +85,25 @@
 | Autoware Disengage   | ○                          |
 | Vehicle Engage       | △                          |
 | Vehicle Disengage    | △                          |
+
+## XONE Joystick Key Map
+
+| Action               | Button                |
+| -------------------- | --------------------- |
+| Acceleration         | RT                    |
+| Brake                | LT                    |
+| Steering             | Left Stick Left Right |
+| Shift up             | Cursor Up             |
+| Shift down           | Cursor Down           |
+| Shift Drive          | Cursor Left           |
+| Shift Reverse        | Cursor Right          |
+| Turn Signal Left     | LB                    |
+| Turn Signal Right    | RB                    |
+| Clear Turn Signal    | A                     |
+| Gate Mode            | B                     |
+| Emergency Stop       | View                  |
+| Clear Emergency Stop | Menu                  |
+| Autoware Engage      | X                     |
+| Autoware Disengage   | Y                     |
+| Vehicle Engage       | Left Trigger          |
+| Vehicle Disengage    | Right Trigger         |

--- a/control/joy_controller/include/joy_controller/joy_converter/xbox_joy_converter.hpp
+++ b/control/joy_controller/include/joy_controller/joy_converter/xbox_joy_converter.hpp
@@ -49,8 +49,8 @@ public:
   bool autoware_engage() const { return X(); }
   bool autoware_disengage() const { return Y(); }
 
-  bool vehicle_engage() const { return LTrigger(); }
-  bool vehicle_disengage() const { return RTrigger(); }
+  bool vehicle_engage() const { return LStickButton(); }
+  bool vehicle_disengage() const { return RStickButton(); }
 
 private:
   float LStickLeftRight() const { return j_.axes.at(0); }
@@ -69,8 +69,8 @@ private:
   bool LB() const { return j_.buttons.at(6); }
   bool RB() const { return j_.buttons.at(7); }
   bool Menu() const { return j_.buttons.at(11); }
-  bool LTrigger() const { return j_.buttons.at(13); }
-  bool RTrigger() const { return j_.buttons.at(14); }
+  bool LStickButton() const { return j_.buttons.at(13); }
+  bool RStickButton() const { return j_.buttons.at(14); }
   bool ChangeView() const { return j_.buttons.at(15); }
   bool Xbox() const { return j_.buttons.at(16); }
 

--- a/control/joy_controller/include/joy_controller/joy_converter/xbox_joy_converter.hpp
+++ b/control/joy_controller/include/joy_controller/joy_converter/xbox_joy_converter.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef JOY_CONTROLLER__JOY_CONVERTER__XONE_JOY_CONVERTER_HPP_
-#define JOY_CONTROLLER__JOY_CONVERTER__XONE_JOY_CONVERTER_HPP_
+#ifndef JOY_CONTROLLER__JOY_CONVERTER__XBOX_JOY_CONVERTER_HPP_
+#define JOY_CONTROLLER__JOY_CONVERTER__XBOX_JOY_CONVERTER_HPP_
 
 #include "joy_controller/joy_converter/joy_converter_base.hpp"
 
@@ -21,10 +21,10 @@
 
 namespace joy_controller
 {
-class XONEJoyConverter : public JoyConverterBase
+class XBOXJoyConverter : public JoyConverterBase
 {
 public:
-  explicit XONEJoyConverter(const sensor_msgs::msg::Joy & j) : j_(j) {}
+  explicit XBOXJoyConverter(const sensor_msgs::msg::Joy & j) : j_(j) {}
 
   float accel() const { return std::max(0.0f, -((RT() - 1.0f) / 2.0f)); }
 
@@ -78,4 +78,4 @@ private:
 };
 }  // namespace joy_controller
 
-#endif  // JOY_CONTROLLER__JOY_CONVERTER__XONE_JOY_CONVERTER_HPP_
+#endif  // JOY_CONTROLLER__JOY_CONVERTER__XBOX_JOY_CONVERTER_HPP_

--- a/control/joy_controller/include/joy_controller/joy_converter/xone_joy_converter.hpp
+++ b/control/joy_controller/include/joy_controller/joy_converter/xone_joy_converter.hpp
@@ -1,0 +1,81 @@
+// Copyright 2023 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef JOY_CONTROLLER__JOY_CONVERTER__XONE_JOY_CONVERTER_HPP_
+#define JOY_CONTROLLER__JOY_CONVERTER__XONE_JOY_CONVERTER_HPP_
+
+#include "joy_controller/joy_converter/joy_converter_base.hpp"
+
+#include <algorithm>
+
+namespace joy_controller
+{
+class XONEJoyConverter : public JoyConverterBase
+{
+public:
+  explicit XONEJoyConverter(const sensor_msgs::msg::Joy & j) : j_(j) {}
+
+  float accel() const { return std::max(0.0f, -((RT() - 1.0f) / 2.0f)); }
+
+  float brake() const { return std::max(0.0f, -((LT() - 1.0f) / 2.0f)); }
+
+  float steer() const { return LStickLeftRight(); }
+
+  bool shift_up() const { return CursorUpDown() == 1.0f; }
+  bool shift_down() const { return CursorUpDown() == -1.0f; }
+  bool shift_drive() const { return CursorLeftRight() == 1.0f; }
+  bool shift_reverse() const { return CursorLeftRight() == -1.0f; }
+
+  bool turn_signal_left() const { return LB(); }
+  bool turn_signal_right() const { return RB(); }
+  bool clear_turn_signal() const { return A(); }
+
+  bool gate_mode() const { return B(); }
+
+  bool emergency_stop() const { return ChangeView(); }
+  bool clear_emergency_stop() const { return Menu(); }
+
+  bool autoware_engage() const { return X(); }
+  bool autoware_disengage() const { return Y(); }
+
+  bool vehicle_engage() const { return LTrigger(); }
+  bool vehicle_disengage() const { return RTrigger(); }
+
+private:
+  float LStickLeftRight() const { return j_.axes.at(0); }
+  float LStickUpDown() const { return j_.axes.at(1); }
+  float RStickLeftRight() const { return j_.axes.at(2); }
+  float RStickUpDown() const { return j_.axes.at(3); }
+  float RT() const { return j_.axes.at(4); }
+  float LT() const { return j_.axes.at(5); }
+  float CursorLeftRight() const { return j_.axes.at(6); }
+  float CursorUpDown() const { return j_.axes.at(7); }
+
+  bool A() const { return j_.buttons.at(0); }
+  bool B() const { return j_.buttons.at(1); }
+  bool X() const { return j_.buttons.at(3); }
+  bool Y() const { return j_.buttons.at(4); }
+  bool LB() const { return j_.buttons.at(6); }
+  bool RB() const { return j_.buttons.at(7); }
+  bool Menu() const { return j_.buttons.at(11); }
+  bool LTrigger() const { return j_.buttons.at(13); }
+  bool RTrigger() const { return j_.buttons.at(14); }
+  bool ChangeView() const { return j_.buttons.at(15); }
+  bool Xbox() const { return j_.buttons.at(16); }
+
+  const sensor_msgs::msg::Joy j_;
+};
+}  // namespace joy_controller
+
+#endif  // JOY_CONTROLLER__JOY_CONVERTER__XONE_JOY_CONVERTER_HPP_

--- a/control/joy_controller/launch/joy_controller.launch.xml
+++ b/control/joy_controller/launch/joy_controller.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="joy_type" default="DS4" description="options: DS4, G29, P65, XONE"/>
+  <arg name="joy_type" default="DS4" description="options: DS4, G29, P65, XBOX"/>
   <arg name="external_cmd_source" default="remote" description="options: local, remote"/>
 
   <arg name="input_joy" default="/joy"/>

--- a/control/joy_controller/launch/joy_controller.launch.xml
+++ b/control/joy_controller/launch/joy_controller.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="joy_type" default="DS4" description="options: DS4, G29, P65"/>
+  <arg name="joy_type" default="DS4" description="options: DS4, G29, P65, XONE"/>
   <arg name="external_cmd_source" default="remote" description="options: local, remote"/>
 
   <arg name="input_joy" default="/joy"/>

--- a/control/joy_controller/schema/joy_controller.schema.json
+++ b/control/joy_controller/schema/joy_controller.schema.json
@@ -10,7 +10,7 @@
           "type": "string",
           "description": "Joy controller type",
           "default": "DS4",
-          "enum": ["P65", "DS4", "G29"]
+          "enum": ["P65", "DS4", "G29", "XONE"]
         },
         "update_rate": {
           "type": "number",

--- a/control/joy_controller/schema/joy_controller.schema.json
+++ b/control/joy_controller/schema/joy_controller.schema.json
@@ -10,7 +10,7 @@
           "type": "string",
           "description": "Joy controller type",
           "default": "DS4",
-          "enum": ["P65", "DS4", "G29", "XONE"]
+          "enum": ["P65", "DS4", "G29", "XBOX"]
         },
         "update_rate": {
           "type": "number",

--- a/control/joy_controller/src/joy_controller/joy_controller_node.cpp
+++ b/control/joy_controller/src/joy_controller/joy_controller_node.cpp
@@ -16,7 +16,7 @@
 #include "joy_controller/joy_converter/ds4_joy_converter.hpp"
 #include "joy_controller/joy_converter/g29_joy_converter.hpp"
 #include "joy_controller/joy_converter/p65_joy_converter.hpp"
-#include "joy_controller/joy_converter/xone_joy_converter.hpp"
+#include "joy_controller/joy_converter/xbox_joy_converter.hpp"
 
 #include <tier4_api_utils/tier4_api_utils.hpp>
 
@@ -155,8 +155,8 @@ void AutowareJoyControllerNode::onJoy(const sensor_msgs::msg::Joy::ConstSharedPt
     joy_ = std::make_shared<const G29JoyConverter>(*msg);
   } else if (joy_type_ == "DS4") {
     joy_ = std::make_shared<const DS4JoyConverter>(*msg);
-  } else if (joy_type_ == "XONE") {
-    joy_ = std::make_shared<const XONEJoyConverter>(*msg);
+  } else if (joy_type_ == "XBOX") {
+    joy_ = std::make_shared<const XBOXJoyConverter>(*msg);
   } else {
     joy_ = std::make_shared<const P65JoyConverter>(*msg);
   }

--- a/control/joy_controller/src/joy_controller/joy_controller_node.cpp
+++ b/control/joy_controller/src/joy_controller/joy_controller_node.cpp
@@ -16,6 +16,7 @@
 #include "joy_controller/joy_converter/ds4_joy_converter.hpp"
 #include "joy_controller/joy_converter/g29_joy_converter.hpp"
 #include "joy_controller/joy_converter/p65_joy_converter.hpp"
+#include "joy_controller/joy_converter/xone_joy_converter.hpp"
 
 #include <tier4_api_utils/tier4_api_utils.hpp>
 
@@ -154,6 +155,8 @@ void AutowareJoyControllerNode::onJoy(const sensor_msgs::msg::Joy::ConstSharedPt
     joy_ = std::make_shared<const G29JoyConverter>(*msg);
   } else if (joy_type_ == "DS4") {
     joy_ = std::make_shared<const DS4JoyConverter>(*msg);
+  } else if (joy_type_ == "XONE") {
+    joy_ = std::make_shared<const XONEJoyConverter>(*msg);
   } else {
     joy_ = std::make_shared<const P65JoyConverter>(*msg);
   }


### PR DESCRIPTION
## Description
Simply adds Xbox One **bluetooth** joy key mapping. It is worth mentioning that Xbox One joy connected via USB acts like a P65 joy.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
