### PR TITLE
fix(object_velocity_splitter): refactor CMakeLists

### DIFF
--- a/perception/object_velocity_splitter/CMakeLists.txt
+++ b/perception/object_velocity_splitter/CMakeLists.txt
@@ -1,17 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(object_velocity_splitter)
 
-# Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Dependencies
 find_package(autoware_cmake REQUIRED)
 autoware_package()


### PR DESCRIPTION
## Description

Refactor CMakeLists of `object_velocity_splitter`

## Tests performed

Checked by compile

## Effects on system behavior

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
