### PR TITLE
fix(lane_change): approval chatters when no valid paths

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -208,11 +208,6 @@ bool LaneChangeInterface::canTransitSuccessState()
     }
   }
 
-  if (!module_type_->isValidPath()) {
-    log_debug_throttled("Has no valid path.");
-    return true;
-  }
-
   if (module_type_->isAbortState() && module_type_->hasFinishedAbort()) {
     log_debug_throttled("Abort process has completed.");
     return true;


### PR DESCRIPTION
## Description

Fix approval chatter when lane change is running while no valid path is available

### Before PR

[Before](https://github.com/autowarefoundation/autoware.universe/assets/93502286/85c02277-3825-4f80-9677-53a1f2c570b1)

### After PR

[After](https://github.com/autowarefoundation/autoware.universe/assets/93502286/27223870-64e8-4f48-a08e-b5653a1a9d92)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
