### PR TITLE
fix(obstacle_avoidance_planner, path_smoother): change logger level of debug print

### DIFF
--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
@@ -178,7 +178,7 @@ std::optional<size_t> updateFrontPointForFix(
   const double lon_offset_to_prev_front =
     motion_utils::calcSignedArcLength(points, 0, front_fix_point.pose.position);
   if (0 < lon_offset_to_prev_front) {
-    RCLCPP_WARN(
+    RCLCPP_DEBUG(
       rclcpp::get_logger("obstacle_avoidance_planner.trajectory_utils"),
       "Fixed point will not be inserted due to the error during calculation.");
     return std::nullopt;
@@ -189,7 +189,7 @@ std::optional<size_t> updateFrontPointForFix(
   // check if deviation is not too large
   constexpr double max_lat_error = 3.0;
   if (max_lat_error < dist) {
-    RCLCPP_WARN(
+    RCLCPP_DEBUG(
       rclcpp::get_logger("obstacle_avoidance_planner.trajectory_utils"),
       "New Fixed point is too far from points %f [m]", dist);
   }

--- a/planning/path_smoother/include/path_smoother/utils/trajectory_utils.hpp
+++ b/planning/path_smoother/include/path_smoother/utils/trajectory_utils.hpp
@@ -136,7 +136,7 @@ std::optional<size_t> updateFrontPointForFix(
   const double lon_offset_to_prev_front =
     motion_utils::calcSignedArcLength(points, 0, front_fix_point.pose.position);
   if (0 < lon_offset_to_prev_front) {
-    RCLCPP_WARN(
+    RCLCPP_DEBUG(
       rclcpp::get_logger("path_smoother.trajectory_utils"),
       "Fixed point will not be inserted due to the error during calculation.");
     return std::nullopt;
@@ -147,7 +147,7 @@ std::optional<size_t> updateFrontPointForFix(
   // check if deviation is not too large
   constexpr double max_lat_error = 3.0;
   if (max_lat_error < dist) {
-    RCLCPP_WARN(
+    RCLCPP_DEBUG(
       rclcpp::get_logger("path_smoother.trajectory_utils"),
       "New Fixed point is too far from points %f [m]", dist);
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/autowarefoundation/autoware.universe/issues/6205

Changed the logger level of debug print from WARN to DEBUG.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
