### PR TITLE
fix(behavior_velocity_crosswalk_module): check if p_safety_slow is empty

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -813,7 +813,7 @@ void CrosswalkModule::applySafetySlowDownSpeed(
     const auto & p_safety_slow =
       calcLongitudinalOffsetPoint(ego_path.points, ego_pos, safety_slow_point_range);
 
-    if (p_safety_slow.has_value()){
+    if (p_safety_slow.has_value()) {
       insertDecelPointWithDebugInfo(p_safety_slow.value(), safety_slow_down_speed, output);
     }
 

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -813,7 +813,9 @@ void CrosswalkModule::applySafetySlowDownSpeed(
     const auto & p_safety_slow =
       calcLongitudinalOffsetPoint(ego_path.points, ego_pos, safety_slow_point_range);
 
-    insertDecelPointWithDebugInfo(p_safety_slow.value(), safety_slow_down_speed, output);
+    if (p_safety_slow.has_value()){
+      insertDecelPointWithDebugInfo(p_safety_slow.value(), safety_slow_down_speed, output);
+    }
 
     if (safety_slow_point_range < 0.0) {
       passed_safety_slow_point_ = true;


### PR DESCRIPTION
## Description

Fixes: https://github.com/autowarefoundation/autoware.universe/issues/6102

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/32412808/6963af10-4b71-4f72-a281-f171481d6eb2

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
