### PR TITLE
feat: add pull over to autoware_state_panel of rviz

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -502,6 +502,11 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
         style_sheet = "background-color: #00FF00;";  // green
         break;
 
+      case MRMState::PULL_OVER:
+        text = "PULL_OVER";
+        style_sheet = "background-color: #FFFF00;";  // yellow
+        break;
+
       case MRMState::COMFORTABLE_STOP:
         text = "COMFORTABLE_STOP";
         style_sheet = "background-color: #FFFF00;";  // yellow


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR adds pull over indicator to AutowareStatePanel.
Since the pull over has already been added to [MrmState.msg](https://github.com/autowarefoundation/autoware_adapi_msgs/pull/43/files), it will not cause a build error.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

[Screencast from 2024年03月04日 17時23分27秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/70682030/b62cd858-2522-4df0-ba2b-a2f31874137d)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
