### PR TITLE
feat(planning_validator): add invalid size error

### DIFF
--- a/planning/planning_validator/include/planning_validator/planning_validator.hpp
+++ b/planning/planning_validator/include/planning_validator/planning_validator.hpp
@@ -64,6 +64,7 @@ public:
 
   void onTrajectory(const Trajectory::ConstSharedPtr msg);
 
+  bool checkValidSize(const Trajectory & trajectory);
   bool checkValidFiniteValue(const Trajectory & trajectory);
   bool checkValidInterval(const Trajectory & trajectory);
   bool checkValidRelativeAngle(const Trajectory & trajectory);

--- a/planning/planning_validator/include/planning_validator/planning_validator.hpp
+++ b/planning/planning_validator/include/planning_validator/planning_validator.hpp
@@ -64,7 +64,7 @@ public:
 
   void onTrajectory(const Trajectory::ConstSharedPtr msg);
 
-  bool checkValidSize(const Trajectory & trajectory);
+  bool checkValidSize(const Trajectory & trajectory) const;
   bool checkValidFiniteValue(const Trajectory & trajectory);
   bool checkValidInterval(const Trajectory & trajectory);
   bool checkValidRelativeAngle(const Trajectory & trajectory);

--- a/planning/planning_validator/include/planning_validator/planning_validator.hpp
+++ b/planning/planning_validator/include/planning_validator/planning_validator.hpp
@@ -117,7 +117,7 @@ private:
 
   vehicle_info_util::VehicleInfo vehicle_info_;
 
-  bool isAllValid(const PlanningValidatorStatus & status);
+  bool isAllValid(const PlanningValidatorStatus & status) const;
 
   Trajectory::ConstSharedPtr current_trajectory_;
   Trajectory::ConstSharedPtr previous_published_trajectory_;

--- a/planning/planning_validator/msg/PlanningValidatorStatus.msg
+++ b/planning/planning_validator/msg/PlanningValidatorStatus.msg
@@ -1,6 +1,7 @@
 builtin_interfaces/Time stamp
 
 # states
+bool is_valid_size
 bool is_valid_finite_value
 bool is_valid_interval
 bool is_valid_relative_angle

--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -296,7 +296,7 @@ void PlanningValidator::validate(const Trajectory & trajectory)
 
 bool PlanningValidator::checkValidSize(const Trajectory & trajectory)
 {
-  return trajectory.points.size() < 2 ? false : true;
+  return trajectory.points.size() >=2;
 }
 
 bool PlanningValidator::checkValidFiniteValue(const Trajectory & trajectory)

--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -296,7 +296,7 @@ void PlanningValidator::validate(const Trajectory & trajectory)
 
 bool PlanningValidator::checkValidSize(const Trajectory & trajectory) const
 {
-  return trajectory.points.size() >=2;
+  return trajectory.points.size() >= 2;
 }
 
 bool PlanningValidator::checkValidFiniteValue(const Trajectory & trajectory)
@@ -447,7 +447,7 @@ bool PlanningValidator::checkValidDistanceDeviation(const Trajectory & trajector
   return true;
 }
 
-bool PlanningValidator::isAllValid(const PlanningValidatorStatus & s)
+bool PlanningValidator::isAllValid(const PlanningValidatorStatus & s) const
 {
   return s.is_valid_size && s.is_valid_finite_value && s.is_valid_interval &&
          s.is_valid_relative_angle && s.is_valid_curvature && s.is_valid_lateral_acc &&

--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -294,7 +294,7 @@ void PlanningValidator::validate(const Trajectory & trajectory)
   s.invalid_count = isAllValid(s) ? 0 : s.invalid_count + 1;
 }
 
-bool PlanningValidator::checkValidSize(const Trajectory & trajectory)
+bool PlanningValidator::checkValidSize(const Trajectory & trajectory) const
 {
   return trajectory.points.size() >=2;
 }

--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -113,6 +113,9 @@ void PlanningValidator::setupDiag()
   d->setHardwareID("planning_validator");
 
   std::string ns = "trajectory_validation_";
+  d->add(ns + "size", [&](auto & stat) {
+    setStatus(stat, validation_status_.is_valid_size, "invalid trajectory size is found");
+  });
   d->add(ns + "finite", [&](auto & stat) {
     setStatus(stat, validation_status_.is_valid_finite_value, "infinite value is found");
   });
@@ -251,14 +254,26 @@ void PlanningValidator::publishDebugInfo()
 
 void PlanningValidator::validate(const Trajectory & trajectory)
 {
-  if (trajectory.points.size() < 2) {
-    RCLCPP_ERROR(get_logger(), "trajectory size is less than 2. Cannot validate.");
-    return;
-  }
-
   auto & s = validation_status_;
 
+  const auto terminateValidation = [&](const auto & ss) {
+    RCLCPP_ERROR_STREAM(get_logger(), ss);
+    s.invalid_count += 1;
+  };
+
+  s.is_valid_size = checkValidSize(trajectory);
+  if (!s.is_valid_size) {
+    return terminateValidation(
+      "trajectory has invalid point size (" + std::to_string(trajectory.points.size()) +
+      "). Stop validation process, raise an error.");
+  }
+
   s.is_valid_finite_value = checkValidFiniteValue(trajectory);
+  if (!s.is_valid_finite_value) {
+    return terminateValidation(
+      "trajectory has invalid value (NaN, Inf, etc). Stop validation process, raise an error.");
+  }
+
   s.is_valid_interval = checkValidInterval(trajectory);
   s.is_valid_lateral_acc = checkValidLateralAcceleration(trajectory);
   s.is_valid_longitudinal_max_acc = checkValidMaxLongitudinalAcceleration(trajectory);
@@ -277,6 +292,11 @@ void PlanningValidator::validate(const Trajectory & trajectory)
   s.is_valid_steering_rate = checkValidSteeringRate(resampled);
 
   s.invalid_count = isAllValid(s) ? 0 : s.invalid_count + 1;
+}
+
+bool PlanningValidator::checkValidSize(const Trajectory & trajectory)
+{
+  return trajectory.points.size() < 2 ? false : true;
 }
 
 bool PlanningValidator::checkValidFiniteValue(const Trajectory & trajectory)
@@ -429,10 +449,11 @@ bool PlanningValidator::checkValidDistanceDeviation(const Trajectory & trajector
 
 bool PlanningValidator::isAllValid(const PlanningValidatorStatus & s)
 {
-  return s.is_valid_finite_value && s.is_valid_interval && s.is_valid_relative_angle &&
-         s.is_valid_curvature && s.is_valid_lateral_acc && s.is_valid_longitudinal_max_acc &&
-         s.is_valid_longitudinal_min_acc && s.is_valid_steering && s.is_valid_steering_rate &&
-         s.is_valid_velocity_deviation && s.is_valid_distance_deviation;
+  return s.is_valid_size && s.is_valid_finite_value && s.is_valid_interval &&
+         s.is_valid_relative_angle && s.is_valid_curvature && s.is_valid_lateral_acc &&
+         s.is_valid_longitudinal_max_acc && s.is_valid_longitudinal_min_acc &&
+         s.is_valid_steering && s.is_valid_steering_rate && s.is_valid_velocity_deviation &&
+         s.is_valid_distance_deviation;
 }
 
 void PlanningValidator::displayStatus()
@@ -447,6 +468,7 @@ void PlanningValidator::displayStatus()
 
   const auto & s = validation_status_;
 
+  warn(s.is_valid_size, "planning trajectory size is invalid, too small.");
   warn(s.is_valid_curvature, "planning trajectory curvature is too large!!");
   warn(s.is_valid_distance_deviation, "planning trajectory is too far from ego!!");
   warn(s.is_valid_finite_value, "planning trajectory has invalid value!!");


### PR DESCRIPTION
## Description

Add a trajectory size check in the planning validator. Before, the `planning_validator` does not perform any validation for trajectories with less than 3 trajectory points. After, the `planning_validator` raises an error for the no-enough-points trajectory.

## Related links

[TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-4973)

## Tests performed

1. change planning_validator publish policy to 1 or 2: https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml/#L7
2. run psim
3. publish an empty trajectory and check if the control module won't show any error message on the terminal.

```sh
$ ros2 topic pub /planning/scenario_planning/motion_velocity_smoother/trajectory autoware_auto_planning_msgs/msg/Trajectory "{header: {frame_id: "base_link"}}"
```


**Before**

The trajectory_follower shows an error message, and the planning_evaluator process died.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/4e243167-56da-405a-9e46-888dac0d5d2a)


**After**

Error raised only from the planing_validator.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/2ca240e1-1bc8-4971-9048-4e60b246b6a7)


## Notes for reviewers

None

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
