### PR TITLE
ci(build-and-test): remove free-disk-space

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,14 +27,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Free disk space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.2.0
-        with:
-          tool-cache: false
-          dotnet: false
-          swap-storage: false
-          large-packages: false
-
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 


### PR DESCRIPTION
## Description

This workflow doesn't do anything because it is being run under `container:` field.

- https://github.com/autowarefoundation/autoware.universe/blob/38b58458fe22377e6dce727b90a76f46a709ddc2/.github/workflows/build-and-test.yaml#L13

- https://github.com/autowarefoundation/autoware.universe/actions/runs/7997414878/job/21841840903#step:4:1

It tries to clean up clutter in the host machine but cannot do so because it is being run in the container.

For it to work, we would need to utilize a docker-bake action to run this.

Till then, I'm removing this.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
