### PR TITLE
fix(mission_planner): fix marker color

### DIFF
--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -212,11 +212,11 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(const LaneletRoute & route)
   const std_msgs::msg::ColorRGBA cl_route =
     tier4_autoware_utils::createMarkerColor(0.8, 0.99, 0.8, 0.15);
   const std_msgs::msg::ColorRGBA cl_ll_borders =
-    tier4_autoware_utils::createMarkerColor(0.2, 0.4, 0.4, 0.05);
+    tier4_autoware_utils::createMarkerColor(1.0, 1.0, 1.0, 0.999);
   const std_msgs::msg::ColorRGBA cl_end =
     tier4_autoware_utils::createMarkerColor(0.2, 0.2, 0.4, 0.05);
   const std_msgs::msg::ColorRGBA cl_goal =
-    tier4_autoware_utils::createMarkerColor(1.0, 1.0, 1.0, 0.999);
+    tier4_autoware_utils::createMarkerColor(0.2, 0.4, 0.4, 0.05);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
   insert_marker_array(


### PR DESCRIPTION
## Description

related PR: https://github.com/autowarefoundation/autoware.universe/pull/6447

fix unexpected marker color.

![Screenshot from 2024-02-20 16-24-54](https://github.com/autowarefoundation/autoware.universe/assets/44889564/82f0496c-e309-4e8c-938c-42caa3c2a5f0)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
