### PR TITLE
fix(tensorrt_common): revert change that breaks build on Jetson Orin

### DIFF
--- a/common/tensorrt_common/include/tensorrt_common/logger.hpp
+++ b/common/tensorrt_common/include/tensorrt_common/logger.hpp
@@ -493,7 +493,7 @@ namespace
 //!
 inline LogStreamConsumer LOG_VERBOSE(const Logger & logger)
 {
-  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kVERBOSE) << "[TRT] ";
+  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kVERBOSE);
 }
 
 //!
@@ -505,7 +505,7 @@ inline LogStreamConsumer LOG_VERBOSE(const Logger & logger)
 //!
 inline LogStreamConsumer LOG_INFO(const Logger & logger)
 {
-  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kINFO) << "[TRT] ";
+  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kINFO);
 }
 
 //!
@@ -517,7 +517,7 @@ inline LogStreamConsumer LOG_INFO(const Logger & logger)
 //!
 inline LogStreamConsumer LOG_WARN(const Logger & logger)
 {
-  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kWARNING) << "[TRT] ";
+  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kWARNING);
 }
 
 //!
@@ -529,7 +529,7 @@ inline LogStreamConsumer LOG_WARN(const Logger & logger)
 //!
 inline LogStreamConsumer LOG_ERROR(const Logger & logger)
 {
-  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kERROR) << "[TRT] ";
+  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kERROR);
 }
 
 //!
@@ -543,7 +543,7 @@ inline LogStreamConsumer LOG_ERROR(const Logger & logger)
 //!
 inline LogStreamConsumer LOG_FATAL(const Logger & logger)
 {
-  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kINTERNAL_ERROR) << "[TRT] ";
+  return LogStreamConsumer(logger.getReportableSeverity(), Severity::kINTERNAL_ERROR);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
## Description

This pull request partially reverts https://github.com/autowarefoundation/autoware.universe/pull/6117 so that tensorrt_common can be built on Jetson Orin.

## Tests performed

tensorrt_common was built on a Jetson Orin ECU.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
