### PR TITLE
refactor(tier4_perception_msgs): rename traffic_signal to traffic_light

### DIFF
--- a/common/traffic_light_utils/include/traffic_light_utils/traffic_light_utils.hpp
+++ b/common/traffic_light_utils/include/traffic_light_utils/traffic_light_utils.hpp
@@ -19,7 +19,7 @@
 #include "autoware_perception_msgs/msg/traffic_signal_element.hpp"
 #include "tier4_perception_msgs/msg/traffic_light_element.hpp"
 #include "tier4_perception_msgs/msg/traffic_light_roi.hpp"
-#include "tier4_perception_msgs/msg/traffic_signal.hpp"
+#include "tier4_perception_msgs/msg/traffic_light.hpp"
 
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>
@@ -35,9 +35,9 @@ bool isRoiValid(
 
 void setRoiInvalid(tier4_perception_msgs::msg::TrafficLightRoi & roi);
 
-bool isSignalUnknown(const tier4_perception_msgs::msg::TrafficSignal & signal);
+bool isSignalUnknown(const tier4_perception_msgs::msg::TrafficLight & signal);
 
-void setSignalUnknown(tier4_perception_msgs::msg::TrafficSignal & signal, float confidence = -1);
+void setSignalUnknown(tier4_perception_msgs::msg::TrafficLight & signal, float confidence = -1);
 
 /**
  * @brief Checks if a traffic light state includes a circle-shaped light with the specified color.

--- a/common/traffic_light_utils/include/traffic_light_utils/traffic_light_utils.hpp
+++ b/common/traffic_light_utils/include/traffic_light_utils/traffic_light_utils.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware_perception_msgs/msg/traffic_signal.hpp"
 #include "autoware_perception_msgs/msg/traffic_signal_element.hpp"
+#include "tier4_perception_msgs/msg/traffic_light.hpp"
 #include "tier4_perception_msgs/msg/traffic_light_element.hpp"
 #include "tier4_perception_msgs/msg/traffic_light_roi.hpp"
-#include "tier4_perception_msgs/msg/traffic_light.hpp"
 
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>

--- a/common/traffic_light_utils/src/traffic_light_utils.cpp
+++ b/common/traffic_light_utils/src/traffic_light_utils.cpp
@@ -33,14 +33,14 @@ void setRoiInvalid(tier4_perception_msgs::msg::TrafficLightRoi & roi)
   roi.roi.height = roi.roi.width = 0;
 }
 
-bool isSignalUnknown(const tier4_perception_msgs::msg::TrafficSignal & signal)
+bool isSignalUnknown(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   return signal.elements.size() == 1 &&
          signal.elements[0].shape == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN &&
          signal.elements[0].color == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
 }
 
-void setSignalUnknown(tier4_perception_msgs::msg::TrafficSignal & signal, float confidence)
+void setSignalUnknown(tier4_perception_msgs::msg::TrafficLight & signal, float confidence)
 {
   signal.elements.resize(1);
   signal.elements[0].shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;

--- a/common/traffic_light_utils/test/test_traffic_light_utils.cpp
+++ b/common/traffic_light_utils/test/test_traffic_light_utils.cpp
@@ -48,7 +48,7 @@ TEST(setRoiInvalid, set_roi_size)
 
 TEST(isSignalUnknown, signal_element)
 {
-  tier4_perception_msgs::msg::TrafficSignal test_signal;
+  tier4_perception_msgs::msg::TrafficLight test_signal;
   tier4_perception_msgs::msg::TrafficLightElement element;
   element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
   element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
@@ -60,7 +60,7 @@ TEST(isSignalUnknown, signal_element)
 
 TEST(setSignalUnknown, set_signal_element)
 {
-  tier4_perception_msgs::msg::TrafficSignal test_signal;
+  tier4_perception_msgs::msg::TrafficLight test_signal;
   tier4_perception_msgs::msg::TrafficLightElement element;
   element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
   element.shape = tier4_perception_msgs::msg::TrafficLightElement::CROSS;

--- a/perception/crosswalk_traffic_light_estimator/README.md
+++ b/perception/crosswalk_traffic_light_estimator/README.md
@@ -8,17 +8,17 @@
 
 ### Input
 
-| Name                                 | Type                                            | Description        |
-| ------------------------------------ | ----------------------------------------------- | ------------------ |
-| `~/input/vector_map`                 | `autoware_auto_mapping_msgs::msg::HADMapBin`    | vector map         |
-| `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`     | route              |
-| `~/input/classified/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | classified signals |
+| Name                                 | Type                                                | Description        |
+| ------------------------------------ | --------------------------------------------------- | ------------------ |
+| `~/input/vector_map`                 | `autoware_auto_mapping_msgs::msg::HADMapBin`        | vector map         |
+| `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`         | route              |
+| `~/input/classified/traffic_signals` | `autoware_perception_msgs::msg::TrafficSignalArray` | classified signals |
 
 ### Output
 
-| Name                       | Type                                            | Description                                               |
-| -------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | output that contains estimated pedestrian traffic signals |
+| Name                       | Type                                                | Description                                               |
+| -------------------------- | --------------------------------------------------- | --------------------------------------------------------- |
+| `~/output/traffic_signals` | `autoware_perception_msgs::msg::TrafficSignalArray` | output that contains estimated pedestrian traffic signals |
 
 ## Parameters
 

--- a/perception/crosswalk_traffic_light_estimator/README.md
+++ b/perception/crosswalk_traffic_light_estimator/README.md
@@ -8,16 +8,16 @@
 
 ### Input
 
-| Name                                 | Type                                             | Description        |
-| ------------------------------------ | ------------------------------------------------ | ------------------ |
-| `~/input/vector_map`                 | `autoware_auto_mapping_msgs::msg::HADMapBin`     | vector map         |
-| `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`      | route              |
+| Name                                 | Type                                            | Description        |
+| ------------------------------------ | ----------------------------------------------- | ------------------ |
+| `~/input/vector_map`                 | `autoware_auto_mapping_msgs::msg::HADMapBin`    | vector map         |
+| `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`     | route              |
 | `~/input/classified/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | classified signals |
 
 ### Output
 
-| Name                       | Type                                             | Description                                               |
-| -------------------------- | ------------------------------------------------ | --------------------------------------------------------- |
+| Name                       | Type                                            | Description                                               |
+| -------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
 | `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | output that contains estimated pedestrian traffic signals |
 
 ## Parameters

--- a/perception/crosswalk_traffic_light_estimator/README.md
+++ b/perception/crosswalk_traffic_light_estimator/README.md
@@ -12,13 +12,13 @@
 | ------------------------------------ | ------------------------------------------------ | ------------------ |
 | `~/input/vector_map`                 | `autoware_auto_mapping_msgs::msg::HADMapBin`     | vector map         |
 | `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`      | route              |
-| `~/input/classified/traffic_signals` | `tier4_perception_msgs::msg::TrafficSignalArray` | classified signals |
+| `~/input/classified/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | classified signals |
 
 ### Output
 
 | Name                       | Type                                             | Description                                               |
 | -------------------------- | ------------------------------------------------ | --------------------------------------------------------- |
-| `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficSignalArray` | output that contains estimated pedestrian traffic signals |
+| `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | output that contains estimated pedestrian traffic signals |
 
 ## Parameters
 

--- a/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
@@ -23,9 +23,6 @@
 #include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <tier4_debug_msgs/msg/float64_stamped.hpp>
-#include <tier4_perception_msgs/msg/traffic_light.hpp>
-#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/LaneletMap.h>

--- a/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
@@ -24,7 +24,7 @@
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <tier4_debug_msgs/msg/float64_stamped.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #include <lanelet2_core/Attribute.h>

--- a/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
@@ -23,8 +23,8 @@
 #include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <tier4_debug_msgs/msg/float64_stamped.hpp>
-#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #include <lanelet2_core/Attribute.h>

--- a/perception/traffic_light_classifier/README.md
+++ b/perception/traffic_light_classifier/README.md
@@ -45,7 +45,7 @@ These colors and shapes are assigned to the message as follows:
 
 | Name                       | Type                                             | Description         |
 | -------------------------- | ------------------------------------------------ | ------------------- |
-| `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficSignalArray` | classified signals  |
+| `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | classified signals  |
 | `~/output/debug/image`     | `sensor_msgs::msg::Image`                        | image for debugging |
 
 ## Parameters

--- a/perception/traffic_light_classifier/README.md
+++ b/perception/traffic_light_classifier/README.md
@@ -43,10 +43,10 @@ These colors and shapes are assigned to the message as follows:
 
 ### Output
 
-| Name                       | Type                                             | Description         |
-| -------------------------- | ------------------------------------------------ | ------------------- |
+| Name                       | Type                                            | Description         |
+| -------------------------- | ----------------------------------------------- | ------------------- |
 | `~/output/traffic_signals` | `tier4_perception_msgs::msg::TrafficLightArray` | classified signals  |
-| `~/output/debug/image`     | `sensor_msgs::msg::Image`                        | image for debugging |
+| `~/output/debug/image`     | `sensor_msgs::msg::Image`                       | image for debugging |
 
 ## Parameters
 

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/classifier_interface.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/classifier_interface.hpp
@@ -29,7 +29,7 @@ class ClassifierInterface
 public:
   virtual bool getTrafficSignals(
     const std::vector<cv::Mat> & input_image,
-    tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals) = 0;
+    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) = 0;
 };
 }  // namespace traffic_light
 

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/classifier_interface.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/classifier_interface.hpp
@@ -18,7 +18,7 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 
 #include <vector>
 

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/cnn_classifier.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/cnn_classifier.hpp
@@ -57,14 +57,14 @@ public:
 
   bool getTrafficSignals(
     const std::vector<cv::Mat> & images,
-    tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals) override;
+    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
 private:
-  void postProcess(int cls, float prob, tier4_perception_msgs::msg::TrafficSignal & traffic_signal);
+  void postProcess(int cls, float prob, tier4_perception_msgs::msg::TrafficLight & traffic_signal);
   bool readLabelfile(std::string filepath, std::vector<std::string> & labels);
   bool isColorLabel(const std::string label);
   void outputDebugImage(
-    cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficSignal & traffic_signal);
+    cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal);
 
 private:
   std::map<int, std::string> state2label_{

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/color_classifier.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/color_classifier.hpp
@@ -22,7 +22,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/color_classifier.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/color_classifier.hpp
@@ -64,7 +64,7 @@ public:
 
   bool getTrafficSignals(
     const std::vector<cv::Mat> & images,
-    tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals) override;
+    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
 private:
   bool filterHSV(

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
@@ -25,9 +25,9 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
@@ -24,9 +24,9 @@
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/header.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
@@ -26,7 +26,7 @@
 #include <std_msgs/msg/header.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
@@ -85,7 +85,7 @@ private:
   typedef message_filters::Synchronizer<ApproximateSyncPolicy> ApproximateSync;
   std::shared_ptr<ApproximateSync> approximate_sync_;
   bool is_approximate_sync_;
-  rclcpp::Publisher<tier4_perception_msgs::msg::TrafficSignalArray>::SharedPtr
+  rclcpp::Publisher<tier4_perception_msgs::msg::TrafficLightArray>::SharedPtr
     traffic_signal_array_pub_;
   std::shared_ptr<ClassifierInterface> classifier_ptr_;
 

--- a/perception/traffic_light_classifier/src/cnn_classifier.cpp
+++ b/perception/traffic_light_classifier/src/cnn_classifier.cpp
@@ -65,7 +65,7 @@ CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
 
 bool CNNClassifier::getTrafficSignals(
   const std::vector<cv::Mat> & images,
-  tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals)
+  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
 {
   if (images.size() != traffic_signals.signals.size()) {
     RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
@@ -106,7 +106,7 @@ bool CNNClassifier::getTrafficSignals(
 }
 
 void CNNClassifier::outputDebugImage(
-  cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficSignal & traffic_signal)
+  cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal)
 {
   float probability;
   std::string label;
@@ -138,7 +138,7 @@ void CNNClassifier::outputDebugImage(
 }
 
 void CNNClassifier::postProcess(
-  int class_index, float prob, tier4_perception_msgs::msg::TrafficSignal & traffic_signal)
+  int class_index, float prob, tier4_perception_msgs::msg::TrafficLight & traffic_signal)
 {
   std::string match_label = labels_[class_index];
 
@@ -196,7 +196,7 @@ bool CNNClassifier::readLabelfile(std::string filepath, std::vector<std::string>
 
 bool CNNClassifier::isColorLabel(const std::string label)
 {
-  using tier4_perception_msgs::msg::TrafficSignal;
+  using tier4_perception_msgs::msg::TrafficLight;
   if (
     label == state2label_[tier4_perception_msgs::msg::TrafficLightElement::GREEN] ||
     label == state2label_[tier4_perception_msgs::msg::TrafficLightElement::AMBER] ||

--- a/perception/traffic_light_classifier/src/color_classifier.cpp
+++ b/perception/traffic_light_classifier/src/color_classifier.cpp
@@ -53,7 +53,7 @@ ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
 
 bool ColorClassifier::getTrafficSignals(
   const std::vector<cv::Mat> & images,
-  tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals)
+  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
 {
   if (images.size() != traffic_signals.signals.size()) {
     RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");

--- a/perception/traffic_light_classifier/src/nodelet.cpp
+++ b/perception/traffic_light_classifier/src/nodelet.cpp
@@ -42,9 +42,8 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
       std::bind(&TrafficLightClassifierNodelet::imageRoiCallback, this, _1, _2));
   }
 
-  traffic_signal_array_pub_ =
-    this->create_publisher<tier4_perception_msgs::msg::TrafficLightArray>(
-      "~/output/traffic_signals", rclcpp::QoS{1});
+  traffic_signal_array_pub_ = this->create_publisher<tier4_perception_msgs::msg::TrafficLightArray>(
+    "~/output/traffic_signals", rclcpp::QoS{1});
 
   using std::chrono_literals::operator""ms;
   timer_ = rclcpp::create_timer(

--- a/perception/traffic_light_classifier/src/nodelet.cpp
+++ b/perception/traffic_light_classifier/src/nodelet.cpp
@@ -43,7 +43,7 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
   }
 
   traffic_signal_array_pub_ =
-    this->create_publisher<tier4_perception_msgs::msg::TrafficSignalArray>(
+    this->create_publisher<tier4_perception_msgs::msg::TrafficLightArray>(
       "~/output/traffic_signals", rclcpp::QoS{1});
 
   using std::chrono_literals::operator""ms;
@@ -95,7 +95,7 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
       input_image_msg->encoding.c_str());
   }
 
-  tier4_perception_msgs::msg::TrafficSignalArray output_msg;
+  tier4_perception_msgs::msg::TrafficLightArray output_msg;
 
   output_msg.signals.resize(input_rois_msg->rois.size());
 
@@ -131,7 +131,7 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
   // append the undetected rois as unknown
   for (const auto & input_roi : input_rois_msg->rois) {
     if (input_roi.roi.height == 0 && input_roi.traffic_light_type == classify_traffic_light_type_) {
-      tier4_perception_msgs::msg::TrafficSignal tlr_sig;
+      tier4_perception_msgs::msg::TrafficLight tlr_sig;
       tlr_sig.traffic_light_id = input_roi.traffic_light_id;
       tlr_sig.traffic_light_type = input_roi.traffic_light_type;
       tier4_perception_msgs::msg::TrafficLightElement element;

--- a/perception/traffic_light_classifier/src/single_image_debug_inference_node.cpp
+++ b/perception/traffic_light_classifier/src/single_image_debug_inference_node.cpp
@@ -123,7 +123,7 @@ private:
         return;
       }
       cv::cvtColor(crop, crop, cv::COLOR_BGR2RGB);
-      tier4_perception_msgs::msg::TrafficSignalArray traffic_signal;
+      tier4_perception_msgs::msg::TrafficLightArray traffic_signal;
       if (!classifier_ptr_->getTrafficSignals({crop}, traffic_signal)) {
         RCLCPP_ERROR(get_logger(), "failed to classify image");
         return;

--- a/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp
+++ b/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp
@@ -46,7 +46,7 @@ struct FusionRecord
   std_msgs::msg::Header header;
   sensor_msgs::msg::CameraInfo cam_info;
   tier4_perception_msgs::msg::TrafficLightRoi roi;
-  tier4_perception_msgs::msg::TrafficSignal signal;
+  tier4_perception_msgs::msg::TrafficLight signal;
 };
 
 struct FusionRecordArr
@@ -54,7 +54,7 @@ struct FusionRecordArr
   std_msgs::msg::Header header;
   sensor_msgs::msg::CameraInfo cam_info;
   tier4_perception_msgs::msg::TrafficLightRoiArray rois;
-  tier4_perception_msgs::msg::TrafficSignalArray signals;
+  tier4_perception_msgs::msg::TrafficLightArray signals;
 };
 
 bool operator<(const FusionRecordArr & r1, const FusionRecordArr & r2)
@@ -67,8 +67,8 @@ class MultiCameraFusion : public rclcpp::Node
 public:
   typedef sensor_msgs::msg::CameraInfo CamInfoType;
   typedef tier4_perception_msgs::msg::TrafficLightRoi RoiType;
-  typedef tier4_perception_msgs::msg::TrafficSignal SignalType;
-  typedef tier4_perception_msgs::msg::TrafficSignalArray SignalArrayType;
+  typedef tier4_perception_msgs::msg::TrafficLight SignalType;
+  typedef tier4_perception_msgs::msg::TrafficLightArray SignalArrayType;
   typedef tier4_perception_msgs::msg::TrafficLightRoiArray RoiArrayType;
   typedef tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type IdType;
   typedef autoware_perception_msgs::msg::TrafficSignal NewSignalType;

--- a/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp
+++ b/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp
@@ -20,8 +20,8 @@
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <message_filters/subscriber.h>

--- a/perception/traffic_light_multi_camera_fusion/src/node.cpp
+++ b/perception/traffic_light_multi_camera_fusion/src/node.cpp
@@ -25,7 +25,7 @@
 namespace
 {
 
-bool isUnknown(const tier4_perception_msgs::msg::TrafficSignal & signal)
+bool isUnknown(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   return signal.elements.size() == 1 &&
          signal.elements[0].color == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN &&

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
@@ -24,8 +24,8 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #include <image_geometry/pinhole_camera_model.h>
 #include <message_filters/subscriber.h>

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
@@ -69,7 +69,7 @@ private:
    *
    */
   void syncCallback(
-    const tier4_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr in_signal_msg,
+    const tier4_perception_msgs::msg::TrafficLightArray::ConstSharedPtr in_signal_msg,
     const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr in_roi_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr in_cam_info_msg,
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr in_cloud_msg,
@@ -80,7 +80,7 @@ private:
    * @brief publishers
    *
    */
-  rclcpp::Publisher<tier4_perception_msgs::msg::TrafficSignalArray>::SharedPtr signal_pub_;
+  rclcpp::Publisher<tier4_perception_msgs::msg::TrafficLightArray>::SharedPtr signal_pub_;
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
@@ -92,7 +92,7 @@ private:
    */
   std::shared_ptr<CloudOcclusionPredictor> cloud_occlusion_predictor_;
   typedef perception_utils::PrimeSynchronizer<
-    tier4_perception_msgs::msg::TrafficSignalArray,
+    tier4_perception_msgs::msg::TrafficLightArray,
     tier4_perception_msgs::msg::TrafficLightRoiArray, sensor_msgs::msg::CameraInfo,
     sensor_msgs::msg::PointCloud2>
     SynchronizerType;
@@ -102,7 +102,7 @@ private:
 
   std::vector<bool> subscribed_;
   std::vector<int> occlusion_ratios_;
-  tier4_perception_msgs::msg::TrafficSignalArray out_msg_;
+  tier4_perception_msgs::msg::TrafficLightArray out_msg_;
 };
 }  // namespace traffic_light
 #endif  // TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__NODELET_HPP_

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
@@ -92,9 +92,8 @@ private:
    */
   std::shared_ptr<CloudOcclusionPredictor> cloud_occlusion_predictor_;
   typedef perception_utils::PrimeSynchronizer<
-    tier4_perception_msgs::msg::TrafficLightArray,
-    tier4_perception_msgs::msg::TrafficLightRoiArray, sensor_msgs::msg::CameraInfo,
-    sensor_msgs::msg::PointCloud2>
+    tier4_perception_msgs::msg::TrafficLightArray, tier4_perception_msgs::msg::TrafficLightRoiArray,
+    sensor_msgs::msg::CameraInfo, sensor_msgs::msg::PointCloud2>
     SynchronizerType;
 
   std::shared_ptr<SynchronizerType> synchronizer_;

--- a/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
+++ b/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
@@ -57,7 +57,7 @@ TrafficLightOcclusionPredictorNodelet::TrafficLightOcclusionPredictorNodelet(
 
   // publishers
   signal_pub_ =
-    create_publisher<tier4_perception_msgs::msg::TrafficSignalArray>("~/output/traffic_signals", 1);
+    create_publisher<tier4_perception_msgs::msg::TrafficLightArray>("~/output/traffic_signals", 1);
 
   // configuration parameters
   config_.azimuth_occlusion_resolution_deg =
@@ -122,7 +122,7 @@ void TrafficLightOcclusionPredictorNodelet::mapCallback(
 }
 
 void TrafficLightOcclusionPredictorNodelet::syncCallback(
-  const tier4_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr in_signal_msg,
+  const tier4_perception_msgs::msg::TrafficLightArray::ConstSharedPtr in_signal_msg,
   const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr in_roi_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr in_cam_info_msg,
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr in_cloud_msg,
@@ -146,7 +146,7 @@ void TrafficLightOcclusionPredictorNodelet::syncCallback(
       }
     }
 
-    tier4_perception_msgs::msg::TrafficSignalArray out_msg = *in_signal_msg;
+    tier4_perception_msgs::msg::TrafficLightArray out_msg = *in_signal_msg;
 
     if (selected_roi_msg.rois.size() != in_signal_msg->signals.size() - not_detected_roi) {
       occlusion_ratios.resize(in_signal_msg->signals.size(), 0);
@@ -177,7 +177,7 @@ void TrafficLightOcclusionPredictorNodelet::syncCallback(
   subscribed_.at(traffic_light_type) = true;
 
   if (std::all_of(subscribed_.begin(), subscribed_.end(), [](bool v) { return v; })) {
-    auto pub_msg = std::make_unique<tier4_perception_msgs::msg::TrafficSignalArray>(out_msg_);
+    auto pub_msg = std::make_unique<tier4_perception_msgs::msg::TrafficLightArray>(out_msg_);
     pub_msg->header = in_signal_msg->header;
     signal_pub_->publish(std::move(pub_msg));
     out_msg_.signals.clear();

--- a/perception/traffic_light_visualization/README.md
+++ b/perception/traffic_light_visualization/README.md
@@ -19,7 +19,7 @@ The `traffic_light_visualization` is a package that includes two visualizing nod
 
 | Name                 | Type                                             | Description              |
 | -------------------- | ------------------------------------------------ | ------------------------ |
-| `~/input/tl_state`   | `tier4_perception_msgs::msg::TrafficSignalArray` | status of traffic lights |
+| `~/input/tl_state`   | `tier4_perception_msgs::msg::TrafficLightArray` | status of traffic lights |
 | `~/input/vector_map` | `autoware_auto_mapping_msgs::msg::HADMapBin`     | vector map               |
 
 #### Output
@@ -34,7 +34,7 @@ The `traffic_light_visualization` is a package that includes two visualizing nod
 
 | Name                          | Type                                               | Description                                             |
 | ----------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| `~/input/tl_state`            | `tier4_perception_msgs::msg::TrafficSignalArray`   | status of traffic lights                                |
+| `~/input/tl_state`            | `tier4_perception_msgs::msg::TrafficLightArray`   | status of traffic lights                                |
 | `~/input/image`               | `sensor_msgs::msg::Image`                          | the image captured by perception cameras                |
 | `~/input/rois`                | `tier4_perception_msgs::msg::TrafficLightRoiArray` | the ROIs detected by `traffic_light_fine_detector`      |
 | `~/input/rough/rois` (option) | `tier4_perception_msgs::msg::TrafficLightRoiArray` | the ROIs detected by `traffic_light_map_based_detector` |

--- a/perception/traffic_light_visualization/README.md
+++ b/perception/traffic_light_visualization/README.md
@@ -17,10 +17,10 @@ The `traffic_light_visualization` is a package that includes two visualizing nod
 
 #### Input
 
-| Name                 | Type                                             | Description              |
-| -------------------- | ------------------------------------------------ | ------------------------ |
+| Name                 | Type                                            | Description              |
+| -------------------- | ----------------------------------------------- | ------------------------ |
 | `~/input/tl_state`   | `tier4_perception_msgs::msg::TrafficLightArray` | status of traffic lights |
-| `~/input/vector_map` | `autoware_auto_mapping_msgs::msg::HADMapBin`     | vector map               |
+| `~/input/vector_map` | `autoware_auto_mapping_msgs::msg::HADMapBin`    | vector map               |
 
 #### Output
 
@@ -34,7 +34,7 @@ The `traffic_light_visualization` is a package that includes two visualizing nod
 
 | Name                          | Type                                               | Description                                             |
 | ----------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| `~/input/tl_state`            | `tier4_perception_msgs::msg::TrafficLightArray`   | status of traffic lights                                |
+| `~/input/tl_state`            | `tier4_perception_msgs::msg::TrafficLightArray`    | status of traffic lights                                |
 | `~/input/image`               | `sensor_msgs::msg::Image`                          | the image captured by perception cameras                |
 | `~/input/rois`                | `tier4_perception_msgs::msg::TrafficLightRoiArray` | the ROIs detected by `traffic_light_fine_detector`      |
 | `~/input/rough/rois` (option) | `tier4_perception_msgs::msg::TrafficLightRoiArray` | the ROIs detected by `traffic_light_map_based_detector` |

--- a/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
@@ -112,8 +112,7 @@ private:
 
   typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::msg::Image, tier4_perception_msgs::msg::TrafficLightRoiArray,
-    tier4_perception_msgs::msg::TrafficLightRoiArray,
-    tier4_perception_msgs::msg::TrafficLightArray>
+    tier4_perception_msgs::msg::TrafficLightRoiArray, tier4_perception_msgs::msg::TrafficLightArray>
     SyncPolicyWithRoughRoi;
   typedef message_filters::Synchronizer<SyncPolicyWithRoughRoi> SyncWithRoughRoi;
   std::shared_ptr<SyncWithRoughRoi> sync_with_rough_roi_;

--- a/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
@@ -51,14 +51,14 @@ public:
   void imageRoiCallback(
     const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
     const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_tl_roi_msg,
-    const tier4_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr &
+    const tier4_perception_msgs::msg::TrafficLightArray::ConstSharedPtr &
       input_traffic_signals_msg);
 
   void imageRoughRoiCallback(
     const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
     const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_tl_roi_msg,
     const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_tl_rough_roi_msg,
-    const tier4_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr &
+    const tier4_perception_msgs::msg::TrafficLightArray::ConstSharedPtr &
       input_traffic_signals_msg);
 
 private:
@@ -90,7 +90,7 @@ private:
     const ClassificationResult & result);
 
   bool getClassificationResult(
-    int id, const tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals,
+    int id, const tier4_perception_msgs::msg::TrafficLightArray & traffic_signals,
     ClassificationResult & result);
 
   bool getRoiFromId(
@@ -101,11 +101,11 @@ private:
   image_transport::SubscriberFilter image_sub_;
   message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightRoiArray> roi_sub_;
   message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightRoiArray> rough_roi_sub_;
-  message_filters::Subscriber<tier4_perception_msgs::msg::TrafficSignalArray> traffic_signals_sub_;
+  message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightArray> traffic_signals_sub_;
   image_transport::Publisher image_pub_;
   typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::msg::Image, tier4_perception_msgs::msg::TrafficLightRoiArray,
-    tier4_perception_msgs::msg::TrafficSignalArray>
+    tier4_perception_msgs::msg::TrafficLightArray>
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   std::shared_ptr<Sync> sync_;
@@ -113,7 +113,7 @@ private:
   typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::msg::Image, tier4_perception_msgs::msg::TrafficLightRoiArray,
     tier4_perception_msgs::msg::TrafficLightRoiArray,
-    tier4_perception_msgs::msg::TrafficSignalArray>
+    tier4_perception_msgs::msg::TrafficLightArray>
     SyncPolicyWithRoughRoi;
   typedef message_filters::Synchronizer<SyncPolicyWithRoughRoi> SyncWithRoughRoi;
   std::shared_ptr<SyncWithRoughRoi> sync_with_rough_roi_;

--- a/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
@@ -20,8 +20,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <sensor_msgs/msg/image.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_signal_array.hpp>
 
 #include <cv_bridge/cv_bridge.h>
 #include <message_filters/subscriber.h>

--- a/perception/traffic_light_visualization/src/traffic_light_roi_visualizer/nodelet.cpp
+++ b/perception/traffic_light_visualization/src/traffic_light_roi_visualizer/nodelet.cpp
@@ -123,7 +123,7 @@ bool TrafficLightRoiVisualizerNodelet::createRect(
 void TrafficLightRoiVisualizerNodelet::imageRoiCallback(
   const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
   const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_tl_roi_msg,
-  [[maybe_unused]] const tier4_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr &
+  [[maybe_unused]] const tier4_perception_msgs::msg::TrafficLightArray::ConstSharedPtr &
     input_traffic_signals_msg)
 {
   cv_bridge::CvImagePtr cv_ptr;
@@ -152,7 +152,7 @@ void TrafficLightRoiVisualizerNodelet::imageRoiCallback(
 }
 
 bool TrafficLightRoiVisualizerNodelet::getClassificationResult(
-  int id, const tier4_perception_msgs::msg::TrafficSignalArray & traffic_signals,
+  int id, const tier4_perception_msgs::msg::TrafficLightArray & traffic_signals,
   ClassificationResult & result)
 {
   bool has_correspond_traffic_signal = false;
@@ -191,7 +191,7 @@ void TrafficLightRoiVisualizerNodelet::imageRoughRoiCallback(
   const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
   const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_tl_roi_msg,
   const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_tl_rough_roi_msg,
-  const tier4_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr & input_traffic_signals_msg)
+  const tier4_perception_msgs::msg::TrafficLightArray::ConstSharedPtr & input_traffic_signals_msg)
 {
   cv_bridge::CvImagePtr cv_ptr;
   try {


### PR DESCRIPTION
## Description
- Rename traffic_signal to traffic_light

## Related Links
- MUST BE MERGED AFTER https://github.com/tier4/tier4_autoware_msgs/pull/112
- [INTERNAL discussion link](https://star4.slack.com/archives/C4P0NSMB5/p1707124882013789?thread_ts=1707108734.051959&cid=C4P0NSMB5) 
## Tests performed

Confirmed that the perception function runs correctly with logging_simulator.launch.xml.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
