### PR TITLE
fix(mpc_lateral_controller): reset ctrl_cmd_prev during manual mode

### DIFF
--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -243,7 +243,9 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   Trajectory predicted_traj;
   Float32MultiArrayStamped debug_values;
 
-  if (!m_is_ctrl_cmd_prev_initialized) {
+  if (
+    !m_is_ctrl_cmd_prev_initialized ||
+    !input_data.current_operation_mode.is_autoware_control_enabled) {
     m_ctrl_cmd_prev = getInitialControlCommand();
     m_is_ctrl_cmd_prev_initialized = true;
   }

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -243,9 +243,11 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   Trajectory predicted_traj;
   Float32MultiArrayStamped debug_values;
 
-  if (
-    !m_is_ctrl_cmd_prev_initialized ||
-    !input_data.current_operation_mode.is_autoware_control_enabled) {
+  const bool is_under_control = input_data.current_operation_mode.is_autoware_control_enabled &&
+                                input_data.current_operation_mode.mode ==
+                                  autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS;
+
+  if (!m_is_ctrl_cmd_prev_initialized || !is_under_control) {
     m_ctrl_cmd_prev = getInitialControlCommand();
     m_is_ctrl_cmd_prev_initialized = true;
   }


### PR DESCRIPTION
## Description

Fix the reported [issue](https://github.com/autowarefoundation/autoware.universe/issues/6421)

reset `m_ctrl_cmd_prev` during manual mode.

problem is described in the issue.

<!-- Write a brief description of this PR. -->

## How to reproduce the problem in local environment

1. run logging_simulator with enabling only control module with following command
```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/path_to_your_map/ vehicle_model:=your_vehicle sensor_model:=aip_xx1 perception:=false sensing:=false control:=true planning:=false localozation:=false
```
2. play rosbag 
To remap topics related to the `trajectory_follower_node` stored in a rosbag to the control topics used by autoware, you can use the following option command
```
--remap /control/trajectory_follower/control_cmd:=/exclude/control_cmd /control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms:=/exclude/lateral_processing_time_ms /control/trajectory_follower/controller_node_exe/longitudinal/debug/processing_time_ms:=/exclude/longitudinal_processing_time_ms /control/trajectory_follower/controller_node_exe/output/debug_marker:=/exclude/debug_marker /control/trajectory_follower/controller_node_exe/output/estimated_steer_offset:=/exclude/estimated_steer_offset /control/trajectory_follower/lateral/predicted_trajectory:=/exclude/lateral/predicted_trajectory
```

## Tests performed

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports?project_id=prd_jt)




<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
