### PR TITLE
feat(pointcloud_preprocessor): add pipeline_latency_ms debug publisher to missed modules

### DIFF
--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
@@ -281,6 +281,20 @@ void PointCloudConcatenationComponent::publish()
   checkSyncStatus();
   combineClouds(concat_cloud_ptr);
 
+  for (const auto & e : cloud_stdmap_) {
+    if (e.second != nullptr) {
+      if (debug_publisher_) {
+        const auto pipeline_latency_ms =
+          std::chrono::duration<double, std::milli>(
+            std::chrono::nanoseconds(
+              (this->get_clock()->now() - e.second->header.stamp).nanoseconds()))
+            .count();
+        debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+          "debug" + e.first + "/pipeline_latency_ms", pipeline_latency_ms);
+      }
+    }
+  }
+
   // publish concatenated pointcloud
   if (concat_cloud_ptr) {
     auto output = std::make_unique<sensor_msgs::msg::PointCloud2>(*concat_cloud_ptr);

--- a/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
@@ -374,6 +374,15 @@ void PointCloudDataSynchronizerComponent::publish()
   // publish transformed raw pointclouds
   for (const auto & e : transformed_raw_points) {
     if (e.second) {
+      if (debug_publisher_) {
+        const auto pipeline_latency_ms =
+          std::chrono::duration<double, std::milli>(
+            std::chrono::nanoseconds(
+              (this->get_clock()->now() - e.second->header.stamp).nanoseconds()))
+            .count();
+        debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+          "debug" + e.first + "/pipeline_latency_ms", pipeline_latency_ms);
+      }
       auto output = std::make_unique<sensor_msgs::msg::PointCloud2>(*e.second);
       transformed_raw_pc_publisher_map_[e.first]->publish(std::move(output));
     } else {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- https://github.com/autowarefoundation/autoware.universe/issues/6032

In the issue above, we discussed that a more efficient method would be for the nodes themselves to report the delays.

I missed adding this debug publisher to concatenate_pointclouds and time_synchronizer.

## Tests performed
Tested with e2e_simulator. Works well.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
