### PR TITLE
feat(motion_velocity_smoother): use common max_vel

### DIFF
--- a/planning/external_velocity_limit_selector/config/default_common.param.yaml
+++ b/planning/external_velocity_limit_selector/config/default_common.param.yaml
@@ -1,6 +1,8 @@
 /**:
   ros__parameters:
     # constraints param for normal driving
+    max_vel: 11.1           # max velocity limit [m/s]
+
     normal:
       min_acc: -0.5         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]

--- a/planning/motion_velocity_smoother/config/default_common.param.yaml
+++ b/planning/motion_velocity_smoother/config/default_common.param.yaml
@@ -1,6 +1,8 @@
 /**:
   ros__parameters:
     # constraints param for normal driving
+    max_vel: 11.1           # max velocity limit [m/s]
+
     normal:
       min_acc: -0.5         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -173,7 +173,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
     update_param_bool("enable_lateral_acc_limit", p.enable_lateral_acc_limit);
     update_param_bool("enable_steering_rate_limit", p.enable_steering_rate_limit);
 
-    update_param("max_velocity", p.max_velocity);
+    update_param("max_vel", p.max_velocity);
     update_param(
       "margin_to_insert_external_velocity_limit", p.margin_to_insert_external_velocity_limit);
     update_param("replan_vel_deviation", p.replan_vel_deviation);
@@ -277,7 +277,7 @@ void MotionVelocitySmootherNode::initCommonParam()
   p.enable_lateral_acc_limit = declare_parameter<bool>("enable_lateral_acc_limit");
   p.enable_steering_rate_limit = declare_parameter<bool>("enable_steering_rate_limit");
 
-  p.max_velocity = declare_parameter<double>("max_velocity");  // 72.0 kmph
+  p.max_velocity = declare_parameter<double>("max_vel");
   p.margin_to_insert_external_velocity_limit =
     declare_parameter<double>("margin_to_insert_external_velocity_limit");
   p.replan_vel_deviation = declare_parameter<double>("replan_vel_deviation");

--- a/planning/obstacle_cruise_planner/config/default_common.param.yaml
+++ b/planning/obstacle_cruise_planner/config/default_common.param.yaml
@@ -1,6 +1,8 @@
 /**:
   ros__parameters:
     # constraints param for normal driving
+    max_vel: 11.1           # max velocity limit [m/s]
+
     normal:
       min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]

--- a/planning/obstacle_stop_planner/config/common.param.yaml
+++ b/planning/obstacle_stop_planner/config/common.param.yaml
@@ -1,6 +1,8 @@
 /**:
   ros__parameters:
     # constraints param for normal driving
+    max_vel: 11.1           # max velocity limit [m/s]
+
     normal:
       min_acc: -0.5         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]

--- a/planning/planning_test_utils/config/test_common.param.yaml
+++ b/planning/planning_test_utils/config/test_common.param.yaml
@@ -1,6 +1,8 @@
 /**:
   ros__parameters:
     # constraints param for normal driving
+    max_vel: 11.1           # max velocity limit [m/s]
+
     normal:
       min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]

--- a/planning/static_centerline_optimizer/config/common.param.yaml
+++ b/planning/static_centerline_optimizer/config/common.param.yaml
@@ -1,6 +1,8 @@
 /**:
   ros__parameters:
     # constraints param for normal driving
+    max_vel: 11.1           # max velocity limit [m/s]
+
     normal:
       min_acc: -0.5         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]


### PR DESCRIPTION
## Description

The maximum velocity is currently defined in the motion_velocity_smoother, though it's a common parameter.
This PR moved the parameter to common.param.yaml
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Unit test
psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
