### PR TITLE
fix(behavior_path_planner): catch exception when calculating curvature

### DIFF
--- a/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -383,11 +383,18 @@ void expand_drivable_area(
 
   stop_watch.tic("curvatures_expansion");
   // Only add curvatures for the new points. Curvatures of reused path points are not updated.
-  const auto new_curvatures =
-    calculate_smoothed_curvatures(path_poses, params.curvature_average_window);
-  const auto first_new_point_idx = curvatures.size();
-  curvatures.insert(
-    curvatures.end(), new_curvatures.begin() + first_new_point_idx, new_curvatures.end());
+  try {
+    if (path_poses.size() > curvatures.size()) {
+      const auto new_curvatures =
+        calculate_smoothed_curvatures(path_poses, params.curvature_average_window);
+      const auto first_new_point_idx = curvatures.size();
+      curvatures.insert(
+        curvatures.end(), new_curvatures.begin() + first_new_point_idx, new_curvatures.end());
+    }
+  } catch (const std::exception & e) {
+    std::cerr << "[drivable_area_expansion] could not calculate path curvatures\n";
+    curvatures.resize(path_poses.size(), 0.0);
+  }
   auto expansion =
     calculate_expansion(path_poses, path.left_bound, path.right_bound, curvatures, params);
   const auto curvature_expansion_ms = stop_watch.toc("curvatures_expansion");


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The `behavior_path_planner` may crash if some points in the map are too close to eachother or form a too sharp angle.
This PR prevents crashes by handling the exception that may occur when calculating curvatures of the path.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No crash on bad maps

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
