### PR TITLE
feat(system_error_monitor): enable invalid trajectory size diag

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/planning.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/planning.param.yaml
@@ -22,6 +22,12 @@
               type: diagnostic_aggregator/AnalyzerGroup
               path: trajectory_validation
               analyzers:
+                trajectory_size:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: trajectory_validation_size
+                  contains: [": trajectory_validation_size"]
+                  timeout: 1.0
+
                 trajectory_finite_value:
                   type: diagnostic_aggregator/GenericAnalyzer
                   path: trajectory_validation_finite


### PR DESCRIPTION
## Description

Enable error diag handling for invalid trajectory size. This is for https://github.com/autowarefoundation/autoware.universe/pull/6126.

## Related links

None

## Tests performed

1. Run psim. 
2. publish empty trajectory as follows.
```
$ ros2 topic pub /planning/scenario_planning/motion_velocity_smoother/trajectory autoware_auto_planning_msgs/msg/Trajectory "{header: {stamp: now, frame_id: "base_link"}}"
```
3. check if the error handling is performed on the terminal message. 

for `/diagnostics` topic, 
```
    sec: 1705844112
    nanosec: 527912365
  frame_id: ''
status:
- level: "\x02"
  name: 'planning_validator: trajectory_validation_size'
  message: invalid trajectory size is found
  hardware_id: planning_validator
  values: []
```

for `/system/emergency/hazard_status` topic, 
```
  - level: "\x02"
    name: '/autoware/planning/performance_monitoring/trajectory_validation/trajectory_validation_size/planning_validator: trajectory_valida...'
    message: invalid trajectory size is found
    hardware_id: planning_validator
    values: []
```


![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/1000e75d-2865-494b-ada0-dce581a8677e)


## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

Error handling is performed for the invalid size trajectory.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
