### PR TITLE
fix(start_planner): start prepare blinker when autonomous mode is available

### DIFF
--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -71,7 +71,7 @@ struct PullOutStatus
   std::shared_ptr<PathWithLaneId> prev_stop_path_after_approval{nullptr};
   std::optional<Pose> stop_pose{std::nullopt};
   //! record the first time when the state changed from !isActivated() to isActivated()
-  std::optional<rclcpp::Time> first_approved_time{std::nullopt};
+  std::optional<rclcpp::Time> first_engaged_time{std::nullopt};
 
   PullOutStatus() {}
 };

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -178,8 +178,8 @@ void StartPlannerModule::updateData()
 
   if (
     planner_data_->operation_mode->mode == OperationModeState::AUTONOMOUS &&
-    !status_.first_approved_time && isActivated()) {
-    status_.first_approved_time = clock_->now();
+    !status_.first_engaged_time) {
+    status_.first_engaged_time = clock_->now();
   }
 
   if (hasFinishedBackwardDriving()) {
@@ -1086,11 +1086,11 @@ bool StartPlannerModule::hasFinishedPullOut() const
 
 bool StartPlannerModule::needToPrepareBlinkerBeforeStart() const
 {
-  if (!status_.first_approved_time) {
+  if (!status_.first_engaged_time) {
     return true;
   }
-  const auto first_approved_time = status_.first_approved_time.value();
-  const double elapsed = rclcpp::Duration(clock_->now() - first_approved_time).seconds();
+  const auto first_engaged_time = status_.first_engaged_time.value();
+  const double elapsed = rclcpp::Duration(clock_->now() - first_engaged_time).seconds();
   return elapsed < parameters_->prepare_time_before_start;
 }
 

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -176,7 +176,9 @@ void StartPlannerModule::updateData()
     DEBUG_PRINT("StartPlannerModule::updateData() received new route, reset status");
   }
 
-  if (!status_.first_approved_time && isActivated()) {
+  if (
+    planner_data_->operation_mode->mode == OperationModeState::AUTONOMOUS &&
+    !status_.first_approved_time && isActivated()) {
     status_.first_approved_time = clock_->now();
   }
 


### PR DESCRIPTION
## Description

Start the timeout count for temporal stop for blinker preparation when AW is engaged and approved.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/6412

## Tests performed

if the prepare time is 3.0, even if the module is auto mode, waits for 3sec before start

https://github.com/autowarefoundation/autoware.universe/assets/28677420/5d8ee65a-154d-4435-b664-d47ca6138da6

By default the parameter is 0 and has no effect.

https://github.com/autowarefoundation/autoware.universe/assets/28677420/07b43371-966b-4cc2-bc49-8173e406fd3b


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
