### PR TITLE
fix(pid_longitudinal_controller): fixed nearest/target index before/after insertion and removal of path points

### DIFF
--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -7,6 +7,7 @@
 
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
 
   <license>Apache 2.0</license>
 

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -456,6 +456,8 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
     current_interpolated_pose.first);
   control_data.nearest_idx = current_interpolated_pose.second + 1;
   control_data.target_idx = control_data.nearest_idx;
+  auto nearest_point = current_interpolated_pose.first;
+  auto target_point = current_interpolated_pose.first;
 
   // check if the deviation is worth emergency
   m_diagnostic_data.trans_deviation =
@@ -491,11 +493,25 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
     control_data.interpolated_traj.points.insert(
       control_data.interpolated_traj.points.begin() + control_data.target_idx,
       target_interpolated_point.first);
+    target_point = target_interpolated_point.first;
   }
 
+  // ==========================================================================================
+  // NOTE: due to removeOverlapPoints(), the obtained control_data.target_idx and
+  // control_data.nearest_idx may become invalid if the number of points decreased.
+  // current API does not provide the way to check duplication beforehand and this function
+  // does not tell how many/which index points were removed, so there is no way
+  // to tell if our `control_data.target_idx` point still exists or removed.
+  // ==========================================================================================
   // Remove overlapped points after inserting the interpolated points
   control_data.interpolated_traj.points =
     motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
+  control_data.nearest_idx = motion_utils::findFirstNearestIndexWithSoftConstraints(
+    control_data.interpolated_traj.points, nearest_point.pose, m_ego_nearest_dist_threshold,
+    m_ego_nearest_yaw_threshold);
+  control_data.target_idx = motion_utils::findFirstNearestIndexWithSoftConstraints(
+    control_data.interpolated_traj.points, target_point.pose, m_ego_nearest_dist_threshold,
+    m_ego_nearest_yaw_threshold);
 
   // send debug values
   m_debug_values.setValues(DebugValues::TYPE::PREDICTED_VEL, control_data.state_after_delay.vel);
@@ -610,8 +626,12 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
       ? (clock_->now() - *m_last_running_time).seconds() > p.stopped_state_entry_duration_time
       : false;
 
-  const double current_vel_cmd =
-    std::fabs(m_trajectory.points.at(control_data.nearest_idx).longitudinal_velocity_mps);
+  // ==========================================================================================
+  // NOTE: due to removeOverlapPoints() in getControlData() m_trajectory and
+  // control_data.interpolated_traj have different size.
+  // ==========================================================================================
+  const double current_vel_cmd = std::fabs(
+    control_data.interpolated_traj.points.at(control_data.nearest_idx).longitudinal_velocity_mps);
   const bool emergency_condition = m_enable_overshoot_emergency &&
                                    stop_dist < -p.emergency_state_overshoot_stop_dist &&
                                    current_vel_cmd < vel_epsilon;

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -456,7 +456,7 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
     current_interpolated_pose.first);
   control_data.nearest_idx = current_interpolated_pose.second + 1;
   control_data.target_idx = control_data.nearest_idx;
-  auto nearest_point = current_interpolated_pose.first;
+  const auto nearest_point = current_interpolated_pose.first;
   auto target_point = current_interpolated_pose.first;
 
   // check if the deviation is worth emergency


### PR DESCRIPTION
## Description

in getControlData(), path points of control_data.interpolated_traj are inserted/removed so the nearest/target index should be obtained later.

```
#12 autoware::motion::control::pid_longitudinal_controller::PidLongitudinalController::getControlData (this=0x7f3794097470, current_pose=...)
    at /home/autoware/workspace/pilot-auto.xx1/src/autoware/universe/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp:504
504         control_data.[interpolated_traj.points.at](http://interpolated_traj.points.at/)(control_data.target_idx).longitudinal_velocity_mps);
(gdb) p target_idx
No symbol "target_idx" in current context.
(gdb) p control_data.target_idx
$1 = 44
(gdb) p control_data.interpolated_traj.points.size()
$2 = 44
(gdb) p control_data.nearest_idx
$3 = 43
(gdb) p control_data.state_after_delay
$4 = {vel = 0.072158616592943342, acc = -0.30248907441951622, running_distance = 0.016637931946162379}
(gdb) p control_data.state_after_delay.running_distance > 0.01
$5 = true
```
## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/af48cc3a-7c07-5188-8a73-62d2450d8a9b?project_id=prd_jt

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
