### PR TITLE
fix(gnss_poser): remove gnss_frame from schema.json

### DIFF
--- a/sensing/gnss_poser/schema/gnss_poser.schema.json
+++ b/sensing/gnss_poser/schema/gnss_poser.schema.json
@@ -42,7 +42,6 @@
       },
       "required": [
         "base_frame",
-        "gnss_frame",
         "gnss_base_frame",
         "map_frame",
         "use_gnss_ins_orientation",


### PR DESCRIPTION
## Description

Removed obsolete parameter `gnss_frame` from `gnss_poser.schema.json`

This should have been removed in https://github.com/autowarefoundation/autoware.universe/pull/6116  But it was not.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

This package passes the JSON schema check.
![image](https://github.com/autowarefoundation/autoware.universe/assets/24854875/9fe9f366-2429-48d0-abb7-1aa6b7f36422)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Does not affect.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
