### PR TITLE
fix(intersection): fix possible invalid access

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection_stuck.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection_stuck.cpp
@@ -34,6 +34,9 @@ lanelet::LineString3d getLineStringFromArcLength(
   lanelet::Points3d points;
   double accumulated_length = 0;
   size_t start_index = linestring.size();
+  if (start_index == 0) {
+    return lanelet::LineString3d{lanelet::InvalId, points};
+  }
   for (size_t i = 0; i < linestring.size() - 1; i++) {
     const auto & p1 = linestring[i];
     const auto & p2 = linestring[i + 1];


### PR DESCRIPTION
## Description

add size check

## Related links

https://github.com/autowarefoundation/autoware_common/pull/240

## Tests performed

This issue is possible if the map contained a lanelet linestring with no points.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
