### PR TITLE
feat(avoidance): wait next shift approval until the ego reaches shift length threshold

### DIFF
--- a/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
+++ b/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
@@ -208,6 +208,10 @@
           max_right_shift_length: 5.0
           max_left_shift_length: 5.0
           max_deviation_from_lane: 0.5                  # [m]
+          # approve next shift line after reaching this percentage of current shift line length.
+          # this param is added so that it can wait return shift approval until the behind occlusion of avoid target is clear.
+          # it's able to disable this feature by setting this param 0.0.
+          ratio_for_return_shift_approval: 0.5          # [-]
         # avoidance distance parameters
         longitudinal:
           min_prepare_time: 1.0                         # [s]

--- a/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
+++ b/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
@@ -209,8 +209,9 @@
           max_left_shift_length: 5.0
           max_deviation_from_lane: 0.5                  # [m]
           # approve the next shift line after reaching this percentage of the current shift line length.
+          # this parameter should be within range of 0.0 to 1.0.
           # this parameter is added to allow waiting for the return of shift approval until the occlusion behind the avoid target is clear.
-          # this feature can be disabled by setting this parameter to 0.0.
+          # this feature can be disabled by setting this parameter to 1.0. (in that case, avoidance module creates return shift as soon as possible.)
           ratio_for_return_shift_approval: 0.5          # [-]
         # avoidance distance parameters
         longitudinal:

--- a/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
+++ b/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
@@ -208,9 +208,9 @@
           max_right_shift_length: 5.0
           max_left_shift_length: 5.0
           max_deviation_from_lane: 0.5                  # [m]
-          # approve next shift line after reaching this percentage of current shift line length.
-          # this param is added so that it can wait return shift approval until the behind occlusion of avoid target is clear.
-          # it's able to disable this feature by setting this param 0.0.
+          # approve the next shift line after reaching this percentage of the current shift line length.
+          # this parameter is added to allow waiting for the return of shift approval until the occlusion behind the avoid target is clear.
+          # this feature can be disabled by setting this parameter to 0.0.
           ratio_for_return_shift_approval: 0.5          # [-]
         # avoidance distance parameters
         longitudinal:

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -276,6 +276,9 @@ struct AvoidanceParameters
   // use for judge if the ego is shifting or not.
   double lateral_avoid_check_threshold{0.0};
 
+  // use for return shift approval.
+  double ratio_for_return_shift_approval{0.0};
+
   // For shift line generation process. The continuous shift length is quantized by this value.
   double quantize_filter_threshold{0.0};
 
@@ -538,6 +541,8 @@ struct AvoidancePlanningData
   bool safe{false};
 
   bool valid{false};
+
+  bool ready{false};
 
   bool success{false};
 

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
@@ -270,6 +270,33 @@ public:
     });
   }
 
+  bool isReady(const AvoidLineArray & new_shift_lines, const double current_shift_length) const
+  {
+    if (std::abs(current_shift_length) < 1e-3) {
+      return true;
+    }
+
+    if (new_shift_lines.empty()) {
+      return true;
+    }
+
+    const auto front_shift_relative_length = new_shift_lines.front().getRelativeLength();
+
+    // same direction shift.
+    if (current_shift_length > 0.0 && front_shift_relative_length > 0.0) {
+      return true;
+    }
+
+    // same direction shift.
+    if (current_shift_length < 0.0 && front_shift_relative_length < 0.0) {
+      return true;
+    }
+
+    // keep waiting the other side shift approval until the ego reaches shift length threshold.
+    const auto ego_shift_ratio = (current_shift_length - getEgoShift()) / current_shift_length;
+    return ego_shift_ratio < parameters_->ratio_for_return_shift_approval;
+  }
+
   bool isShifted() const
   {
     return std::abs(getEgoShift()) > parameters_->lateral_avoid_check_threshold;

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/helper.hpp
@@ -294,7 +294,7 @@ public:
 
     // keep waiting the other side shift approval until the ego reaches shift length threshold.
     const auto ego_shift_ratio = (current_shift_length - getEgoShift()) / current_shift_length;
-    return ego_shift_ratio < parameters_->ratio_for_return_shift_approval;
+    return ego_shift_ratio < parameters_->ratio_for_return_shift_approval + 1e-3;
   }
 
   bool isShifted() const

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
@@ -258,6 +258,8 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
     p.max_left_shift_length = getOrDeclareParameter<double>(*node, ns + "max_left_shift_length");
     p.max_deviation_from_lane =
       getOrDeclareParameter<double>(*node, ns + "max_deviation_from_lane");
+    p.ratio_for_return_shift_approval =
+      getOrDeclareParameter<double>(*node, ns + "ratio_for_return_shift_approval");
   }
 
   // avoidance maneuver (longitudinal)

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
@@ -260,6 +260,10 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
       getOrDeclareParameter<double>(*node, ns + "max_deviation_from_lane");
     p.ratio_for_return_shift_approval =
       getOrDeclareParameter<double>(*node, ns + "ratio_for_return_shift_approval");
+    if (p.ratio_for_return_shift_approval < 0.0 || p.ratio_for_return_shift_approval > 1.0) {
+      throw std::domain_error(
+        "ratio_for_return_shift_approval should be within range of 0.0 to 1.0");
+    }
   }
 
   // avoidance maneuver (longitudinal)

--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -133,7 +133,7 @@ bool AvoidanceModule::isExecutionRequested() const
 bool AvoidanceModule::isExecutionReady() const
 {
   DEBUG_PRINT("AVOIDANCE isExecutionReady");
-  return avoid_data_.safe && avoid_data_.comfortable && avoid_data_.valid;
+  return avoid_data_.safe && avoid_data_.comfortable && avoid_data_.valid && avoid_data_.ready;
 }
 
 bool AvoidanceModule::isSatisfiedSuccessCondition(const AvoidancePlanningData & data) const
@@ -513,6 +513,7 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
    */
   data.comfortable = helper_->isComfortable(data.new_shift_line);
   data.safe = isSafePath(data.candidate_path, debug);
+  data.ready = helper_->isReady(data.new_shift_line, path_shifter_.getLastShiftLength());
 }
 
 void AvoidanceModule::fillEgoStatus(


### PR DESCRIPTION
## Description

Related ticket: https://tier4.atlassian.net/browse/RT1-5327
Related PR: https://github.com/autowarefoundation/autoware_launch/pull/891

Previously, avoidance module created return shift path and approved it as soon as possible. However, I think it is better to wait return shift approval because sometimes the vehicle can't detect objcets behind avoidance target. Othrewise, there is a possibility that the vehicle can't avoid behind object in following situaiton. (avoidance module creats return shift path even when there is anothre object behind current avoidance target.)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/dbd46cfc-1677-4152-b34b-0936f46308a9)

In this PR, I added a param to delay return shift approval.

```yaml
          # approve next shift line after reaching this percentage of current shift line length.
          # this param is added so that it can wait return shift approval until the behind occlusion of avoid target is clear.
          # it's able to disable this feature by setting this param 0.0.
          ratio_for_return_shift_approval: 0.5          # [-]
```

If we set this param to 0.3, the module creates return shift path after reaching 70% of avoidance shift lateral length.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/b00ef609-41b8-474b-8d9b-fcba657405a4

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] PASS TIER IV INTERNAL SCENARIOS

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
