### PR TITLE
fix(intersection): judge pass judge at intersection without tl with occlusion detection

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/decision_result.cpp
+++ b/planning/behavior_velocity_intersection_module/src/decision_result.cpp
@@ -19,11 +19,11 @@ namespace behavior_velocity_planner::intersection
 std::string formatDecisionResult(const DecisionResult & decision_result)
 {
   if (std::holds_alternative<InternalError>(decision_result)) {
-    const auto state = std::get<InternalError>(decision_result);
+    const auto & state = std::get<InternalError>(decision_result);
     return "InternalError because " + state.error;
   }
   if (std::holds_alternative<OverPassJudge>(decision_result)) {
-    const auto state = std::get<OverPassJudge>(decision_result);
+    const auto & state = std::get<OverPassJudge>(decision_result);
     return "OverPassJudge:\nsafety_report:" + state.safety_report + "\nevasive_report:\n" +
            state.evasive_report;
   }
@@ -31,11 +31,11 @@ std::string formatDecisionResult(const DecisionResult & decision_result)
     return "StuckStop";
   }
   if (std::holds_alternative<YieldStuckStop>(decision_result)) {
-    const auto state = std::get<YieldStuckStop>(decision_result);
+    const auto & state = std::get<YieldStuckStop>(decision_result);
     return "YieldStuckStop:\nsafety_report:" + state.safety_report;
   }
   if (std::holds_alternative<NonOccludedCollisionStop>(decision_result)) {
-    const auto state = std::get<NonOccludedCollisionStop>(decision_result);
+    const auto & state = std::get<NonOccludedCollisionStop>(decision_result);
     return "NonOccludedCollisionStop\nsafety_report:" + state.safety_report;
   }
   if (std::holds_alternative<FirstWaitBeforeOcclusion>(decision_result)) {
@@ -45,18 +45,18 @@ std::string formatDecisionResult(const DecisionResult & decision_result)
     return "PeekingTowardOcclusion";
   }
   if (std::holds_alternative<OccludedCollisionStop>(decision_result)) {
-    const auto state = std::get<OccludedCollisionStop>(decision_result);
+    const auto & state = std::get<OccludedCollisionStop>(decision_result);
     return "OccludedCollisionStop\nsafety_report:" + state.safety_report;
   }
   if (std::holds_alternative<OccludedAbsenceTrafficLight>(decision_result)) {
-    const auto state = std::get<OccludedAbsenceTrafficLight>(decision_result);
+    const auto & state = std::get<OccludedAbsenceTrafficLight>(decision_result);
     return "OccludedAbsenceTrafficLight\nsafety_report:" + state.safety_report;
   }
   if (std::holds_alternative<Safe>(decision_result)) {
     return "Safe";
   }
   if (std::holds_alternative<FullyPrioritized>(decision_result)) {
-    const auto state = std::get<FullyPrioritized>(decision_result);
+    const auto & state = std::get<FullyPrioritized>(decision_result);
     return "FullyPrioritized\nsafety_report:" + state.safety_report;
   }
   return "";


### PR DESCRIPTION
## Description

Basically pass judge passage is judged when "was_safe". And when occlusion detection is enabled, at intersection without traffic light, "OccludedAbsenceTrafficLight" context is treated as safe in terms of occlusion.

## Related links

https://tier4.atlassian.net/browse/RT1-4771

## Tests performed

intersection occlusion is ON

### Before this PR

the pass judge line is still green after passage

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/63029832-727e-4abc-b8a5-0904b152deca)

### After this PR

the pass judge line turns red after passage

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/bf0c826a-ee38-4906-90e5-dfa000222eb8)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
