### PR TITLE
feat(start/goal_planner): remove unused param and update time horizon for goal planner's safety check

### DIFF
--- a/planning/behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -127,7 +127,7 @@
           delay_until_departure: 1.0
         # For target object filtering
         target_filtering:
-          safety_check_time_horizon: 5.0
+          safety_check_time_horizon: 10.0
           safety_check_time_resolution: 1.0
           # detection range
           object_check_forward_distance: 10.0

--- a/planning/behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -163,7 +163,6 @@
           method: "integral_predicted_polygon"
           keep_unsafe_time: 3.0
           # collision check parameters
-          check_all_predicted_path: true
           publish_debug_marker: false
           rss_params:
             rear_vehicle_reaction_time: 2.0

--- a/planning/behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_start_planner_module/README.md
@@ -370,31 +370,31 @@ Parameters under `path_safety_check.ego_predicted_path` specify the ego vehicle'
 
 Parameters under `target_filtering` are related to filtering target objects for safety check.
 
-| Name                                            | Unit  | Type   | Description                                        | Default value |
-| :---------------------------------------------- | :---- | :----- | :------------------------------------------------- | :------------ |
-| safety_check_time_horizon                       | [s]   | double | Time horizon for safety check                      | 5.0           |
-| safety_check_time_resolution                    | [s]   | double | Time resolution for safety check                   | 1.0           |
-| object_check_forward_distance                   | [m]   | double | Forward distance for object detection              | 10.0          |
-| object_check_backward_distance                  | [m]   | double | Backward distance for object detection             | 100.0         |
-| ignore_object_velocity_threshold                | [m/s] | double | Velocity threshold below which objects are ignored | 1.0           |
-| object_types_to_check.check_car                 | -     | bool   | Flag to check cars                                 | true          |
-| object_types_to_check.check_truck               | -     | bool   | Flag to check trucks                               | true          |
-| object_types_to_check.check_bus                 | -     | bool   | Flag to check buses                                | true          |
-| object_types_to_check.check_trailer             | -     | bool   | Flag to check trailers                             | true          |
-| object_types_to_check.check_bicycle             | -     | bool   | Flag to check bicycles                             | true          |
-| object_types_to_check.check_motorcycle          | -     | bool   | Flag to check motorcycles                          | true          |
-| object_types_to_check.check_pedestrian          | -     | bool   | Flag to check pedestrians                          | true          |
-| object_types_to_check.check_unknown             | -     | bool   | Flag to check unknown object types                 | false         |
-| object_lane_configuration.check_current_lane    | -     | bool   | Flag to check the current lane                     | true          |
-| object_lane_configuration.check_right_side_lane | -     | bool   | Flag to check the right side lane                  | true          |
-| object_lane_configuration.check_left_side_lane  | -     | bool   | Flag to check the left side lane                   | true          |
-| object_lane_configuration.check_shoulder_lane   | -     | bool   | Flag to check the shoulder lane                    | true          |
-| object_lane_configuration.check_other_lane      | -     | bool   | Flag to check other lanes                          | false         |
-| include_opposite_lane                           | -     | bool   | Flag to include the opposite lane in check         | false         |
-| invert_opposite_lane                            | -     | bool   | Flag to invert the opposite lane check             | false         |
-| check_all_predicted_path                        | -     | bool   | Flag to check all predicted paths                  | true          |
-| use_all_predicted_path                          | -     | bool   | Flag to use all predicted paths                    | true          |
-| use_predicted_path_outside_lanelet              | -     | bool   | Flag to use predicted paths outside of lanelets    | false         |
+| Name                                            | Unit  | Type   | Description                                                        | Default value |
+| :---------------------------------------------- | :---- | :----- | :----------------------------------------------------------------- | :------------ |
+| safety_check_time_horizon                       | [s]   | double | Time horizon for predicted paths of the ego and dynamic objects    | 5.0           |
+| safety_check_time_resolution                    | [s]   | double | Time resolution for predicted paths of the ego and dynamic objects | 1.0           |
+| object_check_forward_distance                   | [m]   | double | Forward distance for object detection                              | 10.0          |
+| object_check_backward_distance                  | [m]   | double | Backward distance for object detection                             | 100.0         |
+| ignore_object_velocity_threshold                | [m/s] | double | Velocity threshold below which objects are ignored                 | 1.0           |
+| object_types_to_check.check_car                 | -     | bool   | Flag to check cars                                                 | true          |
+| object_types_to_check.check_truck               | -     | bool   | Flag to check trucks                                               | true          |
+| object_types_to_check.check_bus                 | -     | bool   | Flag to check buses                                                | true          |
+| object_types_to_check.check_trailer             | -     | bool   | Flag to check trailers                                             | true          |
+| object_types_to_check.check_bicycle             | -     | bool   | Flag to check bicycles                                             | true          |
+| object_types_to_check.check_motorcycle          | -     | bool   | Flag to check motorcycles                                          | true          |
+| object_types_to_check.check_pedestrian          | -     | bool   | Flag to check pedestrians                                          | true          |
+| object_types_to_check.check_unknown             | -     | bool   | Flag to check unknown object types                                 | false         |
+| object_lane_configuration.check_current_lane    | -     | bool   | Flag to check the current lane                                     | true          |
+| object_lane_configuration.check_right_side_lane | -     | bool   | Flag to check the right side lane                                  | true          |
+| object_lane_configuration.check_left_side_lane  | -     | bool   | Flag to check the left side lane                                   | true          |
+| object_lane_configuration.check_shoulder_lane   | -     | bool   | Flag to check the shoulder lane                                    | true          |
+| object_lane_configuration.check_other_lane      | -     | bool   | Flag to check other lanes                                          | false         |
+| include_opposite_lane                           | -     | bool   | Flag to include the opposite lane in check                         | false         |
+| invert_opposite_lane                            | -     | bool   | Flag to invert the opposite lane check                             | false         |
+| check_all_predicted_path                        | -     | bool   | Flag to check all predicted paths                                  | true          |
+| use_all_predicted_path                          | -     | bool   | Flag to use all predicted paths                                    | true          |
+| use_predicted_path_outside_lanelet              | -     | bool   | Flag to use predicted paths outside of lanelets                    | false         |
 
 ### Safety Check Parameters
 

--- a/planning/behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -126,7 +126,6 @@
           # safety check configuration
           enable_safety_check: true
           # collision check parameters
-          check_all_predicted_path: true
           publish_debug_marker: false
           rss_params:
             rear_vehicle_reaction_time: 2.0


### PR DESCRIPTION
## Description

remove unused param and update time horizon for goal planner's safety check

launcher change in this [PR](https://github.com/autowarefoundation/autoware_launch/pull/863) should be merged first

<!-- Write a brief description of this PR. -->

## Tests performed

confirmed goal planner's safety check properly working
 
[Screencast from 2024年02月07日 21時56分46秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/32741405/5a71dbe9-fcab-44e3-9db5-c9ca153e3090)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
