### PR TITLE
fix(avoidance): turn signal doesn't turn on

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -2278,11 +2278,11 @@ TurnSignalInfo calcTurnSignalInfo(
     return {};
   }
 
-  const auto left_lanelets = rh->getAllLeftSharedLinestringLanelets(lanelet, true, true);
-  const auto right_lanelets = rh->getAllRightSharedLinestringLanelets(lanelet, true, true);
+  const auto left_lane = rh->getLeftLanelet(lanelet, true, true);
+  const auto right_lane = rh->getRightLanelet(lanelet, true, true);
 
   if (!existShiftSideLane(
-        start_shift_length, end_shift_length, left_lanelets.empty(), right_lanelets.empty())) {
+        start_shift_length, end_shift_length, !left_lane.has_value(), !right_lane.has_value())) {
     return {};
   }
 


### PR DESCRIPTION
## Description

Turn signal doesn't turn on if the adjacent and current lanelet share its previous lanelet.

[Screencast from 2024年01月23日 16時14分37秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/44889564/00c65d43-2a46-4238-b5d2-9ec094dbf690)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim.

Uploading simplescreenrecorder-2024-01-26_18.11.19.mp4…

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix turn signal bug.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
