### PR TITLE
revert(map_loader): revert the change error handling when pcd_metadata file

### DIFF
--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -90,9 +90,8 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
 {
   std::map<std::string, PCDFileMetadata> pcd_metadata_dict;
   if (pcd_paths.size() != 1) {
-    while (!fs::exists(pcd_metadata_path)) {
-      RCLCPP_ERROR_STREAM(get_logger(), "PCD metadata file not found: " << pcd_metadata_path);
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+    if (!fs::exists(pcd_metadata_path)) {
+      throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
     }
 
     pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);


### PR DESCRIPTION
## Description

This reverts commit https://github.com/autowarefoundation/autoware.universe/pull/6227 (25bc636fe0f796c63daac60123aa6138146e515d).

After the pull request above, if "divided map is used and pointcloud_map_metadata.yaml is missing", initial_pose_adaptor does not work properly and there is unexpected side effects in planning_simulator, so we decide to revert.

## Tests performed

* It has been confirmed that Autoware works properly if `pointcloud_map_metadata.yaml` is present (in AWSIM).
* It has been confirmed that the above error message continues to appear if `pointcloud_map_metadata.yaml` is missing (in AWSIM).

## Effects on system behavior

The error message will change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
