### PR TITLE
ci(build-and-test-differential): use github runner

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -16,7 +16,7 @@ jobs:
   build-and-test-differential:
     needs: prevent-no-label-execution
     if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}
-    runs-on: [self-hosted, linux, X64]
+    runs-on: ubuntu-latest
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -70,7 +70,7 @@ jobs:
           flags: differential
 
   clang-tidy-differential:
-    runs-on: [self-hosted, linux, X64]
+    runs-on: ubuntu-latest
     container: ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda
     needs: build-and-test-differential
     steps:


### PR DESCRIPTION
## Description

Use GitHub runner.

The runner has been changed as follows:
- https://github.com/autowarefoundation/autoware.universe/pull/4364 GitHub runner -> self-hosted runner
- https://github.com/autowarefoundation/autoware.universe/pull/4413 self-hosted runner -> EC2 runner
- https://github.com/autowarefoundation/autoware.universe/pull/4477 EC2 runner -> self-hosted runner

Apparently the disk image size has been reduced, and thus we would like to use GitHub Runner again, since current self-hosted runner based CI is too slow to execute multiple PRs.

Test run: https://github.com/HansRobo/autoware.universe/actions/runs/7736637727/job/21094318337
Remaining disk space:
```
$ dh -a

Filesystem     1K-blocks     Used Available Use% Mounted on
overlay         87204404 75316916  11871104  87% /
```

`du` results in the latest full-built Autoware: 
```
$ cd /path/to/pre-built/autoware
$ du -d0
11311632        .  
```
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

As shown above

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
There is a risk in a near future that the CI will fail again due to the disk usage limit as it was before.

Autoware developers need to understand the importance of reducing the file size of both scripts and the generated binaries.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
