### PR TITLE
feat(tier4_autoware_utils): add published time debug class into utils

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -16,6 +16,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
     version: main
+  core/autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main
   core/external/autoware_auto_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/published_time_publisher.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/published_time_publisher.hpp
@@ -1,0 +1,131 @@
+// Copyright 2024 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__ROS__PUBLISHED_TIME_PUBLISHER_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__PUBLISHED_TIME_PUBLISHER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_msgs/msg/published_time.hpp>
+#include <std_msgs/msg/header.hpp>
+
+#include <functional>
+#include <map>
+#include <string>
+
+namespace tier4_autoware_utils
+{
+using autoware_internal_msgs::msg::PublishedTime;
+
+struct GidHash
+{
+  size_t operator()(const rmw_gid_t & gid) const noexcept
+  {
+    // Hashing function that computes a hash value for the GID
+    std::hash<std::string> hasher;
+    return hasher(std::string(reinterpret_cast<const char *>(gid.data), RMW_GID_STORAGE_SIZE));
+  }
+};
+
+struct GidEqual
+{
+  bool operator()(const rmw_gid_t & lhs, const rmw_gid_t & rhs) const noexcept
+  {
+    return std::memcmp(lhs.data, rhs.data, RMW_GID_STORAGE_SIZE) == 0;
+  }
+};
+
+class PublishedTimePublisher
+{
+public:
+  static std::unique_ptr<PublishedTimePublisher> create(
+    rclcpp::Node * node, const std::string & end_name = "/debug/published_time",
+    const rclcpp::QoS & qos = rclcpp::QoS(1))
+  {
+    const bool use_published_time = node->declare_parameter<bool>("use_published_time", false);
+    if (use_published_time) {
+      return std::unique_ptr<PublishedTimePublisher>(
+        new PublishedTimePublisher(node, end_name, qos));
+    } else {
+      return nullptr;
+    }
+  }
+
+  void publish(const rclcpp::PublisherBase::ConstSharedPtr & publisher, const rclcpp::Time & stamp)
+  {
+    const auto & gid = publisher->get_gid();
+    const auto & topic_name = publisher->get_topic_name();
+
+    // if the publisher is not in the map, create a new publisher for published time
+    if (publishers_.find(gid) == publishers_.end()) {
+      publishers_[gid] = node_->create_publisher<PublishedTime>(
+        static_cast<std::string>(topic_name) + end_name_, qos_);
+    }
+
+    const auto & pub_published_time_ = publishers_[gid];
+
+    // Check if there are any subscribers, otherwise don't do anything
+    if (pub_published_time_->get_subscription_count() > 0) {
+      PublishedTime published_time;
+
+      published_time.header.stamp = stamp;
+      published_time.published_stamp = rclcpp::Clock().now();
+
+      pub_published_time_->publish(published_time);
+    }
+  }
+
+  void publish(
+    const rclcpp::PublisherBase::ConstSharedPtr & publisher, const std_msgs::msg::Header & header)
+  {
+    const auto & gid = publisher->get_gid();
+    const auto & topic_name = publisher->get_topic_name();
+
+    // if the publisher is not in the map, create a new publisher for published time
+    if (publishers_.find(gid) == publishers_.end()) {
+      publishers_[gid] = node_->create_publisher<PublishedTime>(
+        static_cast<std::string>(topic_name) + end_name_, qos_);
+    }
+
+    const auto & pub_published_time_ = publishers_[gid];
+
+    // Check if there are any subscribers, otherwise don't do anything
+    if (pub_published_time_->get_subscription_count() > 0) {
+      PublishedTime published_time;
+
+      published_time.header = header;
+      published_time.published_stamp = rclcpp::Clock().now();
+
+      pub_published_time_->publish(published_time);
+    }
+  }
+
+private:
+  explicit PublishedTimePublisher(
+    rclcpp::Node * node, const std::string & end_name, const rclcpp::QoS & qos)
+  : node_(node), end_name_(end_name), qos_(qos)
+  {
+  }
+
+  rclcpp::Node * node_;
+  std::string end_name_;
+  rclcpp::QoS qos_;
+
+  // store them for each different publisher of the node
+  std::unordered_map<rmw_gid_t, rclcpp::Publisher<PublishedTime>::SharedPtr, GidHash, GidEqual>
+    publishers_;
+};
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__ROS__PUBLISHED_TIME_PUBLISHER_HPP_

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -15,6 +15,7 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_internal_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
## Description

Part of:
- https://github.com/autowarefoundation/autoware.universe/issues/6255

Required for:
- https://github.com/autowarefoundation/autoware.universe/pull/6490

Depends on:
- https://github.com/autowarefoundation/autoware/pull/4212
- https://github.com/autowarefoundation/autoware_internal_msgs/pull/1

This interface would be enabled only if the use_published_time = true. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested on PSim and e2e_simulator, worked well.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
