### PR TITLE
fix(ci): remove json-schema-check filter

### DIFF
--- a/.github/workflows/json-schema-check.yaml
+++ b/.github/workflows/json-schema-check.yaml
@@ -2,9 +2,6 @@ name: json-schema-check
 
 on:
   pull_request:
-    paths:
-      - "**/schema/*.schema.json"
-      - "**/config/*.param.yaml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

The `json-schema-check` workflow is required for merging pull-request now.
But `json-schema-check` fires only when you edited parameter files or schema files.
So, `json-schema-check` blocks merging pull-requests without parameter files or schema files changes.
This is a naive solution, and there may be a more elegant method, but I will suggest it for now.

Related: #6473 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
