### PR TITLE
refactor(behavior_velocity_planner): output path's interval can be designated by yaml

### DIFF
--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     forward_path_length: 1000.0
     backward_path_length: 5.0
+    behavior_output_path_interval: 1.0
     stop_line_extend_length: 5.0
     max_accel: -2.8
     max_jerk: -5.0

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -138,6 +138,7 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
   // Parameters
   forward_path_length_ = declare_parameter<double>("forward_path_length");
   backward_path_length_ = declare_parameter<double>("backward_path_length");
+  behavior_output_path_interval_ = declare_parameter<double>("behavior_output_path_interval");
   planner_data_.stop_line_extend_length = declare_parameter<double>("stop_line_extend_length");
 
   // nearest search
@@ -409,7 +410,8 @@ autoware_auto_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath
   const auto filtered_path = filterLitterPathPoint(to_path(velocity_planned_path));
 
   // interpolation
-  const auto interpolated_path_msg = interpolatePath(filtered_path, forward_path_length_);
+  const auto interpolated_path_msg =
+    interpolatePath(filtered_path, forward_path_length_, behavior_output_path_interval_);
 
   // check stop point
   output_path_msg = filterStopPathPoint(interpolated_path_msg);

--- a/planning/behavior_velocity_planner/src/node.hpp
+++ b/planning/behavior_velocity_planner/src/node.hpp
@@ -102,6 +102,7 @@ private:
   //  parameter
   double forward_path_length_;
   double backward_path_length_;
+  double behavior_output_path_interval_;
 
   // member
   PlannerData planner_data_;

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/path_utilization.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/path_utilization.hpp
@@ -28,8 +28,7 @@ bool splineInterpolate(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input, const double interval,
   autoware_auto_planning_msgs::msg::PathWithLaneId & output, const rclcpp::Logger logger);
 autoware_auto_planning_msgs::msg::Path interpolatePath(
-  const autoware_auto_planning_msgs::msg::Path & path, const double length,
-  const double interval = 1.0);
+  const autoware_auto_planning_msgs::msg::Path & path, const double length, const double interval);
 autoware_auto_planning_msgs::msg::Path filterLitterPathPoint(
   const autoware_auto_planning_msgs::msg::Path & path);
 autoware_auto_planning_msgs::msg::Path filterStopPathPoint(


### PR DESCRIPTION
## Description

Currently, the output path's interval of the behavior_velocity_planner is decided in the default argument of the utility function, which is hard to find and cannot be changed easily.

This PR moves the interval variable to the yaml file.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
