### PR TITLE
feat(mkdocs_macros): ignore  when creating a table

### DIFF
--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -42,6 +42,8 @@ def format_param_range(param):
 def extract_parameter_info(parameters, namespace=""):
     params = []
     for k, v in parameters.items():
+        if "$ref" in v.keys():
+            continue
         if v["type"] != "object":
             param = {}
             param["Name"] = namespace + k


### PR DESCRIPTION
## Description


I want to add an item to properties in [this part](https://github.com/autowarefoundation/autoware.universe/blob/2d819a3a217562e1df5cd43ba7274813add77f08/localization/ndt_scan_matcher/schema/sub/ndt.json#L38-L40) of [this PR](https://github.com/autowarefoundation/autoware.universe/pull/6229
), just for reference. However, when creating a table in a JSON file, it gives the following error.

![Screenshot from 2024-01-30 15-40-30](https://github.com/autowarefoundation/autoware.universe/assets/13819566/d029d5f7-bcdc-4609-a9d9-58a8b69e04a8)

So, if an item contains $ref, I would like to exclude it from the table creation.


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

 browse several pages using  `mkdocs serve` and confirmed that the formatting is not distorted.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
