### PR TITLE
feat(ekf_localizer): tf publisher as an option

### DIFF
--- a/localization/ekf_localizer/README.md
+++ b/localization/ekf_localizer/README.md
@@ -121,6 +121,7 @@ The parameters are set in `launch/ekf_localizer.launch` .
 | show_debug_info            | bool   | Flag to display debug info                                                                | false         |
 | predict_frequency          | double | Frequency for filtering and publishing [Hz]                                               | 50.0          |
 | tf_rate                    | double | Frequency for tf broadcasting [Hz]                                                        | 10.0          |
+| publish_tf                 | bool   | Whether to publish tf                                                                     | true          |
 | extend_state_step          | int    | Max delay step which can be dealt with in EKF. Large number increases computational cost. | 50            |
 | enable_yaw_bias_estimation | bool   | Flag to enable yaw bias estimation                                                        | true          |
 

--- a/localization/ekf_localizer/config/ekf_localizer.param.yaml
+++ b/localization/ekf_localizer/config/ekf_localizer.param.yaml
@@ -4,6 +4,7 @@
     enable_yaw_bias_estimation: true
     predict_frequency: 50.0
     tf_rate: 50.0
+    publish_tf: true
     extend_state_step: 50
 
     # for Pose measurement

--- a/localization/ekf_localizer/include/ekf_localizer/hyper_parameters.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/hyper_parameters.hpp
@@ -28,6 +28,7 @@ public:
     ekf_rate(node->declare_parameter("predict_frequency", 50.0)),
     ekf_dt(1.0 / std::max(ekf_rate, 0.1)),
     tf_rate_(node->declare_parameter("tf_rate", 10.0)),
+    publish_tf_(node->declare_parameter("publish_tf", true)),
     enable_yaw_bias_estimation(node->declare_parameter("enable_yaw_bias_estimation", true)),
     extend_state_step(node->declare_parameter("extend_state_step", 50)),
     pose_frame_id(node->declare_parameter("pose_frame_id", std::string("map"))),
@@ -60,6 +61,7 @@ public:
   const double ekf_rate;
   const double ekf_dt;
   const double tf_rate_;
+  const bool publish_tf_;
   const bool enable_yaw_bias_estimation;
   const int extend_state_step;
   const std::string pose_frame_id;

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -60,9 +60,11 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
     this, get_clock(), rclcpp::Duration::from_seconds(ekf_dt_),
     std::bind(&EKFLocalizer::timerCallback, this));
 
-  timer_tf_ = rclcpp::create_timer(
-    this, get_clock(), rclcpp::Rate(params_.tf_rate_).period(),
-    std::bind(&EKFLocalizer::timerTFCallback, this));
+  if (params_.publish_tf_) {
+    timer_tf_ = rclcpp::create_timer(
+      this, get_clock(), rclcpp::Rate(params_.tf_rate_).period(),
+      std::bind(&EKFLocalizer::timerTFCallback, this));
+  }
 
   pub_pose_ = create_publisher<geometry_msgs::msg::PoseStamped>("ekf_pose", 1);
   pub_pose_cov_ =


### PR DESCRIPTION
## Description

`ekf_localizer` broadcasts `map` -> `base_link` transformation which is fundamental to the operation of the entire system. However, custom modifications within the architecture (e.g. using Cartographer) may require to turn off this feature. Setting up `tf_rate` to 0.0 returns an exception, remapping `/tf` is inappropriate due to the need to use `EKFLocalizer::callbackInitialPose`. Therefore, the `tf_publish` parameter would be welcome. The parameter will be set to `true` by default so that it does not affect the current developers workspace.

Similar solution is used in [geo_pose_projector](https://github.com/autowarefoundation/autoware.universe/blob/7c6666051157d2f26572144296700eb1238f4f08/localization/geo_pose_projector/src/geo_pose_projector.cpp#L46).

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
