### PR TITLE
feat(lane_change): additional debug markers

### DIFF
--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/debug_structs.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/debug_structs.hpp
@@ -21,6 +21,9 @@
 
 #include <geometry_msgs/msg/detail/polygon__struct.hpp>
 
+#include <lanelet2_core/Forward.h>
+
+#include <limits>
 #include <string>
 
 namespace behavior_path_planner::data::lane_change
@@ -34,7 +37,17 @@ struct Debug
   CollisionCheckDebugMap collision_check_objects_after_approval;
   LaneChangeTargetObjects filtered_objects;
   geometry_msgs::msg::Polygon execution_area;
+  geometry_msgs::msg::Pose ego_pose;
+  lanelet::ConstLanelets current_lanes;
+  lanelet::ConstLanelets target_lanes;
+  lanelet::ConstLanelets target_backward_lanes;
   double collision_check_object_debug_lifetime{0.0};
+  double distance_to_end_of_current_lane{std::numeric_limits<double>::max()};
+  double distance_to_lane_change_finished{std::numeric_limits<double>::max()};
+  double distance_to_abort_finished{std::numeric_limits<double>::max()};
+  bool is_able_to_return_to_current_lane{false};
+  bool is_stuck{false};
+  bool is_abort{false};
 
   void reset()
   {
@@ -44,7 +57,18 @@ struct Debug
     filtered_objects.current_lane.clear();
     filtered_objects.target_lane.clear();
     filtered_objects.other_lane.clear();
+    execution_area.points.clear();
+    current_lanes.clear();
+    target_lanes.clear();
+    target_backward_lanes.clear();
+
     collision_check_object_debug_lifetime = 0.0;
+    distance_to_end_of_current_lane = std::numeric_limits<double>::max();
+    distance_to_lane_change_finished = std::numeric_limits<double>::max();
+    distance_to_abort_finished = std::numeric_limits<double>::max();
+    is_able_to_return_to_current_lane = false;
+    is_stuck = false;
+    is_abort = false;
   }
 };
 }  // namespace behavior_path_planner::data::lane_change

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/markers.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/markers.hpp
@@ -20,6 +20,7 @@
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 
 #include <geometry_msgs/msg/detail/polygon__struct.hpp>
+#include <geometry_msgs/msg/detail/pose__struct.hpp>
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -42,7 +43,9 @@ MarkerArray showFilteredObjects(
   const ExtendedPredictedObjects & target_lane_objects,
   const ExtendedPredictedObjects & other_lane_objects, const std::string & ns);
 MarkerArray createExecutionArea(const geometry_msgs::msg::Polygon & execution_area);
-MarkerArray createDebugMarkerArray(const Debug & debug_data);
+MarkerArray showExecutionInfo(const Debug & debug_data, const geometry_msgs::msg::Pose & ego_pose);
+MarkerArray createDebugMarkerArray(
+  const Debug & debug_data, const geometry_msgs::msg::Pose & ego_pose);
 
 }  // namespace marker_utils::lane_change_markers
 #endif  // BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__MARKERS_HPP_

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -85,9 +85,9 @@ void LaneChangeInterface::updateData()
   if (isWaitingApproval()) {
     module_type_->updateLaneChangeStatus();
   }
-  updateDebugMarker();
 
   module_type_->resetStopPose();
+  updateDebugMarker();
 }
 
 void LaneChangeInterface::postProcess()
@@ -97,6 +97,7 @@ void LaneChangeInterface::postProcess()
     post_process_safety_status_ =
       module_type_->evaluateApprovedPathWithUnsafeHysteresis(safety_status);
   }
+  updateDebugMarker();
 }
 
 BehaviorModuleOutput LaneChangeInterface::plan()
@@ -196,6 +197,7 @@ bool LaneChangeInterface::canTransitSuccessState()
   auto log_debug_throttled = [&](std::string_view message) -> void {
     RCLCPP_DEBUG(getLogger(), "%s", message.data());
   };
+  updateDebugMarker();
 
   if (module_type_->specialExpiredCheck() && isWaitingApproval()) {
     log_debug_throttled("Run specialExpiredCheck.");
@@ -225,6 +227,7 @@ bool LaneChangeInterface::canTransitFailureState()
     RCLCPP_DEBUG(getLogger(), "%s", message.data());
   };
 
+  updateDebugMarker();
   log_debug_throttled(__func__);
 
   if (module_type_->isAbortState() && !module_type_->hasFinishedAbort()) {
@@ -300,7 +303,7 @@ void LaneChangeInterface::updateDebugMarker() const
     return;
   }
   using marker_utils::lane_change_markers::createDebugMarkerArray;
-  debug_marker_ = createDebugMarkerArray(module_type_->getDebugData());
+  debug_marker_ = createDebugMarkerArray(module_type_->getDebugData(), module_type_->getEgoPose());
 }
 
 MarkerArray LaneChangeInterface::getModuleVirtualWall()


### PR DESCRIPTION
## Description

Adding additional debug marker for lane change module
- visualize current, target, backward target lanes
- visualize distances metrics
- visualize some of the reasons

![Screenshot from 2024-03-01 17-51-13](https://github.com/autowarefoundation/autoware.universe/assets/93502286/a1702340-83d0-4136-a92d-411c6268bc59)

![image](https://github.com/autowarefoundation/autoware.universe/assets/93502286/72586e5a-c07c-46a5-9188-eee4c10cbe48)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
