### PR TITLE
fix(motion_velocity_smoother): make stopping_distance and stopping_velocity be able to work

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -453,6 +453,9 @@ void MotionVelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstShar
     return;
   }
 
+  // Set 0 at the end of the trajectory
+  input_points.back().longitudinal_velocity_mps = 0.0;
+
   // calculate prev closest point
   if (!prev_output_.empty()) {
     current_closest_point_from_prev_output_ = calcProjectedTrajectoryPointFromEgo(prev_output_);


### PR DESCRIPTION
## Description
Closes: https://github.com/autowarefoundation/autoware.universe/issues/6027
<!-- Write a brief description of this PR. -->
The input trajectory of the applyStopApproachingVelocity() function does not have zero velocity on the last point. Because there is no zero velocity on the last point, applyStopApproachingVelocity() function returns none. Therefore,  stopping_distance and stopping_velocity parameters do not work. 
## Tests performed
Tested on PSim for stopping_velocity: 0.0, stopping_distance: 5.0 :

https://github.com/autowarefoundation/autoware.universe/assets/45468306/c6eac644-2b73-4488-8844-88ee881a241c

Vehicle can stop before 5.0 meters from the goal point.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
