### PR TITLE
fix(tracker_object_merger): add sanity check for tracker merger

### DIFF
--- a/perception/tracking_object_merger/README.md
+++ b/perception/tracking_object_merger/README.md
@@ -59,8 +59,8 @@ We use the `existence_probability` to manage tracklet.
 - When we create a new tracklet, we set the `existence_probability` to $p_{sensor}$ value.
 - In each update with specific sensor, we set the `existence_probability` to $p_{sensor}$ value.
 - When tracklet does not have update with specific sensor, we reduce the `existence_probability` by `decay_rate`
-- Object can be published if `existence_probability` is larger than `publish_probability_threshold`
-- Object will be removed if `existence_probability` is smaller than `remove_probability_threshold`
+- Object can be published if `existence_probability` is larger than `publish_probability_threshold` and time from last update is smaller than `max_dt`
+- Object will be removed if `existence_probability` is smaller than `remove_probability_threshold` and time from last update is larger than `max_dt`
 
 ![tracklet_management](./image/tracklet_management.drawio.svg)
 

--- a/perception/tracking_object_merger/include/tracking_object_merger/utils/tracker_state.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/utils/tracker_state.hpp
@@ -118,7 +118,7 @@ public:
     std::function<void(TrackedObject &, const TrackedObject &)> update_func);
   // const functions
   bool hasUUID(const MEASUREMENT_STATE input, const unique_identifier_msgs::msg::UUID & uuid) const;
-  bool isValid() const;
+  bool isValid(const rclcpp::Time & current_time) const;
   bool canPublish() const;
   TrackedObject getObject() const;
 

--- a/perception/tracking_object_merger/src/decorative_tracker_merger.cpp
+++ b/perception/tracking_object_merger/src/decorative_tracker_merger.cpp
@@ -250,9 +250,6 @@ bool DecorativeTrackerMergerNode::decorativeMerger(
 {
   // get current time
   const auto current_time = rclcpp::Time(input_objects_msg->header.stamp);
-  if (input_objects_msg->objects.empty()) {
-    return false;
-  }
   if (inner_tracker_objects_.empty()) {
     for (const auto & object : input_objects_msg->objects) {
       inner_tracker_objects_.push_back(createNewTracker(input_sensor, current_time, object));

--- a/perception/tracking_object_merger/src/utils/tracker_state.cpp
+++ b/perception/tracking_object_merger/src/utils/tracker_state.cpp
@@ -271,8 +271,14 @@ bool TrackerState::hasUUID(
   return input_uuid_map_.at(input) == uuid;
 }
 
-bool TrackerState::isValid() const
+bool TrackerState::isValid(const rclcpp::Time & current_time) const
 {
+  // check dt from last update
+  double dt = (current_time - last_update_time_).seconds();
+  if (std::abs(dt) > max_dt_) {
+    return false;
+  }
+
   // check if tracker state is valid
   if (existence_probability_ < remove_probability_threshold_) {
     return false;
@@ -302,7 +308,7 @@ TrackedObjects getTrackedObjectsFromTrackerStates(
   // sanitize and get tracked objects
   for (auto it = tracker_states.begin(); it != tracker_states.end();) {
     // check if tracker state is valid
-    if (it->isValid()) {
+    if (it->isValid(current_time)) {
       if (it->canPublish()) {
         // if valid, get tracked object
         tracked_objects.objects.push_back(it->getObject());


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
As reported in https://github.com/autowarefoundation/autoware.universe/issues/6373, tracker object merger fails to manage tracklets when input objects are empty.

This PR fixes that unintended behavior by
- Do not skip update when input objects are empty
- Add additional tracklet survival check before publishing it


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/issues/6373

## Tests performed

<!-- Describe how you have tested this PR. -->
@brkay54 could you check this PR with your error case?

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
