### PR TITLE
fix(static_drivable_area_expansion): remove process to make drivable bound longitudinally monotonic

### DIFF
--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp
@@ -87,13 +87,8 @@ std::vector<geometry_msgs::msg::Point> calcBound(
 std::vector<geometry_msgs::msg::Point> postProcess(
   const std::vector<geometry_msgs::msg::Point> & original_bound, const PathWithLaneId & path,
   const std::shared_ptr<const PlannerData> planner_data,
-  const std::vector<DrivableLanes> & drivable_lanes,
-  const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
-  const bool is_left, const bool is_driving_forward = true);
-
-std::vector<geometry_msgs::msg::Point> makeBoundLongitudinallyMonotonic(
-  const std::vector<geometry_msgs::msg::Point> & original_bound, const PathWithLaneId & path,
-  const std::shared_ptr<const PlannerData> & planner_data, const bool is_left);
+  const std::vector<DrivableLanes> & drivable_lanes, const bool is_left,
+  const bool is_driving_forward = true);
 
 DrivableAreaInfo combineDrivableAreaInfo(
   const DrivableAreaInfo & drivable_area_info1, const DrivableAreaInfo & drivable_area_info2);


### PR DESCRIPTION
## Description

Remove function `makeBoundLongitudinallyMonotonic` due to the following reasons:

- It is NOT necessary to make bound monotonic for any modules. (Even for `obstacle_avoidance_planner`)
- It is difficult to maintain the function when planner supports drivable expansion for various area (e.g. zebra, intersection, freespace...).
- It is too complex and unreadable to understand the process.

|    | in lane following  | in avoidance maneuver |
| ---- | ---- | ---- |
|  BEFORE  | ![Screenshot from 2024-02-13 10-35-13](https://github.com/autowarefoundation/autoware.universe/assets/44889564/aa09ccd9-1415-451c-aa14-4dfb2ffe9eab) | ![Screenshot from 2024-02-13 10-35-04](https://github.com/autowarefoundation/autoware.universe/assets/44889564/84503c44-c504-4e50-9c86-a45e42f08c16)  |
|  AFTER  |  ![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/6ecd551b-1dcd-424b-b069-899b88d466a5) | ![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/352d6d36-e2a4-4cc8-bf16-4c5a7c003de3) |

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] Test in public road.
- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/3162d16d-c1eb-500a-a53a-3dadd51e5cdf?project_id=prd_jt) 2677/2694
- [x] [BASE LINE](https://evaluation.tier4.jp/evaluation/reports/8d154c67-09a3-5de4-aa9a-cfdb036eb74d?project_id=prd_jt) 2673/2694

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
