### PR TITLE
fix(map_loader): change error handling when pcd_metadata file not found

### DIFF
--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -90,8 +90,9 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
 {
   std::map<std::string, PCDFileMetadata> pcd_metadata_dict;
   if (pcd_paths.size() != 1) {
-    if (!fs::exists(pcd_metadata_path)) {
-      throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
+    while (!fs::exists(pcd_metadata_path)) {
+      RCLCPP_ERROR_STREAM(get_logger(), "PCD metadata file not found: " << pcd_metadata_path);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);


### PR DESCRIPTION
## Description

When using a divided map, `pointcloud_map_metadata.yaml` is required.
However, when autoware was run without it, the cause was not displayed in the error message.

This pull request has been modified so that the following error message appears once per second.

```
[map.pointcloud_map_loader]: PCD metadata file not found: /path/to/pointcloud_map_metadata.yaml
```

<details>

<summary>Example of error messages that appears on the screen</summary>

```
[component_container-27] [ERROR] [1706590993.214443999] [map.pointcloud_map_loader]: PCD metadata file not found: /home/shintarosakoda/Downloads/nishishinjuku_autoware_map_divided_without_metadata/pointcloud_map_metadata.yaml
[scenario_selector-68] [INFO] [1706590993.254920052] [planning.scenario_planning.scenario_selector]: Waiting for current pose.
[rviz2-82] [INFO] [1706590993.268865110] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.083 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590993.396571425] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.183 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590993.463349786] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.283 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590993.588860103] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.383 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590993.684589796] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.483 for reason 'discarding message because the queue is full'
[component_container-76] [INFO] [1706590993.707601195] [control.trajectory_follower.controller_node_exe]: Waiting for trajectory.
[component_container-76] [INFO] [1706590993.707680319] [control.trajectory_follower.controller_node_exe]: Control is skipped since input data is not ready.
[rviz2-82] [INFO] [1706590993.780842434] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.583 for reason 'discarding message because the queue is full'
[component_container-76] [INFO] [1706590993.857439456] [control.trajectory_follower.lane_departure_checker_node]: waiting for current_twist msg...
[rviz2-82] [INFO] [1706590993.876582624] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.683 for reason 'discarding message because the queue is full'
[ndt_scan_matcher-36] [INFO] [1706590993.930756094] [localization.pose_estimator.ndt_scan_matcher]: Waiting for pcd loader service. Check the pointcloud_map_loader.
[rviz2-82] [INFO] [1706590993.973515148] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.783 for reason 'discarding message because the queue is full'
[component_container_mt-71] [INFO] [1706590994.029525023] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner]: waiting for scenario_topic
[component_container_mt-1] [INFO] [1706590994.095233718] [perception.object_recognition.detection.voxel_based_compare_map_filter]: service not available, waiting again ...
[rviz2-82] [INFO] [1706590994.100704500] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.883 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.164888226] [rviz2]: Message Filter dropping message: frame 'base_link' at time 67.983 for reason 'discarding message because the queue is full'
[component_container-27] [ERROR] [1706590994.214579152] [map.pointcloud_map_loader]: PCD metadata file not found: /home/shintarosakoda/Downloads/nishishinjuku_autoware_map_divided_without_metadata/pointcloud_map_metadata.yaml
[rviz2-82] [INFO] [1706590994.293013012] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.083 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.389248047] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.183 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.485010621] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.283 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.580677308] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.383 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.645155357] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.483 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.821647231] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.583 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590994.853816203] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.683 for reason 'discarding message because the queue is full'
[ndt_scan_matcher-36] [INFO] [1706590994.931021846] [localization.pose_estimator.ndt_scan_matcher]: Waiting for pcd loader service. Check the pointcloud_map_loader.
[rviz2-82] [INFO] [1706590994.980618426] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.783 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.076895840] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.883 for reason 'discarding message because the queue is full'
[component_container_mt-1] [INFO] [1706590995.095719142] [perception.object_recognition.detection.voxel_based_compare_map_filter]: service not available, waiting again ...
[component_container-27] [ERROR] [1706590995.214654536] [map.pointcloud_map_loader]: PCD metadata file not found: /home/shintarosakoda/Downloads/nishishinjuku_autoware_map_divided_without_metadata/pointcloud_map_metadata.yaml
[ekf_localizer-40] [WARN] [1706590995.225584397] [localization.pose_twist_fusion_filter.ekf_localizer]: The node is not activated. Provide initial pose to pose_initializer
[rviz2-82] [INFO] [1706590995.265770357] [rviz2]: Message Filter dropping message: frame 'base_link' at time 68.983 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.297999970] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.083 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.361397183] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.183 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.457273137] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.283 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.584966048] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.383 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.713184015] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.483 for reason 'discarding message because the queue is full'
[rviz2-82] [INFO] [1706590995.777173097] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.583 for reason 'discarding message because the queue is full'
[component_container_mt-77] [INFO] [1706590995.852325872] [default_ad_api.node.operation_mode]: control, planning, localization, perception component state is unhealthy. Autonomous is not available.
[rviz2-82] [INFO] [1706590995.872599750] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.683 for reason 'discarding message because the queue is full'
[ndt_scan_matcher-36] [INFO] [1706590995.931498228] [localization.pose_estimator.ndt_scan_matcher]: Waiting for pcd loader service. Check the pointcloud_map_loader.
[rviz2-82] [INFO] [1706590996.001703225] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.783 for reason 'discarding message because the queue is full'
[component_container_mt-1] [INFO] [1706590996.096227737] [perception.object_recognition.detection.voxel_based_compare_map_filter]: service not available, waiting again ...
[rviz2-82] [INFO] [1706590996.097127921] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.883 for reason 'discarding message because the queue is full'
[component_container-66] [INFO] [1706590996.181444623] [planning.mission_planning.mission_planner]: waiting odometry... Route API is not ready.
[rviz2-82] [INFO] [1706590996.193463338] [rviz2]: Message Filter dropping message: frame 'base_link' at time 69.983 for reason 'discarding message because the queue is full'
[component_container-27] [ERROR] [1706590996.214784703] [map.pointcloud_map_loader]: PCD metadata file not found: /home/shintarosakoda/Downloads/nishishinjuku_autoware_map_divided_without_metadata/pointcloud_map_metadata.yaml

```

</details>

Note: If you place the `pointcloud_map_metadata.yaml` after the error message appears, the `map_loader` startup sequence itself will probably proceed, but it is unclear whether other Autoware modules will work properly after a long wait. It is safer to restart Autoware.

## Tests performed

* It has been confirmed that Autoware works properly if `pointcloud_map_metadata.yaml` is present (in AWSIM).
* It has been confirmed that the above error message continues to appear if `pointcloud_map_metadata.yaml` is missing (in AWSIM).

## Effects on system behavior

The error message will change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
