### PR TITLE
fix(tier4_planning_rviz_plugin): fix crash on modified goal update

### DIFF
--- a/common/tier4_planning_rviz_plugin/package.xml
+++ b/common/tier4_planning_rviz_plugin/package.xml
@@ -6,6 +6,7 @@
   <description>The tier4_planning_rviz_plugin package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/common/tier4_planning_rviz_plugin/src/pose_with_uuid_stamped/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/pose_with_uuid_stamped/display.cpp
@@ -72,7 +72,7 @@ void AutowarePoseWithUuidStampedDisplay::onEnable()
 
 void AutowarePoseWithUuidStampedDisplay::onDisable()
 {
-  unsubscribe();
+  // unsubscribe();
   axes_->getSceneNode()->setVisible(false);
 }
 


### PR DESCRIPTION
## Description

fixed the rviz plugin not to crash

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/6521

## Tests performed

rviz does not crash when the goal is updated.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
