### PR TITLE
fix(out_of_lane): calculate path lanelets that we can miss during a lane change

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
@@ -41,6 +41,13 @@ inline bool contains_lanelet(const lanelet::ConstLanelets & lanelets, const lane
 /// @return lanelets crossed by the ego vehicle
 lanelet::ConstLanelets calculate_path_lanelets(
   const EgoData & ego_data, const route_handler::RouteHandler & route_handler);
+/// @brief calculate lanelets that may not be crossed by the path but may be overlapped during a
+/// lane change
+/// @param [in] path_lanelets lanelets driven by the ego vehicle
+/// @param [in] route_handler route handler
+/// @return lanelets that may be overlapped by a lane change (and are not already in path_lanelets)
+lanelet::ConstLanelets get_missing_lane_change_lanelets(
+  lanelet::ConstLanelets & path_lanelets, const route_handler::RouteHandler & route_handler);
 /// @brief calculate lanelets that should be ignored
 /// @param [in] ego_data data about the ego vehicle
 /// @param [in] path_lanelets lanelets driven by the ego vehicle


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
`path_lanelets` are not considered for overlaps in the `out_of_lane`. They are currently calculated as all the lanelets crossed by the ego path linestring.
In some lane change edge cases, the ego path linestring does not cross a lanelet but the ego footprint will overlap the lanelet, possibly causing the `out_of_lane` module to detect a collision and cause a stop.

With this PR, a function to add the missing lane change lanelets is added.

### Illustration of the issue

In the following picture, the lane changing path (green) overlaps the 4 lanelets, but the current `path_lanelets` only includes 3 lanelets (in blue). With this PR, all 4 lanelets are correctly found.

![image](https://github.com/autowarefoundation/autoware.universe/assets/78338830/98d97112-e27a-4ab3-99f4-5a1ad37b4293) | ![image](https://github.com/autowarefoundation/autoware.universe/assets/78338830/a5f41fc7-97ed-44ae-b09b-33ef22572357)
--- | ---

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim
Evaluator (TIER IV INTERNAL LINK): https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=095ae8b3-a23b-4a08-8674-10a681449693&filter=&job_id=f10ea9b0-4317-557e-99d6-c0648cc11dcd&project_id=prd_jt&table_config=date

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
