### PR TITLE
fix: rename `score_threshold` into `score_thresh` in config

### DIFF
--- a/perception/tensorrt_yolo/config/yolov3.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov3.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [116.0, 90.0, 156.0, 198.0, 373.0, 326.0, 30.0, 61.0, 62.0, 45.0, 59.0, 119.0, 10.0, 13.0, 16.0, 30.0, 33.0, 23.0]
     scale_x_y: [1.0, 1.0, 1.0]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: true

--- a/perception/tensorrt_yolo/config/yolov4-tiny.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov4-tiny.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [81.0, 82.0, 135.0, 169.0, 344.0, 319.0, 23.0, 27.0, 37.0, 58.0, 81.0, 82.0]
     scale_x_y: [1.05, 1.05]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: true

--- a/perception/tensorrt_yolo/config/yolov4.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov4.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [12.0, 16.0, 19.0, 36.0, 40.0, 28.0, 36.0, 75.0, 76.0, 55.0, 72.0, 146.0, 142.0, 110.0, 192.0, 243.0, 459.0, 401.0]
     scale_x_y: [1.2, 1.1, 1.05]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: true

--- a/perception/tensorrt_yolo/config/yolov5l.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov5l.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [10.0, 13.0, 16.0, 30.0, 33.0, 23.0, 30.0, 61.0, 62.0, 45.0, 59.0, 119.0, 116.0, 90.0, 156.0, 198.0, 373.0, 326.0]
     scale_x_y: [1.0, 1.0, 1.0]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: false

--- a/perception/tensorrt_yolo/config/yolov5m.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov5m.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [10.0, 13.0, 16.0, 30.0, 33.0, 23.0, 30.0, 61.0, 62.0, 45.0, 59.0, 119.0, 116.0, 90.0, 156.0, 198.0, 373.0, 326.0]
     scale_x_y: [1.0, 1.0, 1.0]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: false

--- a/perception/tensorrt_yolo/config/yolov5s.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov5s.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [10.0, 13.0, 16.0, 30.0, 33.0, 23.0, 30.0, 61.0, 62.0, 45.0, 59.0, 119.0, 116.0, 90.0, 156.0, 198.0, 373.0, 326.0]
     scale_x_y: [1.0, 1.0, 1.0]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: false

--- a/perception/tensorrt_yolo/config/yolov5x.param.yaml
+++ b/perception/tensorrt_yolo/config/yolov5x.param.yaml
@@ -3,7 +3,7 @@
     num_anchors: 3
     anchors: [10.0, 13.0, 16.0, 30.0, 33.0, 23.0, 30.0, 61.0, 62.0, 45.0, 59.0, 119.0, 116.0, 90.0, 156.0, 198.0, 373.0, 326.0]
     scale_x_y: [1.0, 1.0, 1.0]
-    score_threshold: 0.1
+    score_thresh: 0.1
     iou_thresh: 0.45
     detections_per_im: 100
     use_darknet_layer: false


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Before this PR I got the following error when I launched `tensorrt_yolo`.

```shell
$ ros2 launch tensorrt_yolo tensorrt_yolo.launch.xml build_only:=true
[INFO] [launch]: All log files can be found below /home/ktro2828/.ros/log/2024-01-17-11-08-58-611535-ktro2828-desktop-31696
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [tensorrt_yolo_node-1]: process started with pid [31697]
[tensorrt_yolo_node-1] terminate called after throwing an instance of 'rclcpp::exceptions::UninitializedStaticallyTypedParameterException'
[tensorrt_yolo_node-1]   what():  Statically typed parameter 'score_thresh' must be initialized.
[ERROR] [tensorrt_yolo_node-1]: process has died [pid 31697, exit code -6, cmd '/home/ktro2828/workspace/autoware.universe/install/tensorrt_yolo/lib/tensorrt_yolo/tensorrt_yolo_node --ros-args -r __node:=tensorrt_yolo_ktro2828_desktop_31696_4920084585225657278 --params-file /tmp/launch_params_1jadhh89 --params-file /tmp/launch_params_v_bbh_37 --params-file /tmp/launch_params_u_39eegc --params-file /tmp/launch_params_u3px8wcu --params-file /tmp/launch_params_t6mfi6zv --params-file /tmp/launch_params__pt5s79l --params-file /tmp/launch_params_vli5b635 --params-file /home/ktro2828/workspace/autoware.universe/install/tensorrt_yolo/share/tensorrt_yolo/config/yolov3.param.yaml -r in/image:=/image_raw -r out/objects:=rois -r out/image:=rois/debug/image'].
```

Therefore I renamed `score_threshold` into `score_thresh` to avoid in `*.param.yaml`. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I checked the launcher works without any errors.

```shell
$ ros2 launch tensorrt_yolo tensorrt_yolo.launch.xml build_only:=true
[INFO] [launch]: All log files can be found below /home/ktro2828/.ros/log/2024-01-17-11-09-04-179115-ktro2828-desktop-31763
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [tensorrt_yolo_node-1]: process started with pid [31764]
[tensorrt_yolo_node-1] [INFO 1705457344.397106666] [tensorrt_yolo_ktro2828_desktop_31763_9216909878093977374]: Found /home/ktro2828/autoware_data/tensorrt_yolo/yolov3.engine
[tensorrt_yolo_node-1] [I] [TRT] Loaded engine size: 248 MiB
[tensorrt_yolo_node-1] [I] [TRT] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +6, GPU +10, now: CPU 293, GPU 900 (MiB)
[tensorrt_yolo_node-1] [I] [TRT] [MemUsageChange] Init cuDNN: CPU +2, GPU +10, now: CPU 295, GPU 910 (MiB)
[tensorrt_yolo_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in engine deserialization: CPU +0, GPU +245, now: CPU 0, GPU 245 (MiB)
[tensorrt_yolo_node-1] [I] [TRT] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +10, now: CPU 47, GPU 902 (MiB)
[tensorrt_yolo_node-1] [I] [TRT] [MemUsageChange] Init cuDNN: CPU +0, GPU +8, now: CPU 47, GPU 910 (MiB)
[tensorrt_yolo_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +118, now: CPU 0, GPU 363 (MiB)
[tensorrt_yolo_node-1] [INFO 1705457344.567039197] [tensorrt_yolo_ktro2828_desktop_31763_9216909878093977374]: Inference engine prepared.
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[tensorrt_yolo_node-1] [INFO 1705457346.438145886] [rclcpp]: signal_handler(signum=2)
[INFO] [tensorrt_yolo_node-1]: process has finished cleanly [pid 31764]
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
