### PR TITLE
fix(no_stopping_area): fix stopping in front of a no stopping area in parking on the shoulder

### DIFF
--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -339,7 +339,7 @@ Polygon2d NoStoppingAreaModule::generateEgoNoStoppingAreaLanePolygon(
 
       // do not take extra distance and exit as soon as p is outside no stopping area
       // just a temporary fix
-      ego_area_end_idx = i-1;
+      ego_area_end_idx = i - 1;
       break;
     }
     if (dist_from_start_sum > extra_dist || dist_from_area_sum > margin) {

--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -324,9 +324,7 @@ Polygon2d NoStoppingAreaModule::generateEgoNoStoppingAreaLanePolygon(
     }
     ++ego_area_start_idx;
   }
-  if (ego_area_start_idx > num_ignore_nearest) {
-    ego_area_start_idx--;
-  }
+
   if (!is_in_area) {
     return ego_area;
   }
@@ -338,6 +336,11 @@ Polygon2d NoStoppingAreaModule::generateEgoNoStoppingAreaLanePolygon(
     const auto & p = pp.at(i).point.pose.position;
     if (!bg::within(Point2d{p.x, p.y}, lanelet::utils::to2D(no_stopping_area).basicPolygon())) {
       dist_from_area_sum += tier4_autoware_utils::calcDistance2d(pp.at(i), pp.at(i - 1));
+
+      // do not take extra distance and exit as soon as p is outside no stopping area
+      // just a temporary fix
+      ego_area_end_idx = i-1;
+      break;
     }
     if (dist_from_start_sum > extra_dist || dist_from_area_sum > margin) {
       break;


### PR DESCRIPTION
## Description

In a current path planning and in a no stopping area module, there is a margin after a no stopping area so that the ego vehicle can’t stop right behind the no stopping areas. 

For example, if the distance from the goal position to the end of the no stopping area is shorter than 2.6 m, in the case of the medium size car with the rear overhang about 0.85 m, the ego vehicle can not enter into the no stopping area, which is problematic. 

The details of the problem are described in the JIRA  Ticket : https://tier4.atlassian.net/browse/RT1-5039

To resolve this problem, I added the following 2 changes to the source file of no stopping area module.

1. Deletion of the 3 lines ( L327-L329 of the old file ).
    
    This sets the index value from which to start the search of `ego_area_end_idx` to be `ego_area_start_idx`. This is for the consistency with the second modification.
    
2. Insertion of the following 2 lines inside the if block ( L339-L343 of the new file).
    
    This sets the `ego_area_end_idx` to be the last index of the `interpolated_path` whose corresponding point position is inside the no_stopping_area. 
    
    Note: because of this change, the `dist_from_area_sum` variable is not used any more and also the related calculations are unnecessary. Please make sure that this code file situation will be resolved in the future refactoring, after a consideration on whether or not the margin after no stopping areas should be taken.
    

## Tests performed

I compared the movies of parking on the shoulder near the no stopping area by the cross walk before and after the changes.
The movies are shown in the JIRA Ticket : https://tier4.atlassian.net/browse/RT1-5039. 

## Effects on system behavior

After the changes, the ego vehicle passes through the no stopping area and stops at the goal right behind the no stopping area.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ]  There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/