### PR TITLE
fix(tracking_object_merger): flip main object direction when the object velocity is backward.

### DIFF
--- a/perception/tracking_object_merger/src/utils/utils.cpp
+++ b/perception/tracking_object_merger/src/utils/utils.cpp
@@ -323,22 +323,24 @@ autoware_auto_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMe
   autoware_auto_perception_msgs::msg::TrackedObjectKinematics output_kinematics;
   // copy main object at first
   output_kinematics = main_obj.kinematics;
-  // if the main object is run opposite direction, flip the main object
+
+    // if the main object is run opposite direction, flip the main object
   if (output_kinematics.twist_with_covariance.twist.linear.x < 0.0) {
     // flip velocity
     output_kinematics.twist_with_covariance.twist.linear.x *= -1.0;
     output_kinematics.twist_with_covariance.twist.linear.y *= -1.0;
-    // flip orientation, convert quaternion to have the opposite direction
+    // flip orientation, rotate 180 deg
     const auto q = tf2::Quaternion(
       output_kinematics.pose_with_covariance.pose.orientation.x,
       output_kinematics.pose_with_covariance.pose.orientation.y,
       output_kinematics.pose_with_covariance.pose.orientation.z,
       output_kinematics.pose_with_covariance.pose.orientation.w);
-    const auto q_flip = q * tf2::Quaternion(0, 0, 1, 0);
-    output_kinematics.pose_with_covariance.pose.orientation.x = q_flip.x();
-    output_kinematics.pose_with_covariance.pose.orientation.y = q_flip.y();
-    output_kinematics.pose_with_covariance.pose.orientation.z = q_flip.z();
-    output_kinematics.pose_with_covariance.pose.orientation.w = q_flip.w();
+    const auto q_rot = tf2::Quaternion(tf2::Vector3(0, 0, 1), M_PI);
+    const auto q_rotated = q * q_rot;
+    output_kinematics.pose_with_covariance.pose.orientation.x = q_rotated.x();
+    output_kinematics.pose_with_covariance.pose.orientation.y = q_rotated.y();
+    output_kinematics.pose_with_covariance.pose.orientation.z = q_rotated.z();
+    output_kinematics.pose_with_covariance.pose.orientation.w = q_rotated.w();
   }
 
   auto sub_obj_ = sub_obj;

--- a/perception/tracking_object_merger/src/utils/utils.cpp
+++ b/perception/tracking_object_merger/src/utils/utils.cpp
@@ -323,6 +323,24 @@ autoware_auto_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMe
   autoware_auto_perception_msgs::msg::TrackedObjectKinematics output_kinematics;
   // copy main object at first
   output_kinematics = main_obj.kinematics;
+  // if the main object is run opposite direction, flip the main object
+  if (output_kinematics.twist_with_covariance.twist.linear.x < 0.0) {
+    // flip velocity
+    output_kinematics.twist_with_covariance.twist.linear.x *= -1.0;
+    output_kinematics.twist_with_covariance.twist.linear.y *= -1.0;
+    // flip orientation, convert quaternion to have the opposite direction
+    const auto q = tf2::Quaternion(
+      output_kinematics.pose_with_covariance.pose.orientation.x,
+      output_kinematics.pose_with_covariance.pose.orientation.y,
+      output_kinematics.pose_with_covariance.pose.orientation.z,
+      output_kinematics.pose_with_covariance.pose.orientation.w);
+    const auto q_flip = q * tf2::Quaternion(0, 0, 1, 0);
+    output_kinematics.pose_with_covariance.pose.orientation.x = q_flip.x();
+    output_kinematics.pose_with_covariance.pose.orientation.y = q_flip.y();
+    output_kinematics.pose_with_covariance.pose.orientation.z = q_flip.z();
+    output_kinematics.pose_with_covariance.pose.orientation.w = q_flip.w();
+  }
+
   auto sub_obj_ = sub_obj;
   // do not merge reverse direction objects
   if (!objectsHaveSameMotionDirections(main_obj, sub_obj)) {


### PR DESCRIPTION
## Description

Issue: At the 

Issue tracker (Tier4 internal): https://tier4.atlassian.net/browse/RT1-5257


## Tests performed

Before fix:

https://github.com/autowarefoundation/autoware.universe/assets/42434141/46363424-011b-4555-945d-da9daeab5806

The multi-object tracker (mainly from lidar, blue box) has opposite direction and when the radar object is also used to obtain velocity, the merger trusts the orientation of the main object (lidar object). as result, the merged object (yellow box) has the reversed direction. 


After fix:

https://github.com/autowarefoundation/autoware.universe/assets/42434141/7b9227a8-ce07-4a6e-ba9e-cc84e38cc6c6

Since the merger assumes the object is driving forward, the merger will flip the velocity vector and its orientation when the incoming object has negative x velocity (driving backward).


## Effects on system behavior

The merger result will have more stable result when MOT tracker has orientation error.
The merger cannot output backward-driving vehicle correctly.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
