### PR TITLE
feat(goal_planner): exclude goals located laterally in no_parking_areas

### DIFF
--- a/planning/behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -170,11 +170,13 @@ GoalCandidates GoalSearcher::search()
         transformVector(vehicle_footprint_, tier4_autoware_utils::pose2transform(search_pose));
 
       if (isInAreas(transformed_vehicle_footprint, getNoParkingAreaPolygons(pull_over_lanes))) {
-        continue;
+        // break here to exclude goals located laterally in no_parking_areas
+        break;
       }
 
       if (isInAreas(transformed_vehicle_footprint, getNoStoppingAreaPolygons(pull_over_lanes))) {
-        continue;
+        // break here to exclude goals located laterally in no_stopping_areas
+        break;
       }
 
       if (LaneDepartureChecker::isOutOfLane(lanes, transformed_vehicle_footprint)) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

exclude goals located laterally in no_parking_areas

green small arrows are goal candidates.

before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/27726897-ad5d-4f5f-b2a3-62d6369a9474)


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/67aa7bc0-7123-47c8-a816-b0fd9579e80c)


after


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/b7ba7f9f-de9c-438f-b6d2-a323b63a8e96)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

evaluator_description: feat/excule_goals
2024/01/16 https://evaluation.tier4.jp/evaluation/reports/3d4e05ae-9697-5f39-a988-a23aa971982e/?project_id=prd_jt


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
