### PR TITLE
fix: remove `tensorrt_yolo` from package dependencies in launcher

### DIFF
--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -37,7 +37,6 @@
   <exec_depend>radar_object_clustering</exec_depend>
   <exec_depend>radar_object_tracker</exec_depend>
   <exec_depend>shape_estimation</exec_depend>
-  <exec_depend>tensorrt_yolo</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>tracking_object_merger</exec_depend>
   <exec_depend>traffic_light_arbiter</exec_depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

By https://github.com/autowarefoundation/autoware.universe/pull/6361, `tensorrt_yolo` has been removed but still remained as `exec_depend` in `tier4_perception_launch`.

This PR will fix the following error.
```
tier4_perception_launch: Cannot locate rosdep definition for [tensorrt_yolo]
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
