### PR TITLE
feat(behavior_path_start_planner_module): add support for rqt reconfig

### DIFF
--- a/planning/behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_start_planner_module/src/manager.cpp
@@ -334,15 +334,288 @@ void StartPlannerModuleManager::updateModuleParams(
 
   auto & p = parameters_;
 
-  [[maybe_unused]] const std::string ns = name_ + ".";
+  const std::string ns = "start_planner.";
 
-  std::for_each(observers_.begin(), observers_.end(), [&](const auto & observer) {
-    if (!observer.expired()) {
-      const auto start_planner_ptr = std::dynamic_pointer_cast<StartPlannerModule>(observer.lock());
-      if (start_planner_ptr) {
-        start_planner_ptr->updateModuleParams(p);
-      }
-    }
+  {
+    updateParam<double>(parameters, ns + "th_arrived_distance", p->th_arrived_distance);
+    updateParam<double>(parameters, ns + "th_stopped_velocity", p->th_stopped_velocity);
+    updateParam<double>(parameters, ns + "th_stopped_time", p->th_stopped_time);
+    updateParam<double>(parameters, ns + "prepare_time_before_start", p->prepare_time_before_start);
+    updateParam<double>(
+      parameters, ns + "th_turn_signal_on_lateral_offset", p->th_turn_signal_on_lateral_offset);
+    updateParam<double>(
+      parameters, ns + "th_distance_to_middle_of_the_road", p->th_distance_to_middle_of_the_road);
+    updateParam<double>(
+      parameters, ns + "intersection_search_length", p->intersection_search_length);
+    updateParam<double>(
+      parameters, ns + "length_ratio_for_turn_signal_deactivation_near_intersection",
+      p->length_ratio_for_turn_signal_deactivation_near_intersection);
+
+    updateParam<double>(
+      parameters, ns + "collision_check_margin_from_front_object",
+      p->collision_check_margin_from_front_object);
+    updateParam<double>(parameters, ns + "th_moving_object_velocity", p->th_moving_object_velocity);
+    updateParam<double>(parameters, ns + "center_line_path_interval", p->center_line_path_interval);
+    updateParam<bool>(parameters, ns + "enable_shift_pull_out", p->enable_shift_pull_out);
+    updateParam<double>(
+      parameters, ns + "shift_collision_check_distance_from_end",
+      p->shift_collision_check_distance_from_end);
+    updateParam<double>(
+      parameters, ns + "minimum_shift_pull_out_distance", p->minimum_shift_pull_out_distance);
+    updateParam<int>(
+      parameters, ns + "lateral_acceleration_sampling_num", p->lateral_acceleration_sampling_num);
+    updateParam<double>(parameters, ns + "lateral_jerk", p->lateral_jerk);
+    updateParam<double>(parameters, ns + "maximum_lateral_acc", p->maximum_lateral_acc);
+    updateParam<double>(parameters, ns + "minimum_lateral_acc", p->minimum_lateral_acc);
+    updateParam<double>(parameters, ns + "maximum_curvature", p->maximum_curvature);
+    updateParam<double>(parameters, ns + "deceleration_interval", p->deceleration_interval);
+    updateParam<bool>(parameters, ns + "enable_geometric_pull_out", p->enable_geometric_pull_out);
+    updateParam<bool>(parameters, ns + "divide_pull_out_path", p->divide_pull_out_path);
+    updateParam<double>(
+      parameters, ns + "arc_path_interval", p->parallel_parking_parameters.pull_out_path_interval);
+    updateParam<double>(
+      parameters, ns + "lane_departure_margin",
+      p->parallel_parking_parameters.pull_out_lane_departure_margin);
+    updateParam<double>(
+      parameters, ns + "pull_out_max_steer_angle",
+      p->parallel_parking_parameters.pull_out_max_steer_angle);
+    updateParam<bool>(parameters, ns + "enable_back", p->enable_back);
+    updateParam<double>(parameters, ns + "max_back_distance", p->max_back_distance);
+    updateParam<double>(
+      parameters, ns + "backward_search_resolution", p->backward_search_resolution);
+    updateParam<double>(
+      parameters, ns + "backward_path_update_duration", p->backward_path_update_duration);
+    updateParam<double>(
+      parameters, ns + "ignore_distance_from_lane_end", p->ignore_distance_from_lane_end);
+  }
+  {
+    const std::string ns = "start_planner.freespace_planner.";
+
+    updateParam<bool>(parameters, ns + "enable_freespace_planner", p->enable_freespace_planner);
+    updateParam<double>(
+      parameters, ns + "end_pose_search_start_distance", p->end_pose_search_start_distance);
+    updateParam<double>(
+      parameters, ns + "end_pose_search_end_distance", p->end_pose_search_end_distance);
+    updateParam<double>(parameters, ns + "end_pose_search_interval", p->end_pose_search_interval);
+    updateParam<double>(parameters, ns + "velocity", p->freespace_planner_velocity);
+    updateParam<double>(parameters, ns + "vehicle_shape_margin", p->vehicle_shape_margin);
+    updateParam<double>(
+      parameters, ns + "time_limit", p->freespace_planner_common_parameters.time_limit);
+    updateParam<double>(
+      parameters, ns + "minimum_turning_radius",
+      p->freespace_planner_common_parameters.minimum_turning_radius);
+    updateParam<double>(
+      parameters, ns + "maximum_turning_radius",
+      p->freespace_planner_common_parameters.maximum_turning_radius);
+    updateParam<int>(
+      parameters, ns + "turning_radius_size",
+      p->freespace_planner_common_parameters.turning_radius_size);
+  }
+  {
+    const std::string ns = "start_planner.freespace_planner.search_configs.";
+
+    updateParam<int>(
+      parameters, ns + "theta_size", p->freespace_planner_common_parameters.theta_size);
+    updateParam<double>(
+      parameters, ns + "angle_goal_range", p->freespace_planner_common_parameters.angle_goal_range);
+    updateParam<double>(
+      parameters, ns + "curve_weight", p->freespace_planner_common_parameters.curve_weight);
+    updateParam<double>(
+      parameters, ns + "reverse_weight", p->freespace_planner_common_parameters.reverse_weight);
+    updateParam<double>(
+      parameters, ns + "lateral_goal_range",
+      p->freespace_planner_common_parameters.lateral_goal_range);
+    updateParam<double>(
+      parameters, ns + "longitudinal_goal_range",
+      p->freespace_planner_common_parameters.longitudinal_goal_range);
+  }
+
+  {
+    const std::string ns = "start_planner.freespace_planner.costmap_configs.";
+
+    updateParam<int>(
+      parameters, ns + "obstacle_threshold",
+      p->freespace_planner_common_parameters.obstacle_threshold);
+  }
+
+  {
+    const std::string ns = "start_planner.freespace_planner.astar.";
+
+    updateParam<bool>(parameters, ns + "use_back", p->astar_parameters.use_back);
+  }
+  {
+    const std::string ns = "start_planner.freespace_planner.rrtstar.";
+
+    updateParam<bool>(parameters, ns + "enable_update", p->rrt_star_parameters.enable_update);
+    updateParam<bool>(
+      parameters, ns + "use_informed_sampling", p->rrt_star_parameters.use_informed_sampling);
+    updateParam<double>(
+      parameters, ns + "max_planning_time", p->rrt_star_parameters.max_planning_time);
+    updateParam<double>(parameters, ns + "neighbor_radius", p->rrt_star_parameters.neighbor_radius);
+    updateParam<double>(parameters, ns + "margin", p->rrt_star_parameters.margin);
+    updateParam<double>(
+      parameters, ns + "stop_condition.maximum_deceleration_for_stop",
+      p->maximum_deceleration_for_stop);
+    updateParam<double>(
+      parameters, ns + "stop_condition.maximum_jerk_for_stop", p->maximum_jerk_for_stop);
+  }
+
+  const std::string base_ns = "start_planner.path_safety_check.";
+
+  const std::string ego_path_ns = base_ns + "ego_predicted_path.";
+
+  {
+    updateParam<double>(
+      parameters, ego_path_ns + "min_velocity", p->ego_predicted_path_params.min_velocity);
+    updateParam<double>(
+      parameters, ego_path_ns + "min_acceleration", p->ego_predicted_path_params.acceleration);
+    updateParam<double>(
+      parameters, ego_path_ns + "time_horizon_for_front_object",
+      p->ego_predicted_path_params.time_horizon_for_front_object);
+    updateParam<double>(
+      parameters, ego_path_ns + "time_horizon_for_rear_object",
+      p->ego_predicted_path_params.time_horizon_for_rear_object);
+    updateParam<double>(
+      parameters, ego_path_ns + "time_resolution", p->ego_predicted_path_params.time_resolution);
+    updateParam<double>(
+      parameters, ego_path_ns + "delay_until_departure",
+      p->ego_predicted_path_params.delay_until_departure);
+  }
+
+  const std::string obj_filter_ns = base_ns + "target_filtering.";
+
+  {
+    updateParam<double>(
+      parameters, obj_filter_ns + "safety_check_time_horizon",
+      p->objects_filtering_params.safety_check_time_horizon);
+    updateParam<double>(
+      parameters, obj_filter_ns + "safety_check_time_resolution",
+      p->objects_filtering_params.safety_check_time_resolution);
+    updateParam<double>(
+      parameters, obj_filter_ns + "object_check_forward_distance",
+      p->objects_filtering_params.object_check_forward_distance);
+    updateParam<double>(
+      parameters, obj_filter_ns + "object_check_backward_distance",
+      p->objects_filtering_params.object_check_backward_distance);
+    updateParam<double>(
+      parameters, obj_filter_ns + "ignore_object_velocity_threshold",
+      p->objects_filtering_params.ignore_object_velocity_threshold);
+    updateParam<bool>(
+      parameters, obj_filter_ns + "include_opposite_lane",
+      p->objects_filtering_params.include_opposite_lane);
+    updateParam<bool>(
+      parameters, obj_filter_ns + "invert_opposite_lane",
+      p->objects_filtering_params.invert_opposite_lane);
+    updateParam<bool>(
+      parameters, obj_filter_ns + "check_all_predicted_path",
+      p->objects_filtering_params.check_all_predicted_path);
+    updateParam<bool>(
+      parameters, obj_filter_ns + "use_all_predicted_path",
+      p->objects_filtering_params.use_all_predicted_path);
+    updateParam<bool>(
+      parameters, obj_filter_ns + "use_predicted_path_outside_lanelet",
+      p->objects_filtering_params.use_predicted_path_outside_lanelet);
+  }
+
+  const std::string obj_types_ns = obj_filter_ns + "object_types_to_check.";
+
+  {
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_car",
+      p->objects_filtering_params.object_types_to_check.check_car);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_truck",
+      p->objects_filtering_params.object_types_to_check.check_truck);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_bus",
+      p->objects_filtering_params.object_types_to_check.check_bus);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_trailer",
+      p->objects_filtering_params.object_types_to_check.check_trailer);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_unknown",
+      p->objects_filtering_params.object_types_to_check.check_unknown);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_bicycle",
+      p->objects_filtering_params.object_types_to_check.check_bicycle);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_motorcycle",
+      p->objects_filtering_params.object_types_to_check.check_motorcycle);
+    updateParam<bool>(
+      parameters, obj_types_ns + "check_pedestrian",
+      p->objects_filtering_params.object_types_to_check.check_pedestrian);
+  }
+  const std::string obj_lane_ns = obj_filter_ns + "object_lane_configuration.";
+
+  {
+    updateParam<bool>(
+      parameters, obj_lane_ns + "check_current_lane",
+      p->objects_filtering_params.object_lane_configuration.check_current_lane);
+    updateParam<bool>(
+      parameters, obj_lane_ns + "check_right_side_lane",
+      p->objects_filtering_params.object_lane_configuration.check_right_lane);
+    updateParam<bool>(
+      parameters, obj_lane_ns + "check_left_side_lane",
+      p->objects_filtering_params.object_lane_configuration.check_left_lane);
+    updateParam<bool>(
+      parameters, obj_lane_ns + "check_shoulder_lane",
+      p->objects_filtering_params.object_lane_configuration.check_shoulder_lane);
+    updateParam<bool>(
+      parameters, obj_lane_ns + "check_other_lane",
+      p->objects_filtering_params.object_lane_configuration.check_other_lane);
+  }
+  const std::string safety_check_ns = base_ns + "safety_check_params.";
+  {
+    updateParam<bool>(
+      parameters, safety_check_ns + "enable_safety_check",
+      p->safety_check_params.enable_safety_check);
+    updateParam<double>(
+      parameters, safety_check_ns + "hysteresis_factor_expand_rate",
+      p->safety_check_params.hysteresis_factor_expand_rate);
+    updateParam<double>(
+      parameters, safety_check_ns + "backward_path_length",
+      p->safety_check_params.backward_path_length);
+    updateParam<double>(
+      parameters, safety_check_ns + "forward_path_length",
+      p->safety_check_params.forward_path_length);
+    updateParam<bool>(
+      parameters, safety_check_ns + "publish_debug_marker",
+      p->safety_check_params.publish_debug_marker);
+  }
+  const std::string rss_ns = safety_check_ns + "rss_params.";
+  {
+    updateParam<double>(
+      parameters, rss_ns + "rear_vehicle_reaction_time",
+      p->safety_check_params.rss_params.rear_vehicle_reaction_time);
+    updateParam<double>(
+      parameters, rss_ns + "rear_vehicle_safety_time_margin",
+      p->safety_check_params.rss_params.rear_vehicle_safety_time_margin);
+    updateParam<double>(
+      parameters, rss_ns + "lateral_distance_max_threshold",
+      p->safety_check_params.rss_params.lateral_distance_max_threshold);
+    updateParam<double>(
+      parameters, rss_ns + "longitudinal_distance_min_threshold",
+      p->safety_check_params.rss_params.longitudinal_distance_min_threshold);
+    updateParam<double>(
+      parameters, rss_ns + "longitudinal_velocity_delta_time",
+      p->safety_check_params.rss_params.longitudinal_velocity_delta_time);
+  }
+  std::string surround_moving_obstacle_check_ns = ns + "surround_moving_obstacle_check.";
+  {
+    updateParam<double>(
+      parameters, surround_moving_obstacle_check_ns + "search_radius", p->search_radius);
+    updateParam<double>(
+      parameters, surround_moving_obstacle_check_ns + "th_moving_obstacle_velocity",
+      p->th_moving_obstacle_velocity);
+  }
+
+  std::string debug_ns = ns + "debug.";
+  {
+    updateParam<bool>(parameters, debug_ns + "print_debug_info", p->print_debug_info);
+  }
+
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
 

--- a/planning/behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_start_planner_module/src/manager.cpp
@@ -350,7 +350,8 @@ void StartPlannerModuleManager::updateModuleParams(
     updateParam<double>(
       parameters, ns + "length_ratio_for_turn_signal_deactivation_near_intersection",
       p->length_ratio_for_turn_signal_deactivation_near_intersection);
-
+    updateParam<std::vector<double>>(
+      parameters, ns + "collision_check_margins", p->collision_check_margins);
     updateParam<double>(
       parameters, ns + "collision_check_margin_from_front_object",
       p->collision_check_margin_from_front_object);
@@ -380,6 +381,16 @@ void StartPlannerModuleManager::updateModuleParams(
       parameters, ns + "pull_out_max_steer_angle",
       p->parallel_parking_parameters.pull_out_max_steer_angle);
     updateParam<bool>(parameters, ns + "enable_back", p->enable_back);
+    updateParam<double>(parameters, ns + "backward_velocity", p->backward_velocity);
+    updateParam<double>(
+      parameters, ns + "geometric_pull_out_velocity",
+      p->parallel_parking_parameters.pull_out_velocity);
+    updateParam<double>(
+      parameters, ns + "geometric_collision_check_distance_from_end",
+      p->geometric_collision_check_distance_from_end);
+    updateParam<bool>(
+      parameters, ns + "check_shift_path_lane_departure", p->check_shift_path_lane_departure);
+    updateParam<std::string>(parameters, ns + "search_priority", p->search_priority);
     updateParam<double>(parameters, ns + "max_back_distance", p->max_back_distance);
     updateParam<double>(
       parameters, ns + "backward_search_resolution", p->backward_search_resolution);
@@ -392,6 +403,8 @@ void StartPlannerModuleManager::updateModuleParams(
     const std::string ns = "start_planner.freespace_planner.";
 
     updateParam<bool>(parameters, ns + "enable_freespace_planner", p->enable_freespace_planner);
+    updateParam<std::string>(
+      parameters, ns + "freespace_planner_algorithm", p->freespace_planner_algorithm);
     updateParam<double>(
       parameters, ns + "end_pose_search_start_distance", p->end_pose_search_start_distance);
     updateParam<double>(
@@ -410,6 +423,11 @@ void StartPlannerModuleManager::updateModuleParams(
     updateParam<int>(
       parameters, ns + "turning_radius_size",
       p->freespace_planner_common_parameters.turning_radius_size);
+    p->freespace_planner_common_parameters.maximum_turning_radius = std::max(
+      p->freespace_planner_common_parameters.maximum_turning_radius,
+      p->freespace_planner_common_parameters.minimum_turning_radius);
+    p->freespace_planner_common_parameters.turning_radius_size =
+      std::max(p->freespace_planner_common_parameters.turning_radius_size, 1);
   }
   {
     const std::string ns = "start_planner.freespace_planner.search_configs.";
@@ -442,6 +460,10 @@ void StartPlannerModuleManager::updateModuleParams(
     const std::string ns = "start_planner.freespace_planner.astar.";
 
     updateParam<bool>(parameters, ns + "use_back", p->astar_parameters.use_back);
+    updateParam<bool>(
+      parameters, ns + "only_behind_solutions", p->astar_parameters.only_behind_solutions);
+    updateParam<double>(
+      parameters, ns + "distance_heuristic_weight", p->astar_parameters.distance_heuristic_weight);
   }
   {
     const std::string ns = "start_planner.freespace_planner.rrtstar.";
@@ -453,6 +475,9 @@ void StartPlannerModuleManager::updateModuleParams(
       parameters, ns + "max_planning_time", p->rrt_star_parameters.max_planning_time);
     updateParam<double>(parameters, ns + "neighbor_radius", p->rrt_star_parameters.neighbor_radius);
     updateParam<double>(parameters, ns + "margin", p->rrt_star_parameters.margin);
+  }
+
+  {
     updateParam<double>(
       parameters, ns + "stop_condition.maximum_deceleration_for_stop",
       p->maximum_deceleration_for_stop);
@@ -461,7 +486,6 @@ void StartPlannerModuleManager::updateModuleParams(
   }
 
   const std::string base_ns = "start_planner.path_safety_check.";
-
   const std::string ego_path_ns = base_ns + "ego_predicted_path.";
 
   {
@@ -607,6 +631,35 @@ void StartPlannerModuleManager::updateModuleParams(
     updateParam<double>(
       parameters, surround_moving_obstacle_check_ns + "th_moving_obstacle_velocity",
       p->th_moving_obstacle_velocity);
+
+    // ObjectTypesToCheck
+    std::string obj_types_ns = surround_moving_obstacle_check_ns + "object_types_to_check.";
+    {
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_car",
+        p->surround_moving_obstacles_type_to_check.check_car);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_truck",
+        p->surround_moving_obstacles_type_to_check.check_truck);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_bus",
+        p->surround_moving_obstacles_type_to_check.check_bus);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_trailer",
+        p->surround_moving_obstacles_type_to_check.check_trailer);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_unknown",
+        p->surround_moving_obstacles_type_to_check.check_unknown);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_bicycle",
+        p->surround_moving_obstacles_type_to_check.check_bicycle);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_motorcycle",
+        p->surround_moving_obstacles_type_to_check.check_motorcycle);
+      updateParam<bool>(
+        parameters, obj_types_ns + "check_pedestrian",
+        p->surround_moving_obstacles_type_to_check.check_pedestrian);
+    }
   }
 
   std::string debug_ns = ns + "debug.";


### PR DESCRIPTION
## Description

Add support for rqt reconfigure for the start planner

## Tests performed

Tests in PSim: 


https://github.com/autowarefoundation/autoware.universe/assets/25967964/75984661-2190-44c3-8fa6-75214a86d00c

In the above example, I use a custom script to place the ego vehicle in the same position for each test, at the beggining, both geometric pull out and shift pull out are enabled, then I disable both and call my script to place the start and goal in the same pose, this time, there is no path since both pull out methods are disabled (params updated successfully) , then I enable geometric_pull out and set the ego poses again and a path is generated using geom pull out
Note that the start and goal pose must be placed again after updating parameters. 
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
