### PR TITLE
feat(tier4_localization_launch): create a launcher for a node_container of pointcloud preprocessing in the localization component

### DIFF
--- a/launch/tier4_localization_launch/launch/localization.launch.xml
+++ b/launch/tier4_localization_launch/launch/localization.launch.xml
@@ -18,14 +18,14 @@
   <arg name="ar_tag_based_localizer_param_path"/>
 
   <arg name="input_pointcloud" default="/sensing/lidar/top/pointcloud"/>
-  <arg name="lidar_container_name" default="/sensing/lidar/top/pointcloud_preprocessor/pointcloud_container"/>
+  <arg name="target_pointcloud_container_name" default="/localization/util/pointcloud_preprocessor/pointcloud_container" description="The name of the container preprocessing the pointcloud"/>
 
   <!-- localization module -->
   <group>
     <push-ros-namespace namespace="localization"/>
     <!-- pose_twist_estimator module -->
     <include file="$(find-pkg-share tier4_localization_launch)/launch/pose_twist_estimator/pose_twist_estimator.launch.xml">
-      <arg name="lidar_container_name" value="$(var lidar_container_name)"/>
+      <arg name="target_pointcloud_container_name" value="$(var target_pointcloud_container_name)"/>
     </include>
 
     <!-- pose_twist_fusion_filter module -->

--- a/launch/tier4_localization_launch/launch/pose_twist_estimator/pose_twist_estimator.launch.xml
+++ b/launch/tier4_localization_launch/launch/pose_twist_estimator/pose_twist_estimator.launch.xml
@@ -109,7 +109,6 @@
     <let name="override_input_pointcloud" value="$(var input_pointcloud)"/>
     <let name="override_input_pointcloud" value="$(var input_pointcloud)/relay" if="$(var multi_localizer_mode)"/>
     <include file="$(find-pkg-share tier4_localization_launch)/launch/util/util.launch.xml" if="$(var use_ndt_pose)">
-      <arg name="lidar_container_name" value="$(var lidar_container_name)"/>
       <arg name="input_pointcloud" value="$(var override_input_pointcloud)"/>
     </include>
   </group>

--- a/launch/tier4_localization_launch/launch/util/util.launch.xml
+++ b/launch/tier4_localization_launch/launch/util/util.launch.xml
@@ -3,12 +3,15 @@
   <arg name="output/pointcloud" default="downsample/pointcloud" description="final output topic name"/>
 
   <!-- container -->
-  <arg name="lidar_container_name" default="/sensing/lidar/top/pointcloud_preprocessor/pointcloud_container" description="container name of main lidar used for localization"/>
+  <arg name="target_pointcloud_container_name" default="/localization/util/pointcloud_preprocessor/pointcloud_container" description="container name of the pointcloud used for localization"/>
+  <let name="use_existing_pointcloud_container" value="$(eval &quot;'$(var target_pointcloud_container_name)' != '/localization/util/pointcloud_preprocessor/pointcloud_container' &quot;)"/>
+
+  <node_container unless="$(var use_existing_pointcloud_container)" pkg="rclcpp_components" exec="component_container" name="pointcloud_container" namespace="pointcloud_preprocessor"/>
 
   <!-- whether use intra-process -->
   <arg name="use_intra_process" default="true" description="use ROS 2 component container communication"/>
 
-  <load_composable_node target="$(var lidar_container_name)">
+  <load_composable_node target="$(var target_pointcloud_container_name)">
     <composable_node pkg="pointcloud_preprocessor" plugin="pointcloud_preprocessor::CropBoxFilterComponent" name="crop_box_filter_measurement_range">
       <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/crop_box_filter_measurement_range_param_path)"/>
       <remap from="input" to="$(var input_pointcloud)"/>


### PR DESCRIPTION
## Description

Due to the upcoming demands, [Autoware should cover the use cases where the concatenated pointcloud will be applied as an input to the localization component](https://github.com/orgs/autowarefoundation/discussions/4172). Since the architecture of the pointcloud container has changed, we can't have a straight node container from the preprocessor in the sensing component to that of the localization component when we want to use the concatenated pointcloud.

**Therefore, the launch system in the localization component should have a feature to launch its own pointcloud preprocessing node container, and this PR is meant to do so.**

Plus, we can launch the localization component cleanly if it can launch the pointcloud container by its own.

A simple flowchart of how the launching goes is described here.

![localization_pointcloud_container drawio](https://github.com/autowarefoundation/autoware.universe/assets/129915538/9fa4b6c9-8179-44b3-9379-1425d49bb29d)

The argument `lidar_container_name` is changed to `target_pointcloud_container_name` since it might not be a node container related to a specific LiDAR.


## Related links

**This PR should be merged with [this PR](https://github.com/autowarefoundation/autoware_launch/pull/890) in autoware_launch!!**

## Tests performed

I tested this launch system via the logging_simulator tutorial and get the following results when I `ros2 component list`
```
(Excerpted)
/localization/util/pointcloud_preprocessor/pointcloud_container
  1  /localization/util/crop_box_filter_measurement_range
  2  /localization/util/voxel_grid_downsample_filter
  3  /localization/util/random_downsample_filter
```

## Notes for reviewers

**This PR should be merged with [this PR](https://github.com/autowarefoundation/autoware_launch/pull/890) in autoware_launch!!**

## Interface changes

A new node_container named `/localization/util/pointcloud_preprocessor/pointcloud_container` will be launched, and `/localization/util/crop_box_filter_measurement_range`, ` /localization/util/voxel_grid_downsample_filter`, and `/localization/util/random_downsample_filter` will be added to it.

## Effects on system behavior

If the user didn't define `target_pointcloud_container_name` in the `tier4_localization_component.launch.xml` of autoware_launch, the pointcloud publication/subscription between sensing & localization components will be done outside the node container, which leads to an increase of latency. (about + 20ms in my PC).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
