### PR TITLE
feat(dynamic_obstacle_stop): add option to ignore unavoidable collisions

### DIFF
--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/README.md
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/README.md
@@ -38,7 +38,10 @@ An object is considered by the module only if it meets all of the following cond
 - it is a vehicle (pedestrians are ignored);
 - it is moving at a velocity higher than defined by the `minimum_object_velocity` parameter;
 - it is not too close to the current position of the ego vehicle;
+- it is not unavoidable (only if parameter `ignore_unavoidance_collisions` is set to `true`);
 - it is close to the ego path.
+
+An object is considered unavoidable if it is heading towards the ego vehicle such that even if ego stops, a collision would still occur (assuming the object keeps driving in a straight line).
 
 For the last condition,
 the object is considered close enough if its lateral distance from the ego path is less than the threshold parameter `minimum_object_distance_from_ego_path` plus half the width of ego and of the object (including the `extra_object_width` parameter).
@@ -74,12 +77,13 @@ the stop point arc length is calculated to be the arc length of the previously f
 
 ### Module Parameters
 
-| Parameter                               | Type   | Description                                                                                |
-| --------------------------------------- | ------ | ------------------------------------------------------------------------------------------ |
-| `extra_object_width`                    | double | [m] extra width around detected objects                                                    |
-| `minimum_object_velocity`               | double | [m/s] objects with a velocity bellow this value are ignored                                |
-| `stop_distance_buffer`                  | double | [m] extra distance to add between the stop point and the collision point                   |
-| `time_horizon`                          | double | [s] time horizon used for collision checks                                                 |
-| `hysteresis`                            | double | [m] once a collision has been detected, this hysteresis is used on the collision detection |
-| `decision_duration_buffer`              | double | [s] duration between no collision being detected and the stop decision being cancelled     |
-| `minimum_object_distance_from_ego_path` | double | [m] minimum distance between the footprints of ego and an object to consider for collision |
+| Parameter                               | Type   | Description                                                                                                        |
+| --------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `extra_object_width`                    | double | [m] extra width around detected objects                                                                            |
+| `minimum_object_velocity`               | double | [m/s] objects with a velocity bellow this value are ignored                                                        |
+| `stop_distance_buffer`                  | double | [m] extra distance to add between the stop point and the collision point                                           |
+| `time_horizon`                          | double | [s] time horizon used for collision checks                                                                         |
+| `hysteresis`                            | double | [m] once a collision has been detected, this hysteresis is used on the collision detection                         |
+| `decision_duration_buffer`              | double | [s] duration between no collision being detected and the stop decision being cancelled                             |
+| `minimum_object_distance_from_ego_path` | double | [m] minimum distance between the footprints of ego and an object to consider for collision                         |
+| `ignore_unavoidable_collisions`         | bool   | [-] if true, ignore collisions that cannot be avoided by stopping (assuming the obstacle continues going straight) |

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/README.md
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/README.md
@@ -38,7 +38,7 @@ An object is considered by the module only if it meets all of the following cond
 - it is a vehicle (pedestrians are ignored);
 - it is moving at a velocity higher than defined by the `minimum_object_velocity` parameter;
 - it is not too close to the current position of the ego vehicle;
-- it is not unavoidable (only if parameter `ignore_unavoidance_collisions` is set to `true`);
+- it is not unavoidable (only if parameter `ignore_unavoidable_collisions` is set to `true`);
 - it is close to the ego path.
 
 An object is considered unavoidable if it is heading towards the ego vehicle such that even if ego stops, a collision would still occur (assuming the object keeps driving in a straight line).

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/config/dynamic_obstacle_stop.param.yaml
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/config/dynamic_obstacle_stop.param.yaml
@@ -8,3 +8,4 @@
       hysteresis: 1.0  # [m] once a collision has been detected, this hysteresis is used on the collision detection
       decision_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being cancelled
       minimum_object_distance_from_ego_path: 1.0  # [m] minimum distance between the footprints of ego and an object to consider for collision
+      ignore_unavoidable_collisions : true  # if true, ignore collisions that cannot be avoided by stopping (assuming the obstacle continues going straight)

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/manager.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/manager.cpp
@@ -39,6 +39,8 @@ DynamicObstacleStopModuleManager::DynamicObstacleStopModuleManager(rclcpp::Node 
     getOrDeclareParameter<double>(node, ns + ".decision_duration_buffer");
   pp.minimum_object_distance_from_ego_path =
     getOrDeclareParameter<double>(node, ns + ".minimum_object_distance_from_ego_path");
+  pp.ignore_unavoidable_collisions =
+    getOrDeclareParameter<bool>(node, ns + ".ignore_unavoidable_collisions");
 
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
   pp.ego_lateral_offset =

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_filtering.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_filtering.cpp
@@ -59,13 +59,34 @@ std::vector<autoware_auto_perception_msgs::msg::PredictedObject> filter_predicte
     return obj_arc_length > ego_data.longitudinal_offset_to_first_path_idx +
                               params.ego_longitudinal_offset + o.shape.dimensions.x / 2.0;
   };
-  for (const auto & object : objects.objects)
+  const auto is_unavoidable = [&](const auto & o) {
+    const auto & o_pose = o.kinematics.initial_pose_with_covariance.pose;
+    const auto o_yaw = tf2::getYaw(o_pose.orientation);
+    const auto ego_yaw = tf2::getYaw(ego_data.pose.orientation);
+    const auto yaw_diff = std::abs(tier4_autoware_utils::normalizeRadian(o_yaw - ego_yaw));
+    const auto opposite_heading = yaw_diff > M_PI_2 + M_PI_4;
+    auto distance = std::abs(
+      (o_pose.position.y - ego_data.pose.position.y) * std::cos(o_yaw) -
+      (o_pose.position.x - ego_data.pose.position.x) * std::sin(o_yaw));
+    if (ego_data.earliest_stop_pose) {
+      distance = std::min(
+        distance,
+        std::abs(
+          (o_pose.position.y - ego_data.earliest_stop_pose->position.y) * std::cos(o_yaw) -
+          (o_pose.position.x - ego_data.earliest_stop_pose->position.x) * std::sin(o_yaw)));
+    }
+    return opposite_heading &&
+           distance <= params.ego_lateral_offset + o.shape.dimensions.y / 2.0 + hysteresis;
+  };
+  for (const auto & object : objects.objects) {
     if (
       is_vehicle(object) &&
       object.kinematics.initial_twist_with_covariance.twist.linear.x >=
         params.minimum_object_velocity &&
-      is_in_range(object) && is_not_too_close(object))
+      is_in_range(object) && is_not_too_close(object) &&
+      (!params.ignore_unavoidable_collisions || !is_unavoidable(object)))
       filtered_objects.push_back(object);
+  }
   return filtered_objects;
 }
 }  // namespace behavior_velocity_planner::dynamic_obstacle_stop

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_filtering.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_filtering.cpp
@@ -69,8 +69,8 @@ std::vector<autoware_auto_perception_msgs::msg::PredictedObject> filter_predicte
       params.ego_lateral_offset + o.shape.dimensions.y / 2.0 + params.hysteresis;
     // https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_point_and_angle
     const auto lat_distance = std::abs(
-                           (o_pose.position.y - ego_data.pose.position.y) * std::cos(o_yaw) -
-                           (o_pose.position.x - ego_data.pose.position.x) * std::sin(o_yaw));
+      (o_pose.position.y - ego_data.pose.position.y) * std::cos(o_yaw) -
+      (o_pose.position.x - ego_data.pose.position.x) * std::sin(o_yaw));
     auto has_collision = lat_distance <= collision_distance_threshold;
     if (ego_data.earliest_stop_pose) {
       const auto collision_at_earliest_stop_pose =

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_filtering.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_filtering.cpp
@@ -67,10 +67,11 @@ std::vector<autoware_auto_perception_msgs::msg::PredictedObject> filter_predicte
     const auto opposite_heading = yaw_diff > M_PI_2 + M_PI_4;
     const auto collision_distance_threshold =
       params.ego_lateral_offset + o.shape.dimensions.y / 2.0 + params.hysteresis;
-    auto has_collision = std::abs(
+    // https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_point_and_angle
+    const auto lat_distance = std::abs(
                            (o_pose.position.y - ego_data.pose.position.y) * std::cos(o_yaw) -
-                           (o_pose.position.x - ego_data.pose.position.x) * std::sin(o_yaw)) <=
-                         collision_distance_threshold;
+                           (o_pose.position.x - ego_data.pose.position.x) * std::sin(o_yaw));
+    auto has_collision = lat_distance <= collision_distance_threshold;
     if (ego_data.earliest_stop_pose) {
       const auto collision_at_earliest_stop_pose =
         std::abs(

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/types.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/types.hpp
@@ -44,6 +44,7 @@ struct PlannerParam
   double ego_longitudinal_offset;
   double ego_lateral_offset;
   double minimum_object_distance_from_ego_path;
+  bool ignore_unavoidable_collisions;
 };
 
 struct EgoData
@@ -54,6 +55,7 @@ struct EgoData
   geometry_msgs::msg::Pose pose;
   tier4_autoware_utils::MultiPolygon2d path_footprints;
   Rtree rtree;
+  std::optional<geometry_msgs::msg::Pose> earliest_stop_pose;
 };
 
 /// @brief debug data


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add an option to ignore unavoidable collisions with the `dynamic_obstacle_stop` module.
If an object is detected as heading straight toward the ego vehicle, such that even if ego stops the collision would be unavoidable, then the object is ignored by the module.
This is to avoid sudden stops caused by noise in the perception.

Required launch PR: https://github.com/autowarefoundation/autoware_launch/pull/916

(TIER IV INTERNAL LINK) https://tier4.atlassian.net/browse/RT1-5690

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
