### PR TITLE
chore(tier4_control_launch): fix control validator name duplication

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -379,7 +379,14 @@ def launch_setup(context, *args, **kwargs):
                 namespace="",
                 package="rclcpp_components",
                 executable=LaunchConfiguration("container_executable"),
-                composable_node_descriptions=[control_validator_component, glog_component],
+                composable_node_descriptions=[
+                    control_validator_component,
+                    ComposableNode(
+                        package="glog_component",
+                        plugin="GlogComponent",
+                        name="glog_validator_component",
+                    ),
+                ],
             ),
         ]
     )

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -375,11 +375,18 @@ def launch_setup(context, *args, **kwargs):
         [
             PushRosNamespace("control"),
             ComposableNodeContainer(
-                name="control_validator_container",
+                name="control_container_validator",
                 namespace="",
                 package="rclcpp_components",
                 executable=LaunchConfiguration("container_executable"),
-                composable_node_descriptions=[control_validator_component, glog_component],
+                composable_node_descriptions=[
+                    control_validator_component,
+                    ComposableNode(
+                        package="glog_component",
+                        plugin="GlogComponent",
+                        name="glog_component_validator",
+                    ),
+                ],
             ),
         ]
     )

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -375,18 +375,11 @@ def launch_setup(context, *args, **kwargs):
         [
             PushRosNamespace("control"),
             ComposableNodeContainer(
-                name="control_container_validator",
+                name="control_validator_container",
                 namespace="",
                 package="rclcpp_components",
                 executable=LaunchConfiguration("container_executable"),
-                composable_node_descriptions=[
-                    control_validator_component,
-                    ComposableNode(
-                        package="glog_component",
-                        plugin="GlogComponent",
-                        name="glog_component_validator",
-                    ),
-                ],
+                composable_node_descriptions=[control_validator_component, glog_component],
             ),
         ]
     )


### PR DESCRIPTION
## Description

fixed the glog_component duplication

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/f84f38ac-829c-514c-82d9-ffce7155efd7?project_id=prd_jt

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
