### PR TITLE
feat(lidar_apollo_instance_segmentation): add build_only option

### DIFF
--- a/perception/lidar_apollo_instance_segmentation/README.md
+++ b/perception/lidar_apollo_instance_segmentation/README.md
@@ -47,6 +47,7 @@ None
 | `use_constant_feature`  | bool   | false                | The flag to use direction and distance feature of pointcloud.                      |
 | `target_frame`          | string | "base_link"          | Pointcloud data is transformed into this frame.                                    |
 | `z_offset`              | int    | 2                    | z offset from target frame. [m]                                                    |
+| `build_only`            | bool   | `false`              | shutdown the node after TensorRT engine file is built                              |
 
 ## Assumptions / Known limits
 

--- a/perception/lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
+++ b/perception/lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
@@ -2,6 +2,7 @@
   <arg name="input/pointcloud" default="/sensing/lidar/pointcloud"/>
   <arg name="model" default="model_128"/>
   <arg name="output/objects" default="labeled_clusters"/>
+  <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
 
   <arg if="$(eval &quot;'$(var model)'=='model_16'&quot;)" name="base_name" default="vlp-16"/>
   <arg if="$(eval &quot;'$(var model)'=='model_64'&quot;)" name="base_name" default="hdl-64"/>
@@ -24,5 +25,8 @@
     <param name="precision" value="$(var precision)"/>
     <param name="target_frame" value="$(var target_frame)"/>
     <param from="$(var param_file)"/>
+
+    <!-- This parameter shall NOT be included in param file. -->
+    <param name="build_only" value="$(var build_only)"/>
   </node>
 </launch>

--- a/perception/lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/detector.cpp
@@ -48,6 +48,11 @@ LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation(rclcpp::Node * 
     return;
   }
 
+  if (node_->declare_parameter("build_only", false)) {
+    RCLCPP_INFO(node_->get_logger(), "TensorRT engine is built and shutdown node.");
+    rclcpp::shutdown();
+  }
+
   // GPU memory allocation
   const auto input_dims = trt_common_->getBindingDimensions(0);
   const auto input_size =


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

add build_only option for pre task

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

launch build_only:=true and false

```
$ ros2 launch lidar_apollo_instance_segmentation lidar_apollo_instance_segmentation.launch.xml model_name:=apollo model_path:=/home/autoware/autoware_data/lidar_apollo_instance_segmentation model_param_path:=$(ros2 pkg prefix lidar_apollo_instance_segmentation --share)/config/apollo.param.yaml build_only:=true
[INFO] [launch]: All log files can be found below /home/kosuke55/.ros/log/2024-02-20-01-55-20-283389-DPC2103005-2590669
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [lidar_apollo_instance_segmentation_node-1]: process started with pid [2590672]
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +564, GPU +0, now: CPU 587, GPU 2980 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 606, GPU 2980 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +434, GPU +70, now: CPU 1040, GPU 3050 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] ----------------------------------------------------------------
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Input filename:   /home/kosuke55/autoware_data/lidar_apollo_instance_segmentation/vls-128.onnx
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] ONNX IR version:  0.0.6
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Opset version:    11
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Producer name:    caffe
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Producer version:
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Domain:
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Model version:    0
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Doc string:
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] ----------------------------------------------------------------
[lidar_apollo_instance_segmentation_node-1] L0 [conv 1x1 (1) /1] 864x864x4 -> 864x864x24 weights:96 GFLOPs:0.143327
[lidar_apollo_instance_segmentation_node-1] L2 [conv 3x3 (1) /1] 864x864x24 -> 864x864x24 weights:5184 GFLOPs:7.73967
[lidar_apollo_instance_segmentation_node-1] L4 [conv 3x3 (1) /2] 864x864x24 -> 432x432x48 weights:10368 GFLOPs:3.86984
[lidar_apollo_instance_segmentation_node-1] L6 [conv 3x3 (1) /1] 432x432x48 -> 432x432x48 weights:20736 GFLOPs:7.73967
[lidar_apollo_instance_segmentation_node-1] L8 [conv 3x3 (1) /2] 432x432x48 -> 216x216x64 weights:27648 GFLOPs:2.57989
[lidar_apollo_instance_segmentation_node-1] L10 [conv 3x3 (1) /1] 216x216x64 -> 216x216x64 weights:36864 GFLOPs:3.43985
[lidar_apollo_instance_segmentation_node-1] L12 [conv 3x3 (1) /1] 216x216x64 -> 216x216x64 weights:36864 GFLOPs:3.43985
[lidar_apollo_instance_segmentation_node-1] L14 [conv 3x3 (1) /2] 216x216x64 -> 108x108x96 weights:55296 GFLOPs:1.28995
[lidar_apollo_instance_segmentation_node-1] L16 [conv 3x3 (1) /1] 108x108x96 -> 108x108x96 weights:82944 GFLOPs:1.93492
[lidar_apollo_instance_segmentation_node-1] L18 [conv 3x3 (1) /1] 108x108x96 -> 108x108x96 weights:82944 GFLOPs:1.93492
[lidar_apollo_instance_segmentation_node-1] L20 [conv 3x3 (1) /2] 108x108x96 -> 54x54x128 weights:110592 GFLOPs:0.644973
[lidar_apollo_instance_segmentation_node-1] L22 [conv 3x3 (1) /1] 54x54x128 -> 54x54x128 weights:147456 GFLOPs:0.859963
[lidar_apollo_instance_segmentation_node-1] L24 [conv 3x3 (1) /1] 54x54x128 -> 54x54x128 weights:147456 GFLOPs:0.859963
[lidar_apollo_instance_segmentation_node-1] L26 [conv 3x3 (1) /2] 54x54x128 -> 27x27x192 weights:221184 GFLOPs:0.322486
[lidar_apollo_instance_segmentation_node-1] L28 [conv 3x3 (1) /1] 27x27x192 -> 27x27x192 weights:331776 GFLOPs:0.483729
[lidar_apollo_instance_segmentation_node-1] L30 [conv 3x3 (1) /1] 27x27x192 -> 27x27x192 weights:331776 GFLOPs:0.483729
[lidar_apollo_instance_segmentation_node-1] L35 [conv 3x3 (1) /1] 54x54x256 -> 54x54x128 weights:294912 GFLOPs:1.71993
[lidar_apollo_instance_segmentation_node-1] L40 [conv 3x3 (1) /1] 108x108x192 -> 108x108x96 weights:165888 GFLOPs:3.86984
[lidar_apollo_instance_segmentation_node-1] L45 [conv 3x3 (1) /1] 216x216x128 -> 216x216x64 weights:73728 GFLOPs:6.87971
[lidar_apollo_instance_segmentation_node-1] L50 [conv 3x3 (1) /1] 432x432x96 -> 432x432x48 weights:41472 GFLOPs:15.4793
[lidar_apollo_instance_segmentation_node-1] Total 65.7155 GFLOPs
[lidar_apollo_instance_segmentation_node-1] Total 2.22518 M params
[lidar_apollo_instance_segmentation_node-1] Building... "/home/kosuke55/autoware_data/lidar_apollo_instance_segmentation/vls-128.fp32-batch1.engine"
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Start build engine
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Applying optimizations and building TRT CUDA engine. Please wait for a few minutes...
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 607, GPU 2980 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +433, GPU +102, now: CPU 1040, GPU 3082 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] ----------------------------------------------------------------
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Input filename:   /home/kosuke55/autoware_data/lidar_apollo_instance_segmentation/vls-128.onnx
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] ONNX IR version:  0.0.6
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Opset version:    11
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Producer name:    caffe
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Producer version:
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Domain:
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Model version:    0
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Doc string:
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] ----------------------------------------------------------------
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +1326, GPU +316, now: CPU 2377, GPU 3398 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init cuDNN: CPU +258, GPU +58, now: CPU 2635, GPU 3456 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Local timing cache in use. Profiling results in this builder pass will not be stored.
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Applying optimizations and building TRT CUDA engine. Please wait for a few minutes...
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Some tactics do not have sufficient workspace memory to run. Increasing workspace size will enable more tactics, please check verbose output for requested sizes.
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Applying optimizations and building TRT CUDA engine. Please wait for a few minutes...
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Detected 1 inputs and 1 output network tensors.
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Total Host Persistent Memory: 33792
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Total Device Persistent Memory: 1384960
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Total Scratch Memory: 71746576
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageStats] Peak memory usage of TRT CPU/GPU memory allocators: CPU 3 MiB, GPU 756 MiB
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [BlockAssignment] Algorithm ShiftNTopDown took 0.841753ms to assign 7 blocks to 33 nodes requiring 173830656 bytes.
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Total Activation Memory: 173830656
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init cuDNN: CPU +0, GPU +10, now: CPU 4291, GPU 4048 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in building engine: CPU +0, GPU +16, now: CPU 0, GPU 16 (MiB)
[lidar_apollo_instance_segmentation_node-1] [W] [TRT] The getMaxBatchSize() function should not be used with an engine built from a network created with NetworkDefinitionCreationFlag::kEXPLICIT_BATCH flag. This function will always return 1.
[lidar_apollo_instance_segmentation_node-1] [W] [TRT] The getMaxBatchSize() function should not be used with an engine built from a network created with NetworkDefinitionCreationFlag::kEXPLICIT_BATCH flag. This function will always return 1.
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] Loaded engine size: 15 MiB
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init cuDNN: CPU +0, GPU +10, now: CPU 4306, GPU 4032 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in engine deserialization: CPU +0, GPU +16, now: CPU 0, GPU 16 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] End build engine
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init cuDNN: CPU +0, GPU +8, now: CPU 3848, GPU 3943 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +167, now: CPU 0, GPU 183 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 3848, GPU 4111 (MiB)
[lidar_apollo_instance_segmentation_node-1] [I] [TRT] The profiling verbosity was set to ProfilingVerbosity::kLAYER_NAMES_ONLY when the engine was built, so only the layer names will be returned. Rebuild the engine with ProfilingVerbosity::kDETAILED to get more verbose layer information.
[lidar_apollo_instance_segmentation_node-1] [INFO 1708361736.818817452] [lidar_apollo_instance_segmentation]: TensorRT engine is built and shutdown node. (LidarApolloInstanceSegmentation() at ../../src/autoware/universe/perception/lidar_apollo_instance_segmentation/src/detector.cpp:52)
[lidar_apollo_instance_segmentation_node-1] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
[lidar_apollo_instance_segmentation_node-1]   what():  could not create publisher: rcl node's context is invalid, at ./src/rcl/node.c:428
[ERROR] [lidar_apollo_instance_segmentation_node-1]: process has died [pid 2590672, exit code -6, cmd '/home/kosuke55/pilot-auto.latest/install/lidar_apollo_instance_segmentation/lib/lidar_apollo_instance_segmentation/lidar_apollo_instance_segmentation_node --ros-args -r __node:=lidar_apollo_instance_segmentation --params-file /tmp/launch_params_fzdqfpq0 --params-file /tmp/launch_params_l2l34844 --params-file /tmp/launch_params_iq2fkmuk --params-file /tmp/launch_params_tjmdr3ji --params-file /home/kosuke55/pilot-auto.latest/install/lidar_apollo_instance_segmentation/share/lidar_apollo_instance_segmentation/config/vls-128.param.yaml --params-file /tmp/launch_params_oelgahsh -r input/pointcloud:=/sensing/lidar/pointcloud -r output/labeled_clusters:=labeled_clusters'].
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
