### PR TITLE
fix(planning_evaluator): fix crashes with empty trajectories

### DIFF
--- a/evaluator/planning_evaluator/src/metrics/trajectory_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/trajectory_metrics.cpp
@@ -125,7 +125,7 @@ Stat<double> calcTrajectoryLength(const Trajectory & traj)
 Stat<double> calcTrajectoryDuration(const Trajectory & traj)
 {
   double duration = 0.0;
-  for (size_t i = 0; i < traj.points.size() - 1; ++i) {
+  for (size_t i = 0; i + 1 < traj.points.size(); ++i) {
     const double length = calcDistance2d(traj.points.at(i), traj.points.at(i + 1));
     const double velocity = traj.points.at(i).longitudinal_velocity_mps;
     if (velocity != 0) {
@@ -158,7 +158,7 @@ Stat<double> calcTrajectoryAcceleration(const Trajectory & traj)
 Stat<double> calcTrajectoryJerk(const Trajectory & traj)
 {
   Stat<double> stat;
-  for (size_t i = 0; i < traj.points.size() - 1; ++i) {
+  for (size_t i = 0; i + 1 < traj.points.size(); ++i) {
     const double vel = traj.points.at(i).longitudinal_velocity_mps;
     if (vel != 0) {
       const double duration =


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Crashes were caused by subtracting 1 from unsigned integer (`size_t`), causing crashes with empty trajectories (where the size = 0).

To reproduce the crash, you can publish an empty trajectory with the following command:
```
ros2 topic pub /planning/scenario_planning/trajectory autoware_auto_planning_msgs/msg/Trajectory "{header: {stamp: now, frame_id: "base_link"}}"
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
PSim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
