### PR TITLE
ci(json-schema-check): run only if relevant files are changed

### DIFF
--- a/.github/workflows/json-schema-check.yaml
+++ b/.github/workflows/json-schema-check.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pre-check:
+  check-if-relevant-files-changed:
     runs-on: ubuntu-latest
     outputs:
       run-check: ${{ steps.paths_filter.outputs.json_or_yaml }}
@@ -20,8 +20,8 @@ jobs:
               - '**/config/*.param.yaml'
 
   json-schema-check:
-    needs: pre-check
-    if: needs.pre-check.outputs.run-check == 'true'
+    needs: check-if-relevant-files-changed
+    if: needs.check-if-relevant-files-changed.outputs.run-check == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -31,8 +31,8 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/json-schema-check@v1
 
   no-relevant-changes:
-    needs: pre-check
-    if: needs.pre-check.outputs.run-check == 'false'
+    needs: check-if-relevant-files-changed
+    if: needs.check-if-relevant-files-changed.outputs.run-check == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Dummy step

--- a/.github/workflows/json-schema-check.yaml
+++ b/.github/workflows/json-schema-check.yaml
@@ -5,7 +5,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  pre-check:
+    runs-on: ubuntu-latest
+    outputs:
+      run-check: ${{ steps.set-run-check.outputs.run }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v3
+        id: paths_filter
+        with:
+          filters: |
+            json_or_yaml:
+              - '**/schema/*.schema.json'
+              - '**/config/*.param.yaml'
+      - id: set-run-check
+        run: echo "::set-output name=run::${{ steps.paths_filter.outputs.json_or_yaml == 'true' }}"
+
   json-schema-check:
+    needs: pre-check
+    if: needs.pre-check.outputs.run-check == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -13,3 +31,11 @@ jobs:
 
       - name: Run json-schema-check
         uses: autowarefoundation/autoware-github-actions/json-schema-check@v1
+
+  no-relevant-changes:
+    needs: pre-check
+    if: needs.pre-check.outputs.run-check == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy step
+        run: echo "No relevant changes, passing check"

--- a/.github/workflows/json-schema-check.yaml
+++ b/.github/workflows/json-schema-check.yaml
@@ -8,7 +8,7 @@ jobs:
   pre-check:
     runs-on: ubuntu-latest
     outputs:
-      run-check: ${{ steps.set-run-check.outputs.run }}
+      run-check: ${{ steps.paths_filter.outputs.json_or_yaml }}
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v3
@@ -18,8 +18,6 @@ jobs:
             json_or_yaml:
               - '**/schema/*.schema.json'
               - '**/config/*.param.yaml'
-      - id: set-run-check
-        run: echo "::set-output name=run::${{ steps.paths_filter.outputs.json_or_yaml == 'true' }}"
 
   json-schema-check:
     needs: pre-check

--- a/localization/ekf_localizer/schema/ekf_localizer.schema.json
+++ b/localization/ekf_localizer/schema/ekf_localizer.schema.json
@@ -40,7 +40,7 @@
             "diagnostics",
             "misc"
           ],
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
       "required": ["ros__parameters"],

--- a/localization/ekf_localizer/schema/ekf_localizer.schema.json
+++ b/localization/ekf_localizer/schema/ekf_localizer.schema.json
@@ -38,9 +38,9 @@
             "process_noise",
             "simple_1d_filter_parameters",
             "diagnostics",
-            "misc-break things to test the action"
+            "misc"
           ],
-          "additionalProperties": false
+          "additionalProperties": true
         }
       },
       "required": ["ros__parameters"],

--- a/localization/ekf_localizer/schema/ekf_localizer.schema.json
+++ b/localization/ekf_localizer/schema/ekf_localizer.schema.json
@@ -38,7 +38,7 @@
             "process_noise",
             "simple_1d_filter_parameters",
             "diagnostics",
-            "misc"
+            "misc-break things to test the action"
           ],
           "additionalProperties": false
         }


### PR DESCRIPTION
## Description

Continuation from:
- https://github.com/autowarefoundation/autoware.universe/pull/6524

With this restructuring of the actions,
- `pre-check` will check if relevant files are changed
  - if yes, `json-schema-check` will do its thing
  - if not, `no-relevant-changes` will return successful

## Tests performed

Tests are below:
- https://github.com/autowarefoundation/autoware.universe/pull/6530#issuecomment-1972950391

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
