### PR TITLE
fix(mpc_lateral_controller): remove overlaps when calculating trajectory

### DIFF
--- a/control/mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/mpc_lateral_controller/src/mpc_utils.cpp
@@ -289,6 +289,7 @@ Trajectory convertToAutowareTrajectory(const MPCTrajectory & input)
       break;
     }
   }
+  output.points = motion_utils::removeOverlapPoints(output.points);
   return output;
 }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Remove overlaps in some trajectories calculated in the MPC controller.
This prevents the following error message.
```
[motion_utils] calcLongitudinalOffsetToSegment: Longitudinal offset calculation is not supported for the same points. Return NaN since no_throw option is enabled. The maintainer must check the code. 
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Reduce log messages

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
