### PR TITLE
feat(pointcloud_preprocessor): enable to change synchronized pointcloud topic name

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -136,6 +136,11 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw(
   if (stop_watch_ptr_) {
     stop_watch_ptr_->toc("processing_time", true);
   }
+  // if scan_origin_frame_ is "", replace it with input_raw_msg->header.frame_id
+  if (scan_origin_frame_.empty()) {
+    scan_origin_frame_ = input_raw_msg->header.frame_id;
+  }
+
   // Apply height filter
   PointCloud2 cropped_obstacle_pc{};
   PointCloud2 cropped_raw_pc{};

--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -136,11 +136,6 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw(
   if (stop_watch_ptr_) {
     stop_watch_ptr_->toc("processing_time", true);
   }
-  // if scan_origin_frame_ is "", replace it with input_raw_msg->header.frame_id
-  if (scan_origin_frame_.empty()) {
-    scan_origin_frame_ = input_raw_msg->header.frame_id;
-  }
-
   // Apply height filter
   PointCloud2 cropped_obstacle_pc{};
   PointCloud2 cropped_raw_pc{};

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -85,24 +85,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-// replace topic name postfix
-inline std::string replace_topic_name_postfix(
-  const std::string & original_topic_name, const std::string & postfix)
-{
-  // separate the topic name by '/' and replace the last element with the new postfix
-  size_t pos = original_topic_name.find_last_of("/");
-  if (pos == std::string::npos) {
-    // not found '/': this is not a namespaced topic
-    std::cerr
-      << "The topic name is not namespaced. The postfix will be added to the end of the topic name."
-      << std::endl;
-    return original_topic_name + postfix;
-  } else {
-    // replace the last element with the new postfix
-    return original_topic_name.substr(0, pos) + "/" + postfix;
-  }
-}
-
 namespace pointcloud_preprocessor
 {
 using autoware_point_types::PointXYZI;
@@ -198,6 +180,8 @@ private:
   void timer_callback();
 
   void checkConcatStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string replaceSyncTopicNamePostfix(
+    const std::string & original_topic_name, const std::string & postfix);
 
   /** \brief processing time publisher. **/
   std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -99,7 +99,7 @@ inline std::string replace_topic_name_postfix(
     return original_topic_name + postfix;
   } else {
     // replace the last element with the new postfix
-    return original_topic_name.substr(0, pos) + postfix;
+    return original_topic_name.substr(0, pos) + "/" + postfix;
   }
 }
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -85,6 +85,24 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+// replace topic name postfix
+inline std::string replace_topic_name_postfix(
+  const std::string & original_topic_name, const std::string & postfix)
+{
+  // separate the topic name by '/' and replace the last element with the new postfix
+  size_t pos = original_topic_name.find_last_of("/");
+  if (pos == std::string::npos) {
+    // not found '/': this is not a namespaced topic
+    std::cerr
+      << "The topic name is not namespaced. The postfix will be added to the end of the topic name."
+      << std::endl;
+    return original_topic_name + postfix;
+  } else {
+    // replace the last element with the new postfix
+    return original_topic_name.substr(0, pos) + postfix;
+  }
+}
+
 namespace pointcloud_preprocessor
 {
 using autoware_point_types::PointXYZI;
@@ -126,6 +144,7 @@ private:
   double timeout_sec_ = 0.1;
 
   bool publish_synchronized_pointcloud_;
+  std::string synchronized_pointcloud_postfix_;
 
   std::set<std::string> not_subscribed_topic_names_;
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
@@ -85,23 +85,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-// replace topic name postfix
-inline std::string replace_topic_name_postfix(
-  const std::string & original_topic_name, const std::string & postfix)
-{
-  // separate the topic name by '/' and replace the last element with the new postfix
-  size_t pos = original_topic_name.find_last_of("/");
-  if (pos == std::string::npos) {
-    // not found '/': this is not a namespaced topic
-    std::cerr
-      << "The topic name is not namespaced. The postfix will be added to the end of the topic name."
-      << std::endl;
-    return original_topic_name + postfix;
-  } else {
-    // replace the last element with the new postfix
-    return original_topic_name.substr(0, pos) + '/' + postfix;
-  }
-}
 namespace pointcloud_preprocessor
 {
 using autoware_point_types::PointXYZI;
@@ -194,6 +177,8 @@ private:
   void timer_callback();
 
   void checkSyncStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  std::string replaceSyncTopicNamePostfix(
+    const std::string & original_topic_name, const std::string & postfix);
 
   /** \brief processing time publisher. **/
   std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
@@ -99,7 +99,7 @@ inline std::string replace_topic_name_postfix(
     return original_topic_name + postfix;
   } else {
     // replace the last element with the new postfix
-    return original_topic_name.substr(0, pos) + postfix;
+    return original_topic_name.substr(0, pos) + '/' + postfix;
   }
 }
 namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/time_synchronizer/time_synchronizer_nodelet.hpp
@@ -85,6 +85,23 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+// replace topic name postfix
+inline std::string replace_topic_name_postfix(
+  const std::string & original_topic_name, const std::string & postfix)
+{
+  // separate the topic name by '/' and replace the last element with the new postfix
+  size_t pos = original_topic_name.find_last_of("/");
+  if (pos == std::string::npos) {
+    // not found '/': this is not a namespaced topic
+    std::cerr
+      << "The topic name is not namespaced. The postfix will be added to the end of the topic name."
+      << std::endl;
+    return original_topic_name + postfix;
+  } else {
+    // replace the last element with the new postfix
+    return original_topic_name.substr(0, pos) + postfix;
+  }
+}
 namespace pointcloud_preprocessor
 {
 using autoware_point_types::PointXYZI;

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -61,7 +61,8 @@
 #include <utility>
 #include <vector>
 
-#define POSTFIX_NAME "_synchronized"  // default postfix name for synchronized pointcloud
+#define DEFAULT_SYNC_TOPIC_POSTFIX \
+  "_synchronized"  // default postfix name for synchronized pointcloud
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -190,15 +191,7 @@ PointCloudConcatenateDataSynchronizerComponent::PointCloudConcatenateDataSynchro
   // Transformed Raw PointCloud2 Publisher to publish the transformed pointcloud
   if (publish_synchronized_pointcloud_) {
     for (auto & topic : input_topics_) {
-      std::string new_topic = replace_topic_name_postfix(topic, synchronized_pointcloud_postfix_);
-      if (new_topic == topic) {
-        RCLCPP_WARN_STREAM(
-          get_logger(),
-          "The topic name "
-            << topic
-            << " does not have a postfix. The postfix will be added to the end of the topic name.");
-        new_topic = topic + POSTFIX_NAME;
-      }
+      std::string new_topic = replaceSyncTopicNamePostfix(topic, synchronized_pointcloud_postfix_);
       auto publisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(
         new_topic, rclcpp::SensorDataQoS().keep_last(maximum_queue_size_));
       transformed_raw_pc_publisher_map_.insert({topic, publisher});
@@ -239,6 +232,35 @@ void PointCloudConcatenateDataSynchronizerComponent::transformPointCloud(
   } else {
     out = std::make_shared<PointCloud2>(*in);
   }
+}
+
+std::string PointCloudConcatenateDataSynchronizerComponent::replaceSyncTopicNamePostfix(
+  const std::string & original_topic_name, const std::string & postfix)
+{
+  std::string replaced_topic_name;
+  // separate the topic name by '/' and replace the last element with the new postfix
+  size_t pos = original_topic_name.find_last_of("/");
+  if (pos == std::string::npos) {
+    // not found '/': this is not a namespaced topic
+    RCLCPP_WARN_STREAM(
+      get_logger(),
+      "The topic name is not namespaced. The postfix will be added to the end of the topic name.");
+    return original_topic_name + postfix;
+  } else {
+    // replace the last element with the new postfix
+    replaced_topic_name = original_topic_name.substr(0, pos) + "/" + postfix;
+  }
+
+  // if topic name is the same with original topic name, add postfix to the end of the topic name
+  if (replaced_topic_name == original_topic_name) {
+    RCLCPP_WARN_STREAM(
+      get_logger(), "The topic name "
+                      << original_topic_name
+                      << " have the same postfix with synchronized pointcloud. We use the postfix "
+                         "to the end of the topic name.");
+    replaced_topic_name = original_topic_name + DEFAULT_SYNC_TOPIC_POSTFIX;
+  }
+  return replaced_topic_name;
 }
 
 /**

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -61,7 +61,7 @@
 #include <utility>
 #include <vector>
 
-#define POSTFIX_NAME "_synchronized"
+#define POSTFIX_NAME "_synchronized"  // default postfix name for synchronized pointcloud
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -112,6 +112,8 @@ PointCloudConcatenateDataSynchronizerComponent::PointCloudConcatenateDataSynchro
 
     // Check if publish synchronized pointcloud
     publish_synchronized_pointcloud_ = declare_parameter("publish_synchronized_pointcloud", false);
+    synchronized_pointcloud_postfix_ =
+      declare_parameter("synchronized_pointcloud_postfix", "pointcloud");
   }
 
   // Initialize not_subscribed_topic_names_
@@ -185,10 +187,18 @@ PointCloudConcatenateDataSynchronizerComponent::PointCloudConcatenateDataSynchro
     }
   }
 
-  // Transformed Raw PointCloud2 Publisher
-  {
+  // Transformed Raw PointCloud2 Publisher to publish the transformed pointcloud
+  if (publish_synchronized_pointcloud_) {
     for (auto & topic : input_topics_) {
-      std::string new_topic = topic + POSTFIX_NAME;
+      std::string new_topic = replace_topic_name_postfix(topic, synchronized_pointcloud_postfix_);
+      if (new_topic == topic) {
+        RCLCPP_WARN_STREAM(
+          get_logger(),
+          "The topic name "
+            << topic
+            << " does not have a postfix. The postfix will be added to the end of the topic name.");
+        new_topic = topic + POSTFIX_NAME;
+      }
       auto publisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(
         new_topic, rclcpp::SensorDataQoS().keep_last(maximum_queue_size_));
       transformed_raw_pc_publisher_map_.insert({topic, publisher});

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
@@ -74,12 +74,6 @@ PointCloudConcatenationComponent::PointCloudConcatenationComponent(
       return;
     }
   }
-  // add postfix to topic names
-  {
-    for (auto & topic : input_topics_) {
-      topic = topic + POSTFIX_NAME;
-    }
-  }
 
   // Initialize not_subscribed_topic_names_
   {

--- a/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
@@ -34,7 +34,7 @@
 #include <vector>
 
 // postfix for output topics
-#define POSTFIX_NAME "_synchronized"
+#define DEFAULT_SYNC_TOPIC_POSTFIX "_synchronized"
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 namespace pointcloud_preprocessor
@@ -154,15 +154,7 @@ PointCloudDataSynchronizerComponent::PointCloudDataSynchronizerComponent(
   // Transformed Raw PointCloud2 Publisher
   {
     for (auto & topic : input_topics_) {
-      std::string new_topic = replace_topic_name_postfix(topic, synchronized_pointcloud_postfix);
-      if (new_topic == topic) {
-        RCLCPP_WARN_STREAM(
-          get_logger(),
-          "The topic name "
-            << topic
-            << " does not have a postfix. The postfix will be added to the end of the topic name.");
-        new_topic = topic + POSTFIX_NAME;
-      }
+      std::string new_topic = replaceSyncTopicNamePostfix(topic, synchronized_pointcloud_postfix);
       auto publisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(
         new_topic, rclcpp::SensorDataQoS().keep_last(maximum_queue_size_));
       transformed_raw_pc_publisher_map_.insert({topic, publisher});
@@ -183,6 +175,35 @@ PointCloudDataSynchronizerComponent::PointCloudDataSynchronizerComponent(
     updater_.setHardwareID("synchronize_data_checker");
     updater_.add("concat_status", this, &PointCloudDataSynchronizerComponent::checkSyncStatus);
   }
+}
+
+std::string PointCloudDataSynchronizerComponent::replaceSyncTopicNamePostfix(
+  const std::string & original_topic_name, const std::string & postfix)
+{
+  std::string replaced_topic_name;
+  // separate the topic name by '/' and replace the last element with the new postfix
+  size_t pos = original_topic_name.find_last_of("/");
+  if (pos == std::string::npos) {
+    // not found '/': this is not a namespaced topic
+    RCLCPP_WARN_STREAM(
+      get_logger(),
+      "The topic name is not namespaced. The postfix will be added to the end of the topic name.");
+    return original_topic_name + postfix;
+  } else {
+    // replace the last element with the new postfix
+    replaced_topic_name = original_topic_name.substr(0, pos) + "/" + postfix;
+  }
+
+  // if topic name is the same with original topic name, add postfix to the end of the topic name
+  if (replaced_topic_name == original_topic_name) {
+    RCLCPP_WARN_STREAM(
+      get_logger(), "The topic name "
+                      << original_topic_name
+                      << " have the same postfix with synchronized pointcloud. We use the postfix "
+                         "to the end of the topic name.");
+    replaced_topic_name = original_topic_name + DEFAULT_SYNC_TOPIC_POSTFIX;
+  }
+  return replaced_topic_name;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR enables to `concatenate_node` or `time_sync_node` to publish any name.
This feature is going to used in interface change: 
https://github.com/orgs/autowarefoundation/discussions/4158

### inner works

- The topic rename function tries to rename input topic by replacing last part of the topic name
  -  example: `/sensing/lidar/sample/input_pointcloud` to `/sensing/lidar/sample/<postfix>`
  -  postfix is controlled by rosparam `synchronized_pointcloud_postfix`, we set `pointcloud` as default as for [the above discussion](https://github.com/orgs/autowarefoundation/discussions/4158)
- If the input topic end with `pointcloud`, the topic name replace function returns the same name, so we replace synchronized pointcloud name with `pointcloud_synchronized`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->


https://github.com/orgs/autowarefoundation/discussions/4158

## Tests performed

<!-- Describe how you have tested this PR. -->
Tested with Lsim with sample-rosbag

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
