### PR TITLE
feat(safety_check): add option to use polygon along path in safety check

### DIFF
--- a/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
+++ b/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
@@ -187,6 +187,7 @@
         time_horizon_for_rear_object: 10.0               # [s]
         delay_until_departure: 0.0                       # [s]
         # rss parameters
+        steering: "free"                                 # [-] select "fixed" or "free"
         expected_front_deceleration: -1.0                # [m/ss]
         expected_rear_deceleration: -1.0                 # [m/ss]
         rear_vehicle_reaction_time: 2.0                  # [s]

--- a/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
+++ b/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
@@ -187,7 +187,7 @@
         time_horizon_for_rear_object: 10.0               # [s]
         delay_until_departure: 0.0                       # [s]
         # rss parameters
-        steering: "free"                                 # [-] select "fixed" or "free"
+        extended_polygon_policy: "along_path"            # [-] select "rectangle" or "along_path"
         expected_front_deceleration: -1.0                # [m/ss]
         expected_rear_deceleration: -1.0                 # [m/ss]
         rear_vehicle_reaction_time: 2.0                  # [s]

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
@@ -223,6 +223,7 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
   // safety check rss params
   {
     const std::string ns = "avoidance.safety_check.";
+    p.rss_params.steering = getOrDeclareParameter<std::string>(*node, ns + "steering");
     p.rss_params.longitudinal_distance_min_threshold =
       getOrDeclareParameter<double>(*node, ns + "longitudinal_distance_min_threshold");
     p.rss_params.longitudinal_velocity_delta_time =

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
@@ -223,7 +223,8 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
   // safety check rss params
   {
     const std::string ns = "avoidance.safety_check.";
-    p.rss_params.steering = getOrDeclareParameter<std::string>(*node, ns + "steering");
+    p.rss_params.extended_polygon_policy =
+      getOrDeclareParameter<std::string>(*node, ns + "extended_polygon_policy");
     p.rss_params.longitudinal_distance_min_threshold =
       getOrDeclareParameter<double>(*node, ns + "longitudinal_distance_min_threshold");
     p.rss_params.longitudinal_velocity_delta_time =

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -126,6 +126,8 @@ struct TargetObjectsOnLane
  */
 struct RSSparams
 {
+  std::string steering{"fixed"};                ///< Policy to create collision check polygon.
+                                                /// possible values: ["fixed", "free"]
   double rear_vehicle_reaction_time{0.0};       ///< Reaction time of the rear vehicle.
   double rear_vehicle_safety_time_margin{0.0};  ///< Safety time margin for the rear vehicle.
   double lateral_distance_max_threshold{0.0};   ///< Maximum threshold for lateral distance.

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -126,8 +126,9 @@ struct TargetObjectsOnLane
  */
 struct RSSparams
 {
-  std::string steering{"fixed"};                ///< Policy to create collision check polygon.
-                                                /// possible values: ["fixed", "free"]
+  std::string extended_polygon_policy{
+    "rectangle"};                               ///< Policy to create collision check polygon.
+                                                ///< possible values: ["rectangle", "along_path"]
   double rear_vehicle_reaction_time{0.0};       ///< Reaction time of the rear vehicle.
   double rear_vehicle_safety_time_margin{0.0};  ///< Safety time margin for the rear vehicle.
   double lateral_distance_max_threshold{0.0};   ///< Maximum threshold for lateral distance.

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -184,6 +184,88 @@ Polygon2d createExtendedPolygon(
            : tier4_autoware_utils::inverseClockwise(polygon);
 }
 
+Polygon2d createExtendedPolygonAlongPath(
+  const PathWithLaneId & planned_path, const Pose & base_link_pose,
+  const vehicle_info_util::VehicleInfo & vehicle_info, const double lon_length,
+  const double lat_margin, const double is_stopped_obj, CollisionCheckDebug & debug)
+{
+  const double & base_to_front = vehicle_info.max_longitudinal_offset_m;
+  const double & width = vehicle_info.vehicle_width_m;
+  const double & base_to_rear = vehicle_info.rear_overhang_m;
+
+  // if stationary object, extend forward and backward by the half of lon length
+  const double forward_lon_offset = base_to_front + (is_stopped_obj ? lon_length / 2 : lon_length);
+  const double backward_lon_offset =
+    -base_to_rear - (is_stopped_obj ? lon_length / 2 : 0);  // minus value
+  const double lat_offset = width / 2.0 + lat_margin;
+
+  {
+    debug.forward_lon_offset = forward_lon_offset;
+    debug.backward_lon_offset = backward_lon_offset;
+    debug.lat_offset = lat_offset;
+  }
+
+  const auto lon_offset_pose = motion_utils::calcLongitudinalOffsetPose(
+    planned_path.points, base_link_pose.position, lon_length);
+  if (!lon_offset_pose.has_value()) {
+    return createExtendedPolygon(
+      base_link_pose, vehicle_info, lon_length, lat_margin, is_stopped_obj, debug);
+  }
+
+  const size_t start_idx =
+    motion_utils::findNearestSegmentIndex(planned_path.points, base_link_pose.position);
+  const size_t end_idx =
+    motion_utils::findNearestSegmentIndex(planned_path.points, lon_offset_pose.value().position);
+
+  Polygon2d polygon;
+
+  {
+    const auto p_offset =
+      tier4_autoware_utils::calcOffsetPose(base_link_pose, backward_lon_offset, lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  for (size_t i = start_idx + 1; i < end_idx + 1; ++i) {
+    const auto p = tier4_autoware_utils::getPose(planned_path.points.at(i));
+    const auto p_offset = tier4_autoware_utils::calcOffsetPose(p, 0.0, lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  {
+    const auto p_offset = tier4_autoware_utils::calcOffsetPose(
+      lon_offset_pose.value(), forward_lon_offset, lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  {
+    const auto p_offset = tier4_autoware_utils::calcOffsetPose(
+      lon_offset_pose.value(), forward_lon_offset, -lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  for (size_t i = end_idx; i > start_idx; --i) {
+    const auto p = tier4_autoware_utils::getPose(planned_path.points.at(i));
+    const auto p_offset = tier4_autoware_utils::calcOffsetPose(p, 0.0, -lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  {
+    const auto p_offset =
+      tier4_autoware_utils::calcOffsetPose(base_link_pose, backward_lon_offset, -lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  {
+    const auto p_offset =
+      tier4_autoware_utils::calcOffsetPose(base_link_pose, backward_lon_offset, lat_offset, 0.0);
+    appendPointToPolygon(polygon, p_offset.position);
+  }
+
+  return tier4_autoware_utils::isClockwise(polygon)
+           ? polygon
+           : tier4_autoware_utils::inverseClockwise(polygon);
+}
+
 std::vector<Polygon2d> createExtendedPolygonsFromPoseWithVelocityStamped(
   const std::vector<PoseWithVelocityStamped> & predicted_path, const VehicleInfo & vehicle_info,
   const double forward_margin, const double backward_margin, const double lat_margin)
@@ -549,10 +631,24 @@ std::vector<Polygon2d> getCollidedPolygons(
     const auto & lat_margin = rss_parameters.lateral_distance_max_threshold * hysteresis_factor;
     // TODO(watanabe) fix hard coding value
     const bool is_stopped_object = object_velocity < 0.3;
-    const auto & extended_ego_polygon = is_object_front ? createExtendedPolygon(
-                                                            ego_pose, ego_vehicle_info, lon_offset,
-                                                            lat_margin, is_stopped_object, debug)
-                                                        : ego_polygon;
+    const auto extended_ego_polygon = [&]() {
+      if (!is_object_front) {
+        return ego_polygon;
+      }
+
+      if (rss_parameters.steering == "fixed") {
+        return createExtendedPolygon(
+          ego_pose, ego_vehicle_info, lon_offset, lat_margin, is_stopped_object, debug);
+      }
+
+      if (rss_parameters.steering == "free") {
+        return createExtendedPolygonAlongPath(
+          planned_path, ego_pose, ego_vehicle_info, lon_offset, lat_margin, is_stopped_object,
+          debug);
+      }
+
+      throw std::domain_error("invalid rss parameter. please select 'fixed' or 'free'.");
+    }();
     const auto & extended_obj_polygon =
       is_object_front
         ? obj_polygon

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -636,18 +636,18 @@ std::vector<Polygon2d> getCollidedPolygons(
         return ego_polygon;
       }
 
-      if (rss_parameters.steering == "fixed") {
+      if (rss_parameters.extended_polygon_policy == "rectangle") {
         return createExtendedPolygon(
           ego_pose, ego_vehicle_info, lon_offset, lat_margin, is_stopped_object, debug);
       }
 
-      if (rss_parameters.steering == "free") {
+      if (rss_parameters.extended_polygon_policy == "along_path") {
         return createExtendedPolygonAlongPath(
           planned_path, ego_pose, ego_vehicle_info, lon_offset, lat_margin, is_stopped_object,
           debug);
       }
 
-      throw std::domain_error("invalid rss parameter. please select 'fixed' or 'free'.");
+      throw std::domain_error("invalid rss parameter. please select 'rectangle' or 'along_path'.");
     }();
     const auto & extended_obj_polygon =
       is_object_front

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -232,14 +232,14 @@ Polygon2d createExtendedPolygonAlongPath(
   }
 
   {
-    const auto p_offset = tier4_autoware_utils::calcOffsetPose(
-      lon_offset_pose.value(), forward_lon_offset, lat_offset, 0.0);
+    const auto p_offset =
+      tier4_autoware_utils::calcOffsetPose(lon_offset_pose.value(), base_to_front, lat_offset, 0.0);
     appendPointToPolygon(polygon, p_offset.position);
   }
 
   {
     const auto p_offset = tier4_autoware_utils::calcOffsetPose(
-      lon_offset_pose.value(), forward_lon_offset, -lat_offset, 0.0);
+      lon_offset_pose.value(), base_to_front, -lat_offset, 0.0);
     appendPointToPolygon(polygon, p_offset.position);
   }
 


### PR DESCRIPTION
## Description

:warning: Please approve following PR first.
https://github.com/autowarefoundation/autoware_launch/pull/865

Current `safety_checker` assumes that steering angle is fixed during braking and creates rectangle polygon to check safety based on each predicted poses. However, basically it is able to change steering angle anytime. Additionally, previous logic sometimes caused false positive and modules judged unsafe excessively because the detection polygon covered not only adjacent lane but also the area where the ego wouldn't go through.

In this PR, I added option to switch steering policy during breaking from `fixed` or `free`.

### steering policy: `fixed`

In this policy, the safety checker creates rectangle polygon based on each predicted poses. (original method)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/7c842e65-e670-46fa-888a-0f0c89aee8c0)

### steering policy: `free`

In this policy, the safety checker creates polygon along path. Polygon's longitudinal length is calculated by rss parameter.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/c30a0986-e387-4353-92ee-0a86254816eb)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] TEST WITH XX1
- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/eeccd553-6264-59f5-a753-6a3c5d94a81c?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve avoidance behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
