### PR TITLE
chore(cspell): update .cspell-partial.json

### DIFF
--- a/.cspell-partial.json
+++ b/.cspell-partial.json
@@ -5,5 +5,5 @@
     "perception/bytetrack/lib/**"
   ],
   "ignoreRegExpList": [],
-  "words": ["dltype", "tvmgen", "quantizer", "imageio", "mimsave"]
+  "words": ["dltype", "tvmgen"]
 }


### PR DESCRIPTION
## Description

the words, `quantizer`, `imageio` and `mimsave` are added to `autoware-spell-check-dict` in folloing pull-request.

https://github.com/tier4/autoware-spell-check-dict/pull/656
https://github.com/tier4/autoware-spell-check-dict/pull/655

So, I delete these words from `.cspell-partial.json`

## Tests performed

Check `spell-check-partial` is green

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
