### PR TITLE
fix(multi_object_tracker): bicycle motion model - set minimum wheel-to-center length

### DIFF
--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -143,8 +143,8 @@ BicycleTracker::BicycleTracker(
   ekf_.init(X, P);
 
   // Set lf, lr
-  lf_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% front from the center
-  lr_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% front from the center, minimum of 0.3m
+  lr_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% rear from the center, minimum of 0.3m
 }
 
 bool BicycleTracker::predict(const rclcpp::Time & time)

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -143,8 +143,8 @@ BicycleTracker::BicycleTracker(
   ekf_.init(X, P);
 
   // Set lf, lr
-  lf_ = bounding_box_.length * 0.3;  // 30% front from the center
-  lr_ = bounding_box_.length * 0.3;  // 30% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% front from the center
+  lr_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% rear from the center
 }
 
 bool BicycleTracker::predict(const rclcpp::Time & time)
@@ -425,8 +425,8 @@ bool BicycleTracker::measureWithShape(
     bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y, bbox_object.shape.dimensions.z};
 
   // update lf, lr
-  lf_ = bounding_box_.length * 0.3;  // 30% front from the center
-  lr_ = bounding_box_.length * 0.3;  // 30% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% front from the center, minimum of 0.3m
+  lr_ = std::max(bounding_box_.length * 0.3, 0.3);  // 30% rear from the center, minimum of 0.3m
 
   return true;
 }

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -158,8 +158,8 @@ BigVehicleTracker::BigVehicleTracker(
   setNearestCornerOrSurfaceIndex(self_transform);  // this index is used in next measure step
 
   // Set lf, lr
-  lf_ = std::max(bounding_box_.length * 0.3, 1.5);   // 30% front from the center
-  lr_ = std::max(bounding_box_.length * 0.25, 1.5);  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.5);   // 30% front from the center, minimum of 1.5m
+  lr_ = std::max(bounding_box_.length * 0.25, 1.5);  // 25% rear from the center, minimum of 1.5m
 }
 
 bool BigVehicleTracker::predict(const rclcpp::Time & time)
@@ -457,8 +457,8 @@ bool BigVehicleTracker::measureWithShape(
     bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y, bbox_object.shape.dimensions.z};
 
   // update lf, lr
-  lf_ = std::max(bounding_box_.length * 0.3, 1.5);   // 30% front from the center
-  lr_ = std::max(bounding_box_.length * 0.25, 1.5);  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.5);   // 30% front from the center, minimum of 1.5m
+  lr_ = std::max(bounding_box_.length * 0.25, 1.5);  // 25% rear from the center, minimum of 1.5m
   return true;
 }
 

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -158,8 +158,8 @@ BigVehicleTracker::BigVehicleTracker(
   setNearestCornerOrSurfaceIndex(self_transform);  // this index is used in next measure step
 
   // Set lf, lr
-  lf_ = bounding_box_.length * 0.3;   // 30% front from the center
-  lr_ = bounding_box_.length * 0.25;  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.5);   // 30% front from the center
+  lr_ = std::max(bounding_box_.length * 0.25, 1.5);  // 25% rear from the center
 }
 
 bool BigVehicleTracker::predict(const rclcpp::Time & time)
@@ -457,9 +457,8 @@ bool BigVehicleTracker::measureWithShape(
     bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y, bbox_object.shape.dimensions.z};
 
   // update lf, lr
-  lf_ = bounding_box_.length * 0.3;   // 30% front from the center
-  lr_ = bounding_box_.length * 0.25;  // 25% rear from the center
-
+  lf_ = std::max(bounding_box_.length * 0.3, 1.5);   // 30% front from the center
+  lr_ = std::max(bounding_box_.length * 0.25, 1.5);  // 25% rear from the center
   return true;
 }
 

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -158,8 +158,8 @@ NormalVehicleTracker::NormalVehicleTracker(
   setNearestCornerOrSurfaceIndex(self_transform);  // this index is used in next measure step
 
   // Set lf, lr
-  lf_ = bounding_box_.length * 0.3;   // 30% front from the center
-  lr_ = bounding_box_.length * 0.25;  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.0);   // 30% front from the center
+  lr_ = std::max(bounding_box_.length * 0.25, 1.0);  // 25% rear from the center
 }
 
 bool NormalVehicleTracker::predict(const rclcpp::Time & time)
@@ -457,8 +457,8 @@ bool NormalVehicleTracker::measureWithShape(
     bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y, bbox_object.shape.dimensions.z};
 
   // update lf, lr
-  lf_ = bounding_box_.length * 0.3;   // 30% front from the center
-  lr_ = bounding_box_.length * 0.25;  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.0);   // 30% front from the center
+  lr_ = std::max(bounding_box_.length * 0.25, 1.0);  // 25% rear from the center
 
   return true;
 }

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -158,8 +158,8 @@ NormalVehicleTracker::NormalVehicleTracker(
   setNearestCornerOrSurfaceIndex(self_transform);  // this index is used in next measure step
 
   // Set lf, lr
-  lf_ = std::max(bounding_box_.length * 0.3, 1.0);   // 30% front from the center
-  lr_ = std::max(bounding_box_.length * 0.25, 1.0);  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.0);   // 30% front from the center, minimum of 1.0m
+  lr_ = std::max(bounding_box_.length * 0.25, 1.0);  // 25% rear from the center, minimum of 1.0m
 }
 
 bool NormalVehicleTracker::predict(const rclcpp::Time & time)
@@ -457,8 +457,8 @@ bool NormalVehicleTracker::measureWithShape(
     bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y, bbox_object.shape.dimensions.z};
 
   // update lf, lr
-  lf_ = std::max(bounding_box_.length * 0.3, 1.0);   // 30% front from the center
-  lr_ = std::max(bounding_box_.length * 0.25, 1.0);  // 25% rear from the center
+  lf_ = std::max(bounding_box_.length * 0.3, 1.0);   // 30% front from the center, minimum of 1.0m
+  lr_ = std::max(bounding_box_.length * 0.25, 1.0);  // 25% rear from the center, minimum of 1.0m
 
   return true;
 }


### PR DESCRIPTION
## Description

When detected object type is cylinder, it has no length. 
The current tracker always updates its bounding box dimension, and then update the wheel-to-center lengths.

This fix limits the wheel-to-center lengths `lr_` and `lf_` to have a minimum values, so that the prediction do not divide very small number. 

## Tests performed

Tested on Tier4 deployment environment and its data replay.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
