### PR TITLE
feat(map): add launch_pointcloud_map_loader

### DIFF
--- a/launch/tier4_map_launch/launch/map.launch.xml
+++ b/launch/tier4_map_launch/launch/map.launch.xml
@@ -17,11 +17,14 @@
   <let name="container_type" value="component_container" unless="$(var use_multithread)"/>
   <let name="container_type" value="component_container_mt" if="$(var use_multithread)"/>
 
+  <!-- whether use pointcloud map -->
+  <arg name="launch_pointcloud_map_loader" default="true" description="launch pointcloud map loader"/>
+
   <group>
     <push-ros-namespace namespace="map"/>
 
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="map_container" namespace="" output="screen">
-      <composable_node pkg="map_loader" plugin="PointCloudMapLoaderNode" name="pointcloud_map_loader">
+      <composable_node pkg="map_loader" plugin="PointCloudMapLoaderNode" name="pointcloud_map_loader" if="$(var launch_pointcloud_map_loader)">
         <param from="$(var pointcloud_map_loader_param_path)"/>
         <param name="pcd_paths_or_directory" value="[$(var pointcloud_map_path)]"/>
         <param name="pcd_metadata_path" value="$(var pointcloud_map_metadata_path)"/>

--- a/map/map_height_fitter/src/map_height_fitter.cpp
+++ b/map/map_height_fitter/src/map_height_fitter.cpp
@@ -72,8 +72,9 @@ MapHeightFitter::Impl::Impl(rclcpp::Node * node) : tf2_listener_(tf2_buffer_), n
 
   const auto map_loader_name = node->declare_parameter<std::string>("map_loader_name");
   params_map_loader_ = rclcpp::AsyncParametersClient::make_shared(node, map_loader_name);
-  params_map_loader_->wait_for_service();
-  params_map_loader_->get_parameters({enable_partial_load}, callback);
+  if (params_map_loader_->wait_for_service(std::chrono::seconds(5.0))) {
+    params_map_loader_->get_parameters({enable_partial_load}, callback);
+  }
 }
 
 void MapHeightFitter::Impl::on_map(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

loading pcd map and map_hight_fitter with pointcloud ara time consuming (e.g. 3sec for initial pose).
they are not necessary for planning simulator, so add launch_pointcloud_map_loader to disable that
(I also feel it's not a good way)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

put initial pose in psim with following 

```
ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus sensor_model:=aip_xx1 map_path:=/home/kosuke55/data/map/odaiba launch_pointcloud_map_loader:=false
```

```
ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=lexus sensor_model:=aip_xx1 map_path:=/home/kosuke55/data/map/odaiba launch_pointcloud_map_loader:=true
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/1c318cef-2aa6-436d-9217-73a1f01c09a3)



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
