### PR TITLE
fix(map_loader): fix warnings with single point cloud map metadata

### DIFF
--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -89,7 +89,7 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
   const std::string & pcd_metadata_path, const std::vector<std::string> & pcd_paths) const
 {
   if (fs::exists(pcd_metadata_path)) {
-    std::map<std::string, PCDFileMetadata> pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);
+    auto pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);
     pcd_metadata_dict = replaceWithAbsolutePath(pcd_metadata_dict, pcd_paths);
     return pcd_metadata_dict;
   } else if (pcd_paths.size() == 1) {

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -88,10 +88,8 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
 std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
   const std::string & pcd_metadata_path, const std::vector<std::string> & pcd_paths) const
 {
-  std::map<std::string, PCDFileMetadata> pcd_metadata_dict;
-
   if (fs::exists(pcd_metadata_path)) {
-    pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);
+    std::map<std::string, PCDFileMetadata> pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);
     pcd_metadata_dict = replaceWithAbsolutePath(pcd_metadata_dict, pcd_paths);
     return pcd_metadata_dict;
   } else if (pcd_paths.size() == 1) {
@@ -106,8 +104,7 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
     }
     PCDFileMetadata metadata = {};
     pcl::getMinMax3D(single_pcd, metadata.min, metadata.max);
-    pcd_metadata_dict[pcd_paths[0]] = metadata;
-    return pcd_metadata_dict;
+    return std::map<std::string, PCDFileMetadata>{{pcd_paths[0], metadata}};
   } else {
     throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
   }

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -99,12 +99,13 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
     // Autoware users get used to handling the PCD file(s) with metadata.
     RCLCPP_INFO_STREAM(get_logger(), "Create PCD metadata, as the pointcloud is a single file.");
     pcl::PointCloud<pcl::PointXYZ> single_pcd;
-    if (pcl::io::loadPCDFile(pcd_paths[0], single_pcd) == -1) {
-      throw std::runtime_error("PCD load failed: " + pcd_paths[0]);
+    const auto& pcd_path = pcd_paths.front();
+    if (pcl::io::loadPCDFile(pcd_path, single_pcd) == -1) {
+      throw std::runtime_error("PCD load failed: " + pcd_path);
     }
     PCDFileMetadata metadata = {};
     pcl::getMinMax3D(single_pcd, metadata.min, metadata.max);
-    return std::map<std::string, PCDFileMetadata>{{pcd_paths[0], metadata}};
+    return std::map<std::string, PCDFileMetadata>{{pcd_path, metadata}};
   } else {
     throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
   }

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -99,7 +99,7 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
     // Autoware users get used to handling the PCD file(s) with metadata.
     RCLCPP_INFO_STREAM(get_logger(), "Create PCD metadata, as the pointcloud is a single file.");
     pcl::PointCloud<pcl::PointXYZ> single_pcd;
-    const auto& pcd_path = pcd_paths.front();
+    const auto & pcd_path = pcd_paths.front();
     if (pcl::io::loadPCDFile(pcd_path, single_pcd) == -1) {
       throw std::runtime_error("PCD load failed: " + pcd_path);
     }

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -89,15 +89,12 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
   const std::string & pcd_metadata_path, const std::vector<std::string> & pcd_paths) const
 {
   std::map<std::string, PCDFileMetadata> pcd_metadata_dict;
-  if (pcd_paths.size() != 1) {
-    if (!fs::exists(pcd_metadata_path)) {
-      throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
-    }
 
+  if (fs::exists(pcd_metadata_path)) {
     pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);
     pcd_metadata_dict = replaceWithAbsolutePath(pcd_metadata_dict, pcd_paths);
-    RCLCPP_INFO_STREAM(get_logger(), "Loaded PCD metadata: " << pcd_metadata_path);
-  } else {
+    return pcd_metadata_dict;
+  } else if (pcd_paths.size() == 1) {
     // An exception when using a single file PCD map so that the users do not have to provide
     // a metadata file.
     // Note that this should ideally be avoided and thus eventually be removed by someone, until
@@ -110,8 +107,10 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
     PCDFileMetadata metadata = {};
     pcl::getMinMax3D(single_pcd, metadata.min, metadata.max);
     pcd_metadata_dict[pcd_paths[0]] = metadata;
+    return pcd_metadata_dict;
+  } else {
+    throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
   }
-  return pcd_metadata_dict;
 }
 
 std::vector<std::string> PointCloudMapLoaderNode::getPcdPaths(


### PR DESCRIPTION
## Description

Part of:
- https://github.com/autowarefoundation/autoware.universe/issues/5539

Right now, even when we create a metadata with a single pcd, we receive "Create PCD metadata, as the pointcloud is a single file." warning from `pointcloud_map_loader`.

But it should throw the warning if there is no metadata but there is no metadata at all.

I've reordered the logic structure so:
In order:
1. if metadata exists -> use new method
2. if not, but only 1 pcd -> use exceptional method and warn
3. if not -> throw warning (no metadata)

cc. @ahmeddesokyebrahim 

## Tests performed

Help appreciated.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
