### PR TITLE
refactor(lane_change): remove waitApproval dependencies

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/scene.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/scene.hpp
@@ -78,7 +78,7 @@ private:
 
   bool canTransitFailureState() override { return false; }
 
-  bool canTransitIdleToRunningState() override { return true; }
+  bool canTransitIdleToWaitingApprovalState() override { return true; }
 
   /**
    * @brief update RTC status for candidate shift line.

--- a/planning/behavior_path_dynamic_avoidance_module/include/behavior_path_dynamic_avoidance_module/scene.hpp
+++ b/planning/behavior_path_dynamic_avoidance_module/include/behavior_path_dynamic_avoidance_module/scene.hpp
@@ -345,7 +345,7 @@ private:
 
   bool canTransitFailureState() override { return false; }
 
-  bool canTransitIdleToRunningState() override { return false; }
+  bool canTransitIdleToWaitingApprovalState() override { return false; }
 
   bool isLabelTargetObstacle(const uint8_t label) const;
   void updateTargetObjects();

--- a/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -330,7 +330,7 @@ private:
   // If terminating it, it may switch to lane following and could generate an inappropriate path.
   bool canTransitSuccessState() override { return false; }
   bool canTransitFailureState() override { return false; }
-  bool canTransitIdleToRunningState() override { return true; }
+  bool canTransitIdleToWaitingApprovalState() override { return true; }
 
   mutable StartGoalPlannerData goal_planner_data_;
 

--- a/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1765,6 +1765,9 @@ void GoalPlannerModule::updateSafetyCheckTargetObjectsData(
 
 std::pair<bool, bool> GoalPlannerModule::isSafePath() const
 {
+  if (!thread_safe_data_.get_pull_over_path()) {
+    return {false, false};
+  }
   const auto pull_over_path = thread_safe_data_.get_pull_over_path()->getCurrentPath();
   const auto & current_pose = planner_data_->self_odometry->pose.pose;
   const double current_velocity = std::hypot(

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/interface.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/interface.hpp
@@ -96,25 +96,6 @@ public:
   TurnSignalInfo getCurrentTurnSignalInfo(
     const PathWithLaneId & path, const TurnSignalInfo & original_turn_signal_info);
 
-  // TODO(someone): remove this, and use base class function
-  [[deprecated]] BehaviorModuleOutput run() override
-  {
-    updateData();
-
-    if (!isWaitingApproval()) {
-      return plan();
-    }
-
-    // module is waiting approval. Check it.
-    if (isActivated()) {
-      RCLCPP_DEBUG(getLogger(), "Was waiting approval, and now approved. Do plan().");
-      return plan();
-    } else {
-      RCLCPP_DEBUG(getLogger(), "keep waiting approval... Do planCandidate().");
-      return planWaitingApproval();
-    }
-  }
-
 protected:
   std::shared_ptr<LaneChangeParameters> parameters_;
 

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/interface.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/interface.hpp
@@ -126,7 +126,7 @@ protected:
 
   bool canTransitFailureState() override;
 
-  bool canTransitIdleToRunningState() override;
+  bool canTransitIdleToWaitingApprovalState() override;
 
   void setObjectDebugVisualization() const;
 

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/base_class.hpp
@@ -237,7 +237,7 @@ protected:
   LaneChangeStatus status_{};
   PathShifter path_shifter_{};
 
-  LaneChangeStates current_lane_change_state_{};
+  LaneChangeStates current_lane_change_state_{LaneChangeStates::Normal};
 
   std::shared_ptr<LaneChangeParameters> lane_change_parameters_{};
   std::shared_ptr<LaneChangePath> abort_path_{};

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -296,14 +296,6 @@ bool LaneChangeInterface::canTransitIdleToWaitingApprovalState()
 
   log_debug_throttled(__func__);
 
-  if (!isActivated()) {
-    if (module_type_->specialRequiredCheck()) {
-      return true;
-    }
-    log_debug_throttled("Module is idling.");
-    return false;
-  }
-
   log_debug_throttled("Can lane change safely. Executing lane change.");
   module_type_->toNormalState();
   return true;

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -293,7 +293,7 @@ bool LaneChangeInterface::canTransitFailureState()
   return false;
 }
 
-bool LaneChangeInterface::canTransitIdleToRunningState()
+bool LaneChangeInterface::canTransitIdleToWaitingApprovalState()
 {
   setObjectDebugVisualization();
 

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -84,6 +84,7 @@ void LaneChangeInterface::updateData()
   module_type_->setPreviousDrivableAreaInfo(getPreviousModuleOutput().drivable_area_info);
   module_type_->setPreviousTurnSignalInfo(getPreviousModuleOutput().turn_signal_info);
   module_type_->updateSpecialData();
+  setObjectDebugVisualization();
   module_type_->resetStopPose();
 }
 
@@ -224,6 +225,10 @@ bool LaneChangeInterface::canTransitFailureState()
   };
 
   log_debug_throttled(__func__);
+  if (module_type_->isAbortState() && !module_type_->hasFinishedAbort()) {
+    log_debug_throttled("Abort process has on going.");
+    return false;
+  }
 
   if (isWaitingApproval()) {
     log_debug_throttled("Can't transit to failure state. Module is WAITING_FOR_APPROVAL");
@@ -288,16 +293,6 @@ bool LaneChangeInterface::canTransitFailureState()
 
 bool LaneChangeInterface::canTransitIdleToWaitingApprovalState()
 {
-  setObjectDebugVisualization();
-
-  auto log_debug_throttled = [&](std::string_view message) -> void {
-    RCLCPP_DEBUG(getLogger(), "%s", message.data());
-  };
-
-  log_debug_throttled(__func__);
-
-  log_debug_throttled("Can lane change safely. Executing lane change.");
-  module_type_->toNormalState();
   return true;
 }
 

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -296,6 +296,14 @@ bool LaneChangeInterface::canTransitIdleToWaitingApprovalState()
 
   log_debug_throttled(__func__);
 
+  if (!isActivated()) {
+    if (module_type_->specialRequiredCheck()) {
+      return true;
+    }
+    log_debug_throttled("Module is idling.");
+    return false;
+  }
+
   log_debug_throttled("Can lane change safely. Executing lane change.");
   module_type_->toNormalState();
   return true;

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -303,7 +303,7 @@ bool LaneChangeInterface::canTransitIdleToWaitingApprovalState()
 
   log_debug_throttled(__func__);
 
-  if (!isActivated() || isWaitingApproval()) {
+  if (!isActivated()) {
     if (module_type_->specialRequiredCheck()) {
       return true;
     }

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -54,6 +54,7 @@ void LaneChangeInterface::processOnEntry()
   module_type_->setPreviousDrivableAreaInfo(getPreviousModuleOutput().drivable_area_info);
   module_type_->setPreviousTurnSignalInfo(getPreviousModuleOutput().turn_signal_info);
   module_type_->updateLaneChangeStatus();
+  setObjectDebugVisualization();
 }
 
 void LaneChangeInterface::processOnExit()
@@ -84,13 +85,13 @@ void LaneChangeInterface::updateData()
   module_type_->setPreviousDrivableAreaInfo(getPreviousModuleOutput().drivable_area_info);
   module_type_->setPreviousTurnSignalInfo(getPreviousModuleOutput().turn_signal_info);
   module_type_->updateSpecialData();
-  setObjectDebugVisualization();
   module_type_->resetStopPose();
 }
 
 void LaneChangeInterface::postProcess()
 {
   post_process_safety_status_ = module_type_->isApprovedPathSafe();
+  setObjectDebugVisualization();
 }
 
 BehaviorModuleOutput LaneChangeInterface::plan()

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -420,6 +420,7 @@ void NormalLaneChange::resetParameters()
   is_abort_approval_requested_ = false;
   current_lane_change_state_ = LaneChangeStates::Normal;
   abort_path_ = nullptr;
+  status_ = {};
 
   object_debug_.clear();
 }

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -373,9 +373,9 @@ private:
       RCLCPP_DEBUG(getLogger(), "%s", message.data());
     };
     if (current_state_ == ModuleStatus::IDLE) {
-      if (canTransitIdleToRunningState()) {
+      if (canTransitIdleToWaitingApprovalState()) {
         log_debug_throttled("transiting from IDLE to RUNNING");
-        return ModuleStatus::RUNNING;
+        return ModuleStatus::WAITING_APPROVAL;
       }
 
       log_debug_throttled("transiting from IDLE to IDLE");
@@ -462,7 +462,7 @@ protected:
   /**
    * @brief State transition condition IDLE -> RUNNING
    */
-  virtual bool canTransitIdleToRunningState() = 0;
+  virtual bool canTransitIdleToWaitingApprovalState() = 0;
 
   /**
    * @brief Get candidate path. This information is used for external judgement.

--- a/planning/behavior_path_side_shift_module/include/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_side_shift_module/include/behavior_path_side_shift_module/scene.hpp
@@ -75,7 +75,7 @@ private:
 
   bool canTransitFailureState() override { return false; }
 
-  bool canTransitIdleToRunningState() override { return true; }
+  bool canTransitIdleToWaitingApprovalState() override { return true; }
 
   void initVariables();
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -139,7 +139,7 @@ private:
 
   bool canTransitFailureState() override { return false; }
 
-  bool canTransitIdleToRunningState() override;
+  bool canTransitIdleToWaitingApprovalState() override;
 
   /**
    * @brief init member variables.

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -337,7 +337,7 @@ bool StartPlannerModule::canTransitSuccessState()
   return hasFinishedPullOut();
 }
 
-bool StartPlannerModule::canTransitIdleToRunningState()
+bool StartPlannerModule::canTransitIdleToWaitingApprovalState()
 {
   return isActivated() && !isWaitingApproval();
 }

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -339,7 +339,7 @@ bool StartPlannerModule::canTransitSuccessState()
 
 bool StartPlannerModule::canTransitIdleToWaitingApprovalState()
 {
-  return isActivated() && !isWaitingApproval();
+  return isActivated();
 }
 
 BehaviorModuleOutput StartPlannerModule::plan()


### PR DESCRIPTION
## Description

`waitApproval` function will be deprecated, therefore to remove the support, this PR aims to refactor lane change interface to support this behavior.



## Related links

This PR needs to be merge first https://github.com/autowarefoundation/autoware.universe/pull/6051

## Tests performed

Evaluator result [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/73aa2e29-8750-57a0-bfb3-ce21af9dfc26?project_id=prd_jt)

## Notes for reviewers

This PR needs to be merge first https://github.com/autowarefoundation/autoware.universe/pull/6051

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
