### PR TITLE
fix(avoidance): fix bug in turn signal decision

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -2278,11 +2278,15 @@ TurnSignalInfo calcTurnSignalInfo(
     return {};
   }
 
-  const auto left_lane = rh->getLeftLanelet(lanelet, true, true);
-  const auto right_lane = rh->getRightLanelet(lanelet, true, true);
+  const auto left_same_direction_lane = rh->getLeftLanelet(lanelet, true, true);
+  const auto left_opposite_lanes = rh->getLeftOppositeLanelets(lanelet);
+  const auto right_same_direction_lane = rh->getRightLanelet(lanelet, true, true);
+  const auto right_opposite_lanes = rh->getRightOppositeLanelets(lanelet);
+  const auto has_left_lane = left_same_direction_lane.has_value() || !left_opposite_lanes.empty();
+  const auto has_right_lane =
+    right_same_direction_lane.has_value() || !right_opposite_lanes.empty();
 
-  if (!existShiftSideLane(
-        start_shift_length, end_shift_length, !left_lane.has_value(), !right_lane.has_value())) {
+  if (!existShiftSideLane(start_shift_length, end_shift_length, !has_left_lane, !has_right_lane)) {
     return {};
   }
 


### PR DESCRIPTION
## Description

Fix bug caused by https://github.com/autowarefoundation/autoware.universe/pull/6188. Check opposite lane existence.

[CURRENT TEST RESULT](https://evaluation.tier4.jp/evaluation/reports/749ee5ec-b9eb-51d7-ad73-d9793bcc33c2/tests/892400f8-ec6c-51fe-984d-8595d6ba52ad?project_id=prd_jt) (80FAILs: 217/297)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS
](https://evaluation.tier4.jp/evaluation/reports/0d48a29d-80fa-53d3-b043-938a59a63800?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
