### PR TITLE
fix(goal_planner): fix updateCollisionCheckDebugMap timing in checkSafetyWithIntegralPredictedPolygon

### DIFF
--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -461,9 +461,9 @@ bool checkSafetyWithIntegralPredictedPolygon(
           updateCollisionCheckDebugMap(debug_map, debug_pair, /*is_safe=*/false);
           return false;
         }
-        updateCollisionCheckDebugMap(debug_map, debug_pair, /*is_safe=*/true);
       }
     }
+    updateCollisionCheckDebugMap(debug_map, debug_pair, /*is_safe=*/true);
   }
   return true;
 }


### PR DESCRIPTION

## Description

<!-- Write a brief description of this PR. -->

the behavior is not changed.
just modify updateCollisionCheckDebugMap call timing

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
