### PR TITLE
fix(avoidance_by_lane_change): loosen execution condition

### DIFF
--- a/planning/behavior_path_avoidance_by_lane_change_module/include/behavior_path_avoidance_by_lane_change_module/scene.hpp
+++ b/planning/behavior_path_avoidance_by_lane_change_module/include/behavior_path_avoidance_by_lane_change_module/scene.hpp
@@ -54,6 +54,10 @@ private:
     const AvoidancePlanningData & data, const PredictedObject & object) const;
 
   void fillAvoidanceTargetObjects(AvoidancePlanningData & data, AvoidanceDebugData & debug) const;
+
+  double calcMinAvoidanceLength(const ObjectData & nearest_object) const;
+  double calcMinimumLaneChangeLength() const;
+  double calcLateralOffset() const;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_avoidance_by_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_avoidance_by_lane_change_module/src/interface.cpp
@@ -16,13 +16,9 @@
 
 #include "behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "behavior_path_planner_common/interface/scene_module_visitor.hpp"
-#include "behavior_path_planner_common/marker_utils/utils.hpp"
 
-#include <algorithm>
 #include <memory>
 #include <string>
-#include <utility>
-#include <vector>
 
 namespace behavior_path_planner
 {
@@ -45,7 +41,8 @@ AvoidanceByLaneChangeInterface::AvoidanceByLaneChangeInterface(
 
 bool AvoidanceByLaneChangeInterface::isExecutionRequested() const
 {
-  return module_type_->isLaneChangeRequired() && module_type_->specialRequiredCheck();
+  return module_type_->isLaneChangeRequired() && module_type_->specialRequiredCheck() &&
+         module_type_->isValidPath();
 }
 void AvoidanceByLaneChangeInterface::processOnEntry()
 {

--- a/planning/behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -20,16 +20,21 @@
 #include "behavior_path_planner_common/utils/path_utils.hpp"
 #include "behavior_path_planner_common/utils/utils.hpp"
 
+#include <behavior_path_avoidance_module/data_structs.hpp>
+#include <behavior_path_lane_change_module/utils/utils.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <boost/geometry/algorithms/centroid.hpp>
 #include <boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp>
 
+#include <limits>
 #include <utility>
 
 namespace behavior_path_planner
 {
+using behavior_path_planner::utils::lane_change::debug::createExecutionArea;
+
 AvoidanceByLaneChange::AvoidanceByLaneChange(
   const std::shared_ptr<LaneChangeParameters> & parameters,
   std::shared_ptr<AvoidanceByLCParameters> avoidance_parameters)
@@ -68,44 +73,15 @@ bool AvoidanceByLaneChange::specialRequiredCheck() const
     return false;
   }
 
-  const auto current_lanes = getCurrentLanes();
-  if (current_lanes.empty()) {
-    RCLCPP_DEBUG(logger_, "no empty lanes");
-    return false;
-  }
-
   const auto & nearest_object = data.target_objects.front();
+  const auto minimum_avoid_length = calcMinAvoidanceLength(nearest_object);
+  const auto minimum_lane_change_length = calcMinimumLaneChangeLength();
 
-  // get minimum lane change distance
-  const auto shift_intervals =
-    getRouteHandler()->getLateralIntervalsToPreferredLane(current_lanes.back(), direction_);
-  const double minimum_lane_change_length = utils::lane_change::calcMinimumLaneChangeLength(
-    *lane_change_parameters_, shift_intervals,
-    lane_change_parameters_->backward_length_buffer_for_end_of_lane);
+  lane_change_debug_.execution_area = createExecutionArea(
+    getCommonParam().vehicle_info, getEgoPose(),
+    std::max(minimum_lane_change_length, minimum_avoid_length), calcLateralOffset());
 
-  // get minimum avoid distance
-
-  const auto ego_width = getCommonParam().vehicle_width;
-  const auto nearest_object_type = utils::getHighestProbLabel(nearest_object.object.classification);
-  const auto nearest_object_parameter =
-    avoidance_parameters_->object_parameters.at(nearest_object_type);
-  const auto avoid_margin =
-    nearest_object_parameter.safety_buffer_lateral * nearest_object.distance_factor +
-    nearest_object_parameter.avoid_margin_lateral + 0.5 * ego_width;
-
-  avoidance_helper_->setData(planner_data_);
-  const auto shift_length = avoidance_helper_->getShiftLength(
-    nearest_object, utils::avoidance::isOnRight(nearest_object), avoid_margin);
-
-  const auto maximum_avoid_distance = avoidance_helper_->getMaxAvoidanceDistance(shift_length);
-
-  RCLCPP_DEBUG(
-    logger_,
-    "nearest_object.longitudinal %.3f, minimum_lane_change_length %.3f, maximum_avoid_distance "
-    "%.3f",
-    nearest_object.longitudinal, minimum_lane_change_length, maximum_avoid_distance);
-
-  return nearest_object.longitudinal > std::max(minimum_lane_change_length, maximum_avoid_distance);
+  return nearest_object.longitudinal > std::max(minimum_lane_change_length, minimum_avoid_length);
 }
 
 bool AvoidanceByLaneChange::specialExpiredCheck() const
@@ -273,5 +249,49 @@ ObjectData AvoidanceByLaneChange::createObjectData(
   utils::avoidance::fillAvoidanceNecessity(object_data, registered_objects_, vehicle_width, p);
 
   return object_data;
+}
+
+double AvoidanceByLaneChange::calcMinAvoidanceLength(const ObjectData & nearest_object) const
+{
+  const auto ego_width = getCommonParam().vehicle_width;
+  const auto nearest_object_type = utils::getHighestProbLabel(nearest_object.object.classification);
+  const auto nearest_object_parameter =
+    avoidance_parameters_->object_parameters.at(nearest_object_type);
+  const auto avoid_margin =
+    nearest_object_parameter.safety_buffer_lateral * nearest_object.distance_factor +
+    nearest_object_parameter.avoid_margin_lateral + 0.5 * ego_width;
+
+  avoidance_helper_->setData(planner_data_);
+  const auto shift_length = avoidance_helper_->getShiftLength(
+    nearest_object, utils::avoidance::isOnRight(nearest_object), avoid_margin);
+
+  return avoidance_helper_->getMinAvoidanceDistance(shift_length);
+}
+
+double AvoidanceByLaneChange::calcMinimumLaneChangeLength() const
+{
+  const auto current_lanes = getCurrentLanes();
+  if (current_lanes.empty()) {
+    RCLCPP_DEBUG(logger_, "no empty lanes");
+    return std::numeric_limits<double>::infinity();
+  }
+
+  // get minimum lane change distance
+  const auto shift_intervals =
+    getRouteHandler()->getLateralIntervalsToPreferredLane(current_lanes.back(), direction_);
+  return utils::lane_change::calcMinimumLaneChangeLength(
+    *lane_change_parameters_, shift_intervals,
+    lane_change_parameters_->backward_length_buffer_for_end_of_lane);
+}
+
+double AvoidanceByLaneChange::calcLateralOffset() const
+{
+  auto additional_lat_offset{0.0};
+  for (const auto & [type, p] : avoidance_parameters_->object_parameters) {
+    const auto offset =
+      2.0 * p.envelope_buffer_margin + p.safety_buffer_lateral + p.avoid_margin_lateral;
+    additional_lat_offset = std::max(additional_lat_offset, offset);
+  }
+  return additional_lat_offset;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/debug_structs.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/debug_structs.hpp
@@ -19,6 +19,8 @@
 
 #include <behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp>
 
+#include <geometry_msgs/msg/detail/polygon__struct.hpp>
+
 #include <string>
 
 namespace behavior_path_planner::data::lane_change
@@ -31,6 +33,7 @@ struct Debug
   CollisionCheckDebugMap collision_check_objects;
   CollisionCheckDebugMap collision_check_objects_after_approval;
   LaneChangeTargetObjects filtered_objects;
+  geometry_msgs::msg::Polygon execution_area;
   double collision_check_object_debug_lifetime{0.0};
 
   void reset()

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/markers.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/markers.hpp
@@ -19,6 +19,7 @@
 #include "behavior_path_lane_change_module/utils/path.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 
+#include <geometry_msgs/msg/detail/polygon__struct.hpp>
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -40,6 +41,8 @@ MarkerArray showFilteredObjects(
   const ExtendedPredictedObjects & current_lane_objects,
   const ExtendedPredictedObjects & target_lane_objects,
   const ExtendedPredictedObjects & other_lane_objects, const std::string & ns);
+MarkerArray createExecutionArea(const geometry_msgs::msg::Polygon & execution_area);
 MarkerArray createDebugMarkerArray(const Debug & debug_data);
+
 }  // namespace marker_utils::lane_change_markers
 #endif  // BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__MARKERS_HPP_

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
@@ -225,4 +225,14 @@ lanelet::ConstLanelets generateExpandedLanelets(
  */
 rclcpp::Logger getLogger(const std::string & type);
 }  // namespace behavior_path_planner::utils::lane_change
+
+namespace behavior_path_planner::utils::lane_change::debug
+{
+geometry_msgs::msg::Point32 create_point32(const geometry_msgs::msg::Pose & pose);
+
+geometry_msgs::msg::Polygon createExecutionArea(
+  const vehicle_info_util::VehicleInfo & vehicle_info, const Pose & pose,
+  double additional_lon_offset, double additional_lat_offset);
+}  // namespace behavior_path_planner::utils::lane_change::debug
+
 #endif  // BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -15,7 +15,6 @@
 #include "behavior_path_lane_change_module/scene.hpp"
 
 #include "behavior_path_lane_change_module/utils/utils.hpp"
-#include "behavior_path_planner_common/marker_utils/utils.hpp"
 #include "behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp"
@@ -33,7 +32,6 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/planning/behavior_path_lane_change_module/src/utils/markers.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/markers.cpp
@@ -162,6 +162,11 @@ MarkerArray createDebugMarkerArray(const Debug & debug_data)
       "ego_and_target_polygon_relation_after_approval"));
   }
 
+  if (!debug_data.execution_area.points.empty()) {
+    add(createPolygonMarkerArray(
+      debug_data.execution_area, "execution_area", 0, 0.16, 1.0, 0.69, 0.1));
+  }
+
   return debug_marker;
 }
 }  // namespace marker_utils::lane_change_markers


### PR DESCRIPTION
## Description

Previous avoidance by lane change execution condition uses maximum_avoidance_distance. This cause AbLC to be difficult to be execution.
Also there is no way to know visually about the execution check area.

This PR aims to solve two things
1. Use minimum avoidance distance and adopted freenet convention, `length` for longitudinal distance. `min_avoidance_length` is now used.
2. Added debug marker to visualize execution request condition area.
3. Slight refactoring so that `isExecutionRequested` function is not too long.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
