### PR TITLE
fix(crosswalk): stopping besides the stop line

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -393,7 +393,7 @@ std::optional<StopFactor> CrosswalkModule::checkStopForCrosswalkUsers(
     return {};
   }
 
-  // Check if the ego should stop beyond the stop line.
+  // Check if the ego should stop at the stop line or the other points.
   const bool stop_at_stop_line =
     dist_ego_to_stop < nearest_stop_info->second &&
     nearest_stop_info->second < dist_ego_to_stop + planner_param_.far_object_threshold;
@@ -404,9 +404,10 @@ std::optional<StopFactor> CrosswalkModule::checkStopForCrosswalkUsers(
       return createStopFactor(*default_stop_pose, stop_factor_points);
     }
   } else {
-    // Stop beyond the stop line
     const auto stop_pose = calcLongitudinalOffsetPose(
-      ego_path.points, nearest_stop_info->first, planner_param_.stop_distance_from_object);
+      ego_path.points, nearest_stop_info->first,
+      -base_link2front - planner_param_.stop_distance_from_object);
+
     if (stop_pose) {
       return createStopFactor(*stop_pose, stop_factor_points);
     }

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -407,7 +407,6 @@ std::optional<StopFactor> CrosswalkModule::checkStopForCrosswalkUsers(
     const auto stop_pose = calcLongitudinalOffsetPose(
       ego_path.points, nearest_stop_info->first,
       -base_link2front - planner_param_.stop_distance_from_object);
-
     if (stop_pose) {
       return createStopFactor(*stop_pose, stop_factor_points);
     }


### PR DESCRIPTION
## Description
This PR fixes a bug in the stop position calculation besides the stop line.

The figures show psim tests with crosswalk_attention_range: 10.0

Before:
![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/9f92ea01-0843-413a-aa95-5dcc5f6f73e9)


After:
[Screencast from 01-05-2024 06:36:20 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/141538661/652b96ef-36dc-42f7-93f7-2947fdb940d1)


<!-- Write a brief description of this PR. -->

## Tests performed
psim tests and tier4 internal tests were perfomed.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
