### PR TITLE
feat(gnss_poser): use header.frame_id as gnss_frame

### DIFF
--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -11,8 +11,6 @@ If the transformation from `base_link` to the antenna cannot be obtained, it out
 
 ## Inner-workings / Algorithms
 
-
-
 ## Inputs / Outputs
 
 ### Input

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -4,7 +4,14 @@
 
 The `gnss_poser` is a node that subscribes gnss sensing messages and calculates vehicle pose with covariance.
 
+This node subscribes to NavSatFix to publish the pose of **base_link**. The data in NavSatFix represents the antenna's position. Therefore, it performs a coordinate transformation using the tf from `base_link` to the antenna's position. The frame_id of the antenna's position refers to NavSatFix's `header.frame_id`.
+(**Note that `header.frame_id` in NavSatFix indicates the antenna's frame_id, not the Earth or reference ellipsoid.** [See also NavSatFix definition.](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/NavSatFix.html))
+
+If the transformation from `base_link` to the antenna cannot be obtained, it outputs the pose of the antenna position without performing coordinate transformation.
+
 ## Inner-workings / Algorithms
+
+
 
 ## Inputs / Outputs
 

--- a/sensing/gnss_poser/config/gnss_poser.param.yaml
+++ b/sensing/gnss_poser/config/gnss_poser.param.yaml
@@ -2,7 +2,6 @@
   ros__parameters:
     base_frame: base_link
     gnss_base_frame: gnss_base_link
-    gnss_frame: gnss
     map_frame: map
     buff_epoch: 1
     use_gnss_ins_orientation: true

--- a/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
@@ -89,10 +89,9 @@ private:
   rclcpp::Publisher<tier4_debug_msgs::msg::BoolStamped>::SharedPtr fixed_pub_;
 
   MapProjectorInfo::Message projector_info_;
-  std::string base_frame_;
-  std::string gnss_frame_;
-  std::string gnss_base_frame_;
-  std::string map_frame_;
+  const std::string base_frame_;
+  const std::string gnss_base_frame_;
+  const std::string map_frame_;
   bool received_map_projector_info_ = false;
   bool use_gnss_ins_orientation_;
 

--- a/sensing/gnss_poser/schema/gnss_poser.schema.json
+++ b/sensing/gnss_poser/schema/gnss_poser.schema.json
@@ -11,11 +11,6 @@
           "default": "base_link",
           "description": "frame id for base_frame"
         },
-        "gnss_frame": {
-          "type": "string",
-          "default": "gnss",
-          "description": "frame id for gnss_frame"
-        },
         "gnss_base_frame": {
           "type": "string",
           "default": "gnss_base_link",
@@ -64,8 +59,12 @@
           "$ref": "#/definitions/gnss_poser"
         }
       },
-      "required": ["ros__parameters"]
+      "required": [
+        "ros__parameters"
+      ]
     }
   },
-  "required": ["/**"]
+  "required": [
+    "/**"
+  ]
 }

--- a/sensing/gnss_poser/schema/gnss_poser.schema.json
+++ b/sensing/gnss_poser/schema/gnss_poser.schema.json
@@ -59,12 +59,8 @@
           "$ref": "#/definitions/gnss_poser"
         }
       },
-      "required": [
-        "ros__parameters"
-      ]
+      "required": ["ros__parameters"]
     }
   },
-  "required": [
-    "/**"
-  ]
+  "required": ["/**"]
 }

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -31,7 +31,6 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   tf2_listener_(tf2_buffer_),
   tf2_broadcaster_(*this),
   base_frame_(declare_parameter<std::string>("base_frame")),
-  gnss_frame_(declare_parameter<std::string>("gnss_frame")),
   gnss_base_frame_(declare_parameter<std::string>("gnss_base_frame")),
   map_frame_(declare_parameter<std::string>("map_frame")),
   use_gnss_ins_orientation_(declare_parameter<bool>("use_gnss_ins_orientation")),
@@ -142,8 +141,9 @@ void GNSSPoser::callbackNavSatFix(
   // get TF from gnss_antenna to base_link
   auto tf_gnss_antenna2base_link_msg_ptr = std::make_shared<geometry_msgs::msg::TransformStamped>();
 
+  const std::string gnss_frame = nav_sat_fix_msg_ptr->header.frame_id;
   getStaticTransform(
-    base_frame_, gnss_frame_, tf_gnss_antenna2base_link_msg_ptr, nav_sat_fix_msg_ptr->header.stamp);
+    base_frame_, gnss_frame, tf_gnss_antenna2base_link_msg_ptr, nav_sat_fix_msg_ptr->header.stamp);
   tf2::Transform tf_gnss_antenna2base_link{};
   tf2::fromMsg(tf_gnss_antenna2base_link_msg_ptr->transform, tf_gnss_antenna2base_link);
 


### PR DESCRIPTION
## Description

This PR resolves https://github.com/autowarefoundation/autoware.universe/issues/6108

* Removed `gnss_frame` which indicates antenna's frame_id from parameters.
* Changed to identify the antenna's frame_id by referencing `nav_sat_fix.header.frame_id`.

(Please note the `header.frame_id` in NavSatFix indicates the frame_id of the antenna, not the Earth or ellipsoid.  See also https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/NavSatFix.html)

<!-- Write a brief description of this PR. -->

[TIER IV INTERNAL ANNOUNCEMENT LINK](https://star4.slack.com/archives/C4P0NSMB5/p1705640076668249)

### Related PR
* https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/88
* https://github.com/autowarefoundation/awf_reference_sensor_kit_launch/pull/8
* https://github.com/tier4/aip_launcher/pull/201

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I have tested [rosbag-replay-simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) in tutorial, and confirmed that the following warnings are not printed.
```
[gnss_poser-32] [WARN 1705543736.053584803] [sensing.gnss.gnss_poser]: "gnss" passed to lookupTransform argument source_frame does not exist.
[gnss_poser-32] [WARN 1705543736.053649454] [sensing.gnss.gnss_poser]: Please publish TF base_link to gnss
```

## Effects on system behavior

Basically, this PR does not change the system behavior.

If `header.frame_id` of nav_sat_fix is not set correctly, gnss_poser outputs antenna position instead of base_link position.
(However, since this output is only used for initial position estimation, this is not a critical problem.)

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
