### PR TITLE
feat(multi_object_tracker): add object class filtering in tracking process

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
@@ -52,8 +52,6 @@ private:
   int total_no_measurement_count_;
   int total_measurement_count_;
   rclcpp::Time last_update_with_measurement_time_;
-
-public:
   autoware_auto_perception_msgs::msg::ObjectClassification last_filtered_class_;
 
 public:

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
@@ -42,6 +42,8 @@ protected:
   {
     classification_ = classification;
   }
+  void updateClassification(
+    const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification);
 
 private:
   unique_identifier_msgs::msg::UUID uuid_;
@@ -50,6 +52,9 @@ private:
   int total_no_measurement_count_;
   int total_measurement_count_;
   rclcpp::Time last_update_with_measurement_time_;
+
+public:
+  autoware_auto_perception_msgs::msg::ObjectClassification last_filtered_class_;
 
 public:
   Tracker(
@@ -68,6 +73,7 @@ public:
   {
     return object_recognition_utils::getHighestProbLabel(classification_);
   }
+  std::uint8_t getFilteredLabel() const { return last_filtered_class_.label; }
   int getNoMeasurementCount() const { return no_measurement_count_; }
   int getTotalNoMeasurementCount() const { return total_no_measurement_count_; }
   int getTotalMeasurementCount() const { return total_measurement_count_; }

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
@@ -52,7 +52,6 @@ private:
   int total_no_measurement_count_;
   int total_measurement_count_;
   rclcpp::Time last_update_with_measurement_time_;
-  autoware_auto_perception_msgs::msg::ObjectClassification last_filtered_class_;
 
 public:
   Tracker(
@@ -71,7 +70,6 @@ public:
   {
     return object_recognition_utils::getHighestProbLabel(classification_);
   }
-  std::uint8_t getFilteredLabel() const { return last_filtered_class_.label; }
   int getNoMeasurementCount() const { return no_measurement_count_; }
   int getTotalNoMeasurementCount() const { return total_no_measurement_count_; }
   int getTotalMeasurementCount() const { return total_measurement_count_; }

--- a/perception/multi_object_tracker/src/tracker/model/multiple_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/multiple_vehicle_tracker.cpp
@@ -43,7 +43,7 @@ bool MultipleVehicleTracker::measure(
   big_vehicle_tracker_.measure(object, time, self_transform);
   normal_vehicle_tracker_.measure(object, time, self_transform);
   if (object_recognition_utils::getHighestProbLabel(object.classification) != Label::UNKNOWN)
-    setClassification(object.classification);
+    updateClassification(object.classification);
   return true;
 }
 

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_and_bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_and_bicycle_tracker.cpp
@@ -43,7 +43,8 @@ bool PedestrianAndBicycleTracker::measure(
   pedestrian_tracker_.measure(object, time, self_transform);
   bicycle_tracker_.measure(object, time, self_transform);
   if (object_recognition_utils::getHighestProbLabel(object.classification) != Label::UNKNOWN)
-    setClassification(object.classification);
+    // setClassification(object.classification);
+    updateClassification(object.classification);
   return true;
 }
 

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_and_bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_and_bicycle_tracker.cpp
@@ -43,7 +43,6 @@ bool PedestrianAndBicycleTracker::measure(
   pedestrian_tracker_.measure(object, time, self_transform);
   bicycle_tracker_.measure(object, time, self_transform);
   if (object_recognition_utils::getHighestProbLabel(object.classification) != Label::UNKNOWN)
-    // setClassification(object.classification);
     updateClassification(object.classification);
   return true;
 }

--- a/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
@@ -34,9 +34,6 @@ Tracker::Tracker(
   std::mt19937 gen(std::random_device{}());
   std::independent_bits_engine<std::mt19937, 8, uint8_t> bit_eng(gen);
   std::generate(uuid_.uuid.begin(), uuid_.uuid.end(), bit_eng);
-
-  // initialize last_filtered_class_
-  last_filtered_class_ = object_recognition_utils::getHighestProbClassification(classification_);
 }
 
 bool Tracker::updateWithMeasurement(
@@ -116,22 +113,6 @@ void Tracker::updateClassification(
       [](const auto & class_) { return class_.probability < 0.001; }),
     classification_.end());
 
-  // Set the last filtered class
-  // if the highest probability class is not overcome a certain hysteresis, the last
-  // filtered class stays the same
-
-  for (const auto & class_ : classification_) {
-    if (class_.label == last_filtered_class_.label) {
-      last_filtered_class_.probability = class_.probability;
-      break;
-    }
-  }
-  const double hysteresis = 0.1;
-  autoware_auto_perception_msgs::msg::ObjectClassification const new_classification =
-    object_recognition_utils::getHighestProbClassification(classification_);
-  if (new_classification.probability > last_filtered_class_.probability + hysteresis) {
-    last_filtered_class_ = new_classification;
-  }
 }
 
 geometry_msgs::msg::PoseWithCovariance Tracker::getPoseWithCovariance(

--- a/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
@@ -112,7 +112,6 @@ void Tracker::updateClassification(
       classification_.begin(), classification_.end(),
       [](const auto & class_) { return class_.probability < 0.001; }),
     classification_.end());
-
 }
 
 geometry_msgs::msg::PoseWithCovariance Tracker::getPoseWithCovariance(

--- a/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
@@ -65,35 +65,26 @@ void Tracker::updateClassification(
   // 5. Normalize the probability
 
   const double gain = 0.05;
-  const double gain_inv = 1.0 - gain;
-  const double decay = gain_inv;
-
+  const double decay = 1.0 - gain;
+  // decal all existing probability
+  for (auto & class_ : classification_) {
+    class_.probability *= decay;
+  }
   for (const auto & new_class : classification) {
     bool found = false;
     for (auto & old_class : classification_) {
       // Update the matched classification probability with a gain
       if (new_class.label == old_class.label) {
-        old_class.probability = old_class.probability * gain_inv + new_class.probability * gain;
+        old_class.probability += new_class.probability * gain;
         found = true;
         break;
       }
     }
     // If the label is not found, add it to the classification list
     if (!found) {
-      classification_.push_back(new_class);
-    }
-  }
-  // If the old class probability is not found, decay the probability
-  for (auto & old_class : classification_) {
-    bool found = false;
-    for (const auto & new_class : classification) {
-      if (new_class.label == old_class.label) {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      old_class.probability *= decay;
+      auto adding_class = new_class;
+      adding_class.probability *= gain; 
+      classification_.push_back(adding_class);
     }
   }
 

--- a/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
@@ -58,30 +58,36 @@ void Tracker::updateClassification(
   const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification)
 {
   // classification algorithm:
-  // 0. Remove the class with probability < 0.005
-  // 1. Decay all existing probability
-  // 2. Update the matched classification probability with a gain
-  // 3. If the label is not found, add it to the classification list
-  // 4. Normalize
+  // 0. Normalize the input classification
+  // 1-1. Update the matched classification probability with a gain (ratio of 0.05)
+  // 1-2. If the label is not found, add it to the classification list
+  // 2. Remove the class with probability < remove_threshold (0.001)
+  // 3. Normalize tracking classification
 
-  // Gain and decay
+  // Parameters
+  // if the remove_threshold is too high (compare to the gain), the classification will be removed
+  // immediately
   const double gain = 0.05;
-  const double decay = 1.0 - gain;
+  constexpr double remove_threshold = 0.001;
 
-  // If the probability is less than 0.005, remove the class
-  classification_.erase(
-    std::remove_if(
-      classification_.begin(), classification_.end(),
-      [](const auto & class_) { return class_.probability < 0.005; }),
-    classification_.end());
+  // Normalization function
+  auto normalizeProbabilities =
+    [](std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification) {
+      double sum = 0.0;
+      for (const auto & class_ : classification) {
+        sum += class_.probability;
+      }
+      for (auto & class_ : classification) {
+        class_.probability /= sum;
+      }
+    };
 
-  // Decay all existing probability
-  for (auto & class_ : classification_) {
-    class_.probability *= decay;
-  }
+  // Normalize the input
+  auto classification_input = classification;
+  normalizeProbabilities(classification_input);
 
   // Update the matched classification probability with a gain
-  for (const auto & new_class : classification) {
+  for (const auto & new_class : classification_input) {
     bool found = false;
     for (auto & old_class : classification_) {
       if (new_class.label == old_class.label) {
@@ -98,14 +104,15 @@ void Tracker::updateClassification(
     }
   }
 
-  // Normalize
-  double sum = 0.0;
-  for (const auto & class_ : classification_) {
-    sum += class_.probability;
-  }
-  for (auto & class_ : classification_) {
-    class_.probability /= sum;
-  }
+  // If the probability is less than the threshold, remove the class
+  classification_.erase(
+    std::remove_if(
+      classification_.begin(), classification_.end(),
+      [remove_threshold](const auto & class_) { return class_.probability < remove_threshold; }),
+    classification_.end());
+
+  // Normalize tracking classification
+  normalizeProbabilities(classification_);
 }
 
 geometry_msgs::msg::PoseWithCovariance Tracker::getPoseWithCovariance(

--- a/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
@@ -83,7 +83,7 @@ void Tracker::updateClassification(
     // If the label is not found, add it to the classification list
     if (!found) {
       auto adding_class = new_class;
-      adding_class.probability *= gain; 
+      adding_class.probability *= gain;
       classification_.push_back(adding_class);
     }
   }


### PR DESCRIPTION
## Description

The current object tracker uses the incoming classification directly.
When the detection has ambiguous classification, the classification result may changes in a short time.
Frequent classification change may have negative impact on the tracked object consumers (planner). 

In this PR, a simple classification filter is introduced.

  // 0. Normalize the input classification
  // 1-1. Update the matched classification probability with a gain (ratio of 0.05)
  // 1-2. If the label is not found, add it to the classification list
  // 2. Remove the class with probability < remove_threshold (0.001)
  // 3. Normalize tracking classification


## Related links

[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT1-5725)

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/42434141/43ec72ca-951a-4585-a7c5-51f7ee0e06ec


Blue: Detected Object (input)
Yellow: Tracked Object (output)

The result shows the highest probable label is change only when the detection label is changed for a while.

## Notes for reviewers
This PR do not improve performance of detection classification.

## Interface changes
Not Applicable

## Effects on system behavior
Not Applicable

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
