### PR TITLE
fix(intersection): fix stopline midpoint calculation

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/object_manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/object_manager.cpp
@@ -165,7 +165,7 @@ bool ObjectInfo::can_stop_before_ego_lane(
   const auto stopline_p1 = stopline.front();
   const auto stopline_p2 = stopline.back();
   const tier4_autoware_utils::Point2d stopline_mid{
-    stopline_p1.x() + stopline_p2.x() / 2.0, (stopline_p1.y() + stopline_p2.y()) / 2.0};
+    (stopline_p1.x() + stopline_p2.x()) / 2.0, (stopline_p1.y() + stopline_p2.y()) / 2.0};
   const auto attention_lane_end = attention_lanelet.centerline().back();
   const tier4_autoware_utils::LineString2d attention_lane_later_part(
     {tier4_autoware_utils::Point2d{stopline_mid.x(), stopline_mid.y()},


### PR DESCRIPTION
## Description

fixed the wrong midpoint calculation from
```
x + y /  2.0
```
to
```
(x + y) / 2.0
```

## Related links

https://tier4.atlassian.net/browse/RT1-4773

## Tests performed

### before

at [00:15], unnecessary stop happens due to miscalculation

https://github.com/autowarefoundation/autoware.universe/assets/28677420/ea8aa057-2e75-4b04-a7e6-9bcbb020ebe8
### after

https://github.com/autowarefoundation/autoware.universe/assets/28677420/9ebe04a8-0ede-425c-ab05-ca58def7aed8

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
