### PR TITLE
fix(ekf_localizer): fixed timer in ekf_localizer

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -199,7 +199,7 @@ private:
   /**
    * @brief update predict frequency
    */
-  void updatePredictFrequency();
+  void updatePredictFrequency(const rclcpp::Time & current_time);
 
   /**
    * @brief get transform from frame_id
@@ -219,7 +219,7 @@ private:
   /**
    * @brief publish diagnostics message
    */
-  void publishDiagnostics();
+  void publishDiagnostics(const rclcpp::Time & current_time);
 
   /**
    * @brief update simple1DFilter


### PR DESCRIPTION
## Description

Changed the handling of timestamps in `ekf_localizer`.

### Context

I found that `this->now()` returns different timestamps even during a single timer callback execution.

Therefore, I think it would be better to obtain the timestamp only once at the beginning of timer callback execution, and use it commonly in one callback. Please let me know if there is any misunderstanding.

## Tests performed

It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

* Before : 0.051 [m]
* After :  0.050 [m]

I plotted the difference between the value of one step and the value of the next step regarding x, y, z and timestamp of Pose output by EKF.

* Before
![localization__pose_twist_fusion_filter__pose_differential](https://github.com/autowarefoundation/autoware.universe/assets/28504069/ebf527f9-d58f-407b-ad24-030e4562fc3a)
* After
![localization__pose_twist_fusion_filter__pose_differential](https://github.com/autowarefoundation/autoware.universe/assets/28504069/fc73884b-5130-4955-b910-bd2dc06b0f50)

## Effects on system behavior

It seems that the topic timestamps output by EKF will be slightly more stable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
