### PR TITLE
feat(ndt_scan_matcher): change coordinate of output_pose_covariance 

### DIFF
--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -127,6 +127,8 @@ private:
     const double & transform_probability, const double & nearest_voxel_transformation_likelihood);
   static int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array);
 
+  std::array<double, 36> rotate_covariance(
+    const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation) const;
   std::array<double, 36> estimate_covariance(
     const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
     const rclcpp::Time & sensor_ros_time);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -486,7 +486,12 @@ void NDTScanMatcher::callback_sensor_points(
   }
 
   // covariance estimation
-  std::array<double, 36> ndt_covariance = output_pose_covariance_;
+  Eigen::Quaterniond map_to_base_link_quat = Eigen::Quaterniond(result_pose_msg.orientation.w, result_pose_msg.orientation.x, result_pose_msg.orientation.y, result_pose_msg.orientation.z);
+  Eigen::Matrix3d map_to_base_link_rotation = map_to_base_link_quat.normalized().toRotationMatrix();
+
+  std::array<double, 36> ndt_covariance = rotate_covariance(output_pose_covariance_, map_to_base_link_rotation);
+
+
   if (is_converged && use_cov_estimation_) {
     const auto estimated_covariance =
       estimate_covariance(ndt_result, initial_pose_matrix, sensor_ros_time);
@@ -764,6 +769,28 @@ int NDTScanMatcher::count_oscillation(
     max_oscillation_cnt = std::max(max_oscillation_cnt, oscillation_cnt);
   }
   return max_oscillation_cnt;
+}
+
+std::array<double, 36> NDTScanMatcher::rotate_covariance(
+  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation) const
+{
+  std::array<double, 36> ret_covariance = src_covariance;
+
+  Eigen::Matrix3d src_cov;
+  src_cov << src_covariance[0],  src_covariance[1],  src_covariance[2],
+             src_covariance[6],  src_covariance[7],  src_covariance[8],
+             src_covariance[12], src_covariance[13], src_covariance[14];
+
+  Eigen::Matrix3d ret_cov;
+  ret_cov = rotation * src_cov * rotation.transpose();
+
+  for (Eigen::Index i = 0; i < 3; ++i) {
+    ret_covariance[i] = ret_cov(0, i);
+    ret_covariance[i + 6] = ret_cov(1, i);
+    ret_covariance[i + 12] = ret_cov(2, i);
+  }
+
+  return ret_covariance;
 }
 
 std::array<double, 36> NDTScanMatcher::estimate_covariance(

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -489,7 +489,8 @@ void NDTScanMatcher::callback_sensor_points(
   const Eigen::Quaterniond map_to_base_link_quat = Eigen::Quaterniond(
     result_pose_msg.orientation.w, result_pose_msg.orientation.x, result_pose_msg.orientation.y,
     result_pose_msg.orientation.z);
-  const Eigen::Matrix3d map_to_base_link_rotation = map_to_base_link_quat.normalized().toRotationMatrix();
+  const Eigen::Matrix3d map_to_base_link_rotation =
+    map_to_base_link_quat.normalized().toRotationMatrix();
 
   std::array<double, 36> ndt_covariance =
     rotate_covariance(output_pose_covariance_, map_to_base_link_rotation);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -486,11 +486,13 @@ void NDTScanMatcher::callback_sensor_points(
   }
 
   // covariance estimation
-  Eigen::Quaterniond map_to_base_link_quat = Eigen::Quaterniond(result_pose_msg.orientation.w, result_pose_msg.orientation.x, result_pose_msg.orientation.y, result_pose_msg.orientation.z);
+  Eigen::Quaterniond map_to_base_link_quat = Eigen::Quaterniond(
+    result_pose_msg.orientation.w, result_pose_msg.orientation.x, result_pose_msg.orientation.y,
+    result_pose_msg.orientation.z);
   Eigen::Matrix3d map_to_base_link_rotation = map_to_base_link_quat.normalized().toRotationMatrix();
 
-  std::array<double, 36> ndt_covariance = rotate_covariance(output_pose_covariance_, map_to_base_link_rotation);
-
+  std::array<double, 36> ndt_covariance =
+    rotate_covariance(output_pose_covariance_, map_to_base_link_rotation);
 
   if (is_converged && use_cov_estimation_) {
     const auto estimated_covariance =
@@ -777,9 +779,9 @@ std::array<double, 36> NDTScanMatcher::rotate_covariance(
   std::array<double, 36> ret_covariance = src_covariance;
 
   Eigen::Matrix3d src_cov;
-  src_cov << src_covariance[0],  src_covariance[1],  src_covariance[2],
-             src_covariance[6],  src_covariance[7],  src_covariance[8],
-             src_covariance[12], src_covariance[13], src_covariance[14];
+  src_cov << src_covariance[0], src_covariance[1], src_covariance[2], src_covariance[6],
+    src_covariance[7], src_covariance[8], src_covariance[12], src_covariance[13],
+    src_covariance[14];
 
   Eigen::Matrix3d ret_cov;
   ret_cov = rotation * src_cov * rotation.transpose();

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -486,10 +486,10 @@ void NDTScanMatcher::callback_sensor_points(
   }
 
   // covariance estimation
-  Eigen::Quaterniond map_to_base_link_quat = Eigen::Quaterniond(
+  const Eigen::Quaterniond map_to_base_link_quat = Eigen::Quaterniond(
     result_pose_msg.orientation.w, result_pose_msg.orientation.x, result_pose_msg.orientation.y,
     result_pose_msg.orientation.z);
-  Eigen::Matrix3d map_to_base_link_rotation = map_to_base_link_quat.normalized().toRotationMatrix();
+  const Eigen::Matrix3d map_to_base_link_rotation = map_to_base_link_quat.normalized().toRotationMatrix();
 
   std::array<double, 36> ndt_covariance =
     rotate_covariance(output_pose_covariance_, map_to_base_link_rotation);


### PR DESCRIPTION
## Description


I would like to change the handling of `output_pose_covariance` param from the map coordinate system to the base_link coordinate system.
Along with this, a feature to convert `output_pose_covariance` to the map coordinate system based on the estimated pose has been added.

<!-- Write a brief description of this PR. -->

## Tests performed

- LSim works as usual.
※ The output covariance of NDT have changed slightly, so it is not exactly the same as before.


- When [output_pose_covariance](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/localization/ndt_scan_matcher.param.yaml#L62-L70
) is modified, the output covariance becomes aligned with the estimated pose.

example

```
    output_pose_covariance:
      [
        30.0, 0.0,   0.0,   0.0,      0.0,      0.0,
        0.0,   10.0, 0.0,   0.0,      0.0,      0.0,
        0.0,   0.0,   0.0225, 0.0,      0.0,      0.0,
        0.0,   0.0,   0.0,   0.000625, 0.0,      0.0,
        0.0,   0.0,   0.0,   0.0,      0.000625, 0.0,
        0.0,   0.0,   0.0,   0.0,      0.0,      0.000625,
      ]

```
![Screenshot from 2024-01-12 19-41-49](https://github.com/autowarefoundation/autoware.universe/assets/13819566/6edf833e-671c-484f-919e-34f2768f1412)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
