### PR TITLE
fix(lane_change): orientation check when constructing path

### DIFF
--- a/planning/behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/utils.cpp
@@ -23,6 +23,7 @@
 #include "behavior_path_planner_common/utils/path_utils.hpp"
 #include "behavior_path_planner_common/utils/utils.hpp"
 #include "object_recognition_utils/predicted_path_utils.hpp"
+#include "tier4_autoware_utils/math/unit_conversion.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
@@ -40,7 +41,9 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -383,6 +386,19 @@ std::optional<LaneChangePath> constructCandidatePath(
     enable_path_check_in_lanelet &&
     !isPathInLanelets(shifted_path.path, original_lanes, target_lanes)) {
     return std::nullopt;
+  }
+
+  if (prepare_segment.points.size() > 1 && shifted_path.path.points.size() > 1) {
+    const auto & prepare_segment_second_last_point =
+      std::prev(prepare_segment.points.end() - 1)->point.pose;
+    const auto & lane_change_start_from_shifted =
+      std::next(shifted_path.path.points.begin())->point.pose;
+    const auto yaw_diff2 = std::abs(tier4_autoware_utils::normalizeRadian(
+      tf2::getYaw(prepare_segment_second_last_point.orientation) -
+      tf2::getYaw(lane_change_start_from_shifted.orientation)));
+    if (yaw_diff2 > tier4_autoware_utils::deg2rad(5.0)) {
+      return std::nullopt;
+    }
   }
 
   candidate_path.path = utils::combinePath(prepare_segment, shifted_path.path);


### PR DESCRIPTION
## Description

solve this issue[TIER IV internal JIRA link](https://tier4.atlassian.net/browse/RT1-5047)

When start planner performing geometric pull out, it requires time to transition to recovery steering angle. Therefore ego needs to stop during this recovery perios.
However, due to ego is currently in the current lane of lane change, it caused lane change to be activated, and the start planner path and ego vehicle path is combined.

Lane change path uses previous path output as the preparation path, and also compute new lane changing path. As the result of this combination, start planner couldn't perform the recovery steering, due to the discontinuity of the path caused by the combination of start planner path and lane change path.

To avoid this issue, when computing lane change path, the continuity of the path if computed based on the angle of ego. If there is 5 degree differences, lane change will discard the lane changing path, and lane change path will not be generated.

![illustration](https://github.com/autowarefoundation/autoware.universe/assets/93502286/9cec8baa-4a8d-424e-8615-4681dcb42f88)

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Evaluator check [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/5a796a6e-9cbd-5ca1-b047-34e23b97b8be?project_id=prd_jt)


## Notes for reviewers

<!-- Write additional inf

ormation if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
