### PR TITLE
fix(dynamic_avoidance): remove cerr

### DIFF
--- a/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
@@ -1221,7 +1221,6 @@ std::optional<MinMaxValue> DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoi
       prev_object->ref_path_points_for_obj_poly,
       ref_path_points_for_obj_poly.at(obj_point_idx).point.pose.position));
 
-    std::cerr << paths_lat_diff << std::endl;
     constexpr double min_paths_lat_diff = 0.3;
     if (paths_lat_diff < min_paths_lat_diff) {
       return true;


### PR DESCRIPTION
## Description

It seems debug `cerr` is still remaining.

```
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                                                                                             
[component_container_mt-29] 0                                   
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
