### PR TITLE
fix((merge_from_private): fixed first attention lanelet calculation

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
@@ -73,13 +73,11 @@ public:
   motion_utils::VirtualWalls createVirtualWalls() override;
 
   const std::set<lanelet::Id> & getAssociativeIds() const { return associative_ids_; }
+  lanelet::ConstLanelets getAttentionLanelets() const;
 
 private:
   const int64_t lane_id_;
   const std::set<lanelet::Id> associative_ids_;
-
-  autoware_auto_planning_msgs::msg::PathWithLaneId extractPathNearExitOfPrivateRoad(
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double extend_length);
 
   // Parameter
   PlannerParam planner_param_;


### PR DESCRIPTION
## Description

merge from private was calculating first_conflicting_lanelet from the vanilla conflicting_lanelets, so it was including sibling lanelets that should be eliminated.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

evaluator: https://evaluation.tier4.jp/evaluation/reports?project_id=prd_jt + https://evaluation.tier4.jp/evaluation/reports/8c170bc5-37af-5fa2-9316-a65c80e11304?project_id=prd_jt
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
