### PR TITLE
fix(obstacle_avoidance_planner): use update_bounds instead of update_lower/upper_bounds

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1519,8 +1519,7 @@ std::optional<Eigen::VectorXd> MPTOptimizer::calcOptimizedSteerAngles(
     osqp_solver_ptr_->updateCscP(P_csc);
     osqp_solver_ptr_->updateQ(f);
     osqp_solver_ptr_->updateCscA(A_csc);
-    osqp_solver_ptr_->updateL(lower_bound);
-    osqp_solver_ptr_->updateU(upper_bound);
+    osqp_solver_ptr_->updateBounds(lower_bound, upper_bound);
   } else {
     RCLCPP_INFO_EXPRESSION(logger_, enable_debug_info_, "no warm start");
     osqp_solver_ptr_ = std::make_unique<autoware::common::osqp::OSQPInterface>(


### PR DESCRIPTION
## Description

When updating the bounds of QP with a warm start in the obstacle_avoidance_planner package, this PR uses `osqp_update_bounds` instead of `osqp_update_lower/upper_bound`.

According to the OSQP's implementation, the condition of whether the lower bound is smaller than the upper bound is checked in each `osqp_upper_lower/upper_bound` function.
Without this PR, since the lower and upper bounds are updated separately, when the lower bound is updated but the upper bound is not updated, the condition may not be met, resulting in the following printing many times.
```
[ERROR] upper bound must be greater than or equal to lower bound
```

In addition, in the latest version of OSQP's implementation, `osqp_update_lower/upper_bound` will be removed.
https://github.com/osqp/osqp/issues/192


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
