### PR TITLE
fix(bpp): overwrite turn signal by latter module

### DIFF
--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -888,7 +888,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
   updatePathShifter(data.safe_shift_line);
 
   if (data.success) {
-    removeRegisteredShiftLines();
+    return getPreviousModuleOutput();
   }
 
   if (data.yield_required) {

--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -942,7 +942,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
       linear_shift_path, path_shifter_.getShiftLines().front(), helper_->getEgoShift(), avoid_data_,
       planner_data_);
     const auto current_seg_idx = planner_data_->findEgoSegmentIndex(spline_shift_path.path.points);
-    output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+    output.turn_signal_info = planner_data_->turn_signal_decider.overwrite_turn_signal(
       spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
       planner_data_->parameters.ego_nearest_dist_threshold,
       planner_data_->parameters.ego_nearest_yaw_threshold);

--- a/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -971,7 +971,7 @@ void GoalPlannerModule::setTurnSignalInfo(BehaviorModuleOutput & output) const
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
   const auto new_signal = calcTurnSignalInfo();
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
-  output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+  output.turn_signal_info = planner_data_->turn_signal_decider.overwrite_turn_signal(
     output.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
     planner_data_->parameters.ego_nearest_dist_threshold,
     planner_data_->parameters.ego_nearest_yaw_threshold);

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -441,7 +441,7 @@ TurnSignalInfo LaneChangeInterface::getCurrentTurnSignalInfo(
     }
 
     // check the priority of turn signals
-    return module_type_->getTurnSignalDecider().use_prior_turn_signal(
+    return module_type_->getTurnSignalDecider().overwrite_turn_signal(
       path, current_pose, current_nearest_seg_idx, original_turn_signal_info,
       current_turn_signal_info, nearest_dist_threshold, nearest_yaw_threshold);
   }

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -148,7 +148,7 @@ BehaviorModuleOutput NormalLaneChange::getTerminalLaneChangePath() const
     output.turn_signal_info = prev_turn_signal_info_;
     extendOutputDrivableArea(output);
     const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
-    output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+    output.turn_signal_info = planner_data_->turn_signal_decider.overwrite_turn_signal(
       output.path, getEgoPose(), current_seg_idx, prev_turn_signal_info_, output.turn_signal_info,
       planner_data_->parameters.ego_nearest_dist_threshold,
       planner_data_->parameters.ego_nearest_yaw_threshold);
@@ -183,7 +183,7 @@ BehaviorModuleOutput NormalLaneChange::getTerminalLaneChangePath() const
   extendOutputDrivableArea(output);
 
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
-  output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+  output.turn_signal_info = planner_data_->turn_signal_decider.overwrite_turn_signal(
     output.path, getEgoPose(), current_seg_idx, prev_turn_signal_info_, output.turn_signal_info,
     planner_data_->parameters.ego_nearest_dist_threshold,
     planner_data_->parameters.ego_nearest_yaw_threshold);
@@ -226,7 +226,7 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
   extendOutputDrivableArea(output);
 
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
-  output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+  output.turn_signal_info = planner_data_->turn_signal_decider.overwrite_turn_signal(
     output.path, getEgoPose(), current_seg_idx, prev_turn_signal_info_, output.turn_signal_info,
     planner_data_->parameters.ego_nearest_dist_threshold,
     planner_data_->parameters.ego_nearest_yaw_threshold);

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/turn_signal_decider.hpp
@@ -82,6 +82,11 @@ public:
     const TurnSignalInfo & intersection_signal_info, const TurnSignalInfo & behavior_signal_info,
     const double nearest_dist_threshold, const double nearest_yaw_threshold);
 
+  TurnSignalInfo overwrite_turn_signal(
+    const PathWithLaneId & path, const Pose & current_pose, const size_t current_seg_idx,
+    const TurnSignalInfo & original_signal, const TurnSignalInfo & new_signal,
+    const double nearest_dist_threshold, const double nearest_yaw_threshold);
+
   TurnSignalInfo use_prior_turn_signal(
     const PathWithLaneId & path, const Pose & current_pose, const size_t current_seg_idx,
     const TurnSignalInfo & original_signal, const TurnSignalInfo & new_signal,


### PR DESCRIPTION
## Description

Sometimes, behavior path planner module outputs unnecessary turn signal while multiple modules are running simlutaneously.

Related ticket: https://tier4.atlassian.net/browse/RT1-5329

![Screenshot from 2024-03-07 13-52-18](https://github.com/autowarefoundation/autoware.universe/assets/44889564/86d97495-e0b6-439c-9868-0dc7e00e6345)

https://github.com/autowarefoundation/autoware.universe/assets/44889564/61f39129-99fb-48d9-94ea-4a7bbff9f028

Currently, turn signal decider manages multiple turn singal infomation (e.g. lane change, avoidance, turn right/left...) based on [**this**](https://autowarefoundation.github.io/autoware.universe/main/planning/behavior_path_planner_common/docs/behavior_path_planner_turn_signal_design/) logic. But I think it's better to overwrite turn signal simply by latter module one in terms of the signal management among multiple modules because, in most case, the latter module's path modufication is dominant.

In this PR, I added a new function to overwrite turn signal when the ego's in the section that calculated by latter module.


- former module: 
------|--- turn signal section A  ---------|--------------------------------------------------------
- latter module:   
----------------------------------------|------ turn signal section B ------|----------------------
- overwrite:         
------|--- turn signal section A --|------ turn signal section B ------|----------------------


Avoidance -> LC

https://github.com/autowarefoundation/autoware.universe/assets/44889564/6ee98a3c-f8eb-430c-9fdb-3048ac9c8129

LC -> Avoidance

https://github.com/autowarefoundation/autoware.universe/assets/44889564/e8fe682b-d097-44d2-bbfa-d04d60431ffe


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/d7fc49a5-1678-562d-8317-3d5f0905367e?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix unnecessary turn signal.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
