### PR TITLE
chore(traffic_light_module): use RCLCPP_DEBUG for the debug printing

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -217,7 +217,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     // Move to go out state if ego vehicle over deadline.
     constexpr double signed_deadline_length = -2.0;
     if (signed_arc_length_to_stop_point < signed_deadline_length) {
-      RCLCPP_INFO(logger_, "APPROACH -> GO_OUT");
+      RCLCPP_DEBUG(logger_, "APPROACH -> GO_OUT");
       state_ = State::GO_OUT;
       stop_signal_received_time_ptr_.reset();
       return true;
@@ -263,7 +263,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     constexpr double restart_length = 1.0;
     if (use_initialization_after_start) {
       if (signed_arc_length_to_stop_point > restart_length) {
-        RCLCPP_INFO(logger_, "GO_OUT(RESTART) -> APPROACH");
+        RCLCPP_DEBUG(logger_, "GO_OUT(RESTART) -> APPROACH");
         state_ = State::APPROACH;
       }
     }


### PR DESCRIPTION
## Description

The following debug printing is shown every time the ego passes through the traffic light which is not necessary for the daily use.
```
APPROACH -> GO_OUT
GO_OUT(RESTART) -> APPROACH
```
This PR makes them to use RCLCPP_DEBUG instead of RCLCPP_INFO.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
