### PR TITLE
feat(yabloc): add yabloc trigger service to suspend and restart the estimation

### DIFF
--- a/localization/yabloc/yabloc_image_processing/launch/image_processing.launch.xml
+++ b/localization/yabloc/yabloc_image_processing/launch/image_processing.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="src_image" default="/sensing/camera/traffic_light/image_raw"/>
   <arg name="src_info" default="/sensing/camera/traffic_light/camera_info"/>
-  <arg name="resized_image" default="/sensing/camera/undistorted/image_raw/relay"/>
+  <arg name="resized_image" default="/sensing/camera/undistorted/image_raw"/>
   <arg name="resized_info" default="/sensing/camera/undistorted/camera_info"/>
 
   <!-- undistort -->

--- a/localization/yabloc/yabloc_particle_filter/README.md
+++ b/localization/yabloc/yabloc_particle_filter/README.md
@@ -46,6 +46,12 @@ This package contains some executable nodes related to particle filter.
 | `prediction_rate`             | double           | frequency of forecast updates, in Hz                              |
 | `cov_xx_yy`                   | vector\<double\> | the covariance of initial pose                                    |
 
+### Services
+
+| Name                 | Type                     | Description                                      |
+| -------------------- | ------------------------ | ------------------------------------------------ |
+| `yabloc_trigger_srv` | `std_srvs::srv::SetBool` | activation and deactivation of yabloc estimation |
+
 ## gnss_particle_corrector
 
 ### Purpose

--- a/localization/yabloc/yabloc_particle_filter/launch/yabloc_particle_filter.launch.xml
+++ b/localization/yabloc/yabloc_particle_filter/launch/yabloc_particle_filter.launch.xml
@@ -16,6 +16,9 @@
     <remap from="~/output/predicted_particles" to="predicted_particles"/>
     <remap from="~/debug/init_marker" to="init_maker"/>
     <remap from="~/debug/particles_marker_array" to="$(var output_particles_marker_array)"/>
+
+    <remap from="~/input/ekf_pose" to="/localization/pose_with_covariance"/>
+    <remap from="~/yabloc_trigger_srv" to="/localization/pose_estimator/yabloc/pf/yabloc_trigger_srv"/>
   </node>
 
   <!-- camera  correction -->

--- a/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
+++ b/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
@@ -75,8 +75,8 @@ Predictor::Predictor()
 
   // Service server
   using std::placeholders::_2;
-  auto on_suspend_service = std::bind(&Predictor::on_trigger_service, this, _1, _2);
-  yabloc_trigger_server_ = create_service<SetBool>("~/yabloc_trigger_srv", on_suspend_service);
+  auto on_trigger_service = std::bind(&Predictor::on_trigger_service, this, _1, _2);
+  yabloc_trigger_server_ = create_service<SetBool>("~/yabloc_trigger_srv", on_trigger_service);
 
   // Optional modules
   if (declare_parameter<bool>("visualize", false)) {
@@ -216,7 +216,7 @@ void Predictor::on_timer()
 {
   // ==========================================================================
   // Pre-check section
-  // Return if yabloc is suspended
+  // Return if yabloc is not activated
   if (!yabloc_activated_) {
     return;
   }

--- a/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
+++ b/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
@@ -52,7 +52,12 @@ Predictor::Predictor()
   auto on_initial = std::bind(&Predictor::on_initial_pose, this, _1);
   auto on_twist_cov = std::bind(&Predictor::on_twist_cov, this, _1);
   auto on_particle = std::bind(&Predictor::on_weighted_particles, this, _1);
-  auto on_height = [this](std_msgs::msg::Float32 m) -> void { this->ground_height_ = m.data; };
+  auto on_height = [this](std_msgs::msg::Float32::ConstSharedPtr msg) -> void {
+    this->ground_height_ = msg->data;
+  };
+  auto on_ekf_pose = [this](PoseCovStamped::ConstSharedPtr msg) -> void {
+    this->latest_ekf_pose_ptr_ = msg;
+  };
 
   initialpose_sub_ = create_subscription<PoseCovStamped>("~/input/initialpose", 1, on_initial);
   particles_sub_ =
@@ -60,6 +65,7 @@ Predictor::Predictor()
   height_sub_ = create_subscription<std_msgs::msg::Float32>("~/input/height", 10, on_height);
   twist_cov_sub_ =
     create_subscription<TwistCovStamped>("~/input/twist_with_covariance", 10, on_twist_cov);
+  ekf_pose_sub_ = create_subscription<PoseCovStamped>("~/input/ekf_pose", 10, on_ekf_pose);
 
   // Timer callback
   const double prediction_rate = declare_parameter<double>("prediction_rate");
@@ -67,9 +73,38 @@ Predictor::Predictor()
   timer_ = rclcpp::create_timer(
     this, this->get_clock(), rclcpp::Rate(prediction_rate).period(), std::move(on_timer));
 
+  // Service server
+  using std::placeholders::_2;
+  auto on_suspend_service = std::bind(&Predictor::on_trigger_service, this, _1, _2);
+  yabloc_trigger_server_ = create_service<SetBool>("~/yabloc_trigger_srv", on_suspend_service);
+
   // Optional modules
   if (declare_parameter<bool>("visualize", false)) {
     visualizer_ptr_ = std::make_unique<ParticleVisualizer>(*this);
+  }
+}
+
+void Predictor::on_trigger_service(
+  SetBool::Request::ConstSharedPtr request, SetBool::Response::SharedPtr response)
+{
+  if (request->data) {
+    RCLCPP_INFO_STREAM(get_logger(), "yabloc particle filter is activated");
+  } else {
+    RCLCPP_INFO_STREAM(get_logger(), "yabloc particle filter is deactivated");
+  }
+
+  const bool before_activated_ = yabloc_activated_;
+  yabloc_activated_ = request->data;
+  response->success = true;
+
+  if (yabloc_activated_ && (!before_activated_)) {
+    RCLCPP_INFO_STREAM(get_logger(), "restart particle filter");
+    if (latest_ekf_pose_ptr_) {
+      on_initial_pose(latest_ekf_pose_ptr_);
+    } else {
+      yabloc_activated_ = false;
+      response->success = false;
+    }
   }
 }
 
@@ -181,6 +216,10 @@ void Predictor::on_timer()
 {
   // ==========================================================================
   // Pre-check section
+  // Return if yabloc is suspended
+  if (!yabloc_activated_) {
+    return;
+  }
   // Return if particle_array is not initialized yet
   if (!particle_array_opt_.has_value()) {
     return;


### PR DESCRIPTION
## Description

This PR adds a service to stop and resume yabloc.
This was created to split the PR https://github.com/autowarefoundation/autoware.universe/pull/5846

### Minor change
* I have also changed the inappropriate default value for `resized_image`. This change does not affect the behavior since it is overwritten by the upper launch file.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

The following data sets were used to confirm the behavior. 
(We can conrifm the behavior of this [even with the sample rosbag in logging_simulator.](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/))

* [map](https://github.com/tier4/AWSIM/releases/download/v1.1.0/nishishinjuku_autoware_map.zip) : This link was quoted from [AWSIM tutorial](https://tier4.github.io/AWSIM/GettingStarted/QuickStartDemo/#start-the-demo).
* [rosbag](https://drive.google.com/file/d/1zKTGRH4lD-wptpOdNCgpiPfGRDP0XrUm/view?usp=sharing)


```bash
ros2 launch autoware_launch logging_simulator.launch.xml \
    map_path:=/path/to/nishishinjuku  \
    vehicle_model:=sample_vehicle \
    sensor_model:=awsim_sensor_kit
    pose_source:=yabloc

ros2 bag play yabloc_autoware_test_made_in_awsim
ros2 service call /localization/pose_estimator/yabloc/pf/yabloc_trigger_srv std_srvs/srv/SetBool data: false
# We can see "yabloc particle filter is deactivated" in console.
# In the inactive state,  /localization/pose_estimator/pose_with_covariance is NOT published.

ros2 service call /localization/pose_estimator/yabloc/pf/yabloc_trigger_srv std_srvs/srv/SetBool data: true
# We can see "yabloc particle filter is activated" in console.
# In the active state,  /localization/pose_estimator/pose_with_covariance is published.
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

This PR does not change the localization accuracy.

Users can stop & restart YabLoc by callaing the trigger_service like following:
```
ros2 service call /localization/pose_estimator/yabloc/pf/yabloc_trigger_srv std_srvs/srv/SetBool data: true
ros2 service call /localization/pose_estimator/yabloc/pf/yabloc_trigger_srv std_srvs/srv/SetBool data: false
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
