### PR TITLE
perf(bpp): reduce computational cost

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -588,7 +588,7 @@ struct ShiftLineData
  */
 struct DebugData
 {
-  geometry_msgs::msg::Polygon detection_area;
+  std::vector<geometry_msgs::msg::Polygon> detection_areas;
 
   lanelet::ConstLineStrings3d bounds;
 

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/scene.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/scene.hpp
@@ -112,13 +112,12 @@ private:
    */
   void updateRegisteredRTCStatus(const PathWithLaneId & path)
   {
-    const Point ego_position = planner_data_->self_odometry->pose.pose.position;
+    const auto ego_idx = planner_data_->findEgoIndex(path.points);
 
     for (const auto & left_shift : left_shift_array_) {
       const double start_distance =
-        calcSignedArcLength(path.points, ego_position, left_shift.start_pose.position);
-      const double finish_distance =
-        calcSignedArcLength(path.points, ego_position, left_shift.finish_pose.position);
+        calcSignedArcLength(path.points, ego_idx, left_shift.start_pose.position);
+      const double finish_distance = start_distance + left_shift.relative_longitudinal;
       rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
         left_shift.uuid, true, start_distance, finish_distance, clock_->now());
       if (finish_distance > -1.0e-03) {
@@ -130,9 +129,8 @@ private:
 
     for (const auto & right_shift : right_shift_array_) {
       const double start_distance =
-        calcSignedArcLength(path.points, ego_position, right_shift.start_pose.position);
-      const double finish_distance =
-        calcSignedArcLength(path.points, ego_position, right_shift.finish_pose.position);
+        calcSignedArcLength(path.points, ego_idx, right_shift.start_pose.position);
+      const double finish_distance = start_distance + right_shift.relative_longitudinal;
       rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
         right_shift.uuid, true, start_distance, finish_distance, clock_->now());
       if (finish_distance > -1.0e-03) {
@@ -399,6 +397,7 @@ private:
     UUID uuid;
     Pose start_pose;
     Pose finish_pose;
+    double relative_longitudinal{0.0};
   };
 
   using RegisteredShiftLineArray = std::vector<RegisteredShiftLine>;

--- a/planning/behavior_path_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_avoidance_module/src/debug.cpp
@@ -608,10 +608,15 @@ MarkerArray createDebugMarkerArray(
     addShiftGrad(debug.total_backward_grad, debug.total_shift, "grad_backward", 0.4, 0.2, 0.9);
   }
 
+  // detection area
+  size_t i = 0;
+  for (const auto & detection_area : debug.detection_areas) {
+    add(createPolygonMarkerArray(detection_area, "detection_area", i++, 0.16, 1.0, 0.69, 0.1));
+  }
+
   // misc
   {
     add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
-    add(createPolygonMarkerArray(debug.detection_area, "detection_area", 0L, 0.16, 1.0, 0.69, 0.1));
     add(createDrivableBounds(data, "drivable_bound", 1.0, 0.0, 0.42));
     add(laneletsAsTriangleMarkerArray(
       "drivable_lanes", transformToLanelets(data.drivable_lanes),

--- a/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -415,15 +415,7 @@ TurnSignalInfo TurnSignalDecider::use_prior_turn_signal(
 
   const double dist_to_original_desired_start =
     get_distance(original_desired_start_point) - base_link2front_;
-  const double dist_to_original_desired_end = get_distance(original_desired_end_point);
-  const double dist_to_original_required_start =
-    get_distance(original_required_start_point) - base_link2front_;
-  const double dist_to_original_required_end = get_distance(original_required_end_point);
   const double dist_to_new_desired_start = get_distance(new_desired_start_point) - base_link2front_;
-  const double dist_to_new_desired_end = get_distance(new_desired_end_point);
-  const double dist_to_new_required_start =
-    get_distance(new_required_start_point) - base_link2front_;
-  const double dist_to_new_required_end = get_distance(new_required_end_point);
 
   // If we still do not reach the desired front point we ignore it
   if (dist_to_original_desired_start > 0.0 && dist_to_new_desired_start > 0.0) {
@@ -435,6 +427,9 @@ TurnSignalInfo TurnSignalDecider::use_prior_turn_signal(
     return original_signal;
   }
 
+  const double dist_to_original_desired_end = get_distance(original_desired_end_point);
+  const double dist_to_new_desired_end = get_distance(new_desired_end_point);
+
   // If we already passed the desired end point, return the other signal
   if (dist_to_original_desired_end < 0.0 && dist_to_new_desired_end < 0.0) {
     TurnSignalInfo empty_signal_info;
@@ -444,6 +439,13 @@ TurnSignalInfo TurnSignalDecider::use_prior_turn_signal(
   } else if (dist_to_new_desired_end < 0.0) {
     return original_signal;
   }
+
+  const double dist_to_original_required_start =
+    get_distance(original_required_start_point) - base_link2front_;
+  const double dist_to_original_required_end = get_distance(original_required_end_point);
+  const double dist_to_new_required_start =
+    get_distance(new_required_start_point) - base_link2front_;
+  const double dist_to_new_required_end = get_distance(new_required_end_point);
 
   if (dist_to_original_desired_start <= dist_to_new_desired_start) {
     const auto enable_prior = use_prior_turn_signal(

--- a/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -208,27 +208,25 @@ std::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectBound(
   return std::nullopt;
 }
 
-double calcDistanceFromPointToSegment(
+double calcSquaredDistanceFromPointToSegment(
   const geometry_msgs::msg::Point & segment_start_point,
   const geometry_msgs::msg::Point & segment_end_point,
   const geometry_msgs::msg::Point & target_point)
 {
+  using tier4_autoware_utils::calcSquaredDistance2d;
+
   const auto & a = segment_start_point;
   const auto & b = segment_end_point;
   const auto & p = target_point;
 
   const double dot_val = (b.x - a.x) * (p.x - a.x) + (b.y - a.y) * (p.y - a.y);
-  const double squared_segment_length = tier4_autoware_utils::calcSquaredDistance2d(a, b);
+  const double squared_segment_length = calcSquaredDistance2d(a, b);
   if (0 <= dot_val && dot_val <= squared_segment_length) {
-    const double numerator = std::abs((p.x - a.x) * (a.y - b.y) - (p.y - a.y) * (a.x - b.x));
-    const double denominator = std::sqrt(std::pow(a.x - b.x, 2) + std::pow(a.y - b.y, 2));
-    return numerator / denominator;
+    return calcSquaredDistance2d(p, a) - dot_val * dot_val / squared_segment_length;
   }
 
   // target_point is outside the segment.
-  return std::min(
-    tier4_autoware_utils::calcSquaredDistance2d(a, p),
-    tier4_autoware_utils::calcSquaredDistance2d(b, p));
+  return std::min(calcSquaredDistance2d(a, p), calcSquaredDistance2d(b, p));
 }
 
 PolygonPoint transformBoundFrenetCoordinate(
@@ -239,8 +237,8 @@ PolygonPoint transformBoundFrenetCoordinate(
   // find wrong nearest index.
   std::vector<double> dist_to_bound_segment_vec;
   for (size_t i = 0; i < bound_points.size() - 1; ++i) {
-    const double dist_to_bound_segment =
-      calcDistanceFromPointToSegment(bound_points.at(i), bound_points.at(i + 1), target_point);
+    const double dist_to_bound_segment = calcSquaredDistanceFromPointToSegment(
+      bound_points.at(i), bound_points.at(i + 1), target_point);
     dist_to_bound_segment_vec.push_back(dist_to_bound_segment);
   }
 

--- a/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -227,7 +227,8 @@ double calcDistanceFromPointToSegment(
 
   // target_point is outside the segment.
   return std::min(
-    tier4_autoware_utils::calcDistance2d(a, p), tier4_autoware_utils::calcDistance2d(b, p));
+    tier4_autoware_utils::calcSquaredDistance2d(a, p),
+    tier4_autoware_utils::calcSquaredDistance2d(b, p));
 }
 
 PolygonPoint transformBoundFrenetCoordinate(


### PR DESCRIPTION
## Description
Reduce aggregated costs 14.7% to **10.7%** in behavior planning container by following improvement.

- reduce frequecy to call `calcSignedArcLength`
- don't use `boost::geometry::union_`
- don't use `std::hypot`

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/ad5b70cd-daac-43dd-980c-19169bf2525d)
![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/520366ba-fc5e-413f-a97f-1e85b0c744e4)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/ebe8c91f-c4ad-52b0-9b09-731b1066cecd?project_id=prd_jt) 2343/2360
- [x] [BASE LINE](https://evaluation.tier4.jp/evaluation/reports/69880819-a97b-55a2-9d09-325151af2508?project_id=prd_jt) 2332/2360

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
