### PR TITLE
fix(freespace_planning_algorithms): fix issue of astar search planner not reaching goal pose

### DIFF
--- a/planning/freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/freespace_planning_algorithms/src/astar_search.cpp
@@ -292,6 +292,17 @@ void AstarSearch::setPath(const AstarNode & goal_node)
   // From the goal node to the start node
   const AstarNode * node = &goal_node;
 
+  // push exact goal pose first
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header = header;
+  pose.pose = local2global(costmap_, goal_pose_);
+
+  PlannerWaypoint pw;
+  pw.pose = pose;
+  pw.is_back = node->is_back;
+  waypoints_.waypoints.push_back(pw);
+
+  // push astar nodes poses
   while (node != nullptr) {
     geometry_msgs::msg::PoseStamped pose;
     pose.header = header;


### PR DESCRIPTION
## Description
closes https://github.com/autowarefoundation/autoware.universe/issues/5988

The freespace planner output trajectory does not connect to goal pose. It stops before reaching exact pose. Intended behavior is for `base_link` to land on goal pose after completing trajectory.

Example image of current planned trajectory not reaching goal (notice incomplete velocity profile to goal):
![image](https://github.com/autowarefoundation/autoware.universe/assets/130948783/a1dc2718-19a0-4c35-bfa7-49734c38831b)

### Reason for Issue
`lateral_goal_range: 0.5` and `longitudinal_goal_range: 2.0` search parameters are checked to decide if goal has been found in A* search algorithm (half of above values are checked). The nearest node satisfying this condition is found by astar to become the terminal node. This terminal node thus can have a maximum error of `1m` due to  `longitudinal_goal_range: 2.0` constraint. Reducing these search parameters would affect goal finding of astar (may lead to no goal found) so an alternate solution is proposed. 

### Proposed solution
Set actual goal pose as final point of trajectory after astar completion so that instead of terminal node of astar, actual goal pose point is reached. The goal pose will always be a valid final point of astar trajectory since it would be within bounds specified by search parameters and would lie on the found trajectory if interpolated within bounds.

Example image of fix (showing goal pose):
![image](https://github.com/autowarefoundation/autoware.universe/assets/130948783/7aea58ab-a0e5-4b3d-a244-fd5962a0e50e)

Example image of fix (goal pose hidden to show final inserted point):
![image](https://github.com/autowarefoundation/autoware.universe/assets/130948783/18056c9f-a08f-4dfa-822e-3479ded54978)

Video of ego vehicle `base_link` going to goal pose:
[goalposefix.webm](https://github.com/autowarefoundation/autoware.universe/assets/130948783/2f89a8e7-5faf-4906-a9c2-1f2ceebb6db8)

## Tests performed
Fix tested using various goal points in parking lot.

## Effects on system behavior
- To reach gole more precisely `th_arrived_distance_m` parameter also needs to be tuned so that vehicle does not stop earlier in case of some reversing trajectories.
- `longitudinal_goal_range`, `th_arrived_distance_m`, `lateral_goal_range` should be set wrt to costmap resolution to avoid ealry stopping.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
