### PR TITLE
fix(AEB): check empty path at low speed

### DIFF
--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -141,8 +141,7 @@ public:
   bool hasCollision(
     const double current_v, const Path & ego_path, const std::vector<ObjectData> & objects);
 
-  std::optional<Path> generateEgoPath(
-    const double curr_v, const double curr_w, std::vector<Polygon2d> & polygons);
+  Path generateEgoPath(const double curr_v, const double curr_w, std::vector<Polygon2d> & polygons);
   std::optional<Path> generateEgoPath(
     const Trajectory & predicted_traj, std::vector<Polygon2d> & polygons);
   void createObjectData(

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -41,6 +41,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -140,10 +141,10 @@ public:
   bool hasCollision(
     const double current_v, const Path & ego_path, const std::vector<ObjectData> & objects);
 
-  void generateEgoPath(
-    const double curr_v, const double curr_w, Path & path, std::vector<Polygon2d> & polygons);
-  void generateEgoPath(
-    const Trajectory & predicted_traj, Path & path, std::vector<Polygon2d> & polygons);
+  std::optional<Path> generateEgoPath(
+    const double curr_v, const double curr_w, std::vector<Polygon2d> & polygons);
+  std::optional<Path> generateEgoPath(
+    const Trajectory & predicted_traj, std::vector<Polygon2d> & polygons);
   void createObjectData(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);

--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -6,6 +6,7 @@
   <description>Autonomous Emergency Braking package as a ROS 2 node</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
 
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
## Description

AEB calculates empty path when ego is low speed, so empty check is necessary internally.


## Related link

https://tier4.atlassian.net/browse/RT1-5170

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
