### PR TITLE
feat(behavior_velocity_traffic_light): ensure stopping if a signal, once received, is not received again

### DIFF
--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -323,6 +323,8 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
+  planner_data_.has_received_signal_ = true;
+
   // clear previous observation
   planner_data_.traffic_light_id_map_raw_.clear();
   const auto traffic_light_id_map_last_observed_old =

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/planner_data.hpp
@@ -83,6 +83,9 @@ struct PlannerData
   std::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
   tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states;
 
+  // this value becomes true once the signal message is received
+  bool has_received_signal_ = false;
+
   // velocity smoother
   std::shared_ptr<motion_velocity_smoother::SmootherBase> velocity_smoother_;
   // route handler

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -281,21 +281,25 @@ bool TrafficLightModule::isStopSignal()
 {
   updateTrafficSignal();
 
-  // If it never receives traffic signal, it will PASS.
+  // Pass through if no traffic signal information has been received yet
+  // This is to prevent stopping on the planning simulator
   if (!planner_data_->has_received_signal_) {
     return false;
   }
 
-  // If the signal data is not received, the ego stops.
+  // Stop if there is no upcoming traffic signal information
+  // This is to safely stop in cases such that traffic light recognition is not working properly or
+  // the map is incorrect
   if (!traffic_signal_stamp_) {
     return true;
   }
 
-  // If the signal data is timeout, the ego stops.
+  // Stop if the traffic signal information has timed out
   if (isTrafficSignalTimedOut()) {
     return true;
   }
 
+  // Check if the current traffic signal state requires stopping
   return traffic_light_utils::isTrafficSignalStop(lane_, looking_tl_state_);
 }
 

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -291,6 +291,7 @@ bool TrafficLightModule::isStopSignal()
     return true;
   }
 
+  // If the signal data is timeout, the ego stops.
   if (isTrafficSignalTimedOut()) {
     return true;
   }

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -282,8 +282,13 @@ bool TrafficLightModule::isStopSignal()
   updateTrafficSignal();
 
   // If it never receives traffic signal, it will PASS.
-  if (!traffic_signal_stamp_) {
+  if (!planner_data_->has_received_signal_) {
     return false;
+  }
+
+  // If the signal data is not received, the ego stops.
+  if (!traffic_signal_stamp_) {
+    return true;
   }
 
   if (isTrafficSignalTimedOut()) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In the current implementation, the decision to proceed is made individually for each traffic signal. As a result, the ego vehicle sometimes moves forward even when a signal message is not received.
To address this issue, I introduced a variable that tracks whether a signal message has been received. Now, if a signal message is received but a subsequent traffic signal message is not, the ego vehicle will stop.

https://github.com/autowarefoundation/autoware.universe/assets/11865769/a223f88b-35ad-41e5-813c-0630cd4f2741

![image](https://github.com/autowarefoundation/autoware.universe/assets/11865769/8921a203-b6ad-4943-b2a6-3c5b62be220b)


## Related
[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QW0GU6P7/p1707982960796549)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I conducted tests in simple planning simulator.
In the following video, if the traffic signal of 1008 has once received, the stop point is inserted to the traffic signal of 1002 because the signal for it is not received.

https://github.com/autowarefoundation/autoware.universe/assets/11865769/1252bc9d-0faa-437e-bc8b-fdce5651813c


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
