### PR TITLE
fix(avoidance): don't insert stop point for return shift if it is allowed to modify goal position

### DIFF
--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -1396,6 +1396,11 @@ void AvoidanceModule::insertReturnDeadLine(
 {
   const auto & data = avoid_data_;
 
+  if (utils::isAllowedGoalModification(planner_data_->route_handler)) {
+    RCLCPP_DEBUG(getLogger(), "goal pose is modified. do nothing.");
+    return;
+  }
+
   if (data.to_return_point > planner_data_->parameters.forward_path_length) {
     RCLCPP_DEBUG(getLogger(), "return dead line is far enough.");
     return;

--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -1396,11 +1396,6 @@ void AvoidanceModule::insertReturnDeadLine(
 {
   const auto & data = avoid_data_;
 
-  if (utils::isAllowedGoalModification(planner_data_->route_handler)) {
-    RCLCPP_DEBUG(getLogger(), "goal pose is modified. do nothing.");
-    return;
-  }
-
   if (data.to_return_point > planner_data_->parameters.forward_path_length) {
     RCLCPP_DEBUG(getLogger(), "return dead line is far enough.");
     return;


### PR DESCRIPTION
## Description

Avoidance module inserts stop point unexpectedlly even when the pull over module is running. I fixed to skip that process by checking `isAllowedGoalModification`.

![Screenshot from 2024-02-14 09-32-03](https://github.com/autowarefoundation/autoware.universe/assets/44889564/2491bb3b-6bdd-46a7-b0af-c955599cfebc)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] PASS TIER IV INTERNAL SCENARIOS

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
