### PR TITLE
refactor(mission_planner): add comment functions/remove unused stuff/add comment

### DIFF
--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -9,6 +9,7 @@
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</author>

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -71,13 +71,38 @@ private:
 
   void initialize_common(rclcpp::Node * node);
   void map_callback(const HADMapBin::ConstSharedPtr msg);
-  bool check_goal_footprint(
+
+  /**
+   * @brief check if the goal_footprint is within the combined lanelet of route_lanelets plus the
+   * succeeding lanelets around the goal
+   * @attetion this function will terminate when the accumulated search length from the initial
+   * current_lanelet execeeds max_longitudinal_offset_m + search_margin, so under normal assumptions
+   * (i.e. the map is composed of finite elements of practically normal sized lanelets), it is
+   * assured to terminate
+   * @param current_lanelet the start lanelet to begin recursive query
+   * @param combined_prev_lanelet initial entire route_lanelets plus the small consecutive lanelets
+   * around the goal during the query
+   * @param next_lane_length the accumulated total legth from the start lanelet of the search to the
+   * lanelet of current goal query
+   */
+  bool check_goal_footprint_inside_lanes(
     const lanelet::ConstLanelet & current_lanelet,
     const lanelet::ConstLanelet & combined_prev_lanelet,
     const tier4_autoware_utils::Polygon2d & goal_footprint, double & next_lane_length,
     const double search_margin = 2.0);
+
+  /**
+   * @brief return true if (1)the goal is in parking area or (2)the goal is on the lanes and the
+   * footprint around the goal does not overlap the lanes
+   */
   bool is_goal_valid(const geometry_msgs::msg::Pose & goal, lanelet::ConstLanelets path_lanelets);
+
+  /**
+   * @brief project the specified goal pose onto the goal lanelet(the last preferred lanelet of
+   * route_sections) and return the z-aligned goal position
+   */
   Pose refine_goal_height(const Pose & goal, const RouteSections & route_sections);
+
   void updateRoute(const PlannerPlugin::LaneletRoute & route);
   void clearRoute();
 };

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -75,15 +75,15 @@ private:
   /**
    * @brief check if the goal_footprint is within the combined lanelet of route_lanelets plus the
    * succeeding lanelets around the goal
-   * @attetion this function will terminate when the accumulated search length from the initial
-   * current_lanelet execeeds max_longitudinal_offset_m + search_margin, so under normal assumptions
+   * @attention this function will terminate when the accumulated search length from the initial
+   * current_lanelet exceeds max_longitudinal_offset_m + search_margin, so under normal assumptions
    * (i.e. the map is composed of finite elements of practically normal sized lanelets), it is
    * assured to terminate
    * @param current_lanelet the start lanelet to begin recursive query
    * @param combined_prev_lanelet initial entire route_lanelets plus the small consecutive lanelets
    * around the goal during the query
-   * @param next_lane_length the accumulated total legth from the start lanelet of the search to the
-   * lanelet of current goal query
+   * @param next_lane_length the accumulated total length from the start lanelet of the search to
+   * the lanelet of current goal query
    */
   bool check_goal_footprint_inside_lanes(
     const lanelet::ConstLanelet & current_lanelet,

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -84,7 +84,7 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
     } else if (
       // if not exist, add left bound of lanelet to lefts
       // if the **left** of this lanelet does not match any of the **right** bounds of `lanelets`,
-      // then its left bound consitutes the left boundary of the entire merged lanelet
+      // then its left bound constitutes the left boundary of the entire merged lanelet
       std::count(right_bound_ids.begin(), right_bound_ids.end(), llt.leftBound().id()) < 1) {
       add_bound(llt.leftBound(), lefts);
     }
@@ -98,7 +98,7 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
     } else if (
       // if not exist, add right bound of lanelet to rights
       // if the **right** of this lanelet does not match any of the **left** bounds of `lanelets`,
-      // then its right bound consitutes the right bondary of the entire merged lanelet
+      // then its right bound constitutes the right boundary of the entire merged lanelet
       std::count(left_bound_ids.begin(), left_bound_ids.end(), llt.rightBound().id()) < 1) {
       add_bound(llt.rightBound(), rights);
     }

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -21,11 +21,6 @@
 #include <unordered_set>
 #include <utility>
 
-bool exists(const std::unordered_set<lanelet::Id> & set, const lanelet::Id & id)
-{
-  return set.find(id) != set.end();
-}
-
 tier4_autoware_utils::Polygon2d convert_linear_ring_to_polygon(
   tier4_autoware_utils::LinearRing2d footprint)
 {
@@ -38,14 +33,6 @@ tier4_autoware_utils::Polygon2d convert_linear_ring_to_polygon(
   boost::geometry::append(footprint_polygon.outer(), footprint[5]);
   boost::geometry::correct(footprint_polygon);
   return footprint_polygon;
-}
-
-void set_color(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a)
-{
-  cl->r = r;
-  cl->g = g;
-  cl->b = b;
-  cl->a = a;
 }
 
 void insert_marker_array(
@@ -64,7 +51,7 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
   std::vector<uint64_t> right_bound_ids;
 
   for (const auto & llt : lanelets) {
-    if (llt.id() != 0) {
+    if (llt.id() != lanelet::InvalId) {
       left_bound_ids.push_back(llt.leftBound().id());
       right_bound_ids.push_back(llt.rightBound().id());
     }
@@ -96,6 +83,8 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
       add_bound(left_shared_shoulder_it->leftBound(), lefts);
     } else if (
       // if not exist, add left bound of lanelet to lefts
+      // if the **left** of this lanelet does not match any of the **right** bounds of `lanelets`,
+      // then its left bound consitutes the left boundary of the entire merged lanelet
       std::count(right_bound_ids.begin(), right_bound_ids.end(), llt.leftBound().id()) < 1) {
       add_bound(llt.leftBound(), lefts);
     }
@@ -108,6 +97,8 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
       add_bound(right_shared_shoulder_it->rightBound(), rights);
     } else if (
       // if not exist, add right bound of lanelet to rights
+      // if the **right** of this lanelet does not match any of the **left** bounds of `lanelets`,
+      // then its right bound consitutes the right bondary of the entire merged lanelet
       std::count(left_bound_ids.begin(), left_bound_ids.end(), llt.rightBound().id()) < 1) {
       add_bound(llt.rightBound(), rights);
     }

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -30,8 +30,6 @@
 #include <unordered_set>
 #include <vector>
 
-bool exists(const std::unordered_set<lanelet::Id> & set, const lanelet::Id & id);
-
 template <typename T>
 bool exists(const std::vector<T> & vectors, const T & item)
 {
@@ -45,12 +43,18 @@ bool exists(const std::vector<T> & vectors, const T & item)
 
 tier4_autoware_utils::Polygon2d convert_linear_ring_to_polygon(
   tier4_autoware_utils::LinearRing2d footprint);
-void set_color(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a);
 void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
 
+/**
+ * @brief create a single merged lanelet whose left/right bounds consist of the leftmost/rightmost
+ * bound of the original lanelets or the left/right bound of its adjacent road_shoulder respectively
+ * @param lanelets topologically sorted sequence of lanelets
+ * @param shoulder_lanelets list of possible road_shoulder lanelets to combine with lanelets
+ */
 lanelet::ConstLanelet combine_lanelets_with_shoulder(
   const lanelet::ConstLanelets & lanelets, const lanelet::ConstLanelets & shoulder_lanelets);
+
 std::vector<geometry_msgs::msg::Point> convertCenterlineToPoints(const lanelet::Lanelet & lanelet);
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
   const lanelet::BasicPoint3d & point, const double lane_yaw);


### PR DESCRIPTION
## Description

- added doxygen comments to functions
- removed unused functions / replaced with existing utility functions
- for check_goal_footprint, use boost::within instead

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/71566d0a-8f2d-556b-95b0-4ab69d7fd4d4?project_id=prd_jt

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
