### PR TITLE
fix(lane_change): check prepare phase in intersection

### DIFF
--- a/planning/behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_lane_change_module/README.md
@@ -551,13 +551,14 @@ The following parameters are configurable in [lane_change.param.yaml](https://gi
 
 #### Additional parameters
 
-| Name                                       | Unit  | Type    | Description                                                                                                                                                | Default value |
-| :----------------------------------------- | ----- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `enable_collision_check_at_prepare_phase`  | [-]   | boolean | Perform collision check starting from prepare phase. If `false`, collision check only evaluated for lane changing phase.                                   | false         |
-| `prepare_phase_ignore_target_speed_thresh` | [m/s] | double  | Ignore collision check in prepare phase of object speed that is lesser that the configured value. `enable_collision_check_at_prepare_phase` must be `true` | 0.1           |
-| `check_objects_on_current_lanes`           | [-]   | boolean | If true, the lane change module check objects on current lanes when performing collision assessment.                                                       | false         |
-| `check_objects_on_other_lanes`             | [-]   | boolean | If true, the lane change module include objects on other lanes. when performing collision assessment                                                       | false         |
-| `use_all_predicted_path`                   | [-]   | boolean | If false, use only the predicted path that has the maximum confidence.                                                                                     | true          |
+| Name                                                     | Unit  | Type    | Description                                                                                                                                                                                                | Default value |
+| :------------------------------------------------------- | ----- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `enable_collision_check_for_prepare_phase.general_lanes` | [-]   | boolean | Perform collision check starting from the prepare phase for situations not explicitly covered by other settings (e.g., intersections). If `false`, collision check only evaluated for lane changing phase. | false         |
+| `enable_collision_check_for_prepare_phase.intersection`  | [-]   | boolean | Perform collision check starting from prepare phase when ego is in intersection. If `false`, collision check only evaluated for lane changing phase.                                                       | false         |
+| `prepare_phase_ignore_target_speed_thresh`               | [m/s] | double  | Ignore collision check in prepare phase of object speed that is lesser that the configured value. `enable_collision_check_at_prepare_phase` must be `true`                                                 | 0.1           |
+| `check_objects_on_current_lanes`                         | [-]   | boolean | If true, the lane change module check objects on current lanes when performing collision assessment.                                                                                                       | false         |
+| `check_objects_on_other_lanes`                           | [-]   | boolean | If true, the lane change module include objects on other lanes. when performing collision assessment                                                                                                       | false         |
+| `use_all_predicted_path`                                 | [-]   | boolean | If false, use only the predicted path that has the maximum confidence.                                                                                                                                     | true          |
 
 #### safety constraints during lane change path is computed
 

--- a/planning/behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -89,7 +89,9 @@
         stop_time: 3.0 # [s]
 
       # collision check
-      enable_prepare_segment_collision_check: true
+      enable_collision_check_for_prepare_phase:
+        general_lanes: false
+        intersection: true
       prepare_segment_ignore_object_velocity_thresh: 0.1 # [m/s]
       check_objects_on_current_lanes: true
       check_objects_on_other_lanes: true

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/scene.hpp
@@ -174,6 +174,8 @@ protected:
 
   bool isVehicleStuck(const lanelet::ConstLanelets & current_lanes) const;
 
+  bool check_prepare_phase() const;
+
   double calcMaximumLaneChangeLength(
     const lanelet::ConstLanelet & current_terminal_lanelet, const double max_acc) const;
 

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -112,7 +112,8 @@ struct LaneChangeParameters
   double max_longitudinal_acc{1.0};
 
   // collision check
-  bool enable_prepare_segment_collision_check{true};
+  bool enable_prepare_segment_collision_check_in_general_areas{false};
+  bool enable_prepare_segment_collision_check_in_intersection{true};
   double prepare_segment_ignore_object_velocity_thresh{0.1};
   bool check_objects_on_current_lanes{true};
   bool check_objects_on_other_lanes{true};

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -112,8 +112,8 @@ struct LaneChangeParameters
   double max_longitudinal_acc{1.0};
 
   // collision check
-  bool enable_prepare_segment_collision_check_in_general_areas{false};
-  bool enable_prepare_segment_collision_check_in_intersection{true};
+  bool enable_collision_check_for_prepare_phase_in_general_lanes{false};
+  bool enable_collision_check_for_prepare_phase_in_intersection{true};
   double prepare_segment_ignore_object_velocity_thresh{0.1};
   bool check_objects_on_current_lanes{true};
   bool check_objects_on_other_lanes{true};

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
@@ -23,6 +23,7 @@
 #include "rclcpp/logger.hpp"
 
 #include <route_handler/route_handler.hpp>
+#include <tier4_autoware_utils/geometry/boost_geometry.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
@@ -31,6 +32,7 @@
 
 #include <lanelet2_core/Forward.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -185,7 +187,7 @@ std::optional<lanelet::BasicPolygon2d> createPolygon(
 
 ExtendedPredictedObject transform(
   const PredictedObject & object, const BehaviorPathPlannerParameters & common_parameters,
-  const LaneChangeParameters & lane_change_parameters);
+  const LaneChangeParameters & lane_change_parameters, const bool check_at_prepare_phase);
 
 bool isCollidedPolygonsInLanelet(
   const std::vector<Polygon2d> & collided_polygons, const lanelet::ConstLanelets & lanes);
@@ -220,6 +222,13 @@ lanelet::ConstLanelets generateExpandedLanelets(
  * @return rclcpp::Logger The logger instance configured for the specified lane change type.
  */
 rclcpp::Logger getLogger(const std::string & type);
+
+Polygon2d getEgoCurrentFootprint(
+  const Pose & ego_pose, const vehicle_info_util::VehicleInfo & ego_info);
+
+bool isWithinIntersection(
+  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lanelet,
+  const Polygon2d & polygon);
 }  // namespace behavior_path_planner::utils::lane_change
 
 namespace behavior_path_planner::utils::lane_change::debug

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
@@ -223,9 +223,37 @@ lanelet::ConstLanelets generateExpandedLanelets(
  */
 rclcpp::Logger getLogger(const std::string & type);
 
+/**
+ * @brief Computes the current footprint of the ego vehicle based on its pose and size.
+ *
+ * This function calculates the 2D polygon representing the current footprint of the ego vehicle.
+ * The footprint is determined by the vehicle's pose and its dimensions, including the distance
+ * from the base to the front and rear ends of the vehicle, as well as its width.
+ *
+ * @param ego_pose The current pose of the ego vehicle.
+ * @param ego_info The structural information of the ego vehicle, such as its maximum longitudinal
+ *                 offset, rear overhang, and width.
+ *
+ * @return Polygon2d A polygon representing the current 2D footprint of the ego vehicle.
+ */
 Polygon2d getEgoCurrentFootprint(
   const Pose & ego_pose, const vehicle_info_util::VehicleInfo & ego_info);
 
+/**
+ * @brief Checks if the given polygon is within an intersection area.
+ *
+ * This function evaluates whether a specified polygon is located within the bounds of an
+ * intersection. It identifies the intersection area by checking the attributes of the provided
+ * lanelet. If the lanelet has an attribute indicating it is part of an intersection, the function
+ * then checks if the polygon is fully contained within this area.
+ *
+ * @param route_handler a shared pointer to the route_handler
+ * @param lanelet A lanelet to check against the
+ *                intersection area.
+ * @param polygon The polygon to check for containment within the intersection area.
+ *
+ * @return bool True if the polygon is within the intersection area, false otherwise.
+ */
 bool isWithinIntersection(
   const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lanelet,
   const Polygon2d & polygon);

--- a/planning/behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_lane_change_module/src/manager.cpp
@@ -68,10 +68,10 @@ void LaneChangeModuleManager::initParams(rclcpp::Node * node)
   p.max_longitudinal_acc = getOrDeclareParameter<double>(*node, parameter("max_longitudinal_acc"));
 
   // collision check
-  p.enable_prepare_segment_collision_check_in_general_areas = getOrDeclareParameter<bool>(
-    *node, parameter("enable_prepare_segment_collision_check.general_areas"));
-  p.enable_prepare_segment_collision_check_in_intersection = getOrDeclareParameter<bool>(
-    *node, parameter("enable_prepare_segment_collision_check.intersection"));
+  p.enable_collision_check_for_prepare_phase_in_general_lanes = getOrDeclareParameter<bool>(
+    *node, parameter("enable_collision_check_for_prepare_phase.general_lanes"));
+  p.enable_collision_check_for_prepare_phase_in_intersection = getOrDeclareParameter<bool>(
+    *node, parameter("enable_collision_check_for_prepare_phase.intersection"));
   p.prepare_segment_ignore_object_velocity_thresh = getOrDeclareParameter<double>(
     *node, parameter("prepare_segment_ignore_object_velocity_thresh"));
   p.check_objects_on_current_lanes =

--- a/planning/behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_lane_change_module/src/manager.cpp
@@ -68,8 +68,10 @@ void LaneChangeModuleManager::initParams(rclcpp::Node * node)
   p.max_longitudinal_acc = getOrDeclareParameter<double>(*node, parameter("max_longitudinal_acc"));
 
   // collision check
-  p.enable_prepare_segment_collision_check =
-    getOrDeclareParameter<bool>(*node, parameter("enable_prepare_segment_collision_check"));
+  p.enable_prepare_segment_collision_check_in_general_areas = getOrDeclareParameter<bool>(
+    *node, parameter("enable_prepare_segment_collision_check.general_areas"));
+  p.enable_prepare_segment_collision_check_in_intersection = getOrDeclareParameter<bool>(
+    *node, parameter("enable_prepare_segment_collision_check.intersection"));
   p.prepare_segment_ignore_object_velocity_thresh = getOrDeclareParameter<double>(
     *node, parameter("prepare_segment_ignore_object_velocity_thresh"));
   p.check_objects_on_current_lanes =

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -2122,7 +2122,7 @@ bool NormalLaneChange::check_prepare_phase() const
   const auto & vehicle_info = getCommonParam().vehicle_info;
 
   const auto check_prepare_phase_in_intersection = std::invoke([&]() {
-    if (!lane_change_parameters_->enable_prepare_segment_collision_check_in_intersection) {
+    if (!lane_change_parameters_->enable_collision_check_for_prepare_phase_in_intersection) {
       return false;
     }
 
@@ -2138,7 +2138,7 @@ bool NormalLaneChange::check_prepare_phase() const
   });
 
   return check_prepare_phase_in_intersection ||
-         lane_change_parameters_->enable_prepare_segment_collision_check_in_general_areas;
+         lane_change_parameters_->enable_collision_check_for_prepare_phase_in_general_lanes;
 }
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -2128,7 +2128,7 @@ bool NormalLaneChange::check_prepare_phase() const
 
     lanelet::ConstLanelet current_lane;
     if (!route_handler->getClosestLaneletWithinRoute(getEgoPose(), &current_lane)) {
-      RCLCPP_DEBUG(logger_, "unable to retreive current lane");
+      RCLCPP_DEBUG(logger_, "unable to get current lane");
       return false;
     }
 

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -889,10 +889,11 @@ LaneChangeTargetObjects NormalLaneChange::getTargetObjects(
   target_objects.other_lane.reserve(target_obj_index.other_lane.size());
 
   // objects in current lane
+  const auto is_check_prepare_phase = check_prepare_phase();
   for (const auto & obj_idx : target_obj_index.current_lane) {
     const auto extended_object = utils::lane_change::transform(
       objects.objects.at(obj_idx), common_parameters, *lane_change_parameters_,
-      check_prepare_phase());
+      is_check_prepare_phase);
     target_objects.current_lane.push_back(extended_object);
   }
 
@@ -900,7 +901,7 @@ LaneChangeTargetObjects NormalLaneChange::getTargetObjects(
   for (const auto & obj_idx : target_obj_index.target_lane) {
     const auto extended_object = utils::lane_change::transform(
       objects.objects.at(obj_idx), common_parameters, *lane_change_parameters_,
-      check_prepare_phase());
+      is_check_prepare_phase);
     target_objects.target_lane.push_back(extended_object);
   }
 
@@ -908,7 +909,7 @@ LaneChangeTargetObjects NormalLaneChange::getTargetObjects(
   for (const auto & obj_idx : target_obj_index.other_lane) {
     const auto extended_object = utils::lane_change::transform(
       objects.objects.at(obj_idx), common_parameters, *lane_change_parameters_,
-      check_prepare_phase());
+      is_check_prepare_phase);
     target_objects.other_lane.push_back(extended_object);
   }
 


### PR DESCRIPTION
## Description

⚠️ Launch PR needs to be appoved first [launch#930](https://github.com/autowarefoundation/autoware_launch/pull/930)

Due to lane change is performed instantaneously after exiting from the intersection, sometimes the safety check might be a little be delayed, causes the CANCEL process to not be executed when necessary.

To avoid this issue, we have to increase the lane change safety check horizon, by also performing the safety check for the prepare phase when ego vehicle is in the intersection.


#### Before PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/0929fd8b-3927-4e74-80ce-2f881c4f1bac

### After PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/ba470bf0-04bb-425a-9dc1-926024ac24e1


## Related links

None

## Tests performed

PSIM, and rosbag.
Evaluator: TBA

## Notes for reviewers

None

## Interface changes

None
## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
