### PR TITLE
fix(avoidance): unexpected stop decision in avoidance module

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
@@ -261,10 +261,11 @@ public:
 
   bool isComfortable(const AvoidLineArray & shift_lines) const
   {
+    const auto JERK_BUFFER = 0.1;  // [m/sss]
     return std::all_of(shift_lines.begin(), shift_lines.end(), [&](const auto & line) {
       return PathShifter::calcJerkFromLatLonDistance(
                line.getRelativeLength(), line.getRelativeLongitudinal(), getAvoidanceEgoSpeed()) <
-             getLateralMaxJerkLimit();
+             getLateralMaxJerkLimit() + JERK_BUFFER;
     });
   }
 


### PR DESCRIPTION
## Description

### ISSUE-1: There is an inconsistency between avoidable check and path validation.

In following case, the module judge the object is avoidable but the output path violates jerk limitation. The cause is that the module validates path safety with same parameter for path generation. In order to fix this issue, I added small margin to confortable check condition.

```c++
  bool isComfortable(const AvoidLineArray & shift_lines) const
  {
    const auto JERK_BUFFER = 0.1;  // [m/sss]
    return std::all_of(shift_lines.begin(), shift_lines.end(), [&](const auto & line) {
      return PathShifter::calcJerkFromLatLonDistance(
               line.getRelativeLength(), line.getRelativeLongitudinal(), getAvoidanceEgoSpeed()) <
             getLateralMaxJerkLimit() + JERK_BUFFER;
    });
  }
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/58b16377-11e1-4213-b2c6-7e068fcae572)

### ISSUE-2: Insert stop point in avoidance module even when it judge the object is NOT avoidable.

Basically, avoidance module inserts stop point only for objects it can avoid. But sometimes the module inserts stop point unexpectedly for unavoidable objects as follow. This causes stuck.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/22c23bf8-13b0-4611-9c9b-ba3a82bda2a3)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] Psim

https://github.com/autowarefoundation/autoware.universe/assets/44889564/efa81d87-7ade-4814-ada1-08197af1af09

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/6a6a39d4-fe2e-5589-9328-d5ca2f696095?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix bug.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
