### PR TITLE
fix(merge_from_private): fix stop position calculation

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -126,9 +126,13 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
   if (!first_conflicting_idx_opt) {
     return false;
   }
+  // ==========================================================================================
+  // first_conflicting_idx is calculated considering baselink2front already, so there is no need
+  // to subtract baselink2front/ds here
+  // ==========================================================================================
   const auto stopline_idx_ip = static_cast<size_t>(std::max<int>(
     0, static_cast<int>(first_conflicting_idx_opt.value()) -
-         static_cast<int>(baselink2front / planner_param_.path_interpolation_ds)));
+         static_cast<int>(planner_param_.stopline_margin / planner_param_.path_interpolation_ds)));
 
   const auto stopline_idx_opt = util::insertPointIndex(
     interpolated_path_info.path.points.at(stopline_idx_ip).point.pose, path,


### PR DESCRIPTION
## Description

In https://github.com/autowarefoundation/autoware.universe/pull/5972/files, the stopline offset confused with baselink2front.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/ed4aeae1-f94b-580e-81e1-bcfa42680e6f?project_id=prd_jt

### before 
![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/82f7f4c7-5359-43ca-97e9-3641088626e9)


### after
![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/2ed723f2-a55c-4b4f-8069-11e3c4f300b9)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
