### PR TITLE
feat(pointcloud_preprocessor): publish excluded points in ring_outlier_filter for debug purpose

### DIFF
--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -29,6 +29,7 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 | `num_points_threshold`    | int     | 4             |                                                                                     |
 | `max_rings_num`           | uint_16 | 128           |                                                                                     |
 | `max_points_num_per_ring` | size_t  | 4000          | Set this value large enough such that `HFoV / resolution < max_points_num_per_ring` |
+| `publish_excluded_points` | bool    | false         | Flag to publish excluded pointcloud                                                 |
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -22,14 +22,14 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 
 ### Core Parameters
 
-| Name                      | Type    | Default Value | Description                                                                         |
-| ------------------------- | ------- | ------------- | ----------------------------------------------------------------------------------- |
-| `distance_ratio`          | double  | 1.03          |                                                                                     |
-| `object_length_threshold` | double  | 0.1           |                                                                                     |
-| `num_points_threshold`    | int     | 4             |                                                                                     |
-| `max_rings_num`           | uint_16 | 128           |                                                                                     |
-| `max_points_num_per_ring` | size_t  | 4000          | Set this value large enough such that `HFoV / resolution < max_points_num_per_ring` |
-| `publish_excluded_points` | bool    | false         | Flag to publish excluded pointcloud                                                 |
+| Name                      | Type    | Default Value | Description                                                                                                                     |
+| ------------------------- | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `distance_ratio`          | double  | 1.03          |                                                                                                                                 |
+| `object_length_threshold` | double  | 0.1           |                                                                                                                                 |
+| `num_points_threshold`    | int     | 4             |                                                                                                                                 |
+| `max_rings_num`           | uint_16 | 128           |                                                                                                                                 |
+| `max_points_num_per_ring` | size_t  | 4000          | Set this value large enough such that `HFoV / resolution < max_points_num_per_ring`                                             |
+| `publish_excluded_points` | bool    | false         | Flag to publish excluded pointcloud for debugging purpose. Due to performance concerns, please set to false during experiments. |
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -21,6 +21,7 @@
 
 #include <point_cloud_msg_wrapper/point_cloud_msg_wrapper.hpp>
 
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -42,11 +43,15 @@ protected:
     const TransformInfo & transform_info);
 
 private:
+  /** \brief publisher of excluded pointcloud for debug reason. **/
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr excluded_points_publisher_;
+
   double distance_ratio_;
   double object_length_threshold_;
   int num_points_threshold_;
   uint16_t max_rings_num_;
   size_t max_points_num_per_ring_;
+  bool publish_excluded_points_;
 
   /** \brief Parameter service callback result : needed to be hold */
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;
@@ -68,6 +73,8 @@ private:
 
     return x * x + y * y + z * z >= object_length_threshold_ * object_length_threshold_;
   }
+  PointCloud2 extractExcludedPoints(
+    const PointCloud2 & input, const PointCloud2 & output, float epsilon);
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_auto_geometry</depend>
   <depend>autoware_point_types</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -14,6 +14,8 @@
 
 #include "pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp"
 
+#include "autoware_auto_geometry/common_3d.hpp"
+
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <algorithm>
@@ -29,6 +31,8 @@ RingOutlierFilterComponent::RingOutlierFilterComponent(const rclcpp::NodeOptions
     using tier4_autoware_utils::StopWatch;
     stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
     debug_publisher_ = std::make_unique<DebugPublisher>(this, "ring_outlier_filter");
+    excluded_points_publisher_ =
+      this->create_publisher<sensor_msgs::msg::PointCloud2>("debug/ring_outlier_filter", 1);
     stop_watch_ptr_->tic("cyclic_time");
     stop_watch_ptr_->tic("processing_time");
   }
@@ -42,6 +46,8 @@ RingOutlierFilterComponent::RingOutlierFilterComponent(const rclcpp::NodeOptions
     max_rings_num_ = static_cast<uint16_t>(declare_parameter("max_rings_num", 128));
     max_points_num_per_ring_ =
       static_cast<size_t>(declare_parameter("max_points_num_per_ring", 4000));
+    publish_excluded_points_ =
+      static_cast<bool>(declare_parameter("publish_excluded_points", false));
   }
 
   using std::placeholders::_1;
@@ -196,6 +202,17 @@ void RingOutlierFilterComponent::faster_filter(
     sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
     "intensity", 1, sensor_msgs::msg::PointField::FLOAT32);
 
+  if (publish_excluded_points_) {
+    auto excluded_points = extractExcludedPoints(*input, output, 0.01);
+    // set fields
+    sensor_msgs::PointCloud2Modifier excluded_pcd_modifier(excluded_points);
+    excluded_pcd_modifier.setPointCloud2Fields(
+      num_fields, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
+      sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
+      "intensity", 1, sensor_msgs::msg::PointField::FLOAT32);
+    excluded_points_publisher_->publish(excluded_points);
+  }
+
   // add processing time for debug
   if (debug_publisher_) {
     const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
@@ -241,6 +258,10 @@ rcl_interfaces::msg::SetParametersResult RingOutlierFilterComponent::paramCallba
   if (get_param(p, "num_points_threshold", num_points_threshold_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new num_points_threshold to: %d.", num_points_threshold_);
   }
+  if (get_param(p, "publish_excluded_points", publish_excluded_points_)) {
+    RCLCPP_DEBUG(
+      get_logger(), "Setting new publish_excluded_points to: %d.", publish_excluded_points_);
+  }
 
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
@@ -248,6 +269,56 @@ rcl_interfaces::msg::SetParametersResult RingOutlierFilterComponent::paramCallba
 
   return result;
 }
+
+sensor_msgs::msg::PointCloud2 RingOutlierFilterComponent::extractExcludedPoints(
+  const sensor_msgs::msg::PointCloud2 & input, const sensor_msgs::msg::PointCloud2 & output,
+  float epsilon)
+{
+  // Convert ROS PointCloud2 message to PCL point cloud for easier manipulation
+  pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr output_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(input, *input_cloud);
+  pcl::fromROSMsg(output, *output_cloud);
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr excluded_points(new pcl::PointCloud<pcl::PointXYZ>);
+
+  for (const auto & input_point : *input_cloud) {
+    bool is_excluded = true;
+
+    for (const auto & output_point : *output_cloud) {
+      float distance = autoware::common::geometry::distance_3d(input_point, output_point);
+
+      // If the distance is less than the threshold (epsilon), the point is not excluded
+      if (distance < epsilon) {
+        is_excluded = false;
+        break;
+      }
+    }
+
+    // If the point is still marked as excluded after all comparisons, add it to the excluded
+    // pointcloud
+    if (is_excluded) {
+      excluded_points->push_back(input_point);
+    }
+  }
+
+  sensor_msgs::msg::PointCloud2 excluded_points_msg;
+  pcl::toROSMsg(*excluded_points, excluded_points_msg);
+
+  // Set the metadata for the excluded points message based on the input cloud
+  excluded_points_msg.height = 1;
+  excluded_points_msg.width =
+    static_cast<uint32_t>(output.data.size() / output.height / output.point_step);
+  excluded_points_msg.row_step = static_cast<uint32_t>(output.data.size() / output.height);
+  excluded_points_msg.is_bigendian = input.is_bigendian;
+  excluded_points_msg.is_dense = input.is_dense;
+  excluded_points_msg.header = input.header;
+  excluded_points_msg.header.frame_id =
+    !tf_input_frame_.empty() ? tf_input_frame_ : tf_input_orig_frame_;
+
+  return excluded_points_msg;
+}
+
 }  // namespace pointcloud_preprocessor
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -292,12 +292,12 @@ sensor_msgs::msg::PointCloud2 RingOutlierFilterComponent::extractExcludedPoints(
   }
   tree->setInputCloud(output_cloud);
   std::vector<int> nn_indices(1);
-  std::vector<float> nn_dists(1);
+  std::vector<float> nn_distances(1);
   for (const auto & point : input_cloud->points) {
-    if (!tree->nearestKSearch(point, 1, nn_indices, nn_dists)) {
+    if (!tree->nearestKSearch(point, 1, nn_indices, nn_distances)) {
       continue;
     }
-    if (nn_dists[0] > epsilon) {
+    if (nn_distances[0] > epsilon) {
       excluded_points->points.push_back(point);
     }
   }


### PR DESCRIPTION
## Description

Publish excluded points in ring_outlier_filter for visualization.
This feature is disabled by default. 

The white points have been excluded by the ring_outlier_filter, whereas the colorful points represent the pointcloud after the ring_outlier_filter.
![Screenshot from 2024-02-23 19-56-31](https://github.com/autowarefoundation/autoware.universe/assets/32741405/1f457226-2879-4af9-9460-414a486f77fb)


<!-- Write a brief description of this PR. -->

## Tests performed

running [logging_simulator](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/launch-files/#autoware_launch) with enabling sensing moudle. 


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## How to check this feature

1. Visualizing filtered/excluded pointcloud in rviz by applying following change 
<details>
<summary>necessary change for autoware.rviz</summary>

```
    - Alpha: 1
      Autocompute Intensity Bounds: true
      Autocompute Value Bounds:
        Max Value: 5
        Min Value: -10
        Value: false
      Axis: Z
      Channel Name: intensity
      Class: rviz_default_plugins/PointCloud2
      Color: 255; 255; 255
      Color Transformer: Intensity
      Decay Time: 0
      Enabled: true
      Invert Rainbow: false
      Max Color: 255; 255; 255
      Max Intensity: 79
      Min Color: 0; 0; 0
      Min Intensity: 1
      Name: left filterd points
      Position Transformer: XYZ
      Selectable: false
      Size (Pixels): 2
      Size (m): 0.019999999552965164
      Style: Points
      Topic:
        Depth: 5
        Durability Policy: Volatile
        Filter size: 10
        History Policy: Keep Last
        Reliability Policy: Best Effort
        Value: /sensing/lidar/left/pointcloud
      Use Fixed Frame: true
      Use rainbow: true
      Value: true
    - Alpha: 1
      Autocompute Intensity Bounds: true
      Autocompute Value Bounds:
        Max Value: 5
        Min Value: -10
        Value: false
      Axis: Z
      Channel Name: intensity
      Class: rviz_default_plugins/PointCloud2
      Color: 255; 255; 255
      Color Transformer: FlatColor
      Decay Time: 0
      Enabled: true
      Invert Rainbow: false
      Max Color: 255; 255; 255
      Max Intensity: 4096
      Min Color: 0; 0; 0
      Min Intensity: 0
      Name: left lidar excluded points
      Position Transformer: XYZ
      Selectable: false
      Size (Pixels): 7
      Size (m): 0.019999999552965164
      Style: Points
      Topic:
        Depth: 5
        Durability Policy: Volatile
        Filter size: 10
        History Policy: Keep Last
        Reliability Policy: Best Effort
        Value: /sensing/lidar/left/debug/ring_outlier_filter
      Use Fixed Frame: true
      Use rainbow: true
      Value: true
```

</details>

2. launch logging_simulator with following commnad
```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/path_to_your_map vehicle_model:=lexus sensor_model:=aip_xx1 sensing:=true
```

3. Enabling this feature (for left lidar for example) with following command
```
ros2 param set /sensing/lidar/left/ring_outlier_filter publish_excluded_points true
```

4. play rosbag 

sample rosbag for TIER IV developer
[TIERIV INTERNAL LINK](https://console.data-search.tier4.jp/projects/prd_jt/environments/08320237-e08b-4181-ad06-a2622ea85973/rosbags/04293861-5aa2-49d8-b5ec-1ef5f7bd14ed)
Basically I expect this feature works with any rosbag file though.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
