### PR TITLE
feat(perception_rviz_plugin): visualize object heading direction on 3d bounding box

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -90,7 +90,8 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_2d_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width);
+  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
+  const bool & is_orientation_available = true);
 
 /// \brief Convert the given polygon into a marker representing the shape in 3d
 /// \param centroid Centroid position of the shape in Object.header.frame_id frame
@@ -149,6 +150,10 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_direction_lin
   std::vector<geometry_msgs::msg::Point> & points);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_bounding_box_bottom_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_bounding_box_bottom_direction_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -83,7 +83,8 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width);
+  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
+  const bool & is_orientation_available = true);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_2d_shape_marker_ptr(
@@ -140,6 +141,10 @@ get_path_confidence_marker_ptr(
   const std_msgs::msg::ColorRGBA & path_confidence_color);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_direction_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -141,6 +141,10 @@ get_path_confidence_marker_ptr(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const std_msgs::msg::ColorRGBA & path_confidence_color);
 
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_line_list_from_points(
+  const double point_list[][3], const int point_pairs[][2], const int & num_pairs,
+  std::vector<geometry_msgs::msg::Point> & points);
+
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -179,7 +179,7 @@ protected:
         shape_msg, centroid, orientation, color_rgba, line_width, is_orientation_available);
     } else if (m_display_type_property->getOptionInt() == 1) {
       return detail::get_2d_shape_marker_ptr(
-        shape_msg, centroid, orientation, color_rgba, line_width);
+        shape_msg, centroid, orientation, color_rgba, line_width, is_orientation_available);
     } else {
       return std::nullopt;
     }
@@ -189,7 +189,8 @@ protected:
   visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
     const autoware_auto_perception_msgs::msg::Shape & shape_msg,
     const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-    const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width);
+    const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
+    const bool & is_orientation_available);
 
   /// \brief Convert given shape msg into a Marker to visualize label name
   /// \tparam ClassificationContainerT List type with ObjectClassificationMsg

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -170,11 +170,13 @@ protected:
   std::optional<Marker::SharedPtr> get_shape_marker_ptr(
     const autoware_auto_perception_msgs::msg::Shape & shape_msg,
     const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-    const ClassificationContainerT & labels, const double & line_width) const
+    const ClassificationContainerT & labels, const double & line_width,
+    const bool & is_orientation_available) const
   {
     const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
     if (m_display_type_property->getOptionInt() == 0) {
-      return detail::get_shape_marker_ptr(shape_msg, centroid, orientation, color_rgba, line_width);
+      return detail::get_shape_marker_ptr(
+        shape_msg, centroid, orientation, color_rgba, line_width, is_orientation_available);
     } else if (m_display_type_property->getOptionInt() == 1) {
       return detail::get_2d_shape_marker_ptr(
         shape_msg, centroid, orientation, color_rgba, line_width);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -38,7 +38,9 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.pose_with_covariance.pose.position,
       object.kinematics.pose_with_covariance.pose.orientation, object.classification,
-      get_line_width());
+      get_line_width(),
+      object.kinematics.orientation_availability ==
+        autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE);
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -331,6 +331,23 @@ visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
   return marker_ptr;
 }
 
+void calc_line_list_from_points(
+  const double point_list[][3], const int point_pairs[][2], const int & num_pairs,
+  std::vector<geometry_msgs::msg::Point> & points)
+{
+  geometry_msgs::msg::Point point;
+  for (int i = 0; i < num_pairs; ++i) {
+    point.x = point_list[point_pairs[i][0]][0];
+    point.y = point_list[point_pairs[i][0]][1];
+    point.z = point_list[point_pairs[i][0]][2];
+    points.push_back(point);
+    point.x = point_list[point_pairs[i][1]][0];
+    point.y = point_list[point_pairs[i][1]][1];
+    point.z = point_list[point_pairs[i][1]][2];
+    points.push_back(point);
+  }
+}
+
 void calc_bounding_box_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points)
@@ -342,25 +359,16 @@ void calc_bounding_box_line_list(
 
   // bounding box corner points
   // top and bottom surface, clockwise
-  const double corner_points[8][3] = {
+  const double point_list[8][3] = {
     {length_half, width_half, height_half},    {length_half, -width_half, height_half},
     {-length_half, -width_half, height_half},  {-length_half, width_half, height_half},
     {length_half, width_half, -height_half},   {length_half, -width_half, -height_half},
     {-length_half, -width_half, -height_half}, {-length_half, width_half, -height_half},
   };
-  const int bounding_box_pairs[12][2] = {
+  const int point_pairs[12][2] = {
     {0, 1}, {1, 2}, {2, 3}, {3, 0}, {4, 5}, {5, 6}, {6, 7}, {7, 4}, {0, 4}, {1, 5}, {2, 6}, {3, 7},
   };
-  for (int i = 0; i < 12; ++i) {
-    point.x = corner_points[bounding_box_pairs[i][0]][0];
-    point.y = corner_points[bounding_box_pairs[i][0]][1];
-    point.z = corner_points[bounding_box_pairs[i][0]][2];
-    points.push_back(point);
-    point.x = corner_points[bounding_box_pairs[i][1]][0];
-    point.y = corner_points[bounding_box_pairs[i][1]][1];
-    point.z = corner_points[bounding_box_pairs[i][1]][2];
-    points.push_back(point);
-  }
+  calc_line_list_from_points(point_list, point_pairs, 12, points);
 }
 
 void calc_bounding_box_direction_line_list(
@@ -375,7 +383,7 @@ void calc_bounding_box_direction_line_list(
   geometry_msgs::msg::Point point;
 
   // triangle-shaped direction indicator
-  const double triangle_points[6][3] = {
+  const double point_list[6][3] = {
     {length_half, 0, height_half},
     {length_half - triangle_size_half, width_half, height_half},
     {length_half - triangle_size_half, -width_half, height_half},
@@ -383,19 +391,10 @@ void calc_bounding_box_direction_line_list(
     {length_half, width_half, height_half},
     {length_half, -width_half, height_half},
   };
-  const int triangle_pairs[5][2] = {
+  const int point_pairs[5][2] = {
     {0, 1}, {1, 2}, {0, 2}, {3, 4}, {3, 5},
   };
-  for (int i = 0; i < 5; ++i) {
-    point.x = triangle_points[triangle_pairs[i][0]][0];
-    point.y = triangle_points[triangle_pairs[i][0]][1];
-    point.z = triangle_points[triangle_pairs[i][0]][2];
-    points.push_back(point);
-    point.x = triangle_points[triangle_pairs[i][1]][0];
-    point.y = triangle_points[triangle_pairs[i][1]][1];
-    point.z = triangle_points[triangle_pairs[i][1]][2];
-    points.push_back(point);
-  }
+  calc_line_list_from_points(point_list, point_pairs, 5, points);
 }
 
 void calc_2d_bounding_box_bottom_line_list(
@@ -409,28 +408,19 @@ void calc_2d_bounding_box_bottom_line_list(
 
   // bounding box corner points
   // top surface, clockwise
-  const double corner_points[4][3] = {
+  const double point_list[4][3] = {
     {length_half, width_half, -height_half},
     {length_half, -width_half, -height_half},
     {-length_half, -width_half, -height_half},
     {-length_half, width_half, -height_half},
   };
-  const int bounding_box_pairs[4][2] = {
+  const int point_pairs[4][2] = {
     {0, 1},
     {1, 2},
     {2, 3},
     {3, 0},
   };
-  for (int i = 0; i < 4; ++i) {
-    point.x = corner_points[bounding_box_pairs[i][0]][0];
-    point.y = corner_points[bounding_box_pairs[i][0]][1];
-    point.z = corner_points[bounding_box_pairs[i][0]][2];
-    points.push_back(point);
-    point.x = corner_points[bounding_box_pairs[i][1]][0];
-    point.y = corner_points[bounding_box_pairs[i][1]][1];
-    point.z = corner_points[bounding_box_pairs[i][1]][2];
-    points.push_back(point);
-  }
+  calc_line_list_from_points(point_list, point_pairs, 4, points);
 }
 
 void calc_2d_bounding_box_bottom_direction_line_list(
@@ -444,26 +434,17 @@ void calc_2d_bounding_box_bottom_direction_line_list(
   geometry_msgs::msg::Point point;
 
   // triangle-shaped direction indicator
-  const double triangle_points[6][3] = {
+  const double point_list[6][3] = {
     {length_half, 0, -height_half},
     {length_half - triangle_size_half, width_half, -height_half},
     {length_half - triangle_size_half, -width_half, -height_half},
   };
-  const int triangle_pairs[3][2] = {
+  const int point_pairs[3][2] = {
     {0, 1},
     {1, 2},
     {0, 2},
   };
-  for (int i = 0; i < 3; ++i) {
-    point.x = triangle_points[triangle_pairs[i][0]][0];
-    point.y = triangle_points[triangle_pairs[i][0]][1];
-    point.z = triangle_points[triangle_pairs[i][0]][2];
-    points.push_back(point);
-    point.x = triangle_points[triangle_pairs[i][1]][0];
-    point.y = triangle_points[triangle_pairs[i][1]][1];
-    point.z = triangle_points[triangle_pairs[i][1]][2];
-    points.push_back(point);
-  }
+  calc_line_list_from_points(point_list, point_pairs, 3, points);
 }
 
 void calc_cylinder_line_list(

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -327,158 +327,103 @@ void calc_bounding_box_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points)
 {
+  const double length_half = shape.dimensions.x / 2.0;
+  const double width_half = shape.dimensions.y / 2.0;
+  const double height_half = shape.dimensions.z / 2.0;
   geometry_msgs::msg::Point point;
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
 
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
+  // bounding box corner points
+  // top and bottom surface, clockwise
+  const double corner_points[8][3] = {
+    {length_half, width_half, height_half},   {length_half, -width_half, height_half},
+    {-length_half, -width_half, height_half},  {-length_half, width_half, height_half},
+    {length_half, width_half, -height_half},  {length_half, -width_half, -height_half},
+    {-length_half, -width_half, -height_half}, {-length_half, width_half, -height_half},
+  }; 
+  const int bounding_box_pairs[12][2] = {
+    {0, 1}, {1, 2}, {2, 3}, {3, 0}, 
+    {4, 5}, {5, 6}, {6, 7}, {7, 4}, 
+    {0, 4}, {1, 5}, {2, 6}, {3, 7},
+  };
+  for (int i = 0; i < 12; ++i) {
+    point.x = corner_points[bounding_box_pairs[i][0]][0];
+    point.y = corner_points[bounding_box_pairs[i][0]][1];
+    point.z = corner_points[bounding_box_pairs[i][0]][2];
+    points.push_back(point);
+    point.x = corner_points[bounding_box_pairs[i][1]][0];
+    point.y = corner_points[bounding_box_pairs[i][1]][1];
+    point.z = corner_points[bounding_box_pairs[i][1]][2];
+    points.push_back(point);
+  }
 
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  // up surface
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  // down surface
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
+  // direction triangle
+  const double triangle_size_half = shape.dimensions.y / 1.4;
+  const double triangle_points[6][3] = {
+    {length_half, 0, height_half}, {length_half - triangle_size_half, width_half, height_half}, 
+    {length_half - triangle_size_half, -width_half, height_half},
+    {length_half, 0, -height_half}, {length_half - triangle_size_half, width_half, -height_half}, 
+    {length_half - triangle_size_half, -width_half, -height_half},
+  };
+  const int triangle_pairs[6][2] = {
+    {0, 1}, {1, 2}, {0, 2}, 
+    {3, 4}, {4, 5}, {3, 5},
+  };
+  for (int i = 0; i < 6; ++i) {
+    point.x = triangle_points[triangle_pairs[i][0]][0];
+    point.y = triangle_points[triangle_pairs[i][0]][1];
+    point.z = triangle_points[triangle_pairs[i][0]][2];
+    points.push_back(point);
+    point.x = triangle_points[triangle_pairs[i][1]][0];
+    point.y = triangle_points[triangle_pairs[i][1]][1];
+    point.z = triangle_points[triangle_pairs[i][1]][2];
+    points.push_back(point);
+  }
 }
 
 void calc_2d_bounding_box_bottom_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points)
 {
+  const double length_half = shape.dimensions.x / 2.0;
+  const double width_half = shape.dimensions.y / 2.0;
+  const double height_half = shape.dimensions.z / 2.0;
   geometry_msgs::msg::Point point;
+
   // down surface
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
+  point.x = length_half;
+  point.y = width_half;
+  point.z = -height_half;
   points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-
-  point.x = shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
-  points.push_back(point);
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
+  point.x = -length_half;
+  point.y = width_half;
+  point.z = -height_half;
   points.push_back(point);
 
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
+  point.x = length_half;
+  point.y = width_half;
+  point.z = -height_half;
   points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
+  point.x = length_half;
+  point.y = -width_half;
+  point.z = -height_half;
   points.push_back(point);
 
-  point.x = shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
+  point.x = -length_half;
+  point.y = width_half;
+  point.z = -height_half;
   points.push_back(point);
-  point.x = -shape.dimensions.x / 2.0;
-  point.y = -shape.dimensions.y / 2.0;
-  point.z = -shape.dimensions.z / 2.0;
+  point.x = -length_half;
+  point.y = -width_half;
+  point.z = -height_half;
+  points.push_back(point);
+
+  point.x = length_half;
+  point.y = -width_half;
+  point.z = -height_half;
+  points.push_back(point);
+  point.x = -length_half;
+  point.y = -width_half;
+  point.z = -height_half;
   points.push_back(point);
 }
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -77,7 +77,7 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.initial_pose_with_covariance.pose.position,
       object.kinematics.initial_pose_with_covariance.pose.orientation, object.classification,
-      get_line_width());
+      get_line_width(), true);
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -59,7 +59,9 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.pose_with_covariance.pose.position,
-      object.kinematics.pose_with_covariance.pose.orientation, object.classification, line_width);
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification, line_width,
+      object.kinematics.orientation_availability ==
+        autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE);
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;


### PR DESCRIPTION
## Description
This PR is to visualize orientation (heading direction) of objects (detected object, tracked object, predicted object).
The orientation will be visualized only when the object orientation flag is VALID.  The predicted object do not have the flag and the direction will be visualized since the direction is always available.

## Tests performed
Simulations of sensing and perception modules were performed under a tier4 deployment, and the messages were selectively visualized by the Rviz plugin.

https://github.com/autowarefoundation/autoware.universe/assets/42434141/ea56257d-70a3-4909-84f1-bc1942bb42c3


## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
