### PR TITLE
feat(start_planner): add object_types_to_check_for_path_generation

### DIFF
--- a/planning/behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_start_planner_module/README.md
@@ -332,6 +332,13 @@ PullOutPath --o PullOutPlannerBase
 | shift_collision_check_distance_from_end                     | [m]   | double | collision check distance from end shift end pose                            | -10.0                |
 | geometric_collision_check_distance_from_end                 | [m]   | double | collision check distance from end geometric end pose                        | 0.0                  |
 | collision_check_margin_from_front_object                    | [m]   | double | collision check margin from front object                                    | 5.0                  |
+| object_types_to_check_for_path_generation.check_car         | -     | bool   | flag to check car for path generation                                       | true                 |
+| object_types_to_check_for_path_generation.check_truck       | -     | bool   | flag to check truck for path generation                                     | true                 |
+| object_types_to_check_for_path_generation.check_bus         | -     | bool   | flag to check bus for path generation                                       | true                 |
+| object_types_to_check_for_path_generation.check_bicycle     | -     | bool   | flag to check bicycle for path generation                                   | true                 |
+| object_types_to_check_for_path_generation.check_motorcycle  | -     | bool   | flag to check motorcycle for path generation                                | true                 |
+| object_types_to_check_for_path_generation.check_pedestrian  | -     | bool   | flag to check pedestrian for path generation                                | true                 |
+| object_types_to_check_for_path_generation.check_unknown     | -     | bool   | flag to check unknown for path generation                                   | true                 |
 | center_line_path_interval                                   | [m]   | double | reference center line path point interval                                   | 1.0                  |
 
 ### **Ego vehicle's velocity planning**

--- a/planning/behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -8,6 +8,15 @@
       collision_check_margins: [2.0, 1.0, 0.5, 0.1]
       collision_check_margin_from_front_object: 5.0
       th_moving_object_velocity: 1.0
+      object_types_to_check_for_path_generation:
+        check_car: true
+        check_truck: true
+        check_bus: true
+        check_trailer: true
+        check_bicycle: true
+        check_motorcycle: true
+        check_pedestrian: true
+        check_unknown: true
       th_distance_to_middle_of_the_road: 0.5
       center_line_path_interval: 1.0
       # shift pull out

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/data_structs.hpp
@@ -67,6 +67,8 @@ struct StartPlannerParameters
   std::vector<double> collision_check_margins{};
   double collision_check_margin_from_front_object{0.0};
   double th_moving_object_velocity{0.0};
+  behavior_path_planner::utils::path_safety_checker::ObjectTypesToCheck
+    object_types_to_check_for_path_generation{};
   double center_line_path_interval{0.0};
 
   // shift pull out

--- a/planning/behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_start_planner_module/src/manager.cpp
@@ -377,6 +377,33 @@ void StartPlannerModuleManager::updateModuleParams(
       parameters, ns + "collision_check_margin_from_front_object",
       p->collision_check_margin_from_front_object);
     updateParam<double>(parameters, ns + "th_moving_object_velocity", p->th_moving_object_velocity);
+    const std::string obj_types_ns = ns + "object_types_to_check_for_path_generation.";
+    {
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_car",
+        p->object_types_to_check_for_path_generation.check_car);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_truck",
+        p->object_types_to_check_for_path_generation.check_truck);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_bus",
+        p->object_types_to_check_for_path_generation.check_bus);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_trailer",
+        p->object_types_to_check_for_path_generation.check_trailer);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_unknown",
+        p->object_types_to_check_for_path_generation.check_unknown);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_bicycle",
+        p->object_types_to_check_for_path_generation.check_bicycle);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_motorcycle",
+        p->object_types_to_check_for_path_generation.check_motorcycle);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_pedestrian",
+        p->object_types_to_check_for_path_generation.check_pedestrian);
+    }
     updateParam<double>(parameters, ns + "center_line_path_interval", p->center_line_path_interval);
     updateParam<bool>(parameters, ns + "enable_shift_pull_out", p->enable_shift_pull_out);
     updateParam<double>(

--- a/planning/behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_start_planner_module/src/manager.cpp
@@ -49,6 +49,22 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   p.collision_check_margin_from_front_object =
     node->declare_parameter<double>(ns + "collision_check_margin_from_front_object");
   p.th_moving_object_velocity = node->declare_parameter<double>(ns + "th_moving_object_velocity");
+  p.object_types_to_check_for_path_generation.check_car =
+    node->declare_parameter<bool>(ns + "check_car");
+  p.object_types_to_check_for_path_generation.check_truck =
+    node->declare_parameter<bool>(ns + "check_truck");
+  p.object_types_to_check_for_path_generation.check_bus =
+    node->declare_parameter<bool>(ns + "check_bus");
+  p.object_types_to_check_for_path_generation.check_trailer =
+    node->declare_parameter<bool>(ns + "check_trailer");
+  p.object_types_to_check_for_path_generation.check_unknown =
+    node->declare_parameter<bool>(ns + "check_unknown");
+  p.object_types_to_check_for_path_generation.check_bicycle =
+    node->declare_parameter<bool>(ns + "check_bicycle");
+  p.object_types_to_check_for_path_generation.check_motorcycle =
+    node->declare_parameter<bool>(ns + "check_motorcycle");
+  p.object_types_to_check_for_path_generation.check_pedestrian =
+    node->declare_parameter<bool>(ns + "check_pedestrian");
   p.center_line_path_interval = node->declare_parameter<double>(ns + "center_line_path_interval");
   // shift pull out
   p.enable_shift_pull_out = node->declare_parameter<bool>(ns + "enable_shift_pull_out");

--- a/planning/behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_start_planner_module/src/manager.cpp
@@ -49,22 +49,25 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   p.collision_check_margin_from_front_object =
     node->declare_parameter<double>(ns + "collision_check_margin_from_front_object");
   p.th_moving_object_velocity = node->declare_parameter<double>(ns + "th_moving_object_velocity");
-  p.object_types_to_check_for_path_generation.check_car =
-    node->declare_parameter<bool>(ns + "check_car");
-  p.object_types_to_check_for_path_generation.check_truck =
-    node->declare_parameter<bool>(ns + "check_truck");
-  p.object_types_to_check_for_path_generation.check_bus =
-    node->declare_parameter<bool>(ns + "check_bus");
-  p.object_types_to_check_for_path_generation.check_trailer =
-    node->declare_parameter<bool>(ns + "check_trailer");
-  p.object_types_to_check_for_path_generation.check_unknown =
-    node->declare_parameter<bool>(ns + "check_unknown");
-  p.object_types_to_check_for_path_generation.check_bicycle =
-    node->declare_parameter<bool>(ns + "check_bicycle");
-  p.object_types_to_check_for_path_generation.check_motorcycle =
-    node->declare_parameter<bool>(ns + "check_motorcycle");
-  p.object_types_to_check_for_path_generation.check_pedestrian =
-    node->declare_parameter<bool>(ns + "check_pedestrian");
+  {
+    const std::string ns = "start_planner.object_types_to_check_for_path_generation.";
+    p.object_types_to_check_for_path_generation.check_car =
+      node->declare_parameter<bool>(ns + "check_car");
+    p.object_types_to_check_for_path_generation.check_truck =
+      node->declare_parameter<bool>(ns + "check_truck");
+    p.object_types_to_check_for_path_generation.check_bus =
+      node->declare_parameter<bool>(ns + "check_bus");
+    p.object_types_to_check_for_path_generation.check_trailer =
+      node->declare_parameter<bool>(ns + "check_trailer");
+    p.object_types_to_check_for_path_generation.check_unknown =
+      node->declare_parameter<bool>(ns + "check_unknown");
+    p.object_types_to_check_for_path_generation.check_bicycle =
+      node->declare_parameter<bool>(ns + "check_bicycle");
+    p.object_types_to_check_for_path_generation.check_motorcycle =
+      node->declare_parameter<bool>(ns + "check_motorcycle");
+    p.object_types_to_check_for_path_generation.check_pedestrian =
+      node->declare_parameter<bool>(ns + "check_pedestrian");
+  }
   p.center_line_path_interval = node->declare_parameter<double>(ns + "center_line_path_interval");
   // shift pull out
   p.enable_shift_pull_out = node->declare_parameter<bool>(ns + "enable_shift_pull_out");

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -668,9 +668,8 @@ bool StartPlannerModule::findPullOutPath(
   // extract stop objects in pull out lane for collision check
   const auto stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     *dynamic_objects, parameters_->th_moving_object_velocity);
-  auto [pull_out_lane_stop_objects, others] =
-    utils::path_safety_checker::separateObjectsByLanelets(
-      stop_objects, pull_out_lanes, utils::path_safety_checker::isPolygonOverlapLanelet);
+  auto [pull_out_lane_stop_objects, others] = utils::path_safety_checker::separateObjectsByLanelets(
+    stop_objects, pull_out_lanes, utils::path_safety_checker::isPolygonOverlapLanelet);
   utils::path_safety_checker::filterObjectsByClass(
     pull_out_lane_stop_objects, parameters_->object_types_to_check_for_path_generation);
 

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -668,9 +668,11 @@ bool StartPlannerModule::findPullOutPath(
   // extract stop objects in pull out lane for collision check
   const auto stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     *dynamic_objects, parameters_->th_moving_object_velocity);
-  const auto [pull_out_lane_stop_objects, others] =
+  auto [pull_out_lane_stop_objects, others] =
     utils::path_safety_checker::separateObjectsByLanelets(
       stop_objects, pull_out_lanes, utils::path_safety_checker::isPolygonOverlapLanelet);
+  utils::path_safety_checker::filterObjectsByClass(
+    pull_out_lane_stop_objects, parameters_->object_types_to_check_for_path_generation);
 
   // if start_pose_candidate is far from refined_start_pose, backward driving is necessary
   const bool backward_is_unnecessary =
@@ -1035,6 +1037,9 @@ PredictedObjects StartPlannerModule::filterStopObjectsInPullOutLanes(
   utils::path_safety_checker::filterObjectsByPosition(
     stop_objects_in_pull_out_lanes, path.points, current_point, object_check_forward_distance,
     object_check_backward_distance);
+
+  utils::path_safety_checker::filterObjectsByClass(
+    stop_objects_in_pull_out_lanes, parameters_->object_types_to_check_for_path_generation);
 
   return stop_objects_in_pull_out_lanes;
 }


### PR DESCRIPTION
## Description

In the original implementation, when generating path, a constant distance margin was attempted to be maintained regardless of the object's class. This approach led to a problem where path could not be generated due to the occurrence of objects of an unknown type, even when there were actually no objects exist.

Ideally, we expect that objects of unknown type will not be detected when no objects exist. However, as a short-term measure, we will enable path generation by ignoring specific classes through parameter adjustment.

Please be cautious when setting this parameter to false, as objects of an unknown class might be recognized, and there could actually be objects present.

In the PR description, I'd like to explain the path generation based on the following settings:

When the configuration is set as:
```
$ ros2 param get /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner start_planner.object_types_to_check_for_path_generation.check_car
Boolean value is: True
```
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/f5179cd9-8ee8-4e1c-9dad-5288b3ef1edc)


Conversely, when the setting is adjusted to:
```
$ ros2 param get /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner start_planner.object_types_to_check_for_path_generation.check_car
Boolean value is: False
```
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/c26c1336-d4f3-4e27-996a-96781852e882)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/oidc/auth/cb/?code=ory_ac_rrKgMtlCTGJgyBvJEa20kmQCaW17d2FKx_2a7L1TMmw.d5qXWVT5-zCKwNQfDcHtqayoG8jWIb-t1islpkNg6bI&scope=openid+profile+email+offline_access&state=88788eb23e644e72b721f20968bd7526)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
