### PR TITLE
fix(out_of_lane): ignore overlaps over all lanelets crossed by the ego path

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -68,7 +68,8 @@ lanelet::ConstLanelets calculate_other_lanelets(
   const lanelet::BasicPoint2d ego_point(ego_data.pose.position.x, ego_data.pose.position.y);
   const auto lanelets_within_range = lanelet::geometry::findWithin2d(
     route_handler.getLaneletMapPtr()->laneletLayer, ego_point,
-    std::max(params.slow_dist_threshold, params.stop_dist_threshold));
+    std::max(params.slow_dist_threshold, params.stop_dist_threshold) + params.front_offset +
+      params.extra_front_offset);
   for (const auto & ll : lanelets_within_range) {
     if (std::string(ll.second.attributeOr(lanelet::AttributeName::Subtype, "none")) != "road")
       continue;

--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -25,23 +25,18 @@
 namespace behavior_velocity_planner::out_of_lane
 {
 lanelet::ConstLanelets calculate_path_lanelets(
-  const EgoData & ego_data, const route_handler::RouteHandler & route_handler,
-  const lanelet::BasicPolygon2d & ego_footprint)
+  const EgoData & ego_data, const route_handler::RouteHandler & route_handler)
 {
   const auto lanelet_map_ptr = route_handler.getLaneletMapPtr();
   lanelet::ConstLanelets path_lanelets =
     planning_utils::getLaneletsOnPath(ego_data.path, lanelet_map_ptr, ego_data.pose);
-  const auto add_unique_within = [&](const auto & geometry) {
-    const auto dist_lanelet_pairs =
-      lanelet::geometry::findWithin2d(lanelet_map_ptr->laneletLayer, geometry);
-    for (const auto & dist_lanelet_pair : dist_lanelet_pairs)
-      if (!contains_lanelet(path_lanelets, dist_lanelet_pair.second.id()))
-        path_lanelets.push_back(dist_lanelet_pair.second);
-  };
-  add_unique_within(ego_footprint);
-  for (const auto & p : ego_data.path.points) {
-    const auto pt = lanelet::BasicPoint2d(p.point.pose.position.x, p.point.pose.position.y);
-    add_unique_within(pt);
+  lanelet::BasicLineString2d path_ls;
+  for (const auto & p : ego_data.path.points)
+    path_ls.emplace_back(p.point.pose.position.x, p.point.pose.position.y);
+  for (const auto & dist_lanelet :
+       lanelet::geometry::findWithin2d(lanelet_map_ptr->laneletLayer, path_ls)) {
+    if (!contains_lanelet(path_lanelets, dist_lanelet.second.id()))
+      path_lanelets.push_back(dist_lanelet.second);
   }
   return path_lanelets;
 }
@@ -51,10 +46,6 @@ lanelet::ConstLanelets calculate_ignored_lanelets(
   const route_handler::RouteHandler & route_handler, const PlannerParam & params)
 {
   lanelet::ConstLanelets ignored_lanelets;
-  // ignore lanelets that follows path lanelets
-  for (const auto & path_lanelet : path_lanelets)
-    for (const auto & following : route_handler.getRoutingGraphPtr()->following(path_lanelet))
-      if (!contains_lanelet(path_lanelets, following.id())) ignored_lanelets.push_back(following);
   // ignore lanelets directly behind ego
   const auto behind =
     planning_utils::calculateOffsetPoint2d(ego_data.pose, params.rear_offset, 0.0);

--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -69,25 +69,12 @@ lanelet::ConstLanelets calculate_other_lanelets(
   const auto lanelets_within_range = lanelet::geometry::findWithin2d(
     route_handler.getLaneletMapPtr()->laneletLayer, ego_point,
     std::max(params.slow_dist_threshold, params.stop_dist_threshold));
-  const auto is_overlapped_by_path_lanelets = [&](const auto & l) {
-    for (const auto & path_ll : path_lanelets) {
-      if (
-        boost::geometry::overlaps(
-          path_ll.polygon2d().basicPolygon(), l.polygon2d().basicPolygon()) ||
-        boost::geometry::within(path_ll.polygon2d().basicPolygon(), l.polygon2d().basicPolygon()) ||
-        boost::geometry::within(l.polygon2d().basicPolygon(), path_ll.polygon2d().basicPolygon())) {
-        return true;
-      }
-    }
-    return false;
-  };
   for (const auto & ll : lanelets_within_range) {
     if (std::string(ll.second.attributeOr(lanelet::AttributeName::Subtype, "none")) != "road")
       continue;
     const auto is_path_lanelet = contains_lanelet(path_lanelets, ll.second.id());
     const auto is_ignored_lanelet = contains_lanelet(ignored_lanelets, ll.second.id());
-    if (!is_path_lanelet && !is_ignored_lanelet && !is_overlapped_by_path_lanelets(ll.second))
-      other_lanelets.push_back(ll.second);
+    if (!is_path_lanelet && !is_ignored_lanelet) other_lanelets.push_back(ll.second);
   }
   return other_lanelets;
 }

--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
@@ -33,6 +33,17 @@ inline bool contains_lanelet(const lanelet::ConstLanelets & lanelets, const lane
            return l.id() == id;
          }) != lanelets.end();
 };
+
+/// @brief calculate lanelets crossed by the ego path
+/// @details calculated from the ids of the path msg, the lanelets containing path points, and the
+/// lanelets currently overlapped by the ego footprint
+/// @param [in] ego_data data about the ego vehicle
+/// @param [in] route_handler route handler
+/// @param [in] ego_footprint footprint of ego at its current pose
+/// @return lanelets crossed by the ego vehicle
+lanelet::ConstLanelets calculate_path_lanelets(
+  const EgoData & ego_data, const route_handler::RouteHandler & route_handler,
+  const lanelet::BasicPolygon2d & ego_footprint);
 /// @brief calculate lanelets that should be ignored
 /// @param [in] ego_data data about the ego vehicle
 /// @param [in] path_lanelets lanelets driven by the ego vehicle

--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
@@ -35,15 +35,12 @@ inline bool contains_lanelet(const lanelet::ConstLanelets & lanelets, const lane
 };
 
 /// @brief calculate lanelets crossed by the ego path
-/// @details calculated from the ids of the path msg, the lanelets containing path points, and the
-/// lanelets currently overlapped by the ego footprint
+/// @details calculated from the ids of the path msg, the lanelets containing path points
 /// @param [in] ego_data data about the ego vehicle
 /// @param [in] route_handler route handler
-/// @param [in] ego_footprint footprint of ego at its current pose
 /// @return lanelets crossed by the ego vehicle
 lanelet::ConstLanelets calculate_path_lanelets(
-  const EgoData & ego_data, const route_handler::RouteHandler & route_handler,
-  const lanelet::BasicPolygon2d & ego_footprint);
+  const EgoData & ego_data, const route_handler::RouteHandler & route_handler);
 /// @brief calculate lanelets that should be ignored
 /// @param [in] ego_data data about the ego vehicle
 /// @param [in] path_lanelets lanelets driven by the ego vehicle

--- a/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.cpp
@@ -34,6 +34,7 @@ Overlap calculate_overlap(
   Overlap overlap;
   const auto & left_bound = lanelet.leftBound2d().basicLineString();
   const auto & right_bound = lanelet.rightBound2d().basicLineString();
+  // TODO(Maxime): these intersects (for each path footprint, for each lanelet) are too expensive
   const auto overlap_left = boost::geometry::intersects(path_footprint, left_bound);
   const auto overlap_right = boost::geometry::intersects(path_footprint, right_bound);
 

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -197,7 +197,7 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   debug_data_.ranges = inputs.ranges;
 
   const auto total_time_us = stopwatch.toc();
-  RCLCPP_WARN(
+  RCLCPP_DEBUG(
     logger_,
     "Total time = %2.2fus\n"
     "\tcalculate_lanelets = %2.0fus\n"

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -75,9 +75,8 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   const auto path_footprints = calculate_path_footprints(ego_data, params_);
   const auto calculate_path_footprints_us = stopwatch.toc("calculate_path_footprints");
   // Calculate lanelets to ignore and consider
-  const auto path_lanelets = planning_utils::getLaneletsOnPath(
-    ego_data.path, planner_data_->route_handler_->getLaneletMapPtr(),
-    planner_data_->current_odometry->pose);
+  const auto path_lanelets =
+    calculate_path_lanelets(ego_data, *planner_data_->route_handler_, current_ego_footprint);
   const auto ignored_lanelets =
     calculate_ignored_lanelets(ego_data, path_lanelets, *planner_data_->route_handler_, params_);
   const auto other_lanelets = calculate_other_lanelets(

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -56,19 +56,6 @@ OutOfLaneModule::OutOfLaneModule(
   velocity_factor_.init(PlanningBehavior::UNKNOWN);
 }
 
-size_t calculate_index_ahead(
-  const std::vector<PathPointWithLaneId> & points, const size_t start, const double dist_ahead)
-{
-  auto last_idx = start;
-  auto length = 0.0;
-  while (length < dist_ahead && last_idx + 1 < points.size()) {
-    length +=
-      tier4_autoware_utils::calcDistance2d(points[last_idx].point, points[last_idx + 1].point);
-    ++last_idx;
-  }
-  return last_idx;
-}
-
 bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   debug_data_.reset_data();
@@ -81,9 +68,6 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   ego_data.path.points = path->points;
   ego_data.first_path_idx =
     motion_utils::findNearestSegmentIndex(path->points, ego_data.pose.position);
-  ego_data.path.points.resize(calculate_index_ahead(
-    path->points, ego_data.first_path_idx,
-    std::max(params_.slow_dist_threshold, params_.stop_dist_threshold)));
   motion_utils::removeOverlapPoints(ego_data.path.points);
   ego_data.velocity = planner_data_->current_velocity->twist.linear.x;
   ego_data.max_decel = -planner_data_->max_stop_acceleration_threshold;

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -99,6 +99,7 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
       });
     if (overlapped_lanelet_it != other_lanelets.end()) {
       debug_data_.current_overlapped_lanelets.push_back(*overlapped_lanelet_it);
+      // TODO(Maxime): we may want to just add the overlapped lane to the ignored lanelets
       RCLCPP_DEBUG(logger_, "Ego is already overlapping a lane, skipping the module ()\n");
       return true;
     }

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -36,7 +36,6 @@
 
 #include <lanelet2_core/geometry/LaneletMap.h>
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR improves the `out_of_lane` module to reduces the amount of wrong stops it triggers.

The module uses "path lanelets" and assumes that it is fine for the ego footprint to enter these lanelets, and no `out_of_lane` stop can be triggered.
Previously, only the lanelets whose IDs were set in the path message were considered "path lanelets". Now, all lanelets crossed by the ego path linestring are considered.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim, perception reproducer and evaluator (https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=095ae8b3-a23b-4a08-8674-10a681449693&filter=&job_id=6905310e-f675-5fd8-a32a-4f074603610e&project_id=prd_jt&table_config=date).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Less wrong stops with the `out_of_lane` module.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
