### PR TITLE
revert(perf_ring_outlier_filter): temporal revert for further investigation

### DIFF
--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -22,12 +22,13 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 
 ### Core Parameters
 
-| Name                      | Type    | Default Value | Description |
-| ------------------------- | ------- | ------------- | ----------- |
-| `distance_ratio`          | double  | 1.03          |             |
-| `object_length_threshold` | double  | 0.1           |             |
-| `num_points_threshold`    | int     | 4             |             |
-| `max_rings_num`           | uint_16 | 128           |             |
+| Name                      | Type    | Default Value | Description                                                                         |
+| ------------------------- | ------- | ------------- | ----------------------------------------------------------------------------------- |
+| `distance_ratio`          | double  | 1.03          |                                                                                     |
+| `object_length_threshold` | double  | 0.1           |                                                                                     |
+| `num_points_threshold`    | int     | 4             |                                                                                     |
+| `max_rings_num`           | uint_16 | 128           |                                                                                     |
+| `max_points_num_per_ring` | size_t  | 4000          | Set this value large enough such that `HFoV / resolution < max_points_num_per_ring` |
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -46,12 +46,28 @@ private:
   double object_length_threshold_;
   int num_points_threshold_;
   uint16_t max_rings_num_;
+  size_t max_points_num_per_ring_;
 
   /** \brief Parameter service callback result : needed to be hold */
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   /** \brief Parameter service callback */
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
+
+  bool isCluster(
+    const PointCloud2ConstPtr & input, std::pair<int, int> data_idx_both_ends, int walk_size)
+  {
+    if (walk_size > num_points_threshold_) return true;
+
+    auto first_point = reinterpret_cast<const PointXYZI *>(&input->data[data_idx_both_ends.first]);
+    auto last_point = reinterpret_cast<const PointXYZI *>(&input->data[data_idx_both_ends.second]);
+
+    const auto x = first_point->x - last_point->x;
+    const auto y = first_point->y - last_point->y;
+    const auto z = first_point->z - last_point->z;
+
+    return x * x + y * y + z * z >= object_length_threshold_ * object_length_threshold_;
+  }
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -31,7 +31,6 @@
   <depend>pcl_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>point_cloud_msg_wrapper</depend>
-  <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
## Description

This reverts commit e45c1ce8df336aef408650532b0477dd174ae27d.
It reduces computation time of ring_outlier_filter, but also results in missing points for pointpainting.

Part of the concatenated/pointcloud is lost when pointpainting module [filtering the points out of the range](https://github.com/autowarefoundation/autoware.universe/blob/main/perception/image_projection_based_fusion/src/pointpainting_fusion/node.cpp#L239-L241), while they actually lie within the range. This leads to the misdetection of the bus, because only half of its pointcloud is input to the network.
- blue points: /sensing/lidar/concatenated/pointcloud
- red points: /perception/object_recognition/detection/pointpainting/output
- blue bounding boxes: /perception/object_recognition/detection/objects
![image](https://github.com/autowarefoundation/autoware.universe/assets/55872497/6e87944e-5b05-4421-8080-eab0fa1babd6)

After reverting, the pointcloud is correctly accessed and filtered. As a result, the bus is correctly detected.
![image](https://github.com/autowarefoundation/autoware.universe/assets/55872497/6b51355a-5d40-4a08-b791-0bc6aa1bcac1)

Therefore, it will be reverted for the release of v0.44.0.0, and revisited afterwards.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
