### PR TITLE
feat(lane_departure_checker,start_planner): add check for path within lanes for bvspm

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/boost_geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/boost_geometry.hpp
@@ -18,6 +18,7 @@
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/register/point.hpp>
+#include <boost/geometry/geometries/register/ring.hpp>
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
@@ -98,5 +99,6 @@ BOOST_GEOMETRY_REGISTER_POINT_2D(                                       // NOLIN
   tier4_autoware_utils::Point2d, double, cs::cartesian, x(), y())       // NOLINT
 BOOST_GEOMETRY_REGISTER_POINT_3D(                                       // NOLINT
   tier4_autoware_utils::Point3d, double, cs::cartesian, x(), y(), z())  // NOLINT
+BOOST_GEOMETRY_REGISTER_RING(tier4_autoware_utils::LinearRing2d)        // NOLINT
 
 #endif  // TIER4_AUTOWARE_UTILS__GEOMETRY__BOOST_GEOMETRY_HPP_

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -42,6 +42,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace lane_departure_checker
@@ -117,8 +118,18 @@ public:
   bool checkPathWillLeaveLane(
     const lanelet::ConstLanelets & lanelets, const PathWithLaneId & path) const;
 
+  std::vector<std::pair<double, lanelet::Lanelet>> getLaneletsFromPath(
+    const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
+
+  std::optional<lanelet::BasicPolygon2d> getFusedLaneletPolygonForPath(
+    const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
+
   bool checkPathWillLeaveLane(
-    lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
+    const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
+
+  PathWithLaneId cropPointsOutsideOfLanes(
+    const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
+    const size_t end_index);
 
   static bool isOutOfLane(
     const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint);

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -35,6 +35,7 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/LaneletMap.h>
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Polygon.h>
 
@@ -117,7 +118,7 @@ public:
     const lanelet::ConstLanelets & lanelets, const PathWithLaneId & path) const;
 
   bool checkPathWillLeaveLane(
-    lanelet::LaneletMapPtr lanelet_map_ptr, const std::vector<LinearRing2d> & vehicle_footprints);
+    lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
 
   static bool isOutOfLane(
     const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint);
@@ -146,9 +147,6 @@ private:
   static bool willLeaveLane(
     const lanelet::ConstLanelets & candidate_lanelets,
     const std::vector<LinearRing2d> & vehicle_footprints);
-
-  static bool isPathWithinLanelets(
-    lanelet::Lanelets & route_lanelets, LinearRing2d & footprint_hull);
 
   double calcMaxSearchLengthForBoundaries(const Trajectory & trajectory) const;
 

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -29,10 +29,14 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <boost/geometry/algorithms/envelope.hpp>
+#include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/index/rtree.hpp>
-#include <boost/optional.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/geometry/Polygon.h>
 
 #include <map>
 #include <memory>
@@ -112,6 +116,9 @@ public:
   bool checkPathWillLeaveLane(
     const lanelet::ConstLanelets & lanelets, const PathWithLaneId & path) const;
 
+  bool checkPathWillLeaveLane(
+    lanelet::LaneletMapPtr lanelet_map_ptr, const std::vector<LinearRing2d> & vehicle_footprints);
+
   static bool isOutOfLane(
     const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint);
 
@@ -139,6 +146,9 @@ private:
   static bool willLeaveLane(
     const lanelet::ConstLanelets & candidate_lanelets,
     const std::vector<LinearRing2d> & vehicle_footprints);
+
+  static bool isPathWithinLanelets(
+    lanelet::Lanelets & route_lanelets, LinearRing2d & footprint_hull);
 
   double calcMaxSearchLengthForBoundaries(const Trajectory & trajectory) const;
 

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -326,13 +326,16 @@ bool LaneDepartureChecker::checkPathWillLeaveLane(
     if (lanelets_distance_pair.size() == 1)
       return lanelets_distance_pair.at(0).second.polygon2d().basicPolygon();
     std::vector<lanelet::BasicPolygon2d> lanelet_union;
+
+    lanelet::BasicPolygon2d last_polygon =
+      lanelets_distance_pair.at(0).second.polygon2d().basicPolygon();
     for (size_t i = 1; i < lanelets_distance_pair.size(); ++i) {
-      const auto & route_lanelet_1 = lanelets_distance_pair.at(i).second;
-      const auto & poly_1 = route_lanelet_1.polygon2d().basicPolygon();
-      const auto & route_lanelet_2 = lanelets_distance_pair.at(i - 1).second;
-      const auto & poly_2 = route_lanelet_2.polygon2d().basicPolygon();
+      const auto & route_lanelet = lanelets_distance_pair.at(i).second;
+      const auto & poly = route_lanelet.polygon2d().basicPolygon();
+
       std::vector<lanelet::BasicPolygon2d> lanelet_union_temp;
-      boost::geometry::union_(poly_1, poly_2, lanelet_union_temp);
+      boost::geometry::union_(poly, last_polygon, lanelet_union_temp);
+      last_polygon = lanelet_union_temp.back();
       lanelet_union = lanelet_union_temp;
     }
     if (lanelet_union.empty()) return std::nullopt;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -331,7 +331,6 @@ std::optional<lanelet::BasicPolygon2d> LaneDepartureChecker::getFusedLaneletPoly
     if (lanelets_distance_pair.size() == 1)
       return lanelets_distance_pair.at(0).second.polygon2d().basicPolygon();
 
-    std::vector<lanelet::BasicPolygon2d> lanelet_union;
     lanelet::BasicPolygon2d merged_polygon =
       lanelets_distance_pair.at(0).second.polygon2d().basicPolygon();
     for (size_t i = 1; i < lanelets_distance_pair.size(); ++i) {
@@ -340,11 +339,16 @@ std::optional<lanelet::BasicPolygon2d> LaneDepartureChecker::getFusedLaneletPoly
 
       std::vector<lanelet::BasicPolygon2d> lanelet_union_temp;
       boost::geometry::union_(poly, merged_polygon, lanelet_union_temp);
-      merged_polygon = lanelet_union_temp.back();
-      lanelet_union = lanelet_union_temp;
+
+      // Update merged_polygon by accumulating all merged results
+      merged_polygon.clear();
+      for (const auto & temp_poly : lanelet_union_temp) {
+        merged_polygon.insert(merged_polygon.end(), temp_poly.begin(), temp_poly.end());
+      }
+
     }
-    if (lanelet_union.empty()) return std::nullopt;
-    return lanelet_union.back();
+    if(merged_polygon.empty()) return std::nullopt;
+    return merged_polygon;
   }();
 
   return fused_lanelets;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -376,7 +376,7 @@ PathWithLaneId LaneDepartureChecker::cropPointsOutsideOfLanes(
   const auto vehicle_footprints = createVehicleFootprints(path);
   size_t idx = 0;
   std::for_each(vehicle_footprints.begin(), vehicle_footprints.end(), [&](const auto & footprint) {
-    if (boost::geometry::within(footprint, fused_lanelets_polygon.value()) || idx > end_index) {
+    if (idx > end_index || boost::geometry::within(footprint, fused_lanelets_polygon.value())) {
       temp_path.points.push_back(path.points.at(idx));
     }
     ++idx;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -345,9 +345,8 @@ std::optional<lanelet::BasicPolygon2d> LaneDepartureChecker::getFusedLaneletPoly
       for (const auto & temp_poly : lanelet_union_temp) {
         merged_polygon.insert(merged_polygon.end(), temp_poly.begin(), temp_poly.end());
       }
-
     }
-    if(merged_polygon.empty()) return std::nullopt;
+    if (merged_polygon.empty()) return std::nullopt;
     return merged_polygon;
   }();
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
@@ -18,6 +18,8 @@
 #include "behavior_path_planner_common/data_manager.hpp"
 #include "behavior_path_planner_common/parameters.hpp"
 
+#include <lane_departure_checker/lane_departure_checker.hpp>
+
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -72,7 +74,8 @@ public:
     const bool left_side_parking);
   bool planPullOut(
     const Pose & start_pose, const Pose & goal_pose, const lanelet::ConstLanelets & road_lanes,
-    const lanelet::ConstLanelets & shoulder_lanes, const bool left_side_start);
+    const lanelet::ConstLanelets & shoulder_lanes, const bool left_side_start,
+    const std::shared_ptr<lane_departure_checker::LaneDepartureChecker> lane_departure_checker);
   void setParameters(const ParallelParkingParameters & parameters) { parameters_ = parameters; }
   void setPlannerData(const std::shared_ptr<const PlannerData> & planner_data)
   {
@@ -115,7 +118,8 @@ private:
     const Pose & start_pose, const Pose & goal_pose, const double R_E_far,
     const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,
     const bool is_forward, const bool left_side_parking, const double end_pose_offset,
-    const double lane_departure_margin, const double arc_path_interval);
+    const double lane_departure_margin, const double arc_path_interval,
+    const std::shared_ptr<lane_departure_checker::LaneDepartureChecker> lane_departure_checker);
   PathWithLaneId generateArcPath(
     const Pose & center, const double radius, const double start_yaw, double end_yaw,
     const double arc_path_interval, const bool is_left_turn, const bool is_forward);

--- a/planning/behavior_path_planner_common/package.xml
+++ b/planning/behavior_path_planner_common/package.xml
@@ -49,6 +49,7 @@
   <depend>freespace_planning_algorithms</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>
+  <depend>lane_departure_checker</depend>
   <depend>lanelet2_extension</depend>
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -19,20 +19,27 @@
 #include "behavior_path_start_planner_module/pull_out_path.hpp"
 #include "behavior_path_start_planner_module/pull_out_planner_base.hpp"
 
+#include <lane_departure_checker/lane_departure_checker.hpp>
+
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+
+#include <memory>
 
 namespace behavior_path_planner
 {
 class GeometricPullOut : public PullOutPlannerBase
 {
 public:
-  explicit GeometricPullOut(rclcpp::Node & node, const StartPlannerParameters & parameters);
+  explicit GeometricPullOut(
+    rclcpp::Node & node, const StartPlannerParameters & parameters,
+    const std::shared_ptr<lane_departure_checker::LaneDepartureChecker> lane_departure_checker);
 
   PlannerType getPlannerType() override { return PlannerType::GEOMETRIC; };
   std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   GeometricParallelParking planner_;
   ParallelParkingParameters parallel_parking_parameters_;
+  std::shared_ptr<lane_departure_checker::LaneDepartureChecker> lane_departure_checker_;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -50,11 +50,6 @@ public:
     ShiftedPath & shifted_path, const Pose & start_pose, const Pose & end_pose,
     const double longitudinal_acc, const double lateral_acc);
 
-  void setDepartureCheckLanes(const lanelet::ConstLanelets & departure_check_lanes)
-  {
-    departure_check_lanes_ = departure_check_lanes;
-  }
-
   std::shared_ptr<LaneDepartureChecker> lane_departure_checker_;
 
 private:
@@ -63,8 +58,6 @@ private:
   double calcPullOutLongitudinalDistance(
     const double lon_acc, const double shift_time, const double shift_length,
     const double max_curvature, const double min_distance) const;
-
-  lanelet::ConstLanelets departure_check_lanes_;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -275,7 +275,6 @@ private:
     const std::vector<PoseWithVelocityStamped> & ego_predicted_path) const;
   bool isSafePath() const;
   void setDrivableAreaInfo(BehaviorModuleOutput & output) const;
-  void updateDepartureCheckLanes();
   lanelet::ConstLanelets createDepartureCheckLanes() const;
 
   // check if the goal is located behind the ego in the same route segment.

--- a/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -30,9 +30,12 @@ namespace behavior_path_planner
 {
 using start_planner_utils::getPullOutLanes;
 
-GeometricPullOut::GeometricPullOut(rclcpp::Node & node, const StartPlannerParameters & parameters)
+GeometricPullOut::GeometricPullOut(
+  rclcpp::Node & node, const StartPlannerParameters & parameters,
+  const std::shared_ptr<lane_departure_checker::LaneDepartureChecker> lane_departure_checker)
 : PullOutPlannerBase{node, parameters},
-  parallel_parking_parameters_{parameters.parallel_parking_parameters}
+  parallel_parking_parameters_{parameters.parallel_parking_parameters},
+  lane_departure_checker_(lane_departure_checker)
 {
   planner_.setParameters(parallel_parking_parameters_);
 }
@@ -55,8 +58,8 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
   planner_.setTurningRadius(
     planner_data_->parameters, parallel_parking_parameters_.pull_out_max_steer_angle);
   planner_.setPlannerData(planner_data_);
-  const bool found_valid_path =
-    planner_.planPullOut(start_pose, goal_pose, road_lanes, pull_out_lanes, left_side_start);
+  const bool found_valid_path = planner_.planPullOut(
+    start_pose, goal_pose, road_lanes, pull_out_lanes, left_side_start, lane_departure_checker_);
   if (!found_valid_path) {
     return {};
   }

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -107,7 +107,7 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
     // lanelet::ConstLanelets, making it unnecessary to retain departure_check_lanes_ as a member
     // variable.
 
-    const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
+    const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
 
     // if (
     //   parameters_.check_shift_path_lane_departure &&

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -109,19 +109,11 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
 
     const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
 
-    // if (
-    //   parameters_.check_shift_path_lane_departure &&
-    //   lane_departure_checker_->checkPathWillLeaveLane(
-    //     departure_check_lanes_, path_shift_start_to_end)) {
-    //   continue;
-    // }
-
     if (
       parameters_.check_shift_path_lane_departure &&
       lane_departure_checker_->checkPathWillLeaveLane(lanelet_map_ptr, path_shift_start_to_end)) {
       continue;
     }
-
     shift_path.header = planner_data_->route_handler->getRouteHeader();
 
     return pull_out_path;

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -106,10 +106,19 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
     // TODO(someone): improve the method for detecting lane departures without using
     // lanelet::ConstLanelets, making it unnecessary to retain departure_check_lanes_ as a member
     // variable.
+
+    const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
+
+    // if (
+    //   parameters_.check_shift_path_lane_departure &&
+    //   lane_departure_checker_->checkPathWillLeaveLane(
+    //     departure_check_lanes_, path_shift_start_to_end)) {
+    //   continue;
+    // }
+
     if (
       parameters_.check_shift_path_lane_departure &&
-      lane_departure_checker_->checkPathWillLeaveLane(
-        departure_check_lanes_, path_shift_start_to_end)) {
+      lane_departure_checker_->checkPathWillLeaveLane(lanelet_map_ptr, path_shift_start_to_end)) {
       continue;
     }
 

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -60,9 +60,8 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
 
   // get safe path
   for (auto & pull_out_path : pull_out_paths) {
-    auto & shift_path =
-      pull_out_path.partial_paths.front();  // shift path is not separate but only one.
-
+    // shift path is not separate but only one.
+    auto & shift_path = pull_out_path.partial_paths.front();
     // check lane_departure with path between pull_out_start to pull_out_end
     PathWithLaneId path_shift_start_to_end{};
     {
@@ -75,45 +74,30 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
         shift_path.points.begin() + pull_out_end_idx + 1);
     }
 
-    // crop backward path
-    // removes points which are out of lanes up to the start pose.
-    // this ensures that the backward_path stays within the drivable area when starting from a
-    // narrow place.
-    const size_t start_segment_idx = motion_utils::findFirstNearestIndexWithSoftConstraints(
-      shift_path.points, start_pose, common_parameters.ego_nearest_dist_threshold,
-      common_parameters.ego_nearest_yaw_threshold);
-    PathWithLaneId cropped_path{};
-    for (size_t i = 0; i < shift_path.points.size(); ++i) {
-      const Pose pose = shift_path.points.at(i).point.pose;
-      const auto transformed_vehicle_footprint =
-        transformVector(vehicle_footprint_, tier4_autoware_utils::pose2transform(pose));
-      const bool is_out_of_lane =
-        LaneDepartureChecker::isOutOfLane(departure_check_lanes_, transformed_vehicle_footprint);
-      if (i <= start_segment_idx) {
-        if (!is_out_of_lane) {
-          cropped_path.points.push_back(shift_path.points.at(i));
-        }
-      } else {
-        cropped_path.points.push_back(shift_path.points.at(i));
-      }
-    }
-    shift_path.points = cropped_path.points;
-
     // check lane departure
     // The method for lane departure checking verifies if the footprint of each point on the path is
     // contained within a lanelet using `boost::geometry::within`, which incurs a high computational
     // cost.
-    // TODO(someone): improve the method for detecting lane departures without using
-    // lanelet::ConstLanelets, making it unnecessary to retain departure_check_lanes_ as a member
-    // variable.
-
     const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
-
     if (
       parameters_.check_shift_path_lane_departure &&
       lane_departure_checker_->checkPathWillLeaveLane(lanelet_map_ptr, path_shift_start_to_end)) {
       continue;
     }
+
+    // crop backward path
+    // removes points which are out of lanes up to the start pose.
+    // this ensures that the backward_path stays within the drivable area when starting from a
+    // narrow place.
+
+    const size_t start_segment_idx = motion_utils::findFirstNearestIndexWithSoftConstraints(
+      shift_path.points, start_pose, common_parameters.ego_nearest_dist_threshold,
+      common_parameters.ego_nearest_yaw_threshold);
+
+    const auto cropped_path = lane_departure_checker_->cropPointsOutsideOfLanes(
+      lanelet_map_ptr, shift_path, start_segment_idx);
+
+    shift_path.points = cropped_path.points;
     shift_path.header = planner_data_->route_handler->getRouteHeader();
 
     return pull_out_path;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -69,7 +69,8 @@ StartPlannerModule::StartPlannerModule(
       std::make_shared<ShiftPullOut>(node, *parameters, lane_departure_checker_));
   }
   if (parameters_->enable_geometric_pull_out) {
-    start_planners_.push_back(std::make_shared<GeometricPullOut>(node, *parameters));
+    start_planners_.push_back(
+      std::make_shared<GeometricPullOut>(node, *parameters, lane_departure_checker_));
   }
   if (start_planners_.empty()) {
     RCLCPP_ERROR(getLogger(), "Not found enabled planner");

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -142,7 +142,6 @@ void StartPlannerModule::initVariables()
   info_marker_.markers.clear();
   initializeSafetyCheckParameters();
   initializeCollisionCheckDebugMap(debug_data_.collision_check);
-  updateDepartureCheckLanes();
 }
 
 void StartPlannerModule::updateEgoPredictedPathParams(
@@ -608,7 +607,6 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
 void StartPlannerModule::resetStatus()
 {
   status_ = PullOutStatus{};
-  updateDepartureCheckLanes();
 }
 
 void StartPlannerModule::incrementPathIndex()
@@ -1406,22 +1404,6 @@ void StartPlannerModule::setDrivableAreaInfo(BehaviorModuleOutput & output) cons
         ? utils::combineDrivableAreaInfo(
             current_drivable_area_info, getPreviousModuleOutput().drivable_area_info)
         : current_drivable_area_info;
-  }
-}
-
-void StartPlannerModule::updateDepartureCheckLanes()
-{
-  const auto departure_check_lanes = createDepartureCheckLanes();
-  for (auto & planner : start_planners_) {
-    auto shift_pull_out = std::dynamic_pointer_cast<ShiftPullOut>(planner);
-
-    if (shift_pull_out) {
-      shift_pull_out->setDepartureCheckLanes(departure_check_lanes);
-    }
-  }
-  // debug
-  {
-    debug_data_.departure_check_lanes = departure_check_lanes;
   }
 }
 


### PR DESCRIPTION
## Description

In this PR, a new departure check set of functions have been added to lane_departure_checker that:

1. Creates an ego vehicle footprint convex hull.
2. Checks which lanelets are touched by the footprint hull using the MapLayer
3. Then Checks if each individual footprint is fully within the lanelets or not
I have implemented this check for shift pull out and geometric pull out to improve and be able to consider all the necessary lanelets to do a proper out of lane check. This solves the issue in which the ego vehicle cannot start with a shift pull out on overlapped lanes:

Before, the shift pull out planner cannot generate a route when the ego overlaps more than one lane (other planners are disabled): 
![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/ec25364a-6755-414c-9e46-e0e95ad6e1c0)


 After the changes on this PR:
![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/f19bfafa-3aaa-4985-a106-619cbe80da9b)
 

## Related links


## Tests performed

Tests performed: Psim and Scenario tests: [TIER IV INTERNAL LINK](https://evaluation.ci.tier4.jp/evaluation/reports/a3497192-f86e-51c2-a8b1-d814584595f7?project_id=prd_jt) , degradation seems to be caused by an unrelated problem with this PR.

- [ ] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.ci.tier4.jp/evaluation/reports?project_id=prd_jt)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Checked lanes for lane departure are increased to involve all relevant lanelets for the start planner.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
