### PR TITLE
fix(start_planner): consider backward completion before preparing blinker

### DIFF
--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -70,8 +70,9 @@ struct PullOutStatus
   bool prev_is_safe_dynamic_objects{false};
   std::shared_ptr<PathWithLaneId> prev_stop_path_after_approval{nullptr};
   std::optional<Pose> stop_pose{std::nullopt};
-  //! record the first time when the state changed from !isActivated() to isActivated()
-  std::optional<rclcpp::Time> first_engaged_time{std::nullopt};
+  //! record the first time when ego started forward-driving (maybe after backward driving
+  //! completion) in AUTONOMOUS operation mode
+  std::optional<rclcpp::Time> first_engaged_and_driving_forward_time{std::nullopt};
 
   PullOutStatus() {}
 };
@@ -278,7 +279,7 @@ private:
     const lanelet::ConstLanelets & pull_out_lanes, const geometry_msgs::msg::Point & current_pose,
     const double velocity_threshold, const double object_check_backward_distance,
     const double object_check_forward_distance) const;
-  bool needToPrepareBlinkerBeforeStart() const;
+  bool needToPrepareBlinkerBeforeStartDrivingForward() const;
   bool hasFinishedPullOut() const;
   bool hasFinishedBackwardDriving() const;
   bool hasCollisionWithDynamicObjects() const;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -118,7 +118,7 @@ void StartPlannerModule::onFreespacePlannerTimer()
 BehaviorModuleOutput StartPlannerModule::run()
 {
   updateData();
-  if (!isActivated() || needToPrepareBlinkerBeforeStart()) {
+  if (!isActivated() || needToPrepareBlinkerBeforeStartDrivingForward()) {
     return planWaitingApproval();
   }
 
@@ -178,8 +178,8 @@ void StartPlannerModule::updateData()
 
   if (
     planner_data_->operation_mode->mode == OperationModeState::AUTONOMOUS &&
-    !status_.first_engaged_time) {
-    status_.first_engaged_time = clock_->now();
+    status_.driving_forward && !status_.first_engaged_and_driving_forward_time) {
+    status_.first_engaged_and_driving_forward_time = clock_->now();
   }
 
   status_.backward_driving_complete = hasFinishedBackwardDriving();
@@ -1073,13 +1073,15 @@ bool StartPlannerModule::hasFinishedPullOut() const
   return has_finished;
 }
 
-bool StartPlannerModule::needToPrepareBlinkerBeforeStart() const
+bool StartPlannerModule::needToPrepareBlinkerBeforeStartDrivingForward() const
 {
-  if (!status_.first_engaged_time) {
-    return true;
+  if (!status_.first_engaged_and_driving_forward_time) {
+    return false;
   }
-  const auto first_engaged_time = status_.first_engaged_time.value();
-  const double elapsed = rclcpp::Duration(clock_->now() - first_engaged_time).seconds();
+  const auto first_engaged_and_driving_forward_time =
+    status_.first_engaged_and_driving_forward_time.value();
+  const double elapsed =
+    rclcpp::Duration(clock_->now() - first_engaged_and_driving_forward_time).seconds();
   return elapsed < parameters_->prepare_time_before_start;
 }
 


### PR DESCRIPTION
## Description

In the following PRs
- https://github.com/autowarefoundation/autoware.universe/pull/6470
- https://github.com/autowarefoundation/autoware.universe/pull/6438
I intended to "let the vehicle stop for a while before starting pull out action to turn the blinker for a specific time", but forgot the case where the vehicle first drives backward and then start pull out by forward driving. I changed it to start the "blinker preparation" when forward-driving started.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/02465796-fdcb-5949-89d7-aa5dd8ec3e85?project_id=prd_jt

If the prepare time is set to 3 seconds, ego stops a for while before starting forward driving.

https://github.com/autowarefoundation/autoware.universe/assets/28677420/30869363-d253-4a79-9c9f-998a1fdb57dd

https://github.com/autowarefoundation/autoware.universe/assets/28677420/812a05a7-903e-444a-9830-f4bc6e76cea7

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
