### PR TITLE
fix(simple_object_merger): delete default param in src

### DIFF
--- a/perception/simple_object_merger/src/simple_object_merger_node/simple_object_merger_node.cpp
+++ b/perception/simple_object_merger/src/simple_object_merger_node/simple_object_merger_node.cpp
@@ -80,9 +80,9 @@ SimpleObjectMergerNode::SimpleObjectMergerNode(const rclcpp::NodeOptions & node_
     std::bind(&SimpleObjectMergerNode::onSetParam, this, std::placeholders::_1));
 
   // Node Parameter
-  node_param_.update_rate_hz = declare_parameter<double>("update_rate_hz", 20.0);
-  node_param_.new_frame_id = declare_parameter<std::string>("new_frame_id", "base_link");
-  node_param_.timeout_threshold = declare_parameter<double>("timeout_threshold", 0.1);
+  node_param_.update_rate_hz = declare_parameter<double>("update_rate_hz");
+  node_param_.new_frame_id = declare_parameter<std::string>("new_frame_id");
+  node_param_.timeout_threshold = declare_parameter<double>("timeout_threshold");
 
   declare_parameter("input_topics", std::vector<std::string>());
   node_param_.topic_names = get_parameter("input_topics").as_string_array();


### PR DESCRIPTION
## Description

Delete default parameter in src of `simple_object_merger`.

## Tests performed

Test by compile

## Effects on system behavior

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
