### PR TITLE
feat(perception_online_evaluator): publish metrics of each object class

### DIFF
--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -19,6 +19,7 @@
 #include "perception_online_evaluator/metrics/metric.hpp"
 #include "perception_online_evaluator/parameters.hpp"
 #include "perception_online_evaluator/stat.hpp"
+#include "perception_online_evaluator/utils/objects_filtering.hpp"
 
 #include <rclcpp/time.hpp>
 
@@ -118,9 +119,9 @@ private:
   void deleteOldObjects(const rclcpp::Time stamp);
 
   // Calculate metrics
-  MetricStatMap calcLateralDeviationMetrics(const PredictedObjects & objects) const;
-  MetricStatMap calcYawDeviationMetrics(const PredictedObjects & objects) const;
-  MetricStatMap calcPredictedPathDeviationMetrics(const PredictedObjects & objects) const;
+  MetricStatMap calcLateralDeviationMetrics(const ClassObjectsMap & class_objects_map) const;
+  MetricStatMap calcYawDeviationMetrics(const ClassObjectsMap & class_objects_map) const;
+  MetricStatMap calcPredictedPathDeviationMetrics(const ClassObjectsMap & class_objects_map) const;
   Stat<double> calcPredictedPathDeviationMetrics(
     const PredictedObjects & objects, const double time_horizon) const;
 

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/objects_filtering.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/objects_filtering.hpp
@@ -37,6 +37,8 @@ using autoware_auto_perception_msgs::msg::ObjectClassification;
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 
+using ClassObjectsMap = std::unordered_map<uint8_t, PredictedObjects>;
+
 std::uint8_t getHighestProbLabel(const std::vector<ObjectClassification> & classification);
 
 /**
@@ -104,6 +106,14 @@ void filterObjects(PredictedObjects & objects, Func filter)
   [[maybe_unused]] PredictedObjects removed_objects{};
   filterObjects(objects, removed_objects, filter);
 }
+
+/**
+ * @brief Separates the provided objects based on their classification.
+ *
+ * @param objects The predicted objects to be separated.
+ * @return A map of objects separated by their classification.
+ */
+ClassObjectsMap separateObjectsByClass(const PredictedObjects & objects);
 
 /**
  * @brief Filters the provided objects based on their classification.

--- a/evaluator/perception_online_evaluator/package.xml
+++ b/evaluator/perception_online_evaluator/package.xml
@@ -24,6 +24,7 @@
   <depend>libgoogle-glog-dev</depend>
   <depend>motion_utils</depend>
   <depend>nav_msgs</depend>
+  <depend>object_recognition_utils</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/evaluator/perception_online_evaluator/src/utils/objects_filtering.cpp
+++ b/evaluator/perception_online_evaluator/src/utils/objects_filtering.cpp
@@ -83,6 +83,17 @@ bool isTargetObjectType(
     (t == ObjectClassification::PEDESTRIAN && target_object_types.check_pedestrian));
 }
 
+ClassObjectsMap separateObjectsByClass(const PredictedObjects & objects)
+{
+  ClassObjectsMap separated_objects;
+  for (const auto & object : objects.objects) {
+    const auto label = getHighestProbLabel(object.classification);
+    separated_objects[label].objects.push_back(object);
+    separated_objects[label].header = objects.header;
+  }
+  return separated_objects;
+}
+
 void filterObjectsByClass(
   PredictedObjects & objects, const ObjectTypesToCheck & target_object_types)
 {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

publish metrics of each object class
e.g. `predicted_path_deviation_CAR_5.00`



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/98a65d97-2042-4a20-a923-b20dba77f1d7)




evaluator_description: feat/perception_eval_object_class
2024/03/06 https://evaluation.tier4.jp/evaluation/reports/0d75e8bd-369e-5045-b438-8801d9012492/?project_id=prd_jt


unit test

```
1: [==========] Running 16 tests from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 16 tests from EvalTest
1: [ RUN      ] EvalTest.testLateralDeviation_deviation0
1: [       OK ] EvalTest.testLateralDeviation_deviation0 (1627 ms)
1: [ RUN      ] EvalTest.testLateralDeviation_deviation1
1: [       OK ] EvalTest.testLateralDeviation_deviation1 (1625 ms)
1: [ RUN      ] EvalTest.testLateralDeviation_oscillation
1: [       OK ] EvalTest.testLateralDeviation_oscillation (2635 ms)
1: [ RUN      ] EvalTest.testLateralDeviation_distortion
1: [       OK ] EvalTest.testLateralDeviation_distortion (2654 ms)
1: [ RUN      ] EvalTest.testLateralDeviation_deviation0_PEDESTRIAN
1: [       OK ] EvalTest.testLateralDeviation_deviation0_PEDESTRIAN (1621 ms)
1: [ RUN      ] EvalTest.testYawDeviation_deviation0
1: [       OK ] EvalTest.testYawDeviation_deviation0 (1643 ms)
1: [ RUN      ] EvalTest.testYawDeviation_deviation1
1: [       OK ] EvalTest.testYawDeviation_deviation1 (1620 ms)
1: [ RUN      ] EvalTest.testYawDeviation_oscillation
1: [       OK ] EvalTest.testYawDeviation_oscillation (2641 ms)
1: [ RUN      ] EvalTest.testYawDeviation_distortion
1: [       OK ] EvalTest.testYawDeviation_distortion (2637 ms)
1: [ RUN      ] EvalTest.testYawDeviation_oscillation_rotate
1: [       OK ] EvalTest.testYawDeviation_oscillation_rotate (2642 ms)
1: [ RUN      ] EvalTest.testYawDeviation_distortion_rotate
1: [       OK ] EvalTest.testYawDeviation_distortion_rotate (2635 ms)
1: [ RUN      ] EvalTest.testYawDeviation_deviation0_PEDESTRIAN
1: [       OK ] EvalTest.testYawDeviation_deviation0_PEDESTRIAN (1623 ms)
1: [ RUN      ] EvalTest.testPredictedPathDeviation_deviation0
1: [       OK ] EvalTest.testPredictedPathDeviation_deviation0 (1630 ms)
1: [ RUN      ] EvalTest.testPredictedPathDeviation_deviation1
1: [       OK ] EvalTest.testPredictedPathDeviation_deviation1 (1624 ms)
1: [ RUN      ] EvalTest.testPredictedPathDeviation_deviation2
1: [       OK ] EvalTest.testPredictedPathDeviation_deviation2 (1622 ms)
1: [ RUN      ] EvalTest.testPredictedPathDeviation_deviation0_PEDESTRIAN
1: [       OK ] EvalTest.testPredictedPathDeviation_deviation0_PEDESTRIAN (1620 ms)
1: [----------] 16 tests from EvalTest (32100 ms total)
1:
1: [----------] Global test environment tear-down
1: [==========] 16 tests from 1 test suite ran. (32100 ms total)
1: [  PASSED  ] 16 tests.
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
