### PR TITLE
refactor(start_planner): separate debug and info marker for rviz visualization

### DIFF
--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -139,6 +139,7 @@ void StartPlannerModule::initVariables()
   resetPathCandidate();
   resetPathReference();
   debug_marker_.markers.clear();
+  info_marker_.markers.clear();
   initializeSafetyCheckParameters();
   initializeCollisionCheckDebugMap(debug_data_.collision_check);
   updateDepartureCheckLanes();
@@ -1447,25 +1448,35 @@ void StartPlannerModule::setDebugData()
   const auto white_color = createMarkerColor(1.0, 1.0, 1.0, 0.99);
 
   const auto life_time = rclcpp::Duration::from_seconds(1.5);
-  auto add = [&](MarkerArray added) {
+  auto add = [&](MarkerArray added, MarkerArray & target_marker_array) {
     for (auto & marker : added.markers) {
       marker.lifetime = life_time;
     }
-    tier4_autoware_utils::appendMarkerArray(added, &debug_marker_);
+    tier4_autoware_utils::appendMarkerArray(added, &target_marker_array);
   };
 
   debug_marker_.markers.clear();
-  add(createPoseMarkerArray(status_.pull_out_start_pose, "back_end_pose", 0, 0.9, 0.3, 0.3));
-  add(createPoseMarkerArray(status_.pull_out_path.start_pose, "start_pose", 0, 0.3, 0.9, 0.3));
-  add(createPoseMarkerArray(status_.pull_out_path.end_pose, "end_pose", 0, 0.9, 0.9, 0.3));
-  add(createFootprintMarkerArray(
-    debug_data_.refined_start_pose, vehicle_info_, "refined_start_pose", 0, 0.9, 0.9, 0.3));
-  add(createPathMarkerArray(getFullPath(), "full_path", 0, 0.0, 0.5, 0.9));
-  add(createPathMarkerArray(status_.backward_path, "backward_driving_path", 0, 0.0, 0.9, 0.0));
+  info_marker_.markers.clear();
+  add(
+    createPoseMarkerArray(status_.pull_out_start_pose, "back_end_pose", 0, 0.9, 0.3, 0.3),
+    info_marker_);
+  add(
+    createPoseMarkerArray(status_.pull_out_path.start_pose, "start_pose", 0, 0.3, 0.9, 0.3),
+    info_marker_);
+  add(
+    createPoseMarkerArray(status_.pull_out_path.end_pose, "end_pose", 0, 0.9, 0.9, 0.3),
+    info_marker_);
+  add(
+    createFootprintMarkerArray(
+      debug_data_.refined_start_pose, vehicle_info_, "refined_start_pose", 0, 0.9, 0.9, 0.3),
+    debug_marker_);
+  add(createPathMarkerArray(getFullPath(), "full_path", 0, 0.0, 0.5, 0.9), debug_marker_);
+  add(
+    createPathMarkerArray(status_.backward_path, "backward_driving_path", 0, 0.0, 0.9, 0.0),
+    debug_marker_);
 
   // visualize collision_check_end_pose and footprint
   {
-    const auto local_footprint = vehicle_info_.createFootprint();
     std::map<PlannerType, double> collision_check_distances = {
       {PlannerType::SHIFT, parameters_->shift_collision_check_distance_from_end},
       {PlannerType::GEOMETRIC, parameters_->geometric_collision_check_distance_from_end}};
@@ -1475,8 +1486,10 @@ void StartPlannerModule::setDebugData()
       getFullPath().points, status_.pull_out_path.end_pose.position,
       collision_check_distance_from_end);
     if (collision_check_end_pose) {
-      add(createPoseMarkerArray(
-        *collision_check_end_pose, "static_collision_check_end_pose", 0, 1.0, 0.0, 0.0));
+      add(
+        createPoseMarkerArray(
+          *collision_check_end_pose, "static_collision_check_end_pose", 0, 1.0, 0.0, 0.0),
+        info_marker_);
       auto marker = createDefaultMarker(
         "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "static_collision_check_end_polygon", 0,
         Marker::LINE_LIST, createMarkerScale(0.1, 0.1, 0.1), red_color);
@@ -1492,7 +1505,7 @@ void StartPlannerModule::setDebugData()
           tier4_autoware_utils::createPoint(next_point.x(), next_point.y(), ego_z));
       }
       marker.lifetime = life_time;
-      debug_marker_.markers.push_back(marker);
+      info_marker_.markers.push_back(marker);
     }
   }
   // start pose candidates
@@ -1519,8 +1532,8 @@ void StartPlannerModule::setDebugData()
       start_pose_text_marker_array.markers.push_back(text_marker);
     }
 
-    add(start_pose_footprint_marker_array);
-    add(start_pose_text_marker_array);
+    add(start_pose_footprint_marker_array, debug_marker_);
+    add(start_pose_text_marker_array, debug_marker_);
   }
 
   // visualize the footprint from pull_out_start pose to pull_out_end pose along the path
@@ -1552,7 +1565,7 @@ void StartPlannerModule::setDebugData()
       pull_out_path_footprint_marker_array.markers.push_back(pull_out_path_footprint_marker);
     }
 
-    add(pull_out_path_footprint_marker_array);
+    add(pull_out_path_footprint_marker_array, debug_marker_);
   }
 
   // safety check
@@ -1560,18 +1573,24 @@ void StartPlannerModule::setDebugData()
     if (debug_data_.ego_predicted_path.size() > 0) {
       const auto & ego_predicted_path = utils::path_safety_checker::convertToPredictedPath(
         debug_data_.ego_predicted_path, ego_predicted_path_params_->time_resolution);
-      add(createPredictedPathMarkerArray(
-        ego_predicted_path, vehicle_info_, "ego_predicted_path_start_planner", 0, 0.0, 0.5, 0.9));
+      add(
+        createPredictedPathMarkerArray(
+          ego_predicted_path, vehicle_info_, "ego_predicted_path_start_planner", 0, 0.0, 0.5, 0.9),
+        debug_marker_);
     }
 
     if (debug_data_.filtered_objects.objects.size() > 0) {
-      add(createObjectsMarkerArray(
-        debug_data_.filtered_objects, "filtered_objects", 0, 0.0, 0.5, 0.9));
+      add(
+        createObjectsMarkerArray(
+          debug_data_.filtered_objects, "filtered_objects", 0, 0.0, 0.5, 0.9),
+        info_marker_);
     }
 
-    add(showSafetyCheckInfo(debug_data_.collision_check, "object_debug_info"));
-    add(showPredictedPath(debug_data_.collision_check, "ego_predicted_path"));
-    add(showPolygon(debug_data_.collision_check, "ego_and_target_polygon_relation"));
+    add(showSafetyCheckInfo(debug_data_.collision_check, "object_debug_info"), debug_marker_);
+    add(
+      showPredictedPath(debug_data_.collision_check, "predicted_path_for_safety_check"),
+      info_marker_);
+    add(showPolygon(debug_data_.collision_check, "ego_and_target_polygon_relation"), info_marker_);
 
     // set objects of interest
     for (const auto & [uuid, data] : debug_data_.collision_check) {
@@ -1599,17 +1618,21 @@ void StartPlannerModule::setDebugData()
                    std::to_string(status_.pull_out_path.partial_paths.size() - 1);
     marker.lifetime = life_time;
     planner_type_marker_array.markers.push_back(marker);
-    add(planner_type_marker_array);
+    add(planner_type_marker_array, info_marker_);
   }
 
-  add(laneletsAsTriangleMarkerArray(
-    "departure_check_lanes_for_shift_pull_out_path", debug_data_.departure_check_lanes,
-    cyan_color));
+  add(
+    laneletsAsTriangleMarkerArray(
+      "departure_check_lanes_for_shift_pull_out_path", debug_data_.departure_check_lanes,
+      cyan_color),
+    debug_marker_);
 
   const auto pull_out_lanes = start_planner_utils::getPullOutLanes(
     planner_data_, planner_data_->parameters.backward_path_length + parameters_->max_back_distance);
-  add(laneletsAsTriangleMarkerArray(
-    "pull_out_lanes_for_static_objects_collision_check", pull_out_lanes, pink_color));
+  add(
+    laneletsAsTriangleMarkerArray(
+      "pull_out_lanes_for_static_objects_collision_check", pull_out_lanes, pink_color),
+    debug_marker_);
 }
 
 void StartPlannerModule::logPullOutStatus(rclcpp::Logger::Level log_level) const

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1492,18 +1492,8 @@ void StartPlannerModule::setDebugData()
         info_marker_);
       auto marker = createDefaultMarker(
         "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "static_collision_check_end_polygon", 0,
-        Marker::LINE_LIST, createMarkerScale(0.1, 0.1, 0.1), red_color);
-      const auto footprint = transformVector(
-        local_footprint, tier4_autoware_utils::pose2transform(*collision_check_end_pose));
-      const double ego_z = planner_data_->self_odometry->pose.pose.position.z;
-      for (size_t i = 0; i < footprint.size(); i++) {
-        const auto & current_point = footprint.at(i);
-        const auto & next_point = footprint.at((i + 1) % footprint.size());
-        marker.points.push_back(
-          tier4_autoware_utils::createPoint(current_point.x(), current_point.y(), ego_z));
-        marker.points.push_back(
-          tier4_autoware_utils::createPoint(next_point.x(), next_point.y(), ego_z));
-      }
+        Marker::LINE_STRIP, createMarkerScale(0.1, 0.1, 0.1), red_color);
+      addFootprintMarker(marker, *collision_check_end_pose, vehicle_info_);
       marker.lifetime = life_time;
       info_marker_.markers.push_back(marker);
     }


### PR DESCRIPTION
## Description

Originally, all the start_planner specific information is visualized with the same topic of `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/start_planner`.
It becomes cluttered because everything is visualized by just enabling one checkbox as shown in the folloing screenshot.

![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/101c1582-2f1f-40ae-9a14-3099b644cfd9)

After categorizing in this PR,

info marker's are 
- `back_end_pose`
- `start_pose`
- `end_pose`
- `static_collision_check_end_pose`
- `static_collision_check_end_polygon`
- `planner_type`
- `filtered_objects`
- `predicted_path_for_safety_check`
- `ego_and_target_polygon_relation`
- `ego_and_target_polygon_relation_text`
- `ego_and_target_polygon_relation_cube`

![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/9854afb6-e3d1-42f5-8179-e4ae38c7781c)

debug marker's are 
- `refined_start_pose`
- `full_path`
- `backward_driving_path`
- `start_pose_candidates`
- `start_pose_candidates_idx`
- `shift_path_footprint`
- `ego_predicted_path_start_planner`
- `departure_check_lanes_for_shift_pull_out_path`
- `pull_out_lanes_for_static_objects_collision_check`
- `object_debug_info`

![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/11ecfeeb-d496-49d5-b3a9-32721b6c4a8e)


The basic concepts are as follows:
- Info: The purpose of info marker visualization is to visualize information that is helpful in understanding the state and behavior.
- Debug: The purpose of debug visualization is to provide developers with information that is useful in analyzing problems.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
