### PR TITLE
feat(perception_rviz_plugin): rviz object covariances

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -114,11 +114,11 @@ get_uuid_marker_ptr(
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_pose_with_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width);
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_velocity_text_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -116,7 +116,7 @@ get_uuid_marker_ptr(
   const std_msgs::msg::ColorRGBA & color_rgba);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
-get_pose_with_covariance_marker_ptr(
+get_pose_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -20,6 +20,9 @@
 #include <rclcpp/logging.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <Eigen/Core>
+#include <Eigen/Eigen>
+
 #include <autoware_auto_perception_msgs/msg/detected_object.hpp>
 #include <autoware_auto_perception_msgs/msg/object_classification.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_path.hpp>
@@ -164,6 +167,9 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_strip(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_line_list_from_points(
   const double point_list[][3], const int point_pairs[][2], const int & num_pairs,
   std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_covariance_eigen_vectors(
+  const Eigen::Matrix2d & matrix, double & sigma1, double & sigma2, double & yaw);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -117,6 +117,10 @@ get_pose_with_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_yaw_covariance_marker_ptr(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_velocity_text_marker_ptr(
   const geometry_msgs::msg::Twist & twist, const geometry_msgs::msg::Point & vis_pos,
   const std_msgs::msg::ColorRGBA & color_rgba);
@@ -142,7 +146,7 @@ get_path_confidence_marker_ptr(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const std_msgs::msg::ColorRGBA & path_confidence_color);
 
-AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_list(
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_strip(
   const double start_angle, const double end_angle, const double radius,
   std::vector<geometry_msgs::msg::Point> & points);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -136,6 +136,11 @@ get_twist_marker_ptr(
   const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_twist_covariance_marker_ptr(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_predicted_path_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -118,7 +118,8 @@ get_pose_with_covariance_marker_ptr(
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length, const double & line_width);
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length,
+  const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_velocity_text_marker_ptr(
@@ -132,6 +133,11 @@ get_acceleration_text_marker_ptr(
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_twist_marker_ptr(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_yaw_rate_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
   const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -142,6 +142,10 @@ get_path_confidence_marker_ptr(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const std_msgs::msg::ColorRGBA & path_confidence_color);
 
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_list(
+  const double start_angle, const double end_angle, const double radius,
+  std::vector<geometry_msgs::msg::Point> & points);
+
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_line_list_from_points(
   const double point_list[][3], const int point_pairs[][2], const int & num_pairs,
   std::vector<geometry_msgs::msg::Point> & points);

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -115,12 +115,14 @@ get_uuid_marker_ptr(
   const std_msgs::msg::ColorRGBA & color_rgba);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
-get_pose_covariance_marker_ptr(const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
+get_pose_covariance_marker_ptr(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+  const double & confidence_interval_coefficient);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length,
-  const double & line_width);
+  const double & confidence_interval_coefficient, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_velocity_text_marker_ptr(
@@ -140,7 +142,8 @@ get_twist_marker_ptr(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_twist_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance);
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+  const double & confidence_interval_coefficient);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_rate_marker_ptr(
@@ -150,7 +153,8 @@ get_yaw_rate_marker_ptr(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_rate_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+  const double & confidence_interval_coefficient, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_predicted_path_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -17,11 +17,10 @@
 
 #include "autoware_auto_perception_rviz_plugin/visibility_control.hpp"
 
-#include <rclcpp/logging.hpp>
-#include <rclcpp/rclcpp.hpp>
-
 #include <Eigen/Core>
 #include <Eigen/Eigen>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/detected_object.hpp>
 #include <autoware_auto_perception_msgs/msg/object_classification.hpp>
@@ -116,8 +115,7 @@ get_uuid_marker_ptr(
   const std_msgs::msg::ColorRGBA & color_rgba);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
-get_pose_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
+get_pose_covariance_marker_ptr(const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_covariance_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -117,7 +117,7 @@ get_uuid_marker_ptr(
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_pose_with_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width);
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_covariance_marker_ptr(
@@ -140,12 +140,17 @@ get_twist_marker_ptr(
   const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_twist_covariance_marker_ptr(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_yaw_rate_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
   const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
-get_twist_covariance_marker_ptr(
+get_yaw_rate_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
   const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -64,14 +64,14 @@ public:
     // m_display_type_property{"Polygon Type", "3d", "Type of the polygon to display object", this},
     m_display_label_property{"Display Label", true, "Enable/disable label visualization", this},
     m_display_uuid_property{"Display UUID", true, "Enable/disable uuid visualization", this},
-    m_display_pose_with_covariance_property{
-      "Display Pose Covariance", true, "Enable/disable pose covariance visualization", this},
-    m_display_yaw_covariance_property{
-      "Display Yaw Covariance", false, "Enable/disable yaw covariance visualization", this},
     m_display_velocity_text_property{
       "Display Velocity", true, "Enable/disable velocity text visualization", this},
     m_display_acceleration_text_property{
       "Display Acceleration", true, "Enable/disable acceleration text visualization", this},
+    m_display_pose_with_covariance_property{
+      "Display Pose Covariance", true, "Enable/disable pose covariance visualization", this},
+    m_display_yaw_covariance_property{
+      "Display Yaw Covariance", false, "Enable/disable yaw covariance visualization", this},
     m_display_twist_property{"Display Twist", true, "Enable/disable twist visualization", this},
     m_display_twist_covariance_property{
       "Display Twist Covariance", false, "Enable/disable twist covariance visualization", this},
@@ -466,14 +466,14 @@ private:
   rviz_common::properties::BoolProperty m_display_label_property;
   // Property to enable/disable uuid visualization
   rviz_common::properties::BoolProperty m_display_uuid_property;
-  // Property to enable/disable pose with covariance visualization
-  rviz_common::properties::BoolProperty m_display_pose_with_covariance_property;
-  // Property to enable/disable yaw covariance visualization
-  rviz_common::properties::BoolProperty m_display_yaw_covariance_property;
   // Property to enable/disable velocity text visualization
   rviz_common::properties::BoolProperty m_display_velocity_text_property;
   // Property to enable/disable acceleration text visualization
   rviz_common::properties::BoolProperty m_display_acceleration_text_property;
+  // Property to enable/disable pose with covariance visualization
+  rviz_common::properties::BoolProperty m_display_pose_with_covariance_property;
+  // Property to enable/disable yaw covariance visualization
+  rviz_common::properties::BoolProperty m_display_yaw_covariance_property;
   // Property to enable/disable twist visualization
   rviz_common::properties::BoolProperty m_display_twist_property;
   // Property to enable/disable twist covariance visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -73,6 +73,7 @@ public:
     m_display_acceleration_text_property{
       "Display Acceleration", true, "Enable/disable acceleration text visualization", this},
     m_display_twist_property{"Display Twist", true, "Enable/disable twist visualization", this},
+    m_display_twist_covariance_property{"Display Twist Covariance", false, "Enable/disable twist covariance visualization", this},
     m_display_predicted_paths_property{
       "Display Predicted Paths", true, "Enable/disable predicted paths visualization", this},
     m_display_path_confidence_property{
@@ -300,6 +301,18 @@ protected:
     }
   }
 
+  std::optional<Marker::SharedPtr> get_twist_covariance_marker_ptr(
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+    const double & line_width) const
+  {
+    if (m_display_twist_covariance_property.getBool()) {
+      return detail::get_twist_covariance_marker_ptr(pose_with_covariance, twist_with_covariance, line_width);
+    } else {
+      return std::nullopt;
+    }
+  }
+
   std::optional<Marker::SharedPtr> get_predicted_path_marker_ptr(
     const unique_identifier_msgs::msg::UUID & uuid,
     const autoware_auto_perception_msgs::msg::Shape & shape,
@@ -447,6 +460,8 @@ private:
   rviz_common::properties::BoolProperty m_display_acceleration_text_property;
   // Property to enable/disable twist visualization
   rviz_common::properties::BoolProperty m_display_twist_property;
+  // Property to enable/disable twist visualization
+  rviz_common::properties::BoolProperty m_display_twist_covariance_property;
   // Property to enable/disable predicted paths visualization
   rviz_common::properties::BoolProperty m_display_predicted_paths_property;
   // Property to enable/disable predicted path confidence visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -476,10 +476,10 @@ private:
   rviz_common::properties::BoolProperty m_display_acceleration_text_property;
   // Property to enable/disable twist visualization
   rviz_common::properties::BoolProperty m_display_twist_property;
-  // Property to enable/disable yaw rate visualization
-  rviz_common::properties::BoolProperty m_display_yaw_rate_property;
   // Property to enable/disable twist covariance visualization
   rviz_common::properties::BoolProperty m_display_twist_covariance_property;
+  // Property to enable/disable yaw rate visualization
+  rviz_common::properties::BoolProperty m_display_yaw_rate_property;
   // Property to enable/disable predicted paths visualization
   rviz_common::properties::BoolProperty m_display_predicted_paths_property;
   // Property to enable/disable predicted path confidence visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -68,7 +68,7 @@ public:
       "Display Velocity", true, "Enable/disable velocity text visualization", this},
     m_display_acceleration_text_property{
       "Display Acceleration", true, "Enable/disable acceleration text visualization", this},
-    m_display_pose_with_covariance_property{
+    m_display_pose_covariance_property{
       "Display Pose Covariance", true, "Enable/disable pose covariance visualization", this},
     m_display_yaw_covariance_property{
       "Display Yaw Covariance", false, "Enable/disable yaw covariance visualization", this},
@@ -245,12 +245,11 @@ protected:
     }
   }
 
-  std::optional<Marker::SharedPtr> get_pose_with_covariance_marker_ptr(
-    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-    const double & line_width) const
+  std::optional<Marker::SharedPtr> get_pose_covariance_marker_ptr(
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance) const
   {
-    if (m_display_pose_with_covariance_property.getBool()) {
-      return detail::get_pose_with_covariance_marker_ptr(pose_with_covariance, line_width);
+    if (m_display_pose_covariance_property.getBool()) {
+      return detail::get_pose_covariance_marker_ptr(pose_with_covariance);
     } else {
       return std::nullopt;
     }
@@ -307,12 +306,11 @@ protected:
 
   std::optional<Marker::SharedPtr> get_twist_covariance_marker_ptr(
     const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
-    const double & line_width) const
+    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance) const
   {
     if (m_display_twist_covariance_property.getBool()) {
       return detail::get_twist_covariance_marker_ptr(
-        pose_with_covariance, twist_with_covariance, line_width);
+        pose_with_covariance, twist_with_covariance);
     } else {
       return std::nullopt;
     }
@@ -486,7 +484,7 @@ private:
   // Property to enable/disable acceleration text visualization
   rviz_common::properties::BoolProperty m_display_acceleration_text_property;
   // Property to enable/disable pose with covariance visualization
-  rviz_common::properties::BoolProperty m_display_pose_with_covariance_property;
+  rviz_common::properties::BoolProperty m_display_pose_covariance_property;
   // Property to enable/disable yaw covariance visualization
   rviz_common::properties::BoolProperty m_display_yaw_covariance_property;
   // Property to enable/disable twist visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -77,6 +77,8 @@ public:
       "Display Twist Covariance", false, "Enable/disable twist covariance visualization", this},
     m_display_yaw_rate_property{
       "Display Yaw Rate", false, "Enable/disable yaw rate visualization", this},
+    m_display_yaw_rate_covariance_property{
+      "Display Yaw Rate Covariance", false, "Enable/disable yaw rate covariance visualization", this},
     m_display_predicted_paths_property{
       "Display Predicted Paths", true, "Enable/disable predicted paths visualization", this},
     m_display_path_confidence_property{
@@ -303,6 +305,19 @@ protected:
     }
   }
 
+  std::optional<Marker::SharedPtr> get_twist_covariance_marker_ptr(
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+    const double & line_width) const
+  {
+    if (m_display_twist_covariance_property.getBool()) {
+      return detail::get_twist_covariance_marker_ptr(
+        pose_with_covariance, twist_with_covariance, line_width);
+    } else {
+      return std::nullopt;
+    }
+  }
+
   std::optional<Marker::SharedPtr> get_yaw_rate_marker_ptr(
     const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
     const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
@@ -316,13 +331,13 @@ protected:
     }
   }
 
-  std::optional<Marker::SharedPtr> get_twist_covariance_marker_ptr(
+  std::optional<Marker::SharedPtr> get_yaw_rate_covariance_marker_ptr(
     const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
     const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
     const double & line_width) const
   {
-    if (m_display_twist_covariance_property.getBool()) {
-      return detail::get_twist_covariance_marker_ptr(
+    if (m_display_yaw_rate_covariance_property.getBool()) {
+      return detail::get_yaw_rate_covariance_marker_ptr(
         pose_with_covariance, twist_with_covariance, line_width);
     } else {
       return std::nullopt;
@@ -480,6 +495,8 @@ private:
   rviz_common::properties::BoolProperty m_display_twist_covariance_property;
   // Property to enable/disable yaw rate visualization
   rviz_common::properties::BoolProperty m_display_yaw_rate_property;
+  // Property to enable/disable yaw rate covariance visualization
+  rviz_common::properties::BoolProperty m_display_yaw_rate_covariance_property;
   // Property to enable/disable predicted paths visualization
   rviz_common::properties::BoolProperty m_display_predicted_paths_property;
   // Property to enable/disable predicted path confidence visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -65,7 +65,10 @@ public:
     m_display_label_property{"Display Label", true, "Enable/disable label visualization", this},
     m_display_uuid_property{"Display UUID", true, "Enable/disable uuid visualization", this},
     m_display_pose_with_covariance_property{
-      "Display PoseWithCovariance", true, "Enable/disable pose with covariance visualization",
+      "Display Pose Covariance", true, "Enable/disable pose covariance visualization",
+      this},
+    m_display_yaw_covariance_property{
+      "Display Yaw Covariance", true, "Enable/disable yaw covariance visualization",
       this},
     m_display_velocity_text_property{
       "Display Velocity", true, "Enable/disable velocity text visualization", this},
@@ -248,6 +251,16 @@ protected:
     }
   }
 
+  std::optional<Marker::SharedPtr> get_yaw_covariance_marker_ptr(
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width) const
+  {
+    if (m_display_yaw_covariance_property.getBool()) {
+      return detail::get_yaw_covariance_marker_ptr(pose_with_covariance, line_width);
+    } else {
+      return std::nullopt;
+    }
+  }
+
   template <typename ClassificationContainerT>
   std::optional<Marker::SharedPtr> get_velocity_text_marker_ptr(
     const geometry_msgs::msg::Twist & twist, const geometry_msgs::msg::Point & vis_pos,
@@ -425,6 +438,8 @@ private:
   rviz_common::properties::BoolProperty m_display_uuid_property;
   // Property to enable/disable pose with covariance visualization
   rviz_common::properties::BoolProperty m_display_pose_with_covariance_property;
+  // Property to enable/disable yaw covariance visualization
+  rviz_common::properties::BoolProperty m_display_yaw_covariance_property;
   // Property to enable/disable velocity text visualization
   rviz_common::properties::BoolProperty m_display_velocity_text_property;
   // Property to enable/disable acceleration text visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -78,7 +78,8 @@ public:
     m_display_yaw_rate_property{
       "Display Yaw Rate", false, "Enable/disable yaw rate visualization", this},
     m_display_yaw_rate_covariance_property{
-      "Display Yaw Rate Covariance", false, "Enable/disable yaw rate covariance visualization", this},
+      "Display Yaw Rate Covariance", false, "Enable/disable yaw rate covariance visualization",
+      this},
     m_display_predicted_paths_property{
       "Display Predicted Paths", true, "Enable/disable predicted paths visualization", this},
     m_display_path_confidence_property{
@@ -309,8 +310,7 @@ protected:
     const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance) const
   {
     if (m_display_twist_covariance_property.getBool()) {
-      return detail::get_twist_covariance_marker_ptr(
-        pose_with_covariance, twist_with_covariance);
+      return detail::get_twist_covariance_marker_ptr(pose_with_covariance, twist_with_covariance);
     } else {
       return std::nullopt;
     }

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -106,11 +106,11 @@ public:
     m_simple_visualize_mode_property->addOption("Simple", 1);
     // Confidence interval property
     m_confidence_interval_property = new rviz_common::properties::EnumProperty(
-      "Confidence Interval", "95.45%, 2 sigma", "Confidence interval of state estimations.", this);
-    m_confidence_interval_property->addOption("68.27%, 1 sigma", 0);
-    m_confidence_interval_property->addOption("86.64%, 1.5 sigma", 1);
-    m_confidence_interval_property->addOption("95.45%, 2 sigma", 2);
-    m_confidence_interval_property->addOption("99.73%, 3 sigma", 3);
+      "Confidence Interval", "95%", "Confidence interval of state estimations.", this);
+    m_confidence_interval_property->addOption("70%", 0);
+    m_confidence_interval_property->addOption("85%", 1);
+    m_confidence_interval_property->addOption("95%", 2);
+    m_confidence_interval_property->addOption("99%", 3);
 
     // iterate over default values to create and initialize the properties.
     for (const auto & map_property_it : detail::kDefaultObjectPropertyValues) {
@@ -257,8 +257,7 @@ protected:
     const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance) const
   {
     if (m_display_pose_covariance_property.getBool()) {
-      return detail::get_pose_covariance_marker_ptr(
-        pose_with_covariance, get_confidence_interval());
+      return detail::get_pose_covariance_marker_ptr(pose_with_covariance, get_confidence_region());
     } else {
       return std::nullopt;
     }
@@ -320,7 +319,7 @@ protected:
   {
     if (m_display_twist_covariance_property.getBool()) {
       return detail::get_twist_covariance_marker_ptr(
-        pose_with_covariance, twist_with_covariance, get_confidence_interval());
+        pose_with_covariance, twist_with_covariance, get_confidence_region());
     } else {
       return std::nullopt;
     }
@@ -478,19 +477,39 @@ protected:
   {
     switch (m_confidence_interval_property->getOptionInt()) {
       case 0:
-        // 68.27%, 1 sigma
-        return 1.0;
+        // 70%
+        return 1.036;
       case 1:
-        // 86.64%, 1.5 sigma
-        return 1.5;
+        // 85%
+        return 1.440;
       case 2:
-        // 95.45%, 2 sigma
-        return 2.0;
+        // 95%
+        return 1.960;
       case 3:
-        // 99.73%, 3 sigma
-        return 3.0;
+        // 99%
+        return 2.576;
       default:
-        return 2.0;
+        return 1.960;
+    }
+  }
+
+  double get_confidence_region() const
+  {
+    switch (m_confidence_interval_property->getOptionInt()) {
+      case 0:
+        // 70%
+        return 1.552;
+      case 1:
+        // 85%
+        return 1.802;
+      case 2:
+        // 95%
+        return 2.448;
+      case 3:
+        // 99%
+        return 3.035;
+      default:
+        return 2.448;
     }
   }
 

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -65,11 +65,9 @@ public:
     m_display_label_property{"Display Label", true, "Enable/disable label visualization", this},
     m_display_uuid_property{"Display UUID", true, "Enable/disable uuid visualization", this},
     m_display_pose_with_covariance_property{
-      "Display Pose Covariance", true, "Enable/disable pose covariance visualization",
-      this},
+      "Display Pose Covariance", true, "Enable/disable pose covariance visualization", this},
     m_display_yaw_covariance_property{
-      "Display Yaw Covariance", true, "Enable/disable yaw covariance visualization",
-      this},
+      "Display Yaw Covariance", false, "Enable/disable yaw covariance visualization", this},
     m_display_velocity_text_property{
       "Display Velocity", true, "Enable/disable velocity text visualization", this},
     m_display_acceleration_text_property{
@@ -242,20 +240,23 @@ protected:
   }
 
   std::optional<Marker::SharedPtr> get_pose_with_covariance_marker_ptr(
-    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance) const
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+    const double & line_width) const
   {
     if (m_display_pose_with_covariance_property.getBool()) {
-      return detail::get_pose_with_covariance_marker_ptr(pose_with_covariance);
+      return detail::get_pose_with_covariance_marker_ptr(pose_with_covariance, line_width);
     } else {
       return std::nullopt;
     }
   }
 
   std::optional<Marker::SharedPtr> get_yaw_covariance_marker_ptr(
-    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width) const
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+    const double & length,
+    const double & line_width) const
   {
     if (m_display_yaw_covariance_property.getBool()) {
-      return detail::get_yaw_covariance_marker_ptr(pose_with_covariance, line_width);
+      return detail::get_yaw_covariance_marker_ptr(pose_with_covariance, length, line_width);
     } else {
       return std::nullopt;
     }

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -73,7 +73,10 @@ public:
     m_display_acceleration_text_property{
       "Display Acceleration", true, "Enable/disable acceleration text visualization", this},
     m_display_twist_property{"Display Twist", true, "Enable/disable twist visualization", this},
-    m_display_twist_covariance_property{"Display Twist Covariance", false, "Enable/disable twist covariance visualization", this},
+    m_display_twist_covariance_property{
+      "Display Twist Covariance", false, "Enable/disable twist covariance visualization", this},
+    m_display_yaw_rate_property{
+      "Display Yaw Rate", false, "Enable/disable yaw rate visualization", this},
     m_display_predicted_paths_property{
       "Display Predicted Paths", true, "Enable/disable predicted paths visualization", this},
     m_display_path_confidence_property{
@@ -252,8 +255,7 @@ protected:
   }
 
   std::optional<Marker::SharedPtr> get_yaw_covariance_marker_ptr(
-    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-    const double & length,
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length,
     const double & line_width) const
   {
     if (m_display_yaw_covariance_property.getBool()) {
@@ -301,13 +303,27 @@ protected:
     }
   }
 
+  std::optional<Marker::SharedPtr> get_yaw_rate_marker_ptr(
+    const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+    const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+    const double & line_width) const
+  {
+    if (m_display_yaw_rate_property.getBool()) {
+      return detail::get_yaw_rate_marker_ptr(
+        pose_with_covariance, twist_with_covariance, line_width);
+    } else {
+      return std::nullopt;
+    }
+  }
+
   std::optional<Marker::SharedPtr> get_twist_covariance_marker_ptr(
     const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
     const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
     const double & line_width) const
   {
     if (m_display_twist_covariance_property.getBool()) {
-      return detail::get_twist_covariance_marker_ptr(pose_with_covariance, twist_with_covariance, line_width);
+      return detail::get_twist_covariance_marker_ptr(
+        pose_with_covariance, twist_with_covariance, line_width);
     } else {
       return std::nullopt;
     }
@@ -460,7 +476,9 @@ private:
   rviz_common::properties::BoolProperty m_display_acceleration_text_property;
   // Property to enable/disable twist visualization
   rviz_common::properties::BoolProperty m_display_twist_property;
-  // Property to enable/disable twist visualization
+  // Property to enable/disable yaw rate visualization
+  rviz_common::properties::BoolProperty m_display_yaw_rate_property;
+  // Property to enable/disable twist covariance visualization
   rviz_common::properties::BoolProperty m_display_twist_covariance_property;
   // Property to enable/disable predicted paths visualization
   rviz_common::properties::BoolProperty m_display_predicted_paths_property;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -61,7 +61,7 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
 
     // Get marker for pose with covariance
     auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance, get_line_width() / 2);
+      object.kinematics.pose_with_covariance, get_line_width() * 0.5);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -71,7 +71,7 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
 
     // Get marker for yaw covariance
     auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance, object.shape.dimensions.x / 1.6, get_line_width() / 2);
+      object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65, get_line_width() * 0.5);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -119,6 +119,18 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       twist_marker_ptr->id = id++;
       add_marker(twist_marker_ptr);
     }
+
+    // Get marker for twist covariance
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width() * 0.5);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+    
   }
 }
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -59,8 +59,8 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       add_marker(label_marker_ptr);
     }
 
-    // Get marker for pose with covariance
-    auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
+    // Get marker for pose covariance
+    auto pose_with_covariance_marker = get_pose_covariance_marker_ptr(
       object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -61,7 +61,7 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
 
     // Get marker for pose with covariance
     auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance, get_line_width() * 0.5);
+      object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -121,7 +121,17 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       add_marker(twist_marker_ptr);
     }
 
-    // Get marker for twist
+    // Get marker for twist covariance
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for yaw rate
     auto yaw_rate_marker = get_yaw_rate_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
       get_line_width() * 0.4);
@@ -132,12 +142,12 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       add_marker(marker_ptr);
     }
 
-    // Get marker for twist covariance
-    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+    // Get marker for yaw rate covariance
+    auto yaw_rate_covariance_marker = get_yaw_rate_covariance_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
       get_line_width() * 0.3);
-    if (twist_covariance_marker) {
-      auto marker_ptr = twist_covariance_marker.value();
+    if (yaw_rate_covariance_marker) {
+      auto marker_ptr = yaw_rate_covariance_marker.value();
       marker_ptr->header = msg->header;
       marker_ptr->id = id++;
       add_marker(marker_ptr);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -60,8 +60,8 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
     }
 
     // Get marker for pose covariance
-    auto pose_with_covariance_marker = get_pose_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance);
+    auto pose_with_covariance_marker =
+      get_pose_covariance_marker_ptr(object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -71,7 +71,8 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
 
     // Get marker for yaw covariance
     auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65, get_line_width() * 0.5);
+      object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65,
+      get_line_width() * 0.5);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -120,17 +121,27 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       add_marker(twist_marker_ptr);
     }
 
+    // Get marker for twist
+    auto yaw_rate_marker = get_yaw_rate_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width() * 0.4);
+    if (yaw_rate_marker) {
+      auto marker_ptr = yaw_rate_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
     // Get marker for twist covariance
     auto twist_covariance_marker = get_twist_covariance_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
-      get_line_width() * 0.5);
+      get_line_width() * 0.3);
     if (twist_covariance_marker) {
       auto marker_ptr = twist_covariance_marker.value();
       marker_ptr->header = msg->header;
       marker_ptr->id = id++;
       add_marker(marker_ptr);
     }
-    
   }
 }
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -59,6 +59,26 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       add_marker(label_marker_ptr);
     }
 
+    // Get marker for pose with covariance
+    auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, get_line_width() / 2);
+    if (pose_with_covariance_marker) {
+      auto marker_ptr = pose_with_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for yaw covariance
+    auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.shape.dimensions.x / 1.6, get_line_width() / 2);
+    if (yaw_covariance_marker) {
+      auto marker_ptr = yaw_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
     // Get marker for existence probability
     geometry_msgs::msg::Point existence_probability_position;
     existence_probability_position.x = object.kinematics.pose_with_covariance.pose.position.x + 0.5;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -219,8 +219,8 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_covariance_marker_ptr(
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color.a = 0.9;
   marker_ptr->color.r = 1.0;
-  marker_ptr->color.g = 0.5;
-  marker_ptr->color.b = 0.7;
+  marker_ptr->color.g = 0.2;
+  marker_ptr->color.b = 0.4;
 
   return marker_ptr;
 }

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -123,7 +123,8 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
 
 visualization_msgs::msg::Marker::SharedPtr get_twist_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance)
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+  const double & confidence_interval_coefficient)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::CYLINDER;
@@ -163,8 +164,8 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_covariance_marker_ptr(
   marker_ptr->pose.orientation.w = std::cos(phi / 2.0);
 
   // ellipse size
-  marker_ptr->scale.x = sigma1 * 2.448;  // 2.448 sigma is 95%
-  marker_ptr->scale.y = sigma2 * 2.448;  // 2.448 sigma is 95%
+  marker_ptr->scale.x = sigma1 * confidence_interval_coefficient;
+  marker_ptr->scale.y = sigma2 * confidence_interval_coefficient;
   marker_ptr->scale.z = 0.05;
 
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
@@ -223,7 +224,8 @@ visualization_msgs::msg::Marker::SharedPtr get_yaw_rate_marker_ptr(
 
 visualization_msgs::msg::Marker::SharedPtr get_yaw_rate_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
-  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance, const double & line_width)
+  const geometry_msgs::msg::TwistWithCovariance & twist_with_covariance,
+  const double & confidence_interval_coefficient, const double & line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
@@ -234,7 +236,7 @@ visualization_msgs::msg::Marker::SharedPtr get_yaw_rate_covariance_marker_ptr(
 
   // yaw rate covariance
   const double yaw_rate_covariance = twist_with_covariance.covariance[35];
-  const double yaw_rate_sigma = std::sqrt(yaw_rate_covariance) * 2.448;  // 2.448 sigma is 95%
+  const double yaw_rate_sigma = std::sqrt(yaw_rate_covariance) * confidence_interval_coefficient;
   const double yaw_rate = twist_with_covariance.twist.angular.z;
   const double velocity = std::sqrt(
     twist_with_covariance.twist.linear.x * twist_with_covariance.twist.linear.x +
@@ -356,7 +358,8 @@ void calc_covariance_eigen_vectors(
 }
 
 visualization_msgs::msg::Marker::SharedPtr get_pose_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance)
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance,
+  const double & confidence_interval_coefficient)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::CYLINDER;
@@ -379,8 +382,8 @@ visualization_msgs::msg::Marker::SharedPtr get_pose_covariance_marker_ptr(
   marker_ptr->pose.orientation.w = std::cos(yaw / 2.0);
 
   // ellipse size
-  marker_ptr->scale.x = sigma1 * 2.448;  // 2.448 sigma is 95%
-  marker_ptr->scale.y = sigma2 * 2.448;  // 2.448 sigma is 95%
+  marker_ptr->scale.x = sigma1 * confidence_interval_coefficient;
+  marker_ptr->scale.y = sigma2 * confidence_interval_coefficient;
   marker_ptr->scale.z = 0.05;
 
   // ellipse color density
@@ -399,7 +402,7 @@ visualization_msgs::msg::Marker::SharedPtr get_pose_covariance_marker_ptr(
 
 visualization_msgs::msg::Marker::SharedPtr get_yaw_covariance_marker_ptr(
   const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length,
-  const double & line_width)
+  const double & confidence_interval_coefficient, const double & line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_STRIP;
@@ -411,7 +414,8 @@ visualization_msgs::msg::Marker::SharedPtr get_yaw_covariance_marker_ptr(
 
   // orientation covariance
   double yaw_vector_length = std::max(length, 1.0);
-  double yaw_sigma = std::sqrt(pose_with_covariance.covariance[35]) * 2.448;  // 2.448 sigma is 95%
+  double yaw_sigma =
+    std::sqrt(pose_with_covariance.covariance[35]) * confidence_interval_coefficient;
   // get arc points
   if (yaw_sigma > M_PI) {
     yaw_vector_length = 1.0;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -154,7 +154,7 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_covariance_marker_ptr(
   phi = pos_yaw_angle + phi;
   double area = sigma1 * sigma2;
   double alpha = std::min(0.5, 1.0 / area);
-  alpha = std::max(0.05, alpha);
+  alpha = std::max(0.1, alpha);
 
   // ellipse orientation
   marker_ptr->pose.orientation.x = 0.0;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -138,8 +138,8 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_covariance_marker_ptr(
   const double velocity_angle =
     std::atan2(twist_with_covariance.twist.linear.y, twist_with_covariance.twist.linear.x);
   const double pos_yaw_angle = 2.0 * std::atan2(
-    pose_with_covariance.pose.orientation.z,
-    pose_with_covariance.pose.orientation.w);  // [rad]
+                                       pose_with_covariance.pose.orientation.z,
+                                       pose_with_covariance.pose.orientation.w);  // [rad]
   marker_ptr->pose.position.x += velocity * std::cos(pos_yaw_angle + velocity_angle);
   marker_ptr->pose.position.y += velocity * std::sin(pos_yaw_angle + velocity_angle);
 
@@ -166,7 +166,7 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_covariance_marker_ptr(
   marker_ptr->scale.x = sigma1 * 2.448;  // 2.448 sigma is 95%
   marker_ptr->scale.y = sigma2 * 2.448;  // 2.448 sigma is 95%
   marker_ptr->scale.z = 0.05;
-  
+
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color.a = alpha;
   marker_ptr->color.r = 1.0;
@@ -234,7 +234,7 @@ visualization_msgs::msg::Marker::SharedPtr get_yaw_rate_covariance_marker_ptr(
 
   // yaw rate covariance
   const double yaw_rate_covariance = twist_with_covariance.covariance[35];
-  const double yaw_rate_sigma = std::sqrt(yaw_rate_covariance);  // 2.448 sigma is 95%
+  const double yaw_rate_sigma = std::sqrt(yaw_rate_covariance) * 2.448;  // 2.448 sigma is 95%
   const double yaw_rate = twist_with_covariance.twist.angular.z;
   const double velocity = std::sqrt(
     twist_with_covariance.twist.linear.x * twist_with_covariance.twist.linear.x +
@@ -367,9 +367,8 @@ visualization_msgs::msg::Marker::SharedPtr get_pose_covariance_marker_ptr(
   // position covariance
   // extract eigen values and eigen vectors
   Eigen::Matrix2d eigen_pose_covariance;
-  eigen_pose_covariance << pose_with_covariance.covariance[0],
-    pose_with_covariance.covariance[1], pose_with_covariance.covariance[6],
-    pose_with_covariance.covariance[7];
+  eigen_pose_covariance << pose_with_covariance.covariance[0], pose_with_covariance.covariance[1],
+    pose_with_covariance.covariance[6], pose_with_covariance.covariance[7];
   double yaw, sigma1, sigma2;
   calc_covariance_eigen_vectors(eigen_pose_covariance, sigma1, sigma2, yaw);
 
@@ -412,7 +411,7 @@ visualization_msgs::msg::Marker::SharedPtr get_yaw_covariance_marker_ptr(
 
   // orientation covariance
   double yaw_vector_length = std::max(length, 1.0);
-  double yaw_sigma = std::sqrt(pose_with_covariance.covariance[35]);  // 2.448 sigma is 95%
+  double yaw_sigma = std::sqrt(pose_with_covariance.covariance[35]) * 2.448;  // 2.448 sigma is 95%
   // get arc points
   if (yaw_sigma > M_PI) {
     yaw_vector_length = 1.0;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -118,8 +118,8 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
     twist_with_covariance.twist.linear.x * twist_with_covariance.twist.linear.x +
     twist_with_covariance.twist.linear.y * twist_with_covariance.twist.linear.y +
     twist_with_covariance.twist.linear.z * twist_with_covariance.twist.linear.z);
-  const double velocity_angle = std::atan2(
-    twist_with_covariance.twist.linear.y, twist_with_covariance.twist.linear.x);
+  const double velocity_angle =
+    std::atan2(twist_with_covariance.twist.linear.y, twist_with_covariance.twist.linear.x);
   point.x = twist_with_covariance.twist.linear.x;
   point.y = twist_with_covariance.twist.linear.y;
   point.z = twist_with_covariance.twist.linear.z;
@@ -128,7 +128,7 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
   point.y = velocity * std::sin(velocity_angle + yaw_rate);
   point.z = 0;
   marker_ptr->points.push_back(point);
-  
+
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_ptr->color.a = 0.999;
   marker_ptr->color.r = 1.0;
@@ -192,11 +192,11 @@ void calc_arc_line_strip(
   points.push_back(point);
   // arc points
   const double maximum_delta_angle = 10.0 * M_PI / 180.0;
-  const int num_points = std::max(
-    3, static_cast<int>(std::abs(end_angle - start_angle) / maximum_delta_angle));
+  const int num_points =
+    std::max(3, static_cast<int>(std::abs(end_angle - start_angle) / maximum_delta_angle));
   for (int i = 0; i < num_points; ++i) {
     const double angle = start_angle + (end_angle - start_angle) * static_cast<double>(i) /
-                                        static_cast<double>(num_points - 1);
+                                         static_cast<double>(num_points - 1);
     point.x = radius * std::cos(angle);
     point.y = radius * std::sin(angle);
     point.z = 0;
@@ -210,12 +210,12 @@ void calc_arc_line_strip(
 }
 
 visualization_msgs::msg::Marker::SharedPtr get_pose_with_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance)
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_ptr->ns = std::string("position covariance");
-  marker_ptr->scale.x = 0.03;
+  marker_ptr->scale.x = line_width;
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = pose_with_covariance.pose;
   marker_ptr->pose.orientation.x = 0.0;
@@ -262,7 +262,7 @@ visualization_msgs::msg::Marker::SharedPtr get_pose_with_covariance_marker_ptr(
 }
 
 visualization_msgs::msg::Marker::SharedPtr get_yaw_covariance_marker_ptr(
-  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & line_width)
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double & length, const double & line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_STRIP;
@@ -273,7 +273,7 @@ visualization_msgs::msg::Marker::SharedPtr get_yaw_covariance_marker_ptr(
   geometry_msgs::msg::Point point;
 
   // orientation covariance
-  double yaw_vector_length = 3.0;
+  double yaw_vector_length = std::max(length, 1.0);
   double yaw_sigma = std::sqrt(pose_with_covariance.covariance[35]);  // 2.448 sigma is 95%
   // get arc points
   if (yaw_sigma > M_PI) {

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -113,7 +113,7 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
 
     // Get marker for pose with covariance
     auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
-      object.kinematics.initial_pose_with_covariance, get_line_width() / 2);
+      object.kinematics.initial_pose_with_covariance, get_line_width() * 0.5);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -123,7 +123,7 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
 
     // Get marker for yaw covariance
     auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
-      object.kinematics.initial_pose_with_covariance, object.shape.dimensions.x / 1.6, get_line_width() / 2);
+      object.kinematics.initial_pose_with_covariance, object.shape.dimensions.x * 0.65, get_line_width() * 0.5);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -189,6 +189,17 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
       twist_marker_ptr->header = msg->header;
       twist_marker_ptr->id = uuid_to_marker_id(object.object_id);
       markers.push_back(twist_marker_ptr);
+    }
+
+    // Get marker for twist
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.initial_pose_with_covariance,
+      object.kinematics.initial_twist_with_covariance, get_line_width() * 0.5);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      markers.push_back(marker_ptr);
     }
 
     // Add marker for each candidate path

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -123,7 +123,8 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
 
     // Get marker for yaw covariance
     auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
-      object.kinematics.initial_pose_with_covariance, object.shape.dimensions.x * 0.65, get_line_width() * 0.5);
+      object.kinematics.initial_pose_with_covariance, object.shape.dimensions.x * 0.65,
+      get_line_width() * 0.5);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -191,10 +192,21 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
       markers.push_back(twist_marker_ptr);
     }
 
-    // Get marker for twist
+    // Get marker for yaw rate
+    auto yaw_rate_marker = get_yaw_rate_marker_ptr(
+      object.kinematics.initial_pose_with_covariance,
+      object.kinematics.initial_twist_with_covariance, get_line_width() * 0.4);
+    if (yaw_rate_marker) {
+      auto marker_ptr = yaw_rate_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for twist covariance
     auto twist_covariance_marker = get_twist_covariance_marker_ptr(
       object.kinematics.initial_pose_with_covariance,
-      object.kinematics.initial_twist_with_covariance, get_line_width() * 0.5);
+      object.kinematics.initial_twist_with_covariance, get_line_width() * 0.3);
     if (twist_covariance_marker) {
       auto marker_ptr = twist_covariance_marker.value();
       marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -112,8 +112,8 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     }
 
     // Get marker for pose covariance
-    auto pose_with_covariance_marker = get_pose_covariance_marker_ptr(
-      object.kinematics.initial_pose_with_covariance);
+    auto pose_with_covariance_marker =
+      get_pose_covariance_marker_ptr(object.kinematics.initial_pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -73,12 +73,11 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
   std::vector<visualization_msgs::msg::Marker::SharedPtr> markers;
 
   for (const auto & object : msg->objects) {
-    const auto line_width = get_line_width();
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.initial_pose_with_covariance.pose.position,
       object.kinematics.initial_pose_with_covariance.pose.orientation, object.classification,
-      line_width, true);
+      get_line_width(), true);
     if (shape_marker) {
       auto marker_ptr = shape_marker.value();
       marker_ptr->header = msg->header;
@@ -113,8 +112,8 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     }
 
     // Get marker for pose with covariance
-    auto pose_with_covariance_marker =
-      get_pose_with_covariance_marker_ptr(object.kinematics.initial_pose_with_covariance);
+    auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
+      object.kinematics.initial_pose_with_covariance, get_line_width() / 2);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -123,8 +122,8 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     }
 
     // Get marker for yaw covariance
-    auto yaw_covariance_marker =
-      get_yaw_covariance_marker_ptr(object.kinematics.initial_pose_with_covariance, line_width/2);
+    auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
+      object.kinematics.initial_pose_with_covariance, object.shape.dimensions.x / 1.6, get_line_width() / 2);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -113,7 +113,7 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
 
     // Get marker for pose with covariance
     auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
-      object.kinematics.initial_pose_with_covariance, get_line_width() * 0.5);
+      object.kinematics.initial_pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -192,6 +192,17 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
       markers.push_back(twist_marker_ptr);
     }
 
+    // Get marker for twist covariance
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.initial_pose_with_covariance,
+      object.kinematics.initial_twist_with_covariance);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      markers.push_back(marker_ptr);
+    }
+
     // Get marker for yaw rate
     auto yaw_rate_marker = get_yaw_rate_marker_ptr(
       object.kinematics.initial_pose_with_covariance,
@@ -204,11 +215,11 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     }
 
     // Get marker for twist covariance
-    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+    auto yaw_rate_covariance_marker = get_yaw_rate_covariance_marker_ptr(
       object.kinematics.initial_pose_with_covariance,
       object.kinematics.initial_twist_with_covariance, get_line_width() * 0.3);
-    if (twist_covariance_marker) {
-      auto marker_ptr = twist_covariance_marker.value();
+    if (yaw_rate_covariance_marker) {
+      auto marker_ptr = yaw_rate_covariance_marker.value();
       marker_ptr->header = msg->header;
       marker_ptr->id = uuid_to_marker_id(object.object_id);
       markers.push_back(marker_ptr);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -111,8 +111,8 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
       markers.push_back(id_marker_ptr);
     }
 
-    // Get marker for pose with covariance
-    auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
+    // Get marker for pose covariance
+    auto pose_with_covariance_marker = get_pose_covariance_marker_ptr(
       object.kinematics.initial_pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -73,16 +73,17 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
   std::vector<visualization_msgs::msg::Marker::SharedPtr> markers;
 
   for (const auto & object : msg->objects) {
+    const auto line_width = get_line_width();
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.initial_pose_with_covariance.pose.position,
       object.kinematics.initial_pose_with_covariance.pose.orientation, object.classification,
-      get_line_width(), true);
+      line_width, true);
     if (shape_marker) {
-      auto shape_marker_ptr = shape_marker.value();
-      shape_marker_ptr->header = msg->header;
-      shape_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      markers.push_back(shape_marker_ptr);
+      auto marker_ptr = shape_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      markers.push_back(marker_ptr);
     }
 
     // Get marker for label
@@ -90,10 +91,10 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
       object.kinematics.initial_pose_with_covariance.pose.position,
       object.kinematics.initial_pose_with_covariance.pose.orientation, object.classification);
     if (label_marker) {
-      auto label_marker_ptr = label_marker.value();
-      label_marker_ptr->header = msg->header;
-      label_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      markers.push_back(label_marker_ptr);
+      auto marker_ptr = label_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      markers.push_back(marker_ptr);
     }
 
     // Get marker for id
@@ -115,10 +116,20 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
     auto pose_with_covariance_marker =
       get_pose_with_covariance_marker_ptr(object.kinematics.initial_pose_with_covariance);
     if (pose_with_covariance_marker) {
-      auto pose_with_covariance_marker_ptr = pose_with_covariance_marker.value();
-      pose_with_covariance_marker_ptr->header = msg->header;
-      pose_with_covariance_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      markers.push_back(pose_with_covariance_marker_ptr);
+      auto marker_ptr = pose_with_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      markers.push_back(marker_ptr);
+    }
+
+    // Get marker for yaw covariance
+    auto yaw_covariance_marker =
+      get_yaw_covariance_marker_ptr(object.kinematics.initial_pose_with_covariance, line_width/2);
+    if (yaw_covariance_marker) {
+      auto marker_ptr = yaw_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      markers.push_back(marker_ptr);
     }
 
     // Get marker for existence probability

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -97,7 +97,7 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for pose with covariance
     auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance, get_line_width() * 0.5);
+      object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -171,6 +171,16 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
       add_marker(twist_marker_ptr);
     }
 
+    // Get marker for twist covariance
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(marker_ptr);
+    }
+
     // Get marker for yaw rate
     auto yaw_rate_marker = get_yaw_rate_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
@@ -183,11 +193,11 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     }
 
     // Get marker for twist covariance
-    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+    auto yaw_rate_covariance_marker = get_yaw_rate_covariance_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
       get_line_width() * 0.5);
-    if (twist_covariance_marker) {
-      auto marker_ptr = twist_covariance_marker.value();
+    if (yaw_rate_covariance_marker) {
+      auto marker_ptr = yaw_rate_covariance_marker.value();
       marker_ptr->header = msg->header;
       marker_ptr->id = uuid_to_marker_id(object.object_id);
       add_marker(marker_ptr);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -106,8 +106,9 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     }
 
     // Get marker for yaw covariance
-    auto yaw_covariance_marker =
-      get_yaw_covariance_marker_ptr(object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65, get_line_width() * 0.5);
+    auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65,
+      get_line_width() * 0.5);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -170,6 +171,17 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
       add_marker(twist_marker_ptr);
     }
 
+    // Get marker for yaw rate
+    auto yaw_rate_marker = get_yaw_rate_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width() * 0.4);
+    if (yaw_rate_marker) {
+      auto marker_ptr = yaw_rate_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(marker_ptr);
+    }
+
     // Get marker for twist covariance
     auto twist_covariance_marker = get_twist_covariance_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
@@ -180,7 +192,6 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
       marker_ptr->id = uuid_to_marker_id(object.object_id);
       add_marker(marker_ptr);
     }
-
   }
 }
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -96,8 +96,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     }
 
     // Get marker for pose covariance
-    auto pose_with_covariance_marker = get_pose_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance);
+    auto pose_with_covariance_marker =
+      get_pose_covariance_marker_ptr(object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -55,11 +55,11 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
   for (const auto & object : msg->objects) {
     // Filter by object dynamic status
     if (!is_object_to_show(showing_dynamic_status, object)) continue;
-    const auto line_width = get_line_width();
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.pose_with_covariance.pose.position,
-      object.kinematics.pose_with_covariance.pose.orientation, object.classification, line_width,
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification,
+      get_line_width(),
       object.kinematics.orientation_availability ==
         autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE);
     if (shape_marker) {
@@ -96,8 +96,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     }
 
     // Get marker for pose with covariance
-    auto pose_with_covariance_marker =
-      get_pose_with_covariance_marker_ptr(object.kinematics.pose_with_covariance);
+    auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, get_line_width() / 2);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -107,7 +107,7 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for yaw covariance
     auto yaw_covariance_marker =
-      get_yaw_covariance_marker_ptr(object.kinematics.pose_with_covariance, line_width/2);
+      get_yaw_covariance_marker_ptr(object.kinematics.pose_with_covariance, object.shape.dimensions.x / 1.6, get_line_width() / 2);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -161,7 +161,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for twist
     auto twist_marker = get_twist_marker_ptr(
-      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance, line_width);
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width());
     if (twist_marker) {
       auto twist_marker_ptr = twist_marker.value();
       twist_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -95,8 +95,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
       add_marker(id_marker_ptr);
     }
 
-    // Get marker for pose with covariance
-    auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
+    // Get marker for pose covariance
+    auto pose_with_covariance_marker = get_pose_covariance_marker_ptr(
       object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -97,7 +97,7 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for pose with covariance
     auto pose_with_covariance_marker = get_pose_with_covariance_marker_ptr(
-      object.kinematics.pose_with_covariance, get_line_width() / 2);
+      object.kinematics.pose_with_covariance, get_line_width() * 0.5);
     if (pose_with_covariance_marker) {
       auto marker_ptr = pose_with_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -107,7 +107,7 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for yaw covariance
     auto yaw_covariance_marker =
-      get_yaw_covariance_marker_ptr(object.kinematics.pose_with_covariance, object.shape.dimensions.x / 1.6, get_line_width() / 2);
+      get_yaw_covariance_marker_ptr(object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65, get_line_width() * 0.5);
     if (yaw_covariance_marker) {
       auto marker_ptr = yaw_covariance_marker.value();
       marker_ptr->header = msg->header;
@@ -169,6 +169,18 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
       twist_marker_ptr->id = uuid_to_marker_id(object.object_id);
       add_marker(twist_marker_ptr);
     }
+
+    // Get marker for twist covariance
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width() * 0.5);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(marker_ptr);
+    }
+
   }
 }
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -99,11 +99,22 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     auto pose_with_covariance_marker =
       get_pose_with_covariance_marker_ptr(object.kinematics.pose_with_covariance);
     if (pose_with_covariance_marker) {
-      auto pose_with_covariance_marker_ptr = pose_with_covariance_marker.value();
-      pose_with_covariance_marker_ptr->header = msg->header;
-      pose_with_covariance_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(pose_with_covariance_marker_ptr);
+      auto marker_ptr = pose_with_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(marker_ptr);
     }
+
+    // Get marker for yaw covariance
+    auto yaw_covariance_marker =
+      get_yaw_covariance_marker_ptr(object.kinematics.pose_with_covariance, line_width/2);
+    if (yaw_covariance_marker) {
+      auto marker_ptr = yaw_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(marker_ptr);
+    }
+
     // Get marker for existence probability
     geometry_msgs::msg::Point existence_probability_position;
     existence_probability_position.x = object.kinematics.pose_with_covariance.pose.position.x + 0.5;


### PR DESCRIPTION
## Description

1. Modify pose covariance to draw eclipse instead of cross. (white eclipse)
![Screenshot from 2024-01-15 10-17-48](https://github.com/autowarefoundation/autoware.universe/assets/42434141/2bff92f3-7965-45cd-9d55-38c42ad6b648)

2. Add visualizations of
* Yaw Covariance (white section)
![Screenshot from 2024-01-15 10-18-25](https://github.com/autowarefoundation/autoware.universe/assets/42434141/a365050d-e88c-4a83-930f-0edf5c1945eb)

* Twist Covariance (red eclipse)
![Screenshot from 2024-01-15 10-18-48](https://github.com/autowarefoundation/autoware.universe/assets/42434141/d92ef43f-7123-4bf5-bb4f-54d61410a889)

* Yaw Rate (red section)
![Screenshot from 2024-01-15 10-20-03](https://github.com/autowarefoundation/autoware.universe/assets/42434141/e73c3c7e-d05a-4c69-ab0d-b84537b36b1e)

* Yaw Rate Covariance (pink H-shape)
![Screenshot from 2024-01-15 10-20-33](https://github.com/autowarefoundation/autoware.universe/assets/42434141/261ebcbe-9944-4f95-99b6-b02dbcc86185)

3. Add option to configure confidence Interval of 'Covariance' 



## Related links

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/42434141/37c09b2e-2939-4c0d-a447-08b85aaecbc3


## Notes for reviewers
* Default value of the new visualizations are `false`. It is to reduce complexity of default view.
* Naming convention of `covariance` was inherited. The visualizations of `covariance` is the confidence interval.

## Interface changes
Not applicable.

## Effects on system behavior
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
