### PR TITLE
fix(drivable_area_expansion): fix invalid access

### DIFF
--- a/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -1481,6 +1481,10 @@ std::vector<geometry_msgs::msg::Point> postProcess(
   const auto & vehicle_length = planner_data->parameters.vehicle_length;
   constexpr double overlap_threshold = 0.01;
 
+  if (original_bound.size() < 2) {
+    return original_bound;
+  }
+
   const auto addPoints =
     [](const lanelet::ConstLineString3d & points, std::vector<geometry_msgs::msg::Point> & bound) {
       for (const auto & bound_p : points) {


### PR DESCRIPTION
## Description

Related ticket: https://tier4.atlassian.net/browse/RT1-5459

Add guard to prevent `std::out_of_range` in following loop.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/59d44f1c-73f0-4e69-a59c-33dd8b96e91a)

```c++
  // Insert middle points
  for (size_t i = start_idx + 1; i <= goal_idx; ++i) {
    const auto & next_point = tmp_bound.at(i);
    const double dist = tier4_autoware_utils::calcDistance2d(processed_bound.back(), next_point);
    if (dist > overlap_threshold) {
      processed_bound.push_back(next_point);
    }
  }
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
