### PR TITLE
fix(behavior_velocity_planner, behavior_path_planner): refresh raw traffic light id map every callback

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -784,6 +784,7 @@ void BehaviorPathPlannerNode::onTrafficSignals(const TrafficSignalArray::ConstSh
 {
   std::lock_guard<std::mutex> lock(mutex_pd_);
 
+  planner_data_->traffic_light_id_map.clear();
   for (const auto & signal : msg->signals) {
     TrafficSignalStamped traffic_signal;
     traffic_signal.stamp = msg->stamp;

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -325,7 +325,8 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
 
   // clear previous observation
   planner_data_.traffic_light_id_map_raw_.clear();
-  auto traffic_light_id_map_last_observed_old = planner_data_.traffic_light_id_map_last_observed_;
+  const auto traffic_light_id_map_last_observed_old =
+    planner_data_.traffic_light_id_map_last_observed_;
   planner_data_.traffic_light_id_map_last_observed_.clear();
   for (const auto & signal : msg->signals) {
     TrafficSignalStamped traffic_signal;
@@ -338,12 +339,11 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
       });
     // if the observation is UNKNOWN and past observation is available, only update the timestamp
     // and keep the body of the info
-    if (
-      is_unknown_observation &&
-      traffic_light_id_map_last_observed_old.count(signal.traffic_signal_id) == 1) {
+    const auto old_data = traffic_light_id_map_last_observed_old.find(signal.traffic_signal_id);
+    if (is_unknown_observation && old_data != traffic_light_id_map_last_observed_old.end()) {
       // copy last observation
       planner_data_.traffic_light_id_map_last_observed_[signal.traffic_signal_id] =
-        traffic_light_id_map_last_observed_old[signal.traffic_signal_id];
+        old_data->second;
       // update timestamp
       planner_data_.traffic_light_id_map_last_observed_[signal.traffic_signal_id].stamp =
         msg->stamp;

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -323,6 +323,10 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
+  // clear previous observation
+  planner_data_.traffic_light_id_map_raw_.clear();
+  auto traffic_light_id_map_last_observed_old = planner_data_.traffic_light_id_map_last_observed_;
+  planner_data_.traffic_light_id_map_last_observed_.clear();
   for (const auto & signal : msg->signals) {
     TrafficSignalStamped traffic_signal;
     traffic_signal.stamp = msg->stamp;
@@ -336,7 +340,11 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
     // and keep the body of the info
     if (
       is_unknown_observation &&
-      planner_data_.traffic_light_id_map_last_observed_.count(signal.traffic_signal_id) == 1) {
+      traffic_light_id_map_last_observed_old.count(signal.traffic_signal_id) == 1) {
+      // copy last observation
+      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_signal_id] =
+        traffic_light_id_map_last_observed_old[signal.traffic_signal_id];
+      // update timestamp
       planner_data_.traffic_light_id_map_last_observed_[signal.traffic_signal_id].stamp =
         msg->stamp;
     } else {


### PR DESCRIPTION
## Description

Previously PlannerData of behavior_velocity and behavior_path did not clean old data in the traffic_light_id_map.
For planning policy we should not save old data which is missing in current observation. If some module wants to save traffic signal information that is not available currently, it should save it individually.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

I used intersection module for test. The intersection module ignores occlusion when the traffic signal is RED.

### before this PR

occlusion it detected at the beginning because  {10575, GREEN} is available. Then at [00:04] occlusion is not detected because {10575, RED}. Then at [00:14] the info of 10575 is lost, and its info is remaining at planner_data, so occlusion is not detected because it is still interpreted as RED.

https://github.com/autowarefoundation/autoware.universe/assets/28677420/a6d5d81d-198c-4a10-a3e0-c63ae6cf705f


### after this PR

occlusion it detected at the beginning because  {10575, GREEN} is available. Then at [00:03] occlusion is not detected because {10575, RED}. Then at [00:18] the info of 10575 is lost, and its info is not remaining at planner_data, so occlusion is detected again because it is interpreted as UNKNOWN. (until [00:18] /perception/traffic_light_recognition/traffic_signals topic is not updated so no callback happens)

https://github.com/autowarefoundation/autoware.universe/assets/28677420/1b39b027-151f-4d08-8ba0-6359b37194bd

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
