### PR TITLE
feat(start_planner): move collision check to plan method

### DIFF
--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/freespace_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/freespace_pull_out.hpp
@@ -38,7 +38,7 @@ public:
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     const vehicle_info_util::VehicleInfo & vehicle_info);
 
-  PlannerType getPlannerType() override { return PlannerType::FREESPACE; }
+  PlannerType getPlannerType() const override { return PlannerType::FREESPACE; }
 
   std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & end_pose) override;
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -34,7 +34,7 @@ public:
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     const std::shared_ptr<lane_departure_checker::LaneDepartureChecker> lane_departure_checker);
 
-  PlannerType getPlannerType() override { return PlannerType::GEOMETRIC; };
+  PlannerType getPlannerType() const override { return PlannerType::GEOMETRIC; };
   std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   GeometricParallelParking planner_;

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -64,7 +64,9 @@ public:
   virtual std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
 
 protected:
-  bool isPullOutPathCollided(behavior_path_planner::PullOutPath & pull_out_path) const
+  bool isPullOutPathCollided(
+    behavior_path_planner::PullOutPath & pull_out_path,
+    double collision_check_distance_from_end) const
   {
     // check for collisions
     const auto & dynamic_objects = planner_data_->dynamic_object;
@@ -80,12 +82,6 @@ protected:
         stop_objects, pull_out_lanes, utils::path_safety_checker::isPolygonOverlapLanelet);
     utils::path_safety_checker::filterObjectsByClass(
       pull_out_lane_stop_objects, parameters_.object_types_to_check_for_path_generation);
-
-    const auto planner_type = getPlannerType();
-    const double collision_check_distance_from_end =
-      (planner_type == PlannerType::GEOMETRIC)
-        ? parameters_.geometric_collision_check_distance_from_end
-        : parameters_.shift_collision_check_distance_from_end;
 
     return utils::checkCollisionBetweenPathFootprintsAndObjects(
       vehicle_footprint_,

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -16,8 +16,10 @@
 #define BEHAVIOR_PATH_START_PLANNER_MODULE__PULL_OUT_PLANNER_BASE_HPP_
 
 #include "behavior_path_planner_common/data_manager.hpp"
+#include "behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp"
 #include "behavior_path_start_planner_module/data_structs.hpp"
 #include "behavior_path_start_planner_module/pull_out_path.hpp"
+#include "behavior_path_start_planner_module/util.hpp"
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -54,14 +56,48 @@ public:
     planner_data_ = planner_data;
   }
 
-  virtual PlannerType getPlannerType() = 0;
+  void setCollisionCheckMargin(const double collision_check_margin)
+  {
+    collision_check_margin_ = collision_check_margin;
+  };
+  virtual PlannerType getPlannerType() const = 0;
   virtual std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
 
 protected:
+  bool isPullOutPathCollided(behavior_path_planner::PullOutPath & pull_out_path) const
+  {
+    // check for collisions
+    const auto & dynamic_objects = planner_data_->dynamic_object;
+    const auto pull_out_lanes = start_planner_utils::getPullOutLanes(
+      planner_data_,
+      planner_data_->parameters.backward_path_length + parameters_.max_back_distance);
+    const auto & vehicle_footprint = vehicle_info_.createFootprint();
+    // extract stop objects in pull out lane for collision check
+    const auto stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
+      *dynamic_objects, parameters_.th_moving_object_velocity);
+    auto [pull_out_lane_stop_objects, others] =
+      utils::path_safety_checker::separateObjectsByLanelets(
+        stop_objects, pull_out_lanes, utils::path_safety_checker::isPolygonOverlapLanelet);
+    utils::path_safety_checker::filterObjectsByClass(
+      pull_out_lane_stop_objects, parameters_.object_types_to_check_for_path_generation);
+
+    const auto planner_type = getPlannerType();
+    const double collision_check_distance_from_end =
+      (planner_type == PlannerType::GEOMETRIC)
+        ? parameters_.geometric_collision_check_distance_from_end
+        : parameters_.shift_collision_check_distance_from_end;
+
+    return utils::checkCollisionBetweenPathFootprintsAndObjects(
+      vehicle_footprint_,
+      behavior_path_planner::start_planner_utils::extractCollisionCheckSection(
+        pull_out_path, collision_check_distance_from_end),
+      pull_out_lane_stop_objects, collision_check_margin_);
+  };
   std::shared_ptr<const PlannerData> planner_data_;
   vehicle_info_util::VehicleInfo vehicle_info_;
   LinearRing2d vehicle_footprint_;
   StartPlannerParameters parameters_;
+  double collision_check_margin_;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -36,7 +36,7 @@ public:
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     std::shared_ptr<LaneDepartureChecker> & lane_departure_checker);
 
-  PlannerType getPlannerType() override { return PlannerType::SHIFT; };
+  PlannerType getPlannerType() const override { return PlannerType::SHIFT; };
   std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) override;
 
   std::vector<PullOutPath> calcPullOutPaths(

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/util.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/util.hpp
@@ -19,6 +19,7 @@
 #include "behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 #include "behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp"
+#include "behavior_path_start_planner_module/pull_out_path.hpp"
 
 #include <route_handler/route_handler.hpp>
 
@@ -50,6 +51,8 @@ lanelet::ConstLanelets getPullOutLanes(
   const std::shared_ptr<const PlannerData> & planner_data, const double backward_length);
 Pose getBackedPose(
   const Pose & current_pose, const double & yaw_shoulder_lane, const double & back_distance);
+PathWithLaneId extractCollisionCheckSection(
+  const PullOutPath & path, const double collision_check_distance_from_end);
 }  // namespace behavior_path_planner::start_planner_utils
 
 #endif  // BEHAVIOR_PATH_START_PLANNER_MODULE__UTIL_HPP_

--- a/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -114,7 +114,7 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
 
-  if (isPullOutPathCollided(output)) {
+  if (isPullOutPathCollided(output, parameters_.geometric_collision_check_distance_from_end)) {
     return {};
   }
 

--- a/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -114,6 +114,10 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
 
+  if (isPullOutPathCollided(output)) {
+    return {};
+  }
+
   return output;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -99,6 +99,10 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
       continue;
     }
 
+    if (isPullOutPathCollided(pull_out_path)) {
+      continue;
+    }
+
     // crop backward path
     // removes points which are out of lanes up to the start pose.
     // this ensures that the backward_path stays within the drivable area when starting from a

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -99,7 +99,7 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
       continue;
     }
 
-    if (isPullOutPathCollided(pull_out_path)) {
+    if (isPullOutPathCollided(pull_out_path, parameters_.shift_collision_check_distance_from_end)) {
       continue;
     }
 

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -99,10 +99,6 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
       continue;
     }
 
-    if (isPullOutPathCollided(pull_out_path, parameters_.shift_collision_check_distance_from_end)) {
-      continue;
-    }
-
     // crop backward path
     // removes points which are out of lanes up to the start pose.
     // this ensures that the backward_path stays within the drivable area when starting from a
@@ -117,6 +113,10 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
     if (cropped_path.points.empty()) continue;
     shift_path.points = cropped_path.points;
     shift_path.header = planner_data_->route_handler->getRouteHeader();
+
+    if (isPullOutPathCollided(pull_out_path, parameters_.shift_collision_check_distance_from_end)) {
+      continue;
+    }
 
     return pull_out_path;
   }


### PR DESCRIPTION
## Description

Currently, collision checking is done AFTER the geometric and shift pull out planners have decided on a candidate output path. The result is that, a path that is collided might be chosen as an output path and then eliminated by the collision checking. 

With this PR, the collision checking is moved inside the planners themselves, so, especially in the case of shift pull out, if a candidate path has a collision with a target object, it might generate a different path that is inside lanes and not collided.

Further description here: [TIER IV INTERNAL LINK](https://app.slack.com/client/E01J1USSLPP/C03QW0GU6P7)
Related ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-5491)

## Related links

Further description here: [TIER IV INTERNAL LINK](https://app.slack.com/client/E01J1USSLPP/C03QW0GU6P7)
Related ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-5491)

## Tests performed
PSim
Evaluator tests: [TIER IV INTERNAL LINK](https://evaluation.ci.tier4.jp/evaluation/reports/2a9d3308-5e88-5ede-8d79-845bd7aa7680?project_id=prd_jt)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
