### PR TITLE
fix(behavior_path_start_planner_module): check if pull_out_path is empty

### DIFF
--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1202,6 +1202,9 @@ bool StartPlannerModule::isSafePath() const
   // TODO(Sugahara): should safety check for backward path
 
   const auto pull_out_path = getCurrentPath();
+  if (pull_out_path.points.empty()) {
+    return false;
+  }
   const auto & current_pose = planner_data_->self_odometry->pose.pose;
   const double current_velocity = std::hypot(
     planner_data_->self_odometry->twist.twist.linear.x,


### PR DESCRIPTION
## Description

Fixes: https://github.com/autowarefoundation/autoware.universe/issues/6317

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/32412808/04bb7073-9118-4ec0-9d07-219fef8ac466

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
