### PR TITLE
feat(intersection): use different expected deceleration for bike/car

### DIFF
--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -56,7 +56,9 @@
           duration: 3.0
           object_dist_to_stopline: 10.0
         ignore_on_amber_traffic_light:
-          object_expected_deceleration: 2.0
+          object_expected_deceleration:
+            car: 2.0
+            bike: 5.0
         ignore_on_red_traffic_light:
           object_margin_to_path: 2.0
         avoid_collision_by_acceleration:

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -127,9 +127,14 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.collision_detection.yield_on_green_traffic_light.object_dist_to_stopline =
     getOrDeclareParameter<double>(
       node, ns + ".collision_detection.yield_on_green_traffic_light.object_dist_to_stopline");
-  ip.collision_detection.ignore_on_amber_traffic_light.object_expected_deceleration =
+  ip.collision_detection.ignore_on_amber_traffic_light.object_expected_deceleration.car =
     getOrDeclareParameter<double>(
-      node, ns + ".collision_detection.ignore_on_amber_traffic_light.object_expected_deceleration");
+      node,
+      ns + ".collision_detection.ignore_on_amber_traffic_light.object_expected_deceleration.car");
+  ip.collision_detection.ignore_on_amber_traffic_light.object_expected_deceleration.bike =
+    getOrDeclareParameter<double>(
+      node,
+      ns + ".collision_detection.ignore_on_amber_traffic_light.object_expected_deceleration.bike");
   ip.collision_detection.ignore_on_red_traffic_light.object_margin_to_path =
     getOrDeclareParameter<double>(
       node, ns + ".collision_detection.ignore_on_red_traffic_light.object_margin_to_path");

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -123,7 +123,11 @@ public:
       } yield_on_green_traffic_light;
       struct IgnoreOnAmberTrafficLight
       {
-        double object_expected_deceleration;
+        struct ObjectExpectedDeceleration
+        {
+          double car;
+          double bike;
+        } object_expected_deceleration;
       } ignore_on_amber_traffic_light;
       struct IgnoreOnRedTrafficLight
       {

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
@@ -176,18 +176,23 @@ void IntersectionModule::updateObjectInfoManagerCollision(
   for (auto & object_info : object_info_manager_.attentionObjects()) {
     const auto & predicted_object = object_info->predicted_object();
     bool safe_under_traffic_control = false;
+    const auto label = predicted_object.classification.at(0).label;
+    const auto expected_deceleration =
+      (label == autoware_auto_perception_msgs::msg::ObjectClassification::MOTORCYCLE ||
+       label == autoware_auto_perception_msgs::msg::ObjectClassification::BICYCLE)
+        ? planner_param_.collision_detection.ignore_on_amber_traffic_light
+            .object_expected_deceleration.bike
+        : planner_param_.collision_detection.ignore_on_amber_traffic_light
+            .object_expected_deceleration.car;
     if (
       traffic_prioritized_level == TrafficPrioritizedLevel::PARTIALLY_PRIORITIZED &&
-      object_info->can_stop_before_stopline(
-        planner_param_.collision_detection.ignore_on_amber_traffic_light
-          .object_expected_deceleration)) {
+      object_info->can_stop_before_stopline(expected_deceleration)) {
       safe_under_traffic_control = true;
     }
     if (
       traffic_prioritized_level == TrafficPrioritizedLevel::FULLY_PRIORITIZED &&
       object_info->can_stop_before_ego_lane(
-        planner_param_.collision_detection.ignore_on_amber_traffic_light
-          .object_expected_deceleration,
+        expected_deceleration,
         planner_param_.collision_detection.ignore_on_red_traffic_light.object_margin_to_path,
         ego_lane)) {
       safe_under_traffic_control = true;


### PR DESCRIPTION
## Description

use different expected deceleration for bike/car on amber/red traffic light

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/852

https://tier4.atlassian.net/browse/RT1-4773

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/a40b1c77-0f2a-5017-95e8-f397bf4c3f25?project_id=prd_jt

at [00:12] intersection stop line is released

https://github.com/autowarefoundation/autoware.universe/assets/28677420/8a7514ad-73e3-4973-ac40-f43eff873e51

<!-- Describe how you have tested this PR. -->
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
