### PR TITLE
feat(intersection): consider abnormal violating vehicles

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_intersection_module/src/debug.cpp
@@ -291,6 +291,13 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array);
   }
 
+  if (debug_data_.yield_area) {
+    appendMarkerArray(
+      ::createLaneletPolygonsMarkerArray(
+        debug_data_.yield_area.value(), "yield_area", lane_id_, 0.6588235, 0.34509, 0.6588235),
+      &debug_marker_array);
+  }
+
   if (debug_data_.ego_lane) {
     appendMarkerArray(
       ::createLaneletPolygonsMarkerArray(

--- a/planning/behavior_velocity_intersection_module/src/intersection_lanelets.hpp
+++ b/planning/behavior_velocity_intersection_module/src/intersection_lanelets.hpp
@@ -52,19 +52,28 @@ public:
   {
     return is_prioritized_ ? attention_non_preceding_stoplines_ : attention_stoplines_;
   }
+  const lanelet::ConstLanelets & attention_non_preceding() const
+  {
+    return attention_non_preceding_;
+  }
   const lanelet::ConstLanelets & conflicting() const { return conflicting_; }
   const lanelet::ConstLanelets & adjacent() const { return adjacent_; }
   const lanelet::ConstLanelets & occlusion_attention() const
   {
     return is_prioritized_ ? attention_non_preceding_ : occlusion_attention_;
   }
-  const lanelet::ConstLanelets & attention_non_preceding() const
+  const lanelet::ConstLanelets & yield() const { return yield_; }
+  const std::vector<std::optional<lanelet::ConstLineString3d>> & yield_stoplines() const
   {
-    return attention_non_preceding_;
+    return yield_stoplines_;
   }
   const std::vector<lanelet::CompoundPolygon3d> & attention_area() const
   {
     return is_prioritized_ ? attention_non_preceding_area_ : attention_area_;
+  }
+  const std::optional<lanelet::CompoundPolygon3d> & first_attention_area() const
+  {
+    return first_attention_area_;
   }
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_area() const
   {
@@ -75,6 +84,7 @@ public:
   {
     return occlusion_attention_area_;
   }
+  const std::vector<lanelet::CompoundPolygon3d> & yield_area() const { return yield_area_; }
   const std::optional<lanelet::ConstLanelet> & first_conflicting_lane() const
   {
     return first_conflicting_lane_;
@@ -86,10 +96,6 @@ public:
   const std::optional<lanelet::ConstLanelet> & first_attention_lane() const
   {
     return first_attention_lane_;
-  }
-  const std::optional<lanelet::CompoundPolygon3d> & first_attention_area() const
-  {
-    return first_attention_area_;
   }
   const std::optional<lanelet::ConstLanelet> & second_attention_lane() const
   {
@@ -103,48 +109,55 @@ public:
   /**
    * the set of attention lanelets which is topologically merged
    */
-  lanelet::ConstLanelets attention_;
-  std::vector<lanelet::CompoundPolygon3d> attention_area_;
+  lanelet::ConstLanelets attention_{};
+  std::vector<lanelet::CompoundPolygon3d> attention_area_{};
 
   /**
    * the stop lines for each attention_lanelets associated with traffic lights. At intersection
    * without traffic lights, each value is null
    */
-  std::vector<std::optional<lanelet::ConstLineString3d>> attention_stoplines_;
+  std::vector<std::optional<lanelet::ConstLineString3d>> attention_stoplines_{};
 
   /**
    * the conflicting part of attention lanelets
    */
-  lanelet::ConstLanelets attention_non_preceding_;
-  std::vector<lanelet::CompoundPolygon3d> attention_non_preceding_area_;
+  lanelet::ConstLanelets attention_non_preceding_{};
+  std::vector<lanelet::CompoundPolygon3d> attention_non_preceding_area_{};
 
   /**
    * the stop lines for each attention_non_preceding_
    */
-  std::vector<std::optional<lanelet::ConstLineString3d>> attention_non_preceding_stoplines_;
+  std::vector<std::optional<lanelet::ConstLineString3d>> attention_non_preceding_stoplines_{};
 
   /**
    * the conflicting lanelets of the objective intersection lanelet
    */
-  lanelet::ConstLanelets conflicting_;
-  std::vector<lanelet::CompoundPolygon3d> conflicting_area_;
+  lanelet::ConstLanelets conflicting_{};
+  std::vector<lanelet::CompoundPolygon3d> conflicting_area_{};
 
   /**
    *
    */
-  lanelet::ConstLanelets adjacent_;
-  std::vector<lanelet::CompoundPolygon3d> adjacent_area_;
+  lanelet::ConstLanelets adjacent_{};
+  std::vector<lanelet::CompoundPolygon3d> adjacent_area_{};
 
   /**
    * the set of attention lanelets for occlusion detection which is topologically merged
    */
-  lanelet::ConstLanelets occlusion_attention_;
-  std::vector<lanelet::CompoundPolygon3d> occlusion_attention_area_;
+  lanelet::ConstLanelets occlusion_attention_{};
+  std::vector<lanelet::CompoundPolygon3d> occlusion_attention_area_{};
+
+  /**
+   * the set of lanelets that the objective intersection lanelet has RightOfWay over
+   */
+  lanelet::ConstLanelets yield_{};
+  std::vector<std::optional<lanelet::ConstLineString3d>> yield_stoplines_{};
+  std::vector<lanelet::CompoundPolygon3d> yield_area_{};
 
   /**
    * the vector of sum of each occlusion_attention lanelet
    */
-  std::vector<double> occlusion_attention_size_;
+  std::vector<double> occlusion_attention_size_{};
 
   /**
    * the first conflicting lanelet which ego path points intersect for the first time

--- a/planning/behavior_velocity_intersection_module/src/object_manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/object_manager.cpp
@@ -197,38 +197,47 @@ bool ObjectInfo::before_stopline_by(const double margin) const
 }
 
 std::shared_ptr<ObjectInfo> ObjectInfoManager::registerObject(
-  const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-  const bool belong_intersection_area, const bool is_parked_vehicle)
+  const unique_identifier_msgs::msg::UUID & uuid, const bool belong_violating_area,
+  const bool belong_attention_area, const bool belong_intersection_area,
+  const bool is_parked_vehicle)
 {
   if (objects_info_.count(uuid) == 0) {
     auto object = std::make_shared<intersection::ObjectInfo>(uuid);
     objects_info_[uuid] = object;
   }
   auto object = objects_info_[uuid];
-  if (belong_attention_area) {
-    attention_area_objects_.push_back(object);
-  } else if (belong_intersection_area) {
-    intersection_area_objects_.push_back(object);
-  }
-  if (is_parked_vehicle) {
-    parked_objects_.push_back(object);
+  if (belong_violating_area) {
+    violating_objects_.push_back(object);
+  } else {
+    if (belong_attention_area) {
+      attention_area_objects_.push_back(object);
+    } else if (belong_intersection_area) {
+      intersection_area_objects_.push_back(object);
+    }
+    if (is_parked_vehicle) {
+      parked_objects_.push_back(object);
+    }
   }
   return object;
 }
 
 void ObjectInfoManager::registerExistingObject(
-  const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-  const bool belong_intersection_area, const bool is_parked_vehicle,
-  std::shared_ptr<intersection::ObjectInfo> object)
+  const unique_identifier_msgs::msg::UUID & uuid, const bool belong_violating_area,
+  const bool belong_attention_area, const bool belong_intersection_area,
+  const bool is_parked_vehicle, std::shared_ptr<intersection::ObjectInfo> object)
 {
   objects_info_[uuid] = object;
-  if (belong_attention_area) {
-    attention_area_objects_.push_back(object);
-  } else if (belong_intersection_area) {
-    intersection_area_objects_.push_back(object);
-  }
-  if (is_parked_vehicle) {
-    parked_objects_.push_back(object);
+  if (belong_violating_area) {
+    violating_objects_.push_back(object);
+  } else {
+    if (belong_attention_area) {
+      attention_area_objects_.push_back(object);
+    } else if (belong_intersection_area) {
+      intersection_area_objects_.push_back(object);
+    }
+    if (is_parked_vehicle) {
+      parked_objects_.push_back(object);
+    }
   }
 }
 
@@ -240,7 +249,7 @@ void ObjectInfoManager::clearObjects()
   parked_objects_.clear();
 };
 
-std::vector<std::shared_ptr<ObjectInfo>> ObjectInfoManager::allObjects() const
+std::vector<std::shared_ptr<ObjectInfo>> ObjectInfoManager::allAttentionObjects() const
 {
   std::vector<std::shared_ptr<ObjectInfo>> all_objects = attention_area_objects_;
   all_objects.insert(

--- a/planning/behavior_velocity_intersection_module/src/object_manager.hpp
+++ b/planning/behavior_velocity_intersection_module/src/object_manager.hpp
@@ -229,12 +229,12 @@ class ObjectInfoManager
 {
 public:
   std::shared_ptr<ObjectInfo> registerObject(
-    const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-    const bool belong_intersection_area, const bool is_parked);
+    const unique_identifier_msgs::msg::UUID & uuid, const bool belong_violating_area,
+    const bool belong_attention_area, const bool belong_intersection_area, const bool is_parked);
 
   void registerExistingObject(
-    const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-    const bool belong_intersection_area, const bool is_parked,
+    const unique_identifier_msgs::msg::UUID & uuid, const bool belong_violating_area,
+    const bool belong_attention_area, const bool belong_intersection_area, const bool is_parked,
     std::shared_ptr<intersection::ObjectInfo> object);
 
   void clearObjects();
@@ -244,9 +244,17 @@ public:
     return attention_area_objects_;
   }
 
-  const std::vector<std::shared_ptr<ObjectInfo>> & parkedObjects() const { return parked_objects_; }
+  const std::vector<std::shared_ptr<ObjectInfo>> & parkedAttentionObjects() const
+  {
+    return parked_objects_;
+  }
 
-  std::vector<std::shared_ptr<ObjectInfo>> allObjects() const;
+  const std::vector<std::shared_ptr<ObjectInfo>> & violatingObjects() const
+  {
+    return violating_objects_;
+  }
+
+  std::vector<std::shared_ptr<ObjectInfo>> allAttentionObjects() const;
 
   const std::unordered_map<unique_identifier_msgs::msg::UUID, std::shared_ptr<ObjectInfo>> &
   getObjectsMap()
@@ -274,6 +282,9 @@ private:
 
   //! parked objects on attention_area/intersection_area
   std::vector<std::shared_ptr<ObjectInfo>> parked_objects_;
+
+  //! objects violating right of way
+  std::vector<std::shared_ptr<ObjectInfo>> violating_objects_;
 
   std::optional<rclcpp::Time> passed_1st_judge_line_first_time_{std::nullopt};
   std::optional<rclcpp::Time> passed_2nd_judge_line_first_time_{std::nullopt};

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -224,6 +224,7 @@ public:
     std::optional<lanelet::CompoundPolygon3d> ego_lane{std::nullopt};
     std::optional<geometry_msgs::msg::Polygon> stuck_vehicle_detect_area{std::nullopt};
     std::optional<std::vector<lanelet::CompoundPolygon3d>> yield_stuck_detect_area{std::nullopt};
+    std::optional<std::vector<lanelet::CompoundPolygon3d>> yield_area{std::nullopt};
 
     std::optional<geometry_msgs::msg::Polygon> candidate_collision_ego_lane_polygon{std::nullopt};
     autoware_auto_perception_msgs::msg::PredictedObjects safe_under_traffic_control_targets;
@@ -558,10 +559,7 @@ private:
   /**
    * @brief generate IntersectionLanelets
    */
-  intersection::IntersectionLanelets generateObjectiveLanelets(
-    lanelet::LaneletMapConstPtr lanelet_map_ptr,
-    lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-    const lanelet::ConstLanelet assigned_lanelet) const;
+  intersection::IntersectionLanelets generateObjectiveLanelets() const;
 
   /**
    * @brief generate PathLanelets

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
@@ -219,7 +219,7 @@ IntersectionModule::OcclusionType IntersectionModule::detectOcclusion(
   // re-use attention_mask
   attention_mask = cv::Mat(width, height, CV_8UC1, cv::Scalar(0));
   // (3.1) draw all cells on attention_mask behind blocking vehicles as not occluded
-  const auto & blocking_attention_objects = object_info_manager_.parkedObjects();
+  const auto & blocking_attention_objects = object_info_manager_.parkedAttentionObjects();
   for (const auto & blocking_attention_object_info : blocking_attention_objects) {
     debug_data_.parked_targets.objects.push_back(
       blocking_attention_object_info->predicted_object());
@@ -403,7 +403,7 @@ IntersectionModule::OcclusionType IntersectionModule::detectOcclusion(
   LineString2d ego_occlusion_line;
   ego_occlusion_line.emplace_back(current_pose.position.x, current_pose.position.y);
   ego_occlusion_line.emplace_back(nearest_occlusion_point.point.x, nearest_occlusion_point.point.y);
-  for (const auto & attention_object_info : object_info_manager_.allObjects()) {
+  for (const auto & attention_object_info : object_info_manager_.allAttentionObjects()) {
     const auto obj_poly =
       tier4_autoware_utils::toPolygon2d(attention_object_info->predicted_object());
     if (bg::intersects(obj_poly, ego_occlusion_line)) {


### PR DESCRIPTION
## Description

consider abnormal vehicles that are violating the right of way in the context.

This feature considers the vehicles over the stopline of the yield lanes. For the stopline, either traffic light stopline or road marking stopline is used (road marking stopline is prioritized).

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/484e8864-3948-405e-a66b-bbabe34e238d)

```
[component_container_mt-30] [INFO 1708054629.954909385] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection_module]: for yield lane 175066, stopline id is 175215
[component_container_mt-30] [INFO 1708054629.954938931] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection_module]: for yield lane 1104, stopline id is 2036
[component_container_mt-30] [INFO 1708054629.954945512] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection_module]: for yield lane 1103, stopline id is 2036
[component_container_mt-30] [INFO 1708054629.954949123] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection_module]: for yield lane 1101, stopline id is 175303
[component_container_mt-30] [INFO 1708054629.954953227] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection_module]: for yield lane 1097, stopline id is 2014
[component_container_mt-30] [INFO 1708054629.954960151] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.intersection_module]: for yield lane 1098, stopline id is 2026
```
## Related links

https://tier4.atlassian.net/browse/RT1-4769

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
