### PR TITLE
fix(avoidance): fix detection area issue in avoidance module

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -1927,9 +1927,11 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
   const auto arc_length_array =
     utils::calcPathArcLengthArray(reference_path, 0L, reference_path.points.size(), 1e-3);
 
+  const auto points_size = std::min(reference_path.points.size(), spline_path.points.size());
+
   double next_longitudinal_distance = 0.0;
   std::vector<Polygon2d> detection_areas;
-  for (size_t i = 0; i < reference_path.points.size() - 1; ++i) {
+  for (size_t i = 0; i < points_size - 1; ++i) {
     const auto & p_reference_ego_front = reference_path.points.at(i).point.pose;
     const auto & p_reference_ego_back = reference_path.points.at(i + 1).point.pose;
     const auto & p_spline_ego_front = spline_path.points.at(i).point.pose;

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -1913,6 +1913,10 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
   PredictedObjects target_objects;
   PredictedObjects other_objects;
 
+  if (reference_path.points.empty() || spline_path.points.empty()) {
+    return std::make_pair(target_objects, other_objects);
+  }
+
   double max_offset = 0.0;
   for (const auto & object_parameter : parameters->object_parameters) {
     const auto p = object_parameter.second;
@@ -1925,18 +1929,15 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
     createVehiclePolygon(planner_data->parameters.vehicle_info, max_offset);
   const auto ego_idx = planner_data->findEgoIndex(reference_path.points);
   const auto arc_length_array =
-    utils::calcPathArcLengthArray(reference_path, 0L, reference_path.points.size(), 1e-3);
+    utils::calcPathArcLengthArray(reference_path, 0L, reference_path.points.size(), 0.0);
 
   const auto points_size = std::min(reference_path.points.size(), spline_path.points.size());
 
-  double next_longitudinal_distance = 0.0;
   std::vector<Polygon2d> detection_areas;
-  for (size_t i = 0; i < points_size - 1; ++i) {
-    const auto & p_reference_ego_front = reference_path.points.at(i).point.pose;
-    const auto & p_reference_ego_back = reference_path.points.at(i + 1).point.pose;
-    const auto & p_spline_ego_front = spline_path.points.at(i).point.pose;
-    const auto & p_spline_ego_back = spline_path.points.at(i + 1).point.pose;
-
+  Pose p_reference_ego_front = reference_path.points.front().point.pose;
+  Pose p_spline_ego_front = spline_path.points.front().point.pose;
+  double next_longitudinal_distance = parameters->resample_interval_for_output;
+  for (size_t i = 0; i < points_size; ++i) {
     const auto distance_from_ego = calcSignedArcLength(reference_path.points, ego_idx, i);
     if (distance_from_ego > object_check_forward_distance) {
       break;
@@ -1946,9 +1947,15 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
       continue;
     }
 
+    const auto & p_reference_ego_back = reference_path.points.at(i).point.pose;
+    const auto & p_spline_ego_back = spline_path.points.at(i).point.pose;
+
     detection_areas.push_back(createOneStepPolygon(
       p_reference_ego_front, p_reference_ego_back, p_spline_ego_front, p_spline_ego_back,
       detection_area));
+
+    p_reference_ego_front = p_reference_ego_back;
+    p_spline_ego_front = p_spline_ego_back;
 
     next_longitudinal_distance += parameters->resample_interval_for_output;
   }


### PR DESCRIPTION
## Description

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/6084
Issue: there are some gaps between detection areas.

![Screenshot from 2024-01-17 09-32-46](https://github.com/autowarefoundation/autoware.universe/assets/44889564/ecb40a67-bb4a-402c-93f5-ca06f6d8da2b)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim.
![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/b92d326a-011f-435a-8ff1-3ccf99113ba4)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
