### PR TITLE
fix(pose_instability_detector): changed the interval_sec value of pose_instability_detector

### DIFF
--- a/localization/pose_instability_detector/config/pose_instability_detector.param.yaml
+++ b/localization/pose_instability_detector/config/pose_instability_detector.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    interval_sec: 1.0  # [sec]
+    interval_sec: 0.5  # [sec]
     threshold_diff_position_x: 1.0  # [m]
     threshold_diff_position_y: 1.0  # [m]
     threshold_diff_position_z: 1.0  # [m]

--- a/localization/pose_instability_detector/schema/pose_instability_detector.schema.json
+++ b/localization/pose_instability_detector/schema/pose_instability_detector.schema.json
@@ -8,7 +8,7 @@
       "properties": {
         "interval_sec": {
           "type": "number",
-          "default": 1.0,
+          "default": 0.5,
           "exclusiveMinimum": 0,
           "description": "The interval of timer_callback in seconds."
         },


### PR DESCRIPTION
## Description

Currently, `interval_sec` in `pose_instability_detector` is set to 1.0 seconds.

However, the localization_stability timeout in `system_error_monitor`, which aggregates this, is also set to 1.0 seconds.

https://github.com/autowarefoundation/autoware.universe/blob/b2cd2aac9ebd5bb3e8468c10ee2b008a6ef1101b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml#L33-L37

Therefore, if there is even a slight delay, it will become stale.

In thie PR, I have changed `interval_sec` of `pose_instability_detector` to 0.5 seconds so that it does not become stale immediately even if there is a delay.

#### Why not
There are two solutions: increase the `timeout` of `system_monitor` or decrease `interval_sec` of `pose_instability_detector`.
I chose to decrease the `interval_sec` of `pose_instability_detector` in this PR because I was worried that increasing the `system_monitor` timeout would delay noticing timeout errors.

## Tests performed

AWSIM + Autoware works fine without stale in `rqt_robot_monitor`.

```
ros2 run rqt_robot_monitor rqt_robot_monitor
```

Note: Since autoware outputs a large number of topic messages to `/diagnostics`, drops will still occur in `rqt_runtime_monitor` where the queue size is not large enough.

```
ros2 run rqt_runtime_monitor rqt_runtime_monitor
```

## Effects on system behavior

ERRORs in `system_error_monitor` due to `pose_instability_detector` stale are less likely to occur.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
