### PR TITLE
refactor(blind_spot): find first_conflicting_lane just as intersection module

### DIFF
--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -43,6 +43,21 @@ struct BlindSpotPolygons
   std::vector<lanelet::CompoundPolygon3d> opposite_detection_areas;
 };
 
+/**
+ * @brief  wrapper class of interpolated path with lane id
+ */
+struct InterpolatedPathInfo
+{
+  /** the interpolated path */
+  autoware_auto_planning_msgs::msg::PathWithLaneId path;
+  /** discretization interval of interpolation */
+  double ds{0.0};
+  /** the intersection lanelet id */
+  lanelet::Id lane_id{0};
+  /** the range of indices for the path points with associative lane id */
+  std::optional<std::pair<size_t, size_t>> lane_id_interval{std::nullopt};
+};
+
 class BlindSpotModule : public SceneModuleInterface
 {
 public:
@@ -91,12 +106,35 @@ public:
 
 private:
   const int64_t lane_id_;
-  TurnDirection turn_direction_;
-  bool has_traffic_light_;
-  bool is_over_pass_judge_line_;
+  TurnDirection turn_direction_{TurnDirection::INVALID};
+  bool is_over_pass_judge_line_{false};
+  std::optional<lanelet::ConstLanelet> first_conflicting_lanelet_{std::nullopt};
 
   // Parameter
   PlannerParam planner_param_;
+
+  std::optional<InterpolatedPathInfo> generateInterpolatedPathInfo(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path) const;
+
+  std::optional<lanelet::ConstLanelet> getFirstConflictingLanelet(
+    const InterpolatedPathInfo & interpolated_path_info) const;
+
+  std::optional<int> getFirstPointConflictingLanelets(
+    const InterpolatedPathInfo & interpolated_path_info,
+    const lanelet::ConstLanelets & lanelets) const;
+
+  /**
+   * @brief Generate a stop line and insert it into the path.
+   * A stop line is at an intersection point of straight path with vehicle path
+   * @param detection_areas used to generate stop line
+   * @param path            ego-car lane
+   * @param stop_line_idx   generated stop line index
+   * @param pass_judge_line_idx  generated pass judge line index
+   * @return false when generation failed
+   */
+  std::optional<std::pair<size_t, size_t>> generateStopLine(
+    const InterpolatedPathInfo & interpolated_path_info,
+    autoware_auto_planning_msgs::msg::PathWithLaneId * path) const;
 
   /**
    * @brief Check obstacle is in blind spot areas.
@@ -141,17 +179,6 @@ private:
     const geometry_msgs::msg::Pose & pose) const;
 
   /**
-   * @brief Get vehicle edge
-   * @param vehicle_pose pose of ego vehicle
-   * @param vehicle_width width of ego vehicle
-   * @param base_link2front length between base link and front of ego vehicle
-   * @return edge of ego vehicle
-   */
-  lanelet::LineString2d getVehicleEdge(
-    const geometry_msgs::msg::Pose & vehicle_pose, const double vehicle_width,
-    const double base_link2front) const;
-
-  /**
    * @brief Check if object is belong to targeted classes
    * @param object Dynamic object
    * @return True when object belong to targeted classes
@@ -167,54 +194,6 @@ private:
   bool isPredictedPathInArea(
     const autoware_auto_perception_msgs::msg::PredictedObject & object,
     const std::vector<lanelet::CompoundPolygon3d> & areas, geometry_msgs::msg::Pose ego_pose) const;
-
-  /**
-   * @brief Generate a stop line and insert it into the path.
-   * A stop line is at an intersection point of straight path with vehicle path
-   * @param detection_areas used to generate stop line
-   * @param path            ego-car lane
-   * @param stop_line_idx   generated stop line index
-   * @param pass_judge_line_idx  generated pass judge line index
-   * @return false when generation failed
-   */
-  std::optional<std::pair<size_t, size_t>> generateStopLine(
-    const lanelet::ConstLanelets straight_lanelets,
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path) const;
-
-  /**
-   * @brief Insert a point to target path
-   * @param insert_idx_ip insert point index in path_ip
-   * @param path_ip interpolated path
-   * @param path target path for inserting a point
-   * @return inserted point idx in target path, return -1 when could not find valid index
-   */
-  int insertPoint(
-    const int insert_idx_ip, const autoware_auto_planning_msgs::msg::PathWithLaneId path_ip,
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path) const;
-
-  /**
-   * @brief Calculate first path index that is conflicting lanelets.
-   * @param path     target path
-   * @param lanelets target lanelets
-   * @return path point index
-   */
-  std::optional<int> getFirstPointConflictingLanelets(
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const lanelet::ConstLanelets & lanelets) const;
-
-  /**
-   * @brief Get start point from lanelet
-   * @param lane_id lane id of objective lanelet
-   * @return end point of lanelet
-   */
-  std::optional<geometry_msgs::msg::Pose> getStartPointFromLaneLet(const lanelet::Id lane_id) const;
-
-  /**
-   * @brief get straight lanelets in intersection
-   */
-  lanelet::ConstLanelets getStraightLanelets(
-    lanelet::LaneletMapConstPtr lanelet_map_ptr,
-    lanelet::routing::RoutingGraphPtr routing_graph_ptr, const lanelet::Id lane_id);
 
   /**
    * @brief Modify objects predicted path. remove path point if the time exceeds timer_thr.


### PR DESCRIPTION
## Description

find the first_conflicting_lanelet in the same way as intersection module

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/873

https://tier4.atlassian.net/browse/RT1-5048

https://tier4.atlassian.net/browse/RT1-4216

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/d4841d57-9c9e-5027-80d8-0d444a6d8fb5?project_id=prd_jt

### on a single lane

https://github.com/autowarefoundation/autoware.universe/assets/28677420/30c0f90f-5b95-4c51-bae5-4df7c6e4706e

### for adjacent lane

https://github.com/autowarefoundation/autoware.universe/assets/28677420/9e52a6c4-0513-4bf7-a5ab-8a862da9e54a

### for opposite adjacent lane

https://github.com/autowarefoundation/autoware.universe/assets/28677420/54ee900e-0fdb-48c2-9cc0-895ca2bc9575

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Introduced a new `InterpolatedPathInfo` struct to wrap an interpolated path with lane ID information.
- Refactor: Initialized `turn_direction_`, `is_over_pass_judge_line_`, and `first_conflicting_lanelet_` using brace initialization syntax.
- Refactor: Added several private member functions (`generateInterpolatedPathInfo()`, `getFirstConflictingLanelet()`, `getFirstPointConflictingLanelets()`, and `generateStopLine()`).
- Refactor: Removed the `getVehicleEdge()` function.
- Refactor: Refactored the logic for generating a stop line and inserting it into the path.
- Refactor: Removed the `getStraightLanelets()` function.

These changes improve the code structure, enhance functionality related to interpolated paths and lane information, and remove unnecessary functions. There are no direct user-facing impacts, but these changes contribute to overall code quality and maintainability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->