### PR TITLE
fix(radar_crossing_objects_noise_filter): delete default param in src

### DIFF
--- a/perception/radar_crossing_objects_noise_filter/src/radar_crossing_objects_noise_filter_node/radar_crossing_objects_noise_filter_node.cpp
+++ b/perception/radar_crossing_objects_noise_filter/src/radar_crossing_objects_noise_filter_node/radar_crossing_objects_noise_filter_node.cpp
@@ -64,8 +64,8 @@ RadarCrossingObjectsNoiseFilterNode::RadarCrossingObjectsNoiseFilterNode(
     std::bind(&RadarCrossingObjectsNoiseFilterNode::onSetParam, this, std::placeholders::_1));
 
   // Node Parameter
-  node_param_.angle_threshold = declare_parameter<double>("angle_threshold", 1.0472);
-  node_param_.velocity_threshold = declare_parameter<double>("velocity_threshold", 3.0);
+  node_param_.angle_threshold = declare_parameter<double>("angle_threshold");
+  node_param_.velocity_threshold = declare_parameter<double>("velocity_threshold");
 
   // Subscriber
   sub_objects_ = create_subscription<DetectedObjects>(


### PR DESCRIPTION
## Description

Delete default parameter in src of `radar_crossing_objects_noise_filter`.


## Tests performed

Test by compile

## Effects on system behavior

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
