### PR TITLE
feat(obstacle_cruise_planner): yield function for ocp

### DIFF
--- a/planning/obstacle_cruise_planner/README.md
+++ b/planning/obstacle_cruise_planner/README.md
@@ -108,7 +108,8 @@ The obstacles meeting the following condition are determined as obstacles for cr
 | `behavior_determination.cruise.outside_obstacle.obstacle_velocity_threshold`         | double | maximum obstacle velocity for cruise obstacle outside the trajectory |
 | `behavior_determination.cruise.outside_obstacle.ego_obstacle_overlap_time_threshold` | double | maximum overlap time of the collision between the ego and obstacle   |
 
-##### Yield for vehicles that might cut in
+##### Yield for vehicles that might cut in into the ego's lane
+
 It is also possible to yield (cruise) behind vehicles in neighbor lanes if said vehicles might cut in the ego vehicle's current lane.
 
 The obstacles meeting the following condition are determined as obstacles for yielding (cruising).

--- a/planning/obstacle_cruise_planner/README.md
+++ b/planning/obstacle_cruise_planner/README.md
@@ -108,6 +108,19 @@ The obstacles meeting the following condition are determined as obstacles for cr
 | `behavior_determination.cruise.outside_obstacle.obstacle_velocity_threshold`         | double | maximum obstacle velocity for cruise obstacle outside the trajectory |
 | `behavior_determination.cruise.outside_obstacle.ego_obstacle_overlap_time_threshold` | double | maximum overlap time of the collision between the ego and obstacle   |
 
+##### Yield for vehicles that might cut in
+It is also possible to yield (cruise) behind vehicles in neighbor lanes if said vehicles might cut in the ego vehicle's current lane.
+
+The obstacles meeting the following condition are determined as obstacles for yielding (cruising).
+
+- The object type is for cruising according to `common.cruise_obstacle_type.*` and it is moving with a speed greater than `behavior_determination.cruise.yield.stopped_obstacle_velocity_threshold`.
+- The object is not crossing the ego's trajectory (\*1).
+- There is another object of type `common.cruise_obstacle_type.*` stopped in front of the moving obstacle.
+- The lateral distance (using the ego's trajectory as reference) between both obstacles is less than `behavior_determination.cruise.yield.max_lat_dist_between_obstacles`
+- Both obstacles, moving and stopped, are within `behavior_determination.cruise.yield.lat_distance_threshold` and `behavior_determination.cruise.yield.lat_distance_threshold` + `behavior_determination.cruise.yield.max_lat_dist_between_obstacles` lateral distance from the ego's trajectory respectively.
+
+If the above conditions are met, the ego vehicle will cruise behind the moving obstacle, yielding to it so it can cut in into the ego's lane to avoid the stopped obstacle.
+
 #### Determine stop vehicles
 
 Among obstacles which are not for cruising, the obstacles meeting the following condition are determined as obstacles for stopping.

--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -96,7 +96,7 @@
           ego_obstacle_overlap_time_threshold : 2.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
         yield:
-          enable_yield: true
+          enable_yield: false
           lat_distance_threshold: 5.0 # lateral margin between obstacle in neighbor lanes and trajectory band with ego's width for yielding
           max_lat_dist_between_obstacles: 2.5 # lateral margin between moving obstacle in neighbor lanes and stopped obstacle in front of it
           max_obstacles_collision_time: 10.0 # how far the blocking obstacle

--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -95,7 +95,12 @@
           obstacle_velocity_threshold : 3.5 # minimum velocity threshold of obstacles outside the trajectory to cruise or stop [m/s]
           ego_obstacle_overlap_time_threshold : 2.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
-
+        yield:
+          enable_yield: true
+          lat_distance_threshold: 5.0 # lateral margin between obstacle in neighbor lanes and trajectory band with ego's width for yielding
+          max_lat_dist_between_obstacles: 2.5 # lateral margin between moving obstacle in neighbor lanes and stopped obstacle in front of it
+          max_obstacles_collision_time: 10.0 # how far the blocking obstacle
+          stopped_obstacle_velocity_threshold: 0.5
       slow_down:
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -55,7 +55,8 @@ struct Obstacle
 {
   Obstacle(
     const rclcpp::Time & arg_stamp, const PredictedObject & object,
-    const geometry_msgs::msg::Pose & arg_pose)
+    const geometry_msgs::msg::Pose & arg_pose, const double ego_to_obstacle_distance,
+    const double lat_dist_from_obstacle_to_traj)
   : stamp(arg_stamp),
     pose(arg_pose),
     orientation_reliable(true),
@@ -63,7 +64,9 @@ struct Obstacle
     twist_reliable(true),
     classification(object.classification.at(0)),
     uuid(tier4_autoware_utils::toHexString(object.object_id)),
-    shape(object.shape)
+    shape(object.shape),
+    ego_to_obstacle_distance(ego_to_obstacle_distance),
+    lat_dist_from_obstacle_to_traj(lat_dist_from_obstacle_to_traj)
   {
     predicted_paths.clear();
     for (const auto & path : object.kinematics.predicted_paths) {
@@ -82,6 +85,8 @@ struct Obstacle
   std::string uuid;
   Shape shape;
   std::vector<PredictedPath> predicted_paths;
+  double ego_to_obstacle_distance;
+  double lat_dist_from_obstacle_to_traj;
 };
 
 struct TargetObstacleInterface

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -72,7 +72,7 @@ private:
     const Obstacle & obstacle) const;
   std::optional<CruiseObstacle> createYieldCruiseObstacle(
     const Obstacle & obstacle, const std::vector<TrajectoryPoint> & traj_points);
-  std::optional<CruiseObstacle> findYieldCruiseObstacle(
+  std::optional<std::vector<CruiseObstacle>> findYieldCruiseObstacles(
     const std::vector<Obstacle> & obstacles, const std::vector<TrajectoryPoint> & traj_points);
   std::optional<CruiseObstacle> createCruiseObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -202,6 +202,8 @@ private:
     // consideration for the current ego pose
     bool enable_to_consider_current_pose{false};
     bool enable_yield{false};
+    double yield_lat_distance_threshold;
+    double max_lat_dist_between_obstacles;
     double time_to_convergence{1.5};
   };
   BehaviorDeterminationParam behavior_determination_param_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -200,11 +200,13 @@ private:
     int successive_num_to_entry_slow_down_condition;
     int successive_num_to_exit_slow_down_condition;
     // consideration for the current ego pose
+    double time_to_convergence{1.5};
     bool enable_to_consider_current_pose{false};
+    // yield related parameters
     bool enable_yield{false};
     double yield_lat_distance_threshold;
     double max_lat_dist_between_obstacles;
-    double time_to_convergence{1.5};
+    double max_obstacles_collision_time;
   };
   BehaviorDeterminationParam behavior_determination_param_;
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -201,7 +201,7 @@ private:
     int successive_num_to_exit_slow_down_condition;
     // consideration for the current ego pose
     bool enable_to_consider_current_pose{false};
-    bool allow_yield{false};
+    bool enable_yield{false};
     double time_to_convergence{1.5};
   };
   BehaviorDeterminationParam behavior_determination_param_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -206,6 +206,7 @@ private:
     bool enable_yield{false};
     double yield_lat_distance_threshold;
     double max_lat_dist_between_obstacles;
+    double stopped_obstacle_velocity_threshold;
     double max_obstacles_collision_time;
   };
   BehaviorDeterminationParam behavior_determination_param_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -70,6 +70,10 @@ private:
   std::optional<geometry_msgs::msg::Point> createCollisionPointForStopObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle) const;
+  std::optional<CruiseObstacle> createYieldCruiseObstacle(
+    const Obstacle & obstacle, const std::vector<TrajectoryPoint> & traj_points);
+  std::optional<CruiseObstacle> findYieldCruiseObstacle(
+    const std::vector<Obstacle> & obstacles, const std::vector<TrajectoryPoint> & traj_points);
   std::optional<CruiseObstacle> createCruiseObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle, const double precise_lat_dist);
@@ -197,6 +201,7 @@ private:
     int successive_num_to_exit_slow_down_condition;
     // consideration for the current ego pose
     bool enable_to_consider_current_pose{false};
+    bool allow_yield{false};
     double time_to_convergence{1.5};
   };
   BehaviorDeterminationParam behavior_determination_param_;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -640,7 +640,7 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
     }
 
     // 3. Check if rough lateral distance is smaller than the threshold
-    double lat_dist_from_obstacle_to_traj =
+    const double lat_dist_from_obstacle_to_traj =
       motion_utils::calcLateralOffset(traj_points, current_obstacle_pose.pose.position);
 
     const double min_lat_dist_to_traj_poly = [&]() {

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -928,8 +928,7 @@ std::optional<CruiseObstacle> ObstacleCruisePlannerNode::createYieldCruiseObstac
 
   if (!collision_points) return std::nullopt;
   const auto [tangent_vel, normal_vel] = projectObstacleVelocityToTrajectory(traj_points, obstacle);
-  // obstacle is driving on the opposite direction
-  std::cerr << "tangent_vel " << tangent_vel << "\n";
+  // check if obstacle is driving on the opposite direction
   if (tangent_vel < 0.0) return std::nullopt;
   return CruiseObstacle{obstacle.uuid, obstacle.stamp, obstacle.pose,
                         tangent_vel,   normal_vel,     collision_points.value()};

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -248,7 +248,7 @@ ObstacleCruisePlannerNode::BehaviorDeterminationParam::BehaviorDeterminationPara
     node.declare_parameter<double>("behavior_determination.stop.max_lat_margin");
   max_lat_margin_for_cruise =
     node.declare_parameter<double>("behavior_determination.cruise.max_lat_margin");
-  allow_yield = node.declare_parameter<bool>("behavior_determination.cruise.allow_yield");
+  enable_yield = node.declare_parameter<bool>("behavior_determination.cruise.enable_yield");
   max_lat_margin_for_slow_down =
     node.declare_parameter<double>("behavior_determination.slow_down.max_lat_margin");
   lat_hysteresis_margin_for_slow_down =
@@ -305,7 +305,7 @@ void ObstacleCruisePlannerNode::BehaviorDeterminationParam::onParam(
   tier4_autoware_utils::updateParam<double>(
     parameters, "behavior_determination.cruise.max_lat_margin", max_lat_margin_for_cruise);
   tier4_autoware_utils::updateParam<bool>(
-    parameters, "behavior_determination.slow_down.allow_yield", allow_yield);
+    parameters, "behavior_determination.cruise.enable_yield", enable_yield);
   tier4_autoware_utils::updateParam<double>(
     parameters, "behavior_determination.slow_down.max_lat_margin", max_lat_margin_for_slow_down);
   tier4_autoware_utils::updateParam<double>(
@@ -646,7 +646,7 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
   }
 
   // Sort from closest to farthest obstacle
-  if (behavior_determination_param_.allow_yield) {
+  if (behavior_determination_param_.enable_yield) {
     std::sort(
       target_obstacles.begin(), target_obstacles.end(), [](const auto & o1, const auto & o2) {
         return o1.ego_to_obstacle_distance < o2.ego_to_obstacle_distance;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -928,6 +928,9 @@ std::optional<CruiseObstacle> ObstacleCruisePlannerNode::createYieldCruiseObstac
 
   if (!collision_points) return std::nullopt;
   const auto [tangent_vel, normal_vel] = projectObstacleVelocityToTrajectory(traj_points, obstacle);
+  // obstacle is driving on the opposite direction
+  std::cerr << "tangent_vel " << tangent_vel << "\n";
+  if (tangent_vel < 0.0) return std::nullopt;
   return CruiseObstacle{obstacle.uuid, obstacle.stamp, obstacle.pose,
                         tangent_vel,   normal_vel,     collision_points.value()};
 }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -960,26 +960,30 @@ std::optional<std::vector<CruiseObstacle>> ObstacleCruisePlannerNode::findYieldC
       const bool is_moving = std::hypot(o.second.twist.linear.x, o.second.twist.linear.y) > 0.5;
       if (is_moving) {
         const bool is_within_lat_dist_threshold =
-          o.second.lat_dist_from_obstacle_to_traj >= p.yield_lat_distance_threshold;
+          o.second.lat_dist_from_obstacle_to_traj < p.yield_lat_distance_threshold;
         if (is_within_lat_dist_threshold) moving_obstacles.push_back(o);
         return;
       }
       // lat threshold is larger for the stopped obstacle
+      std::cerr << "stopped.lat_dist_from_obstacle_to_traj "
+                << o.second.lat_dist_from_obstacle_to_traj << "id " << o.first << "\n";
       const bool is_within_lat_dist_threshold =
-        o.second.lat_dist_from_obstacle_to_traj >=
+        o.second.lat_dist_from_obstacle_to_traj <
         p.yield_lat_distance_threshold + p.max_lat_dist_between_obstacles;
       if (is_within_lat_dist_threshold) stopped_obstacles.push_back(o);
       return;
     });
 
   if (stopped_obstacles.empty() || moving_obstacles.empty()) return std::nullopt;
-
   std::cerr << "-----Checking for Yield candidates----- \n";
+
   std::vector<CruiseObstacle> yield_obstacles;
   for (const auto & moving_obstacle : moving_obstacles) {
     for (const auto & stopped_obstacle : stopped_obstacles) {
       if (moving_obstacle.first >= stopped_obstacle.first)
         continue;  // TODO(Daniel): is a break here fine?
+      std::cerr << "Stopped obs lat dist " << stopped_obstacle.second.lat_dist_from_obstacle_to_traj
+                << "\n";
       const double lateral_distance_between_obstacles = std::abs(
         moving_obstacle.second.lat_dist_from_obstacle_to_traj -
         stopped_obstacle.second.lat_dist_from_obstacle_to_traj);

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -253,6 +253,8 @@ ObstacleCruisePlannerNode::BehaviorDeterminationParam::BehaviorDeterminationPara
     node.declare_parameter<double>("behavior_determination.cruise.yield.lat_distance_threshold");
   max_lat_dist_between_obstacles = node.declare_parameter<double>(
     "behavior_determination.cruise.yield.max_lat_dist_between_obstacles");
+  stopped_obstacle_velocity_threshold = node.declare_parameter<double>(
+    "behavior_determination.cruise.yield.stopped_obstacle_velocity_threshold");
   max_obstacles_collision_time = node.declare_parameter<double>(
     "behavior_determination.cruise.yield.max_obstacles_collision_time");
   max_lat_margin_for_slow_down =
@@ -318,6 +320,9 @@ void ObstacleCruisePlannerNode::BehaviorDeterminationParam::onParam(
   tier4_autoware_utils::updateParam<double>(
     parameters, "behavior_determination.cruise.yield.max_lat_dist_between_obstacles",
     max_lat_dist_between_obstacles);
+  tier4_autoware_utils::updateParam<double>(
+    parameters, "behavior_determination.cruise.yield.stopped_obstacle_velocity_threshold",
+    stopped_obstacle_velocity_threshold);
   tier4_autoware_utils::updateParam<double>(
     parameters, "behavior_determination.cruise.yield.max_obstacles_collision_time",
     max_obstacles_collision_time);
@@ -946,7 +951,7 @@ std::optional<std::vector<CruiseObstacle>> ObstacleCruisePlannerNode::findYieldC
     indexed_obstacles.begin(), indexed_obstacles.end(),
     [&stopped_obstacles, &moving_obstacles, &p](const auto & o) {
       const bool is_moving = std::hypot(o.second.twist.linear.x, o.second.twist.linear.y) >
-                             p.outside_obstacle_min_velocity_threshold;
+                             p.stopped_obstacle_velocity_threshold;
       if (is_moving) {
         const bool is_within_lat_dist_threshold =
           o.second.lat_dist_from_obstacle_to_traj < p.yield_lat_distance_threshold;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR adds an (optional) yield functionality for the obstacle cruise planner.  The yield action is performed by cruising behind vehicles on neighbor lanes that might cut in into the ego vehicle's current lane. 

How it works: 
The algorithm searches for cruise type obstacles that: 
a) are moving faster than a speed threshold (parameter) and are in front of the ego.
b) have another cruise obstacle that is stopped in front of them.
c) will collide with the stopped obstacle within a given time (if they continue a straight path towards it)

## Related links
[TIER IV internal link](https://tier4.atlassian.net/browse/RT1-3025)

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Scenario Evaluation tests: [TIER IV INTERNAL LINK](https://evaluation.ci.tier4.jp/evaluation/reports/d5ebd35f-0812-5d79-b912-e06fb831f1ed?project_id=prd_jt)

Several tests with PSim: 

Example using time of collision (between static obstacle and moving obstacle) to decide to yield or not. default threshold time is 10 seconds.

 

https://github.com/autowarefoundation/autoware.universe/assets/25967964/40c1a7bd-f0ab-43e5-a93b-aa7fc83ab831



Example 2

 

https://github.com/autowarefoundation/autoware.universe/assets/25967964/c26765f4-be93-478e-bc68-72eb996aa215



Example 3

https://github.com/autowarefoundation/autoware.universe/assets/25967964/f94f871a-f45c-4043-9de4-a48b8a8eebc7



<!-- Describe how you have tested this PR. -->

## Notes for reviewers

Requires changes to launch. https://github.com/autowarefoundation/autoware_launch/pull/837

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
If enabled, the ego will cruise behind neighbor cars that will likely cut in into the ego's lane.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
