### PR TITLE
refactor(tier4_planning_launch): remove duplicate arguments in launchfile

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -16,17 +16,6 @@
   <arg name="launch_start_planner_module" default="true"/>
   <arg name="launch_side_shift_module" default="true"/>
 
-  <arg name="launch_avoidance_module" default="true"/>
-  <arg name="launch_dynamic_avoidance_module" default="true"/>
-  <arg name="launch_side_shift_module" default="true"/>
-  <arg name="launch_goal_planner_module" default="true"/>
-  <arg name="launch_start_planner_module" default="true"/>
-  <arg name="launch_lane_change_right_module" default="true"/>
-  <arg name="launch_lane_change_left_module" default="true"/>
-  <arg name="launch_external_request_lane_change_right_module" default="true"/>
-  <arg name="launch_external_request_lane_change_left_module" default="true"/>
-  <arg name="launch_avoidance_by_lane_change_module" default="true"/>
-
   <arg name="launch_crosswalk_module" default="true"/>
   <arg name="launch_walkway_module" default="true"/>
   <arg name="launch_traffic_light_module" default="true"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Arguments for the behavior path planner to select which modules are run are defined twice.
This PR removes the duplicates.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
