### PR TITLE
fix(raw_vehicle_cmd_converter): fix parameter files to parse path to csv files

### DIFF
--- a/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -6,6 +6,7 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
   <arg name="initial_engage_state" default="false" description="/vehicle/engage state after starting Autoware"/>
   <arg name="config_dir" default="$(find-pkg-share $(var sensor_model)_description)/config" description="path to dir where sensors_calibration.yaml, etc. are located"/>
+  <arg name="raw_vehicle_cmd_converter_param_path" default="$(find-pkg-share raw_vehicle_cmd_converter)/config/raw_vehicle_cmd_converter.param.yaml"/>
 
   <let name="vehicle_launch_pkg" value="$(find-pkg-share $(var vehicle_model)_launch)"/>
 
@@ -21,6 +22,7 @@
   <group if="$(var launch_vehicle_interface)">
     <include file="$(var vehicle_launch_pkg)/launch/vehicle_interface.launch.xml">
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
+      <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
     </include>
   </group>

--- a/vehicle/raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
+++ b/vehicle/raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
@@ -1,8 +1,5 @@
 /**:
   ros__parameters:
-    csv_path_accel_map: "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/accel_map.csv"
-    csv_path_brake_map: "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/brake_map.csv"
-    csv_path_steer_map: "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/steer_map.csv"
     convert_accel_cmd: true
     convert_brake_cmd: true
     convert_steer_cmd: true

--- a/vehicle/raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
+++ b/vehicle/raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="csv_path_accel_map" default="$(find-pkg-share raw_vehicle_cmd_converter)/data/default/accel_map.csv"/>
+  <arg name="csv_path_brake_map" default="$(find-pkg-share raw_vehicle_cmd_converter)/data/default/brake_map.csv"/>
+  <arg name="csv_path_steer_map" default="$(find-pkg-share raw_vehicle_cmd_converter)/data/default/steer_map.csv"/>
+
   <arg name="input_control_cmd" default="/control/command/control_cmd"/>
   <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_steering" default="/vehicle/status/steering_status"/>
@@ -9,6 +13,9 @@
 
   <node pkg="raw_vehicle_cmd_converter" exec="raw_vehicle_cmd_converter_node" name="raw_vehicle_cmd_converter" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
+    <param name="csv_path_accel_map" value="$(var csv_path_accel_map)"/>
+    <param name="csv_path_brake_map" value="$(var csv_path_brake_map)"/>
+    <param name="csv_path_steer_map" value="$(var csv_path_steer_map)"/>
     <remap from="~/input/control_cmd" to="$(var input_control_cmd)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
     <remap from="~/input/steering" to="$(var input_steering)"/>

--- a/vehicle/raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
+++ b/vehicle/raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
@@ -6,21 +6,6 @@
     "raw_vehicle_cmd_converter": {
       "type": "object",
       "properties": {
-        "csv_path_accel_map": {
-          "type": "string",
-          "description": "path for acceleration map csv file",
-          "default": "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/accel_map.csv"
-        },
-        "csv_path_brake_map": {
-          "type": "string",
-          "description": "path for brake map csv file",
-          "default": "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/brake_map.csv"
-        },
-        "csv_path_steer_map": {
-          "type": "string",
-          "description": "path for steer map csv file",
-          "default": "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/steer_map.csv"
-        },
         "convert_accel_cmd": {
           "type": "boolean",
           "description": "use accel or not",


### PR DESCRIPTION
## Description

According to https://github.com/autowarefoundation/autoware.universe/pull/5134, some parameters are moved into yaml files.
However, if we launch `raw_vehicle_cmd_converter` from `autoware_launch`, some parameters defined in launch files does not appear.

In this change, I fixed above problems.

accel/brake/steer map path should change at launch, so I removed `csv_path_**_map` from yaml file and add them into xml file.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
