### PR TITLE
fix(lane_change): check able to return to original lane in abort

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -249,8 +249,10 @@ bool LaneChangeInterface::canTransitFailureState()
       return false;
     }
 
-    log_debug_throttled("It's unsafe and ego is in prepare phase. Cancel lane change.");
-    return true;
+    if (module_type_->isAbleToReturnCurrentLane()) {
+      log_debug_throttled("It's possible to return to current lane. Cancel lane change.");
+      return true;
+    }
   }
 
   if (post_process_safety_status_.is_safe) {

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -248,11 +248,6 @@ bool LaneChangeInterface::canTransitFailureState()
       log_debug_throttled("Can't transit to failure state. Ego is on prepare, and it's safe.");
       return false;
     }
-
-    if (module_type_->isAbleToReturnCurrentLane()) {
-      log_debug_throttled("It's possible to return to current lane. Cancel lane change.");
-      return true;
-    }
   }
 
   if (post_process_safety_status_.is_safe) {
@@ -273,6 +268,11 @@ bool LaneChangeInterface::canTransitFailureState()
   if (!module_type_->isAbortEnabled()) {
     log_debug_throttled(
       "Lane change path is unsafe but abort was not enabled. Continue lane change.");
+    return false;
+  }
+
+  if (!module_type_->isAbleToReturnCurrentLane()) {
+    log_debug_throttled("It's is not possible to return to original lane. Continue lane change.");
     return false;
   }
 

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -248,6 +248,9 @@ bool LaneChangeInterface::canTransitFailureState()
       log_debug_throttled("Can't transit to failure state. Ego is on prepare, and it's safe.");
       return false;
     }
+
+    log_debug_throttled("It's unsafe and ego is in prepare phase. Cancel lane change.");
+    return true;
   }
 
   if (post_process_safety_status_.is_safe) {


### PR DESCRIPTION
## Description

Before abort process, lane change module should check if ego vehicle can return to original lane or not. And if it can't, abort path should not be computed.

## Related links

None.

## Tests performed

Using PSIM to check abort behavior

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
