### PR TITLE
feat(tier4_adapi_rviz_plugin): add change button to the route panel

### DIFF
--- a/common/tier4_adapi_rviz_plugin/src/route_panel.hpp
+++ b/common/tier4_adapi_rviz_plugin/src/route_panel.hpp
@@ -15,8 +15,10 @@
 #ifndef ROUTE_PANEL_HPP_
 #define ROUTE_PANEL_HPP_
 
+#include <QButtonGroup>
 #include <QCheckBox>
 #include <QGroupBox>
+#include <QLabel>
 #include <QPushButton>
 #include <autoware_ad_api_specs/routing.hpp>
 #include <component_interface_utils/rclcpp.hpp>
@@ -35,6 +37,7 @@ class RoutePanel : public rviz_common::Panel
   Q_OBJECT
   using ClearRoute = autoware_ad_api::routing::ClearRoute;
   using SetRoutePoints = autoware_ad_api::routing::SetRoutePoints;
+  using ChangeRoutePoints = autoware_ad_api::routing::ChangeRoutePoints;
   using PoseStamped = geometry_msgs::msg::PoseStamped;
 
 public:
@@ -45,6 +48,11 @@ private:
   QPushButton * waypoints_mode_;
   QPushButton * waypoints_reset_;
   QPushButton * waypoints_apply_;
+  QPushButton * adapi_clear_;
+  QPushButton * adapi_set_;
+  QPushButton * adapi_change_;
+  QLabel * adapi_response_;
+  QCheckBox * adapi_auto_clear_;
   QGroupBox * waypoints_group_;
   QCheckBox * allow_goal_modification_;
 
@@ -52,11 +60,17 @@ private:
   std::vector<PoseStamped> waypoints_;
   void onPose(const PoseStamped::ConstSharedPtr msg);
 
+  enum AdapiMode { Set, Change };
+  AdapiMode adapi_mode_;
+
   component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
-  component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
-  void setRoute(const PoseStamped & pose);
+  component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_set_;
+  component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_change_;
+  void requestRoute(const PoseStamped & pose);
+  void asyncSendRequest(SetRoutePoints::Service::Request::SharedPtr req);
 
 private slots:
+  void clearRoute();
   void onWaypointsMode(bool clicked);
   void onWaypointsReset();
   void onWaypointsApply();


### PR DESCRIPTION
## Description

Add route change button to call `/api/routing/change_route_points` API.
![Screenshot from 2024-02-06 10-08-28](https://github.com/autowarefoundation/autoware.universe/assets/43976882/1fcc9b56-c936-4317-8c60-ea3e526db7f1)


## Related links

None

## Tests performed

1. Launch planning simulation and initialize pose.
2. Add RoutePanel by selecting "Panels" -> "Add new panel" from the rviz menu.
3. Change the topic name of 2D Goal Pose to "/rviz/routing/pose" by the topic property panel. 
4. Clear the "auto clear" checkbox.
5. Set the route.
6. Set the route again
7. Check that setting the route fails.
8. Push change button
9. Check that setting the route succeeds.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
