### PR TITLE
fix(control_validator): process died for an empty trajectory

### DIFF
--- a/control/control_validator/src/control_validator.cpp
+++ b/control/control_validator/src/control_validator.cpp
@@ -121,6 +121,11 @@ bool ControlValidator::isDataReady()
 
 void ControlValidator::onReferenceTrajectory(const Trajectory::ConstSharedPtr msg)
 {
+  if (msg->points.size() < 2) {
+    RCLCPP_ERROR(get_logger(), "planning trajectory size is invalid (%lu)", msg->points.size());
+    return;
+  }
+
   current_reference_trajectory_ = msg;
 
   return;


### PR DESCRIPTION
## Description

Add error handling for an empty trajectory.

Note: this is a temporal fix. This invalid size must be handled as an error diag.

## Related links

[TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-4972)

## Tests performed

run psim and publish an empty trajectory.

```
ros2 topic pub /planning/scenario_planning/trajectory autoware_auto_planning_msgs/msg/Trajectory "{header: {stamp: now, frame_id: map}}"
```

**Before**
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/51a6046d-4eda-48a0-93f8-5938c1b41a5e)


**After**

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/0fb050c8-10fb-42c7-b44b-f4ee379674c0)


## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
