### PR TITLE
fix(object_range_splitter): delete default param in src

### DIFF
--- a/perception/object_range_splitter/src/node.cpp
+++ b/perception/object_range_splitter/src/node.cpp
@@ -20,7 +20,7 @@ ObjectRangeSplitterNode::ObjectRangeSplitterNode(const rclcpp::NodeOptions & nod
 : Node("object_range_splitter_node", node_options)
 {
   using std::placeholders::_1;
-  spilt_range_ = declare_parameter("split_range", 30.0);
+  spilt_range_ = declare_parameter<double>("split_range");
   sub_ = this->create_subscription<autoware_auto_perception_msgs::msg::DetectedObjects>(
     "input/object", rclcpp::QoS{1}, std::bind(&ObjectRangeSplitterNode::objectCallback, this, _1));
   long_range_object_pub_ =


### PR DESCRIPTION
## Description

Delete default parameter in src of `object_range_splitter`.

## Tests performed

Test by compile

## Effects on system behavior

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
