### PR TITLE
feat(map_based_prediction): use obstacle acceleration for map prediction

### DIFF
--- a/perception/map_based_prediction/README.md
+++ b/perception/map_based_prediction/README.md
@@ -124,7 +124,7 @@ See paper [2] for more details.
 
 `lateral_control_time_horizon` parameter supports the tuning of the lateral path shape. This parameter is used to calculate the time to reach the reference path. The smaller the value, the more the path will be generated to reach the reference path quickly. (Mostly the center of the lane.)
 
-#### Pruning predicted paths with lateral acceleration constraint
+#### Pruning predicted paths with lateral acceleration constraint (for vehicle obstacles)
 
 It is possible to apply a maximum lateral acceleration constraint to generated vehicle paths. This check verifies if it is possible for the vehicle to perform the predicted path without surpassing a lateral acceleration threshold `max_lateral_accel` when taking a curve. If it is not possible, it checks if the vehicle can slow down on time to take the curve with a deceleration of `min_acceleration_before_curve` and comply with the constraint. If that is also not possible, the path is eliminated.
 
@@ -136,11 +136,37 @@ Currently we provide three parameters to tune the lateral acceleration constrain
 
 You can change these parameters in rosparam in the table below.
 
-| param name                                | default value  |
-| ----------------------------------------- | -------------- |
-| `check_lateral_acceleration_constraints_` | `false` [bool] |
-| `max_lateral_accel`                       | `2.0` [m/s^2]  |
-| `min_acceleration_before_curve`           | `-2.0` [m/s^2] |
+| param name                               | default value  |
+| ---------------------------------------- | -------------- |
+| `check_lateral_acceleration_constraints` | `false` [bool] |
+| `max_lateral_accel`                      | `2.0` [m/s^2]  |
+| `min_acceleration_before_curve`          | `-2.0` [m/s^2] |
+
+## Using Vehicle Acceleration for Path Prediction (for Vehicle Obstacles)
+
+By default, the `map_based_prediction` module uses the current obstacle's velocity to compute its predicted path length. However, it is possible to use the obstacle's current acceleration to calculate its predicted path's length.
+
+### Decaying Acceleration Model
+
+Since this module tries to predict the vehicle's path several seconds into the future, it is not practical to consider the current vehicle's acceleration as constant (it is not assumed the vehicle will be accelerating for `prediction_time_horizon` seconds after detection). Instead, a decaying acceleration model is used. With the decaying acceleration model, a vehicle's acceleration is modeled as:
+
+\[ a(t) = a\_{t0} \cdot e^{-\lambda \cdot t} \]
+
+where \( a\_{t0} \) is the vehicle acceleration at the time of detection, and \( \lambda \) is the decay constant \( \lambda = \ln(2) / \text{exponential_half_life} \). With this model, the influence of the vehicle's detected instantaneous acceleration on the predicted path's length is diminished but still considered. This feature also considers that the obstacle might not accelerate past its road's speed limit (multiplied by a tunable factor).
+
+Currently, we provide three parameters to tune the use of obstacle acceleration for path prediction:
+
+- `use_vehicle_acceleration`: to enable the feature.
+- `acceleration_exponential_half_life`: The decaying acceleration model considers that the current vehicle acceleration will be halved after this many seconds.
+- `speed_limit_multiplier`: Set the vehicle type obstacle's maximum predicted speed as the legal speed limit in that lanelet times this value. This value should be at least equal or greater than 1.0.
+
+You can change these parameters in `rosparam` in the table below.
+
+| Param Name                           | Default Value  |
+| ------------------------------------ | -------------- |
+| `use_vehicle_acceleration`           | `false` [bool] |
+| `acceleration_exponential_half_life` | `2.5` [s]      |
+| `speed_limit_multiplier`             | `1.5` []       |
 
 ### Path prediction for crosswalk users
 

--- a/perception/map_based_prediction/README.md
+++ b/perception/map_based_prediction/README.md
@@ -150,9 +150,19 @@ By default, the `map_based_prediction` module uses the current obstacle's veloci
 
 Since this module tries to predict the vehicle's path several seconds into the future, it is not practical to consider the current vehicle's acceleration as constant (it is not assumed the vehicle will be accelerating for `prediction_time_horizon` seconds after detection). Instead, a decaying acceleration model is used. With the decaying acceleration model, a vehicle's acceleration is modeled as:
 
-\[ a(t) = a\_{t0} \cdot e^{-\lambda \cdot t} \]
+$\ a(t) = a\_{t0} \cdot e^{-\lambda \cdot t} $
 
-where \( a\_{t0} \) is the vehicle acceleration at the time of detection, and \( \lambda \) is the decay constant \( \lambda = \ln(2) / \text{exponential_half_life} \). With this model, the influence of the vehicle's detected instantaneous acceleration on the predicted path's length is diminished but still considered. This feature also considers that the obstacle might not accelerate past its road's speed limit (multiplied by a tunable factor).
+where $\ a\_{t0} $ is the vehicle acceleration at the time of detection $\ t0 $, and $\ \lambda $ is the decay constant $\ \lambda = \ln(2) / hl $ and $\ hl $ is the exponential's half life.
+
+Furthermore, the integration of $\ a(t) $ over time gives us equations for velocity, $\ v(t) $ and distance $\ x(t) $ as:
+
+$\ v(t) = v*{t0} + a*{t0} \* (1/\lambda) \cdot (1 - e^{-\lambda \cdot t}) $
+
+and
+
+$\ x(t) = x*{t0} + (v*{t0} + a*{t0} \* (1/\lambda)) \cdot t + a*{t0}(1/λ^2)(e^{-\lambda \cdot t} - 1) $
+
+With this model, the influence of the vehicle's detected instantaneous acceleration on the predicted path's length is diminished but still considered. This feature also considers that the obstacle might not accelerate past its road's speed limit (multiplied by a tunable factor).
 
 Currently, we provide three parameters to tune the use of obstacle acceleration for path prediction:
 

--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -16,6 +16,7 @@
     check_lateral_acceleration_constraints: false # whether to check if the predicted path complies with lateral acceleration constraints
     max_lateral_accel: 2.0 # [m/ss] max acceptable lateral acceleration for predicted vehicle paths
     min_acceleration_before_curve: -2.0 # [m/ss] min acceleration a vehicle might take to decelerate before a curve
+    use_vehicle_acceleration: false # whether to consider current vehicle acceleration when predicting paths or not
     # parameter for shoulder lane prediction
     prediction_time_horizon_rate_for_validate_shoulder_lane_length: 0.8
 

--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -17,6 +17,8 @@
     max_lateral_accel: 2.0 # [m/ss] max acceptable lateral acceleration for predicted vehicle paths
     min_acceleration_before_curve: -2.0 # [m/ss] min acceleration a vehicle might take to decelerate before a curve
     use_vehicle_acceleration: false # whether to consider current vehicle acceleration when predicting paths or not
+    speed_limit_multiplier: 1.5 # When using vehicle acceleration. Set vehicle's maximum predicted speed as the legal speed limit in that lanelet times this value
+    acceleration_exponential_half_life: 2.5 # [s] When using vehicle acceleration. The decaying acceleration model considers that the current vehicle acceleration will be halved after this many seconds
     # parameter for shoulder lane prediction
     prediction_time_horizon_rate_for_validate_shoulder_lane_length: 0.8
 

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -367,37 +367,28 @@ private:
     std::vector<TrackedObject> tracked_objects_;
     double smoothing_factor_ = 0.5;
 
-    template <typename T>
-    std::optional<T> getObjectFromUuid(
-      const std::vector<T> & objects, const std::string & target_uuid)
-    {
-      const auto itr = std::find_if(objects.begin(), objects.end(), [&](const auto & object) {
-        return tier4_autoware_utils::toHexString(object.object_id) == target_uuid;
-      });
-
-      if (itr == objects.end()) {
-        return std::nullopt;
-      }
-      return itr;
-    }
     double getFilteredAcceleration(const TrackedObject & object)
     {
-      const auto uuid = tier4_autoware_utils::toHexString(object.object_id);
       const double current_acceleration = std::hypot(
         object.kinematics.acceleration_with_covariance.accel.linear.x,
         object.kinematics.acceleration_with_covariance.accel.linear.y);
-      const auto prev_object_info = getObjectFromUuid(tracked_objects_, uuid);
+
+      const auto uuid = tier4_autoware_utils::toHexString(object.object_id);
+      const auto prev_object_info =
+        std::find_if(tracked_objects_.begin(), tracked_objects_.end(), [&](const auto & object) {
+          return tier4_autoware_utils::toHexString(object.object_id) == uuid;
+        });
 
       if (prev_object_info == tracked_objects_.end()) {
         tracked_objects_.push_back(object);
         return current_acceleration;
       }
       const double prev_acceleration = std::hypot(
-        *prev_object_info.value().kinematics.acceleration_with_covariance.accel.linear.x,
-        *prev_object_info.value().kinematics.acceleration_with_covariance.accel.linear.y);
+        prev_object_info->kinematics.acceleration_with_covariance.accel.linear.x,
+        prev_object_info->kinematics.acceleration_with_covariance.accel.linear.y);
       const double filtered_acceleration =
         smoothing_factor_ * current_acceleration + (1.0 - smoothing_factor_) * prev_acceleration;
-      *prev_object_info.value() = object;
+      *prev_object_info = object;
       return filtered_acceleration;
     }
   };

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -368,37 +368,6 @@ private:
     }
     return true;
   };
-  struct ObjectAccelerationMonitor
-  {
-    std::vector<TrackedObject> tracked_objects_;
-    double smoothing_factor_ = 0.5;
-
-    double getFilteredAcceleration(const TrackedObject & object)
-    {
-      const double current_acceleration = std::hypot(
-        object.kinematics.acceleration_with_covariance.accel.linear.x,
-        object.kinematics.acceleration_with_covariance.accel.linear.y);
-
-      const auto uuid = tier4_autoware_utils::toHexString(object.object_id);
-      const auto prev_object_info =
-        std::find_if(tracked_objects_.begin(), tracked_objects_.end(), [&](const auto & object) {
-          return tier4_autoware_utils::toHexString(object.object_id) == uuid;
-        });
-
-      if (prev_object_info == tracked_objects_.end()) {
-        tracked_objects_.push_back(object);
-        return current_acceleration;
-      }
-      const double prev_acceleration = std::hypot(
-        prev_object_info->kinematics.acceleration_with_covariance.accel.linear.x,
-        prev_object_info->kinematics.acceleration_with_covariance.accel.linear.y);
-      const double filtered_acceleration =
-        smoothing_factor_ * current_acceleration + (1.0 - smoothing_factor_) * prev_acceleration;
-      *prev_object_info = object;
-      return filtered_acceleration;
-    }
-  };
-  ObjectAccelerationMonitor object_acceleration_monitor_;
 };
 }  // namespace map_based_prediction
 

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -177,6 +177,8 @@ private:
   double max_lateral_accel_;
   double min_acceleration_before_curve_;
 
+  bool use_vehicle_acceleration_;
+
   // Stop watch
   StopWatch<std::chrono::milliseconds> stop_watch_;
 

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -90,6 +90,7 @@ struct LaneletData
 struct PredictedRefPath
 {
   float probability;
+  double speed_limit;
   PosePath path;
   Maneuver maneuver;
 };
@@ -232,7 +233,8 @@ private:
   void addReferencePaths(
     const TrackedObject & object, const lanelet::routing::LaneletPaths & candidate_paths,
     const float path_probability, const ManeuverProbability & maneuver_probability,
-    const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths);
+    const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths,
+    const double speed_limit = 0.0);
   std::vector<PosePath> convertPathType(const lanelet::routing::LaneletPaths & paths);
 
   void updateFuturePossibleLanelets(

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -178,6 +178,8 @@ private:
   double min_acceleration_before_curve_;
 
   bool use_vehicle_acceleration_;
+  double speed_limit_multiplier_;
+  double acceleration_exponential_half_life_;
 
   // Stop watch
   StopWatch<std::chrono::milliseconds> stop_watch_;

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -99,12 +99,18 @@ public:
   PredictedPath generatePathToTargetPoint(
     const TrackedObject & object, const Eigen::Vector2d & point) const;
 
+  void setUseVehicleAcceleration(const bool use_vehicle_acceleration)
+  {
+    use_vehicle_acceleration_ = use_vehicle_acceleration;
+  }
+
 private:
   // Parameters
   double time_horizon_;
   double lateral_time_horizon_;
   double sampling_time_interval_;
   double min_crosswalk_user_velocity_;
+  bool use_vehicle_acceleration_;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object) const;

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -104,6 +104,11 @@ public:
     use_vehicle_acceleration_ = use_vehicle_acceleration;
   }
 
+  void setAccelerationHalfLife(const double acceleration_exponential_half_life)
+  {
+    acceleration_exponential_half_life_ = acceleration_exponential_half_life;
+  }
+
 private:
   // Parameters
   double time_horizon_;
@@ -111,6 +116,7 @@ private:
   double sampling_time_interval_;
   double min_crosswalk_user_velocity_;
   bool use_vehicle_acceleration_;
+  double acceleration_exponential_half_life_;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object) const;

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -91,7 +91,7 @@ public:
   PredictedPath generatePathForOffLaneVehicle(const TrackedObject & object);
 
   PredictedPath generatePathForOnLaneVehicle(
-    const TrackedObject & object, const PosePath & ref_paths);
+    const TrackedObject & object, const PosePath & ref_paths, const double speed_limit = 0.0);
 
   PredictedPath generatePathForCrosswalkUser(
     const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk) const;
@@ -109,7 +109,8 @@ private:
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object) const;
 
-  PredictedPath generatePolynomialPath(const TrackedObject & object, const PosePath & ref_path);
+  PredictedPath generatePolynomialPath(
+    const TrackedObject & object, const PosePath & ref_path, const double speed_limit = 0.0);
 
   FrenetPath generateFrenetPath(
     const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length);
@@ -125,7 +126,8 @@ private:
     const TrackedObject & object, const FrenetPath & frenet_predicted_path,
     const PosePath & ref_path);
 
-  FrenetPoint getFrenetPoint(const TrackedObject & object, const PosePath & ref_path);
+  FrenetPoint getFrenetPoint(
+    const TrackedObject & object, const PosePath & ref_path, const double speed_limit = 0.0);
 };
 }  // namespace map_based_prediction
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1569,12 +1569,12 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
   const double acceleration_distance =
     filtered_obj_acc * (1.0 / λ) * prediction_time_horizon_ +
     filtered_obj_acc * (1.0 / std::pow(λ, 2)) * std::exp(-λ * prediction_time_horizon_);
-  std::cerr << "------------------------------------\n";
-  std::cerr << "object " << tier4_autoware_utils::toHexString(object.object_id) << "\n";
-  std::cerr << "acceleration_distance calculated " << acceleration_distance << "\n";
-  std::cerr << "obj_vel " << obj_vel << "\n";
-  std::cerr << "filtered_obj_acc " << filtered_obj_acc << "\n";
-  std::cerr << "prediction_time_horizon_ " << prediction_time_horizon_ << "\n";
+  // std::cerr << "------------------------------------\n";
+  // std::cerr << "object " << tier4_autoware_utils::toHexString(object.object_id) << "\n";
+  // std::cerr << "acceleration_distance calculated " << acceleration_distance << "\n";
+  // std::cerr << "obj_vel " << obj_vel << "\n";
+  // std::cerr << "filtered_obj_acc " << filtered_obj_acc << "\n";
+  // std::cerr << "prediction_time_horizon_ " << prediction_time_horizon_ << "\n";
 
   std::vector<PredictedRefPath> all_ref_paths;
   for (const auto & current_lanelet_data : current_lanelets_data) {
@@ -1582,7 +1582,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     const double search_dist = acceleration_distance + prediction_time_horizon_ * obj_vel +
                                lanelet::utils::getLaneletLength3d(current_lanelet_data.lanelet);
     lanelet::routing::PossiblePathsParams possible_params{search_dist, {}, 0, false, true};
-    std::cerr << "search_dist " << search_dist << "\n";
+    // std::cerr << "search_dist " << search_dist << "\n";
     const double validate_time_horizon =
       prediction_time_horizon_ * prediction_time_horizon_rate_for_validate_lane_length_;
 
@@ -1672,7 +1672,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     addReferencePathsLocal(right_paths, Maneuver::RIGHT_LANE_CHANGE);
     addReferencePathsLocal(center_paths, Maneuver::LANE_FOLLOW);
   }
-  std::cerr << "------------------------------------\n";
+  // std::cerr << "------------------------------------\n";
 
   return all_ref_paths;
 }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1556,7 +1556,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
 
   // Use a filtered-decaying acceleration model
   const double filtered_obj_acc = object_acceleration_monitor_.getFilteredAcceleration(object);
-  const double exponential_half_life = prediction_time_horizon_ / 2.0;
+  const double exponential_half_life = prediction_time_horizon_ / 4.0;
   // The decay constant λ = ln(2) / exponential_half_life
   const double λ = std::log(2) / exponential_half_life;
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1565,13 +1565,13 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
 
   // a(t) = obj_acc - obj_acc(1-e^(-λt)) = obj_acc(e^(-λt))
   // V(t) = Vo + obj_acc(1/λ)(1-e^(-λt))
-  // x(t) = Xo + Vo * t + t * obj_acc(1/λ) + obj_acc(1/λ^2)e^(-λt)
-  // x(t) = Xo + (Vo + obj_acc(1/λ)) * t  + obj_acc(1/λ^2)e^(-λt)
-  // acceleration_distance = obj_acc(1/λ) * t  + obj_acc(1/λ^2)e^(-λt)
+  // x(t) = Xo + Vo * t + t * obj_acc(1/λ) + obj_acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
+  // x(t) = Xo + (Vo + obj_acc(1/λ)) * t  + obj_acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
+  // acceleration_distance = obj_acc(1/λ) * t  + obj_acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
 
   const double acceleration_distance =
     obj_acc * (1.0 / λ) * prediction_time_horizon_ +
-    obj_acc * (1.0 / std::pow(λ, 2)) * std::exp(-λ * prediction_time_horizon_);
+    obj_acc * (1.0 / std::pow(λ, 2)) * (std::exp(-λ * prediction_time_horizon_) - 1);
 
   std::vector<PredictedRefPath> all_ref_paths;
   for (const auto & current_lanelet_data : current_lanelets_data) {

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1630,7 +1630,6 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     search_dist += lanelet::utils::getLaneletLength3d(current_lanelet_data.lanelet);
 
     lanelet::routing::PossiblePathsParams possible_params{search_dist, {}, 0, false, true};
-    // std::cerr << "search_dist " << search_dist << "\n";
     const double validate_time_horizon = T * prediction_time_horizon_rate_for_validate_lane_length_;
 
     // lambda function to get possible paths for isolated lanelet
@@ -1720,7 +1719,6 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     addReferencePathsLocal(right_paths, Maneuver::RIGHT_LANE_CHANGE);
     addReferencePathsLocal(center_paths, Maneuver::LANE_FOLLOW);
   }
-  // std::cerr << "------------------------------------\n";
 
   return all_ref_paths;
 }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1569,6 +1569,12 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
   const double acceleration_distance =
     filtered_obj_acc * (1.0 / λ) * prediction_time_horizon_ +
     filtered_obj_acc * (1.0 / std::pow(λ, 2)) * std::exp(-λ * prediction_time_horizon_);
+  std::cerr << "------------------------------------\n";
+  std::cerr << "object " << tier4_autoware_utils::toHexString(object.object_id) << "\n";
+  std::cerr << "acceleration_distance calculated " << acceleration_distance << "\n";
+  std::cerr << "obj_vel " << obj_vel << "\n";
+  std::cerr << "filtered_obj_acc " << filtered_obj_acc << "\n";
+  std::cerr << "prediction_time_horizon_ " << prediction_time_horizon_ << "\n";
 
   std::vector<PredictedRefPath> all_ref_paths;
   for (const auto & current_lanelet_data : current_lanelets_data) {
@@ -1576,6 +1582,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     const double search_dist = acceleration_distance + prediction_time_horizon_ * obj_vel +
                                lanelet::utils::getLaneletLength3d(current_lanelet_data.lanelet);
     lanelet::routing::PossiblePathsParams possible_params{search_dist, {}, 0, false, true};
+    std::cerr << "search_dist " << search_dist << "\n";
     const double validate_time_horizon =
       prediction_time_horizon_ * prediction_time_horizon_rate_for_validate_lane_length_;
 
@@ -1665,6 +1672,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     addReferencePathsLocal(right_paths, Maneuver::RIGHT_LANE_CHANGE);
     addReferencePathsLocal(center_paths, Maneuver::LANE_FOLLOW);
   }
+  std::cerr << "------------------------------------\n";
 
   return all_ref_paths;
 }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1572,7 +1572,6 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
                                object.kinematics.acceleration_with_covariance.accel.linear.x,
                                object.kinematics.acceleration_with_covariance.accel.linear.y)
                            : 0.0;
-
   // The decay constant λ = ln(2) / exponential_half_life
   const double T = prediction_time_horizon_;
   const double exponential_half_life = acceleration_exponential_half_life_;
@@ -1583,7 +1582,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     // V(t) = Vo + obj_acc(1/λ)(1-e^(-λt))
     // x(t) = Xo + Vo * t + t * obj_acc(1/λ) + obj_acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
     // x(t) = Xo + (Vo + obj_acc(1/λ)) * t  + obj_acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
-    // acceleration_distance = obj_acc(1/λ) * t  + obj_acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
+    // acceleration_distance = x(T) = obj_acc(1/λ) * T  + obj_acc(1/λ^2)(e^(-λT) - 1)
     const double acceleration_distance =
       obj_acc * (1.0 / λ) * T + obj_acc * (1.0 / std::pow(λ, 2)) * (std::exp(-λ * T) - 1);
     double search_dist = acceleration_distance + obj_vel * T;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1572,8 +1572,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
                                object.kinematics.acceleration_with_covariance.accel.linear.y)
                            : 0.0;
   const double t_h = prediction_time_horizon_;
-  const double exponential_half_life = acceleration_exponential_half_life_;
-  const double λ = std::log(2) / exponential_half_life;
+  const double λ = std::log(2) / acceleration_exponential_half_life_;
 
   auto get_search_distance_with_decaying_acc = [&]() -> double {
     const double acceleration_distance =

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -407,7 +407,7 @@ FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const Po
     static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.y);
 
   // The decay constant λ = ln(2) / exponential_half_life
-  const float exponential_half_life = T / 2.0;
+  const float exponential_half_life = T / 4.0;
   const float λ = std::log(2) / exponential_half_life;
 
   // Vnew * T = Vo * T +  acc(1/λ) * T + acc(1/λ^2)e^(-λT)

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -149,13 +149,13 @@ PredictedPath PathGenerator::generatePathForOffLaneVehicle(const TrackedObject &
 }
 
 PredictedPath PathGenerator::generatePathForOnLaneVehicle(
-  const TrackedObject & object, const PosePath & ref_paths)
+  const TrackedObject & object, const PosePath & ref_paths, const double speed_limit)
 {
   if (ref_paths.size() < 2) {
     return generateStraightPath(object);
   }
 
-  return generatePolynomialPath(object, ref_paths);
+  return generatePolynomialPath(object, ref_paths, speed_limit);
 }
 
 PredictedPath PathGenerator::generateStraightPath(const TrackedObject & object) const
@@ -178,11 +178,11 @@ PredictedPath PathGenerator::generateStraightPath(const TrackedObject & object) 
 }
 
 PredictedPath PathGenerator::generatePolynomialPath(
-  const TrackedObject & object, const PosePath & ref_path)
+  const TrackedObject & object, const PosePath & ref_path, const double speed_limit)
 {
   // Get current Frenet Point
   const double ref_path_len = motion_utils::calcArcLength(ref_path);
-  const auto current_point = getFrenetPoint(object, ref_path);
+  const auto current_point = getFrenetPoint(object, ref_path, speed_limit);
 
   // Step1. Set Target Frenet Point
   // Note that we do not set position s,
@@ -384,7 +384,8 @@ PredictedPath PathGenerator::convertToPredictedPath(
   return predicted_path;
 }
 
-FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const PosePath & ref_path)
+FrenetPoint PathGenerator::getFrenetPoint(
+  const TrackedObject & object, const PosePath & ref_path, const double speed_limit)
 {
   FrenetPoint frenet_point;
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;
@@ -420,35 +421,57 @@ FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const Po
   };
 
   auto get_equivalent_velocity = [&](const double v, const double a) {
+    constexpr double epsilon = 1E-5;
+    if (std::abs(a) < epsilon) {
+      // Assume constant speed
+      return v;
+    }
+    // Get velocity after time horizon
     // V(t) = Vo + acc(1/λ)(1-e^(-λt))
     const auto V_terminal = v + a * (1.0 / λ) * (1 - std::exp(-λ * T));
 
-    //   obj_acc * (1.0 / λ) * prediction_time_horizon_ +
-    // obj_acc * (1.0 / std::pow(λ, 2)) * (std::exp(-λ * prediction_time_horizon_) - 1);
-    if (have_same_sign(V_terminal, v))
+    // If vehicle is decelerating, make sure its speed does not change signs (we assume it will, at
+    // most stop, not reverse its direction)
+    if (!have_same_sign(V_terminal, v)) {
+      // we assume a forwards moving vehicle will not decelerate to 0 and then move backwards
+      // if the velocities don't have the same sign, calculate when the velocity becomes 0 -> time
+      // T_0
+
+      // 0 = Vo + acc(1/λ)(1-e^(-λT0))
+      // e^(-λT0) = 1 - (-Vo* λ)/acc
+      // T0 = (-1/λ)*ln(1 - (-Vo* λ)/acc)
+      auto T_0 = std::log(1 - (-v * λ / a)) * (-1.0 / λ);
+
+      // Calculate what distance will be traveled
+      // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
+      // x(T0) = Xo + (Vo + acc(1/λ)) * T0  + acc(1/λ^2)(e^(-λT0) - 1)
+      auto distance_to_reach_zero_speed =
+        v * T_0 + a * T_0 * (1.0 / λ) + a * (1.0 / std::pow(λ, 2)) * (std::exp(-λ * T) - 1);
+      // Vnew * T = x(T0)
+      // Vnew = x(T0) / T
+      // Output an equivalent constant speed
+      return distance_to_reach_zero_speed / T;
+    }
+
+    // if the vehicle speed limit is not surpassed we return an equivalent speed = x(T) / T
+    // alternatively, if the vehicle is still accelerating and has surpassed the speed limit.
+    // assume it will continue accelerating (reckless driving)
+    const bool object_has_surpassed_limit_already = v > speed_limit;
+    if (V_terminal < speed_limit || object_has_surpassed_limit_already)
       return v + a * (1.0 / λ) + (a / (T * std::pow(λ, 2))) * (std::exp(-λ * T) - 1);
-    // we assume a forwards moving vehicle will not decelerate to 0 and then move backwards
-    // if the velocities don't have the same sign, calculate when the velocity becomes 0
 
-    // 0 = Vo + acc(1/λ)(1-e^(-λT0))
-    // e^(-λT0) = 1 - (-Vo* λ)/acc
-    // T0 = (-1/λ)*ln(1 - (-Vo* λ)/acc)
-    auto T_0 = std::log(1 - (-v * λ / a)) * (-1.0 / λ);
-
-    // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)e^(-λt) - obj_acc(1/λ^2)
-    // x(T0) = Xo + (Vo + acc(1/λ)) * T0  + acc(1/λ^2)(e^(-λT0) - 1)
-    auto distance_to_reach_zero_speed =
-      v * T_0 + a * T_0 * (1.0 / λ) + a * (1.0 / std::pow(λ, 2)) * (std::exp(-λ * T) - 1);
-    std::cerr << "Time to 0 " << T_0 << "\n";
-    std::cerr << "Dist to 0 " << distance_to_reach_zero_speed << "\n";
-    std::cerr << "Vel at 0 ?? " << v + a * (1 / λ) * (1 - std::exp(-λ * T_0)) << "\n";
-    std::cerr << "Veq " << distance_to_reach_zero_speed / T << "\n";
-    std::cerr << "Voriginal " << v << "\n";
-    std::cerr << "Aoriginal " << a << "\n";
-
-    // Vnew * T = x(T0)
-    // Vnew = x(T0) / T
-    return distance_to_reach_zero_speed / T;
+    // It is assumed the vehicle accelerates until final_speed is reached and
+    // then continues at constant speed for the rest of the time horizon
+    // So, we calculate the time it takes to reach the speed limit and compute how far the vehicle
+    // would go if it accelerated until reaching the speed limit, and then continued at a constant
+    // speed.
+    const double T_f = (-1.0 / λ) * std::log(1 - ((speed_limit - v) * λ) / a);
+    const double distance_covered =
+      // Distance covered while accelerating
+      a * (1.0 / λ) * T_f + a * (1.0 / std::pow(λ, 2)) * (std::exp(-λ * T_f) - 1) + v * T_f +
+      // Distance covered at constant speed for the rest of the horizon time
+      speed_limit * (T - T_f);
+    return distance_covered / T;
   };
 
   const float VX = get_equivalent_velocity(vx, ax);

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -407,6 +407,11 @@ FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const Po
     static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.y);
 
   // The decay constant λ = ln(2) / exponential_half_life
+  // a(t) = acc - acc(1-e^(-λt)) = acc(e^(-λt))
+  // V(t) = Vo + acc(1/λ)(1-e^(-λt))
+  // x(t) = Xo + Vo * t + t * acc(1/λ) + acc(1/λ^2)e^(-λt)
+  // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)e^(-λt)
+  // acceleration_distance = acc(1/λ) * t  + acc(1/λ^2)e^(-λt)
   const float exponential_half_life = T / 4.0;
   const float λ = std::log(2) / exponential_half_life;
 
@@ -414,12 +419,6 @@ FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const Po
   // Vnew = Vo + acc(1/λ) + acc(1/T*λ^2)e^(-λT)
   const float VX = vx + ax * (1 / λ + std::exp(-λ * T) / (T * std::pow(λ, 2)));
   const float VY = vy + ay * (1 / λ + std::exp(-λ * T) / (T * std::pow(λ, 2)));
-
-  // a(t) = acc - acc(1-e^(-λt)) = acc(e^(-λt))
-  // V(t) = Vo + acc(1/λ)(1-e^(-λt))
-  // x(t) = Xo + Vo * t + t * acc(1/λ) + acc(1/λ^2)e^(-λt)
-  // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)e^(-λt)
-  // acceleration_distance = acc(1/λ) * t  + acc(1/λ^2)e^(-λt)
 
   frenet_point.s = motion_utils::calcSignedArcLength(ref_path, 0, nearest_segment_idx) + l;
   frenet_point.d = motion_utils::calcLateralOffset(ref_path, obj_point);

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -387,7 +387,6 @@ PredictedPath PathGenerator::convertToPredictedPath(
 FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const PosePath & ref_path)
 {
   FrenetPoint frenet_point;
-  const double T = time_horizon_;
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;
 
   const size_t nearest_segment_idx = motion_utils::findNearestSegmentIndex(ref_path, obj_point);

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -387,6 +387,7 @@ PredictedPath PathGenerator::convertToPredictedPath(
 FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const PosePath & ref_path)
 {
   FrenetPoint frenet_point;
+  const double T = time_horizon_;
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;
 
   const size_t nearest_segment_idx = motion_utils::findNearestSegmentIndex(ref_path, obj_point);

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -402,9 +402,13 @@ FrenetPoint PathGenerator::getFrenetPoint(
   const float delta_yaw = obj_yaw - lane_yaw;
 
   const float ax =
-    static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.x);
+    (use_vehicle_acceleration_)
+      ? static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.x)
+      : 0.0;
   const float ay =
-    static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.y);
+    (use_vehicle_acceleration_)
+      ? static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.y)
+      : 0.0;
 
   // The decay constant λ = ln(2) / exponential_half_life
   // a(t) = acc - acc(1-e^(-λt)) = acc(e^(-λt))

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -413,9 +413,9 @@ FrenetPoint PathGenerator::getFrenetPoint(
   // The decay constant λ = ln(2) / exponential_half_life
   // a(t) = acc - acc(1-e^(-λt)) = acc(e^(-λt))
   // V(t) = Vo + acc(1/λ)(1-e^(-λt))
-  // x(t) = Xo + Vo * t + t * acc(1/λ) + acc(1/λ^2)e^(-λt)
-  // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)e^(-λt)
-  // acceleration_distance = acc(1/λ) * t  + acc(1/λ^2)e^(-λt)
+  // x(t) = Xo + Vo * t + t * acc(1/λ) + acc(1/λ^2)(e^(-λt)-1)
+  // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)(e^(-λt)-1)
+  // acceleration_distance = acc(1/λ) * t  + acc(1/λ^2)(e^(-λt)-1)
   const double T = time_horizon_;
   const float exponential_half_life = acceleration_exponential_half_life_;
   const float λ = std::log(2) / exponential_half_life;

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -417,7 +417,7 @@ FrenetPoint PathGenerator::getFrenetPoint(
   // x(t) = Xo + (Vo + acc(1/λ)) * t  + acc(1/λ^2)e^(-λt)
   // acceleration_distance = acc(1/λ) * t  + acc(1/λ^2)e^(-λt)
   const double T = time_horizon_;
-  const float exponential_half_life = T / 4.0;
+  const float exponential_half_life = acceleration_exponential_half_life_;
   const float λ = std::log(2) / exponential_half_life;
 
   auto have_same_sign = [](double a, double b) -> bool {

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -412,8 +412,7 @@ FrenetPoint PathGenerator::getFrenetPoint(
 
   // Using a decaying acceleration model. Consult the README for more information about the model.
   const double t_h = time_horizon_;
-  const float exponential_half_life = acceleration_exponential_half_life_;
-  const float λ = std::log(2) / exponential_half_life;
+  const float λ = std::log(2) / acceleration_exponential_half_life_;
 
   auto have_same_sign = [](double a, double b) -> bool {
     return (a >= 0.0 && b >= 0.0) || (a < 0.0 && b < 0.0);


### PR DESCRIPTION
## Description

This PR adds acceleration readings from perception into the map_based_prediction module (can be toggled on or off. Off by default) to calculate path lengths more accurately.

Since including acceleration might have a big impact on path length (the time horizon for prediction is usually between 10 to 18s and we cannot assume a car will accelerate for that long) this feature uses a decaying acceleration model to calculate the path length after time_horizon T: 

> a(t) = a_0 * e ^(-λ*t) 

were a_0 is the instantaneous acceleration detected by perception, λ is the exponential decaying constant, and t is time with 0 <= t <= T. 

The result is a map based prediction that also includes (attenuated/decaying) acceleration information for a more accurate prediction.

Also, there is a slightly more detailed explanation in this link: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~7120207d8589d164d74a6d8162863204d3efe2/pages/2984280255/Map+based+prediction+with+acceleration)

Considerations: 

- If a vehicle is braking (decelerating) the path is computed until its predicted velocity reaches 0 (it reaches a full stop) to prevent backwards paths.
- If a vehicle is accelerating, its velocity is capped at the vehicle's lanelet's speed limit times a constant  (almost everyone drives above the speed limit). We assume the vehicle will accelerate until reaching said threshold and then continue at a constant speed.
- If a vehicle is already going at the speed limit times our constant, and still accelerating, we use our normal model an assume there is no speed limit cap (the vehicle is driving recklessly and it is better to be conservative about path prediction).

## Related links

Evaluator tests with the feature turned on: [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/e776ffab-512e-576a-a966-18b6749372b9?project_id=prd_jt). No degradation when compared to base.

Also, there is a slightly more detailed explanation in this link: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~7120207d8589d164d74a6d8162863204d3efe2/pages/2984280255/Map+based+prediction+with+acceleration)

## Tests performed
Evaluator tests (see above) and PSim tests. 
Some examples:



https://github.com/autowarefoundation/autoware.universe/assets/25967964/c3c4b70d-e71a-48aa-8876-588c5eeb8501

Comparison between no acceleration consideration (first) and acc consideration (second) for a vehicle decelerating at -1 m/s^2 from a starting speed of 8 m/s. In the second case, the prediction detects the path is safe, while the first case takes a while before figuring out it will be safe


https://github.com/autowarefoundation/autoware.universe/assets/25967964/d5beee43-99a5-409a-8ca0-3768aa928541

Comparison between no acceleration consideration (first) and acc consideration (second) for a vehicle accelerating at 1.2 m/s^2 from a starting speed of 0 m/s. The second case detects danger faster than the first case.



https://github.com/autowarefoundation/autoware.universe/assets/25967964/346514bd-6af6-4e0c-93e4-d147208d989a

In this video, it can be seen how the predicted path of an accelerating vehicle is longer than a non accelerating and faster vehicle (eventually, the accelerating vehicle will overtake the non accelerating one).

## Notes for reviewers

Launch changes are necessary for this PR, please review too: https://github.com/autowarefoundation/autoware_launch/pull/788

NOTE: acceleration tracking is not implemented in this PR, but will be in the future.
## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

If enabled, this feature changes predicted path length by calculating future path extensions using velocity AND acceleration information from perception.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
