### PR TITLE
ci(build-and-test-differential): add concurrency for job

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-test-differential:
     runs-on: ubuntu-latest
+    concurrency:
+      group: staging_environment
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false
@@ -66,6 +68,8 @@ jobs:
 
   clang-tidy-differential:
     runs-on: ubuntu-latest
+    concurrency:
+      group: staging_environment
     container: ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda
     needs: build-and-test-differential
     steps:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, build-and-test-differential workflow is failed because of the lack of disk space.
Example action: https://github.com/autowarefoundation/autoware.universe/actions/runs/7778913963/job/21209266221?pr=6301

To solve this problem, I set concurrency for the workflow.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Note that this PR will run build-and-test-differential one by one, which means the CI will complete slower.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested in my CI repository.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
