### PR TITLE
feat(joy_controller): allow to control without odometry

### DIFF
--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -37,6 +37,7 @@
 | `steering_angle_velocity` | double | steering angle velocity for operation                                                                              |
 | `accel_sensitivity`       | double | sensitivity to calculate acceleration for external API (commanded acceleration is pow(operation, 1 / sensitivity)) |
 | `brake_sensitivity`       | double | sensitivity to calculate deceleration for external API (commanded acceleration is pow(operation, 1 / sensitivity)) |
+| `raw_control`             | bool   | skip input odometry if true                                                                                        |
 | `velocity_gain`           | double | ratio to calculate velocity by acceleration                                                                        |
 | `max_forward_velocity`    | double | absolute max velocity to go forward                                                                                |
 | `max_backward_velocity`   | double | absolute max velocity to go backward                                                                               |

--- a/control/joy_controller/config/joy_controller.param.yaml
+++ b/control/joy_controller/config/joy_controller.param.yaml
@@ -9,6 +9,7 @@
     accel_sensitivity: 1.0
     brake_sensitivity: 1.0
     control_command:
+      raw_control: false
       velocity_gain: 3.0
       max_forward_velocity: 20.0
       max_backward_velocity: 3.0

--- a/control/joy_controller/include/joy_controller/joy_controller.hpp
+++ b/control/joy_controller/include/joy_controller/joy_controller.hpp
@@ -59,6 +59,7 @@ private:
   double brake_sensitivity_;
 
   // ControlCommand Parameter
+  bool raw_control_;
   double velocity_gain_;
   double max_forward_velocity_;
   double max_backward_velocity_;

--- a/control/joy_controller/schema/joy_controller.schema.json
+++ b/control/joy_controller/schema/joy_controller.schema.json
@@ -55,6 +55,11 @@
         "control_command": {
           "type": "object",
           "properties": {
+            "raw_control": {
+              "type": "boolean",
+              "description": "Whether to skip input odometry",
+              "default": false
+            },
             "velocity_gain": {
               "type": "number",
               "description": "Ratio to calculate velocity by acceleration",
@@ -79,6 +84,7 @@
             }
           },
           "required": [
+            "raw_control",
             "velocity_gain",
             "max_forward_velocity",
             "max_backward_velocity",

--- a/control/joy_controller/src/joy_controller/joy_controller_node.cpp
+++ b/control/joy_controller/src/joy_controller/joy_controller_node.cpp
@@ -217,8 +217,7 @@ bool AutowareJoyControllerNode::isDataReady()
   }
 
   // Twist
-  if (!raw_control_)
-  {
+  if (!raw_control_) {
     if (!twist_) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), std::chrono::milliseconds(5000).count(),

--- a/control/joy_controller/src/joy_controller/joy_controller_node.cpp
+++ b/control/joy_controller/src/joy_controller/joy_controller_node.cpp
@@ -217,6 +217,7 @@ bool AutowareJoyControllerNode::isDataReady()
   }
 
   // Twist
+  if (!raw_control_)
   {
     if (!twist_) {
       RCLCPP_WARN_THROTTLE(
@@ -458,6 +459,7 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
   steering_angle_velocity_ = declare_parameter<double>("steering_angle_velocity");
   accel_sensitivity_ = declare_parameter<double>("accel_sensitivity");
   brake_sensitivity_ = declare_parameter<double>("brake_sensitivity");
+  raw_control_ = declare_parameter<bool>("control_command.raw_control");
   velocity_gain_ = declare_parameter<double>("control_command.velocity_gain");
   max_forward_velocity_ = declare_parameter<double>("control_command.max_forward_velocity");
   max_backward_velocity_ = declare_parameter<double>("control_command.max_backward_velocity");
@@ -477,10 +479,14 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
   sub_joy_ = this->create_subscription<sensor_msgs::msg::Joy>(
     "input/joy", 1, std::bind(&AutowareJoyControllerNode::onJoy, this, std::placeholders::_1),
     subscriber_option);
-  sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "input/odometry", 1,
-    std::bind(&AutowareJoyControllerNode::onOdometry, this, std::placeholders::_1),
-    subscriber_option);
+  if (!raw_control_) {
+    sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
+      "input/odometry", 1,
+      std::bind(&AutowareJoyControllerNode::onOdometry, this, std::placeholders::_1),
+      subscriber_option);
+  } else {
+    twist_ = std::make_shared<geometry_msgs::msg::TwistStamped>();
+  }
 
   // Publisher
   pub_control_command_ =


### PR DESCRIPTION
## Description

Some vehicle platforms has only exposed high level API for velocity commands. At early stage of development the `kinematic_state` topic might not be ready to operate on. With that aspects in mind, a pure velocity control with remote controller would be welcome. The new feature `raw_control` by default is false, therefore it does not affect current developers workspace.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
