### PR TITLE
feat(compare_map_segmentation): change height downsize logic

### DIFF
--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -241,9 +241,10 @@ bool VoxelGridMapLoader::is_in_voxel(
     const double dist_x = map->points.at(voxel_index).x - target_point.x;
     const double dist_y = map->points.at(voxel_index).y - target_point.y;
     const double dist_z = map->points.at(voxel_index).z - target_point.z;
-    const double sqr_distance = dist_x * dist_x + dist_y * dist_y +
-                                dist_z * dist_z * downsize_ratio_z_axis_ * downsize_ratio_z_axis_;
-    if (sqr_distance < distance_threshold * distance_threshold) {
+    // check if the point is inside the distance threshold voxel
+    if (
+      std::abs(dist_x) < distance_threshold && std::abs(dist_y) < distance_threshold &&
+      std::abs(dist_z) < distance_threshold * downsize_ratio_z_axis_) {
       return true;
     }
   }

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -241,8 +241,9 @@ bool VoxelGridMapLoader::is_in_voxel(
     const double dist_x = map->points.at(voxel_index).x - target_point.x;
     const double dist_y = map->points.at(voxel_index).y - target_point.y;
     const double dist_z = map->points.at(voxel_index).z - target_point.z;
-    const double sqr_distance = dist_x * dist_x + dist_y * dist_y + dist_z * dist_z;
-    if (sqr_distance < distance_threshold * distance_threshold * downsize_ratio_z_axis_) {
+    const double sqr_distance = dist_x * dist_x + dist_y * dist_y +
+                                dist_z * dist_z * downsize_ratio_z_axis_ * downsize_ratio_z_axis_;
+    if (sqr_distance < distance_threshold * distance_threshold) {
       return true;
     }
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Focused function has intention to reduce height distance effect so that the function won't filter out ground pointcloud.
Problem in original code is that it will also reduce the horizontal error threshold since 3d euclidean distance is just reduced.

I changed inclusion decision logic from 3d euclidean distance to comparison with each axis: which will more easier to understand and tune.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested with X2 rosbag.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
