### PR TITLE
chore(ground_segmentation_launch): change max_z of cropbox filter to vehicle_height

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -70,6 +70,18 @@ class GroundSegmentationPipeline:
         return p
 
     def create_additional_pipeline(self, lidar_name):
+        max_z = (
+            self.vehicle_info["max_height_offset"]
+            + self.ground_segmentation_param[f"{lidar_name}_crop_box_filter"]["parameters"][
+                "margin_max_z"
+            ]
+        )
+        min_z = (
+            self.vehicle_info["min_height_offset"]
+            - self.ground_segmentation_param[f"{lidar_name}_crop_box_filter"]["parameters"][
+                "margin_min_z"
+            ]
+        )
         components = []
         components.append(
             ComposableNode(
@@ -84,6 +96,8 @@ class GroundSegmentationPipeline:
                     {
                         "input_frame": LaunchConfiguration("base_frame"),
                         "output_frame": LaunchConfiguration("base_frame"),
+                        "max_z": max_z,
+                        "min_z": min_z,
                     },
                     self.ground_segmentation_param[f"{lidar_name}_crop_box_filter"]["parameters"],
                 ],
@@ -206,6 +220,14 @@ class GroundSegmentationPipeline:
         return components
 
     def create_common_pipeline(self, input_topic, output_topic):
+        max_z = (
+            self.vehicle_info["max_height_offset"]
+            + self.ground_segmentation_param["common_crop_box_filter"]["parameters"]["margin_max_z"]
+        )
+        min_z = (
+            self.vehicle_info["min_height_offset"]
+            - self.ground_segmentation_param["common_crop_box_filter"]["parameters"]["margin_min_z"]
+        )
         components = []
         components.append(
             ComposableNode(
@@ -220,6 +242,8 @@ class GroundSegmentationPipeline:
                     {
                         "input_frame": LaunchConfiguration("base_frame"),
                         "output_frame": LaunchConfiguration("base_frame"),
+                        "max_z": max_z,
+                        "min_z": min_z,
                     },
                     self.ground_segmentation_param["common_crop_box_filter"]["parameters"],
                 ],

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -78,7 +78,7 @@ class GroundSegmentationPipeline:
         )
         min_z = (
             self.vehicle_info["min_height_offset"]
-            - self.ground_segmentation_param[f"{lidar_name}_crop_box_filter"]["parameters"][
+            + self.ground_segmentation_param[f"{lidar_name}_crop_box_filter"]["parameters"][
                 "margin_min_z"
             ]
         )
@@ -226,7 +226,7 @@ class GroundSegmentationPipeline:
         )
         min_z = (
             self.vehicle_info["min_height_offset"]
-            - self.ground_segmentation_param["common_crop_box_filter"]["parameters"]["margin_min_z"]
+            + self.ground_segmentation_param["common_crop_box_filter"]["parameters"]["margin_min_z"]
         )
         components = []
         components.append(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- Change to use `vehicle_height` for `max_z` parameter of `/perception/obstacle_segmentation/xx_crop_box_filter' nodes
- Need merge together with https://github.com/autowarefoundation/autoware_launch/pull/906

## Related_link

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03S84LDJGG/p1709688432469209?thread_ts=1709652542.797929&cid=C03S84LDJGG)

## Tests performed
- Confirmed by `logging_simulator` that the correct `max_z` and `min_z` were parsed to `obstacle_segmentation/crop_box_filter' node as desired.
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/95859e7e-0a6c-4912-a944-cf77beec3e00)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
