### PR TITLE
fix(multi_object_tracker): mot multi-step prediction is not work as intended

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
@@ -124,7 +124,7 @@ private:
     const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) const;
 
-  void publish(const rclcpp::Time & time);
+  void publish(const rclcpp::Time & time) const;
   inline bool shouldTrackerPublish(const std::shared_ptr<const Tracker> tracker) const;
 };
 

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -441,7 +441,7 @@ inline bool MultiObjectTracker::shouldTrackerPublish(
   return true;
 }
 
-void MultiObjectTracker::publish(const rclcpp::Time & time)
+void MultiObjectTracker::publish(const rclcpp::Time & time) const
 {
   const auto subscriber_count = tracked_objects_pub_->get_subscription_count() +
                                 tracked_objects_pub_->get_intra_process_subscription_count();

--- a/perception/multi_object_tracker/src/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/multi_object_tracker/src/tracker/motion_model/bicycle_motion_model.cpp
@@ -316,7 +316,7 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
 
   // Current state vector X t
   Eigen::MatrixXd X_t(DIM, 1);
-  getStateVector(X_t);
+  ekf.getX(X_t);
 
   const double cos_yaw = std::cos(X_t(IDX::YAW) + X_t(IDX::SLIP));
   const double sin_yaw = std::sin(X_t(IDX::YAW) + X_t(IDX::SLIP));

--- a/perception/multi_object_tracker/src/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/multi_object_tracker/src/tracker/motion_model/ctrv_motion_model.cpp
@@ -272,7 +272,7 @@ bool CTRVMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) cons
 
   // Current state vector X t
   Eigen::MatrixXd X_t(DIM, 1);
-  getStateVector(X_t);
+  ekf.getX(X_t);
 
   const double cos_yaw = std::cos(X_t(IDX::YAW));
   const double sin_yaw = std::sin(X_t(IDX::YAW));

--- a/perception/multi_object_tracker/src/tracker/motion_model/cv_motion_model.cpp
+++ b/perception/multi_object_tracker/src/tracker/motion_model/cv_motion_model.cpp
@@ -209,7 +209,7 @@ bool CVMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) const
 
   // Current state vector X t
   Eigen::MatrixXd X_t(DIM, 1);
-  getStateVector(X_t);
+  ekf.getX(X_t);
 
   // Predict state vector X t+1
   Eigen::MatrixXd X_next_t(DIM, 1);  // predicted state

--- a/perception/multi_object_tracker/src/tracker/motion_model/motion_model_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/motion_model/motion_model_base.cpp
@@ -50,25 +50,9 @@ bool MotionModel::predictState(const rclcpp::Time & time)
     return true;
   }
 
-  // // if dt is too large, shorten dt and repeat prediction
-  // {
-  //   const uint32_t repeat = std::floor(dt / dt_max_) + 1;
-  //   const double dt_ = dt / repeat;
-  //   for (uint32_t i = 0; i < repeat; ++i) {
-  //     if (!predictStateStep(dt_, ekf_)) {
-  //       return false;
-  //     }
-  //     // add interval to last_update_time_
-  //     last_update_time_ += rclcpp::Duration::from_seconds(dt_);
-  //   }
-  //   std::cout << "MotionModel::predictState predict  dt: " << dt << ", dt_: " << dt_  << ",
-  //   repeat:
-  //   "<< repeat<< std::endl;
-  // }
-
   if (!predictStateStep(dt, ekf_)) return false;
 
-  // update last_update_time_ to the estimation time
+  // update last_update_time_
   last_update_time_ = time;
   return true;
 }
@@ -87,20 +71,6 @@ bool MotionModel::getPredictedState(
     // a naive way to handle the case when the required prediction time is in the past
     dt = 0.0;
   }
-
-  // // predict only when dt is small enough
-  // if (1e-6 /*1usec*/ < dt) {
-  //   // if dt is too large, shorten dt and repeat prediction
-  //   const uint32_t repeat = std::floor(dt / dt_max_) + 1;
-  //   const double dt_ = dt / repeat;
-  //   for (uint32_t i = 0; i < repeat; ++i) {
-  //     if (!predictStateStep(dt_, tmp_ekf_for_no_update)) {
-  //       return false;
-  //     }
-  //   }
-  //   std::cout << "MotionModel::getPredictedStateMatrix predict dt: " << dt << ", dt_: " << dt_ <<
-  //   ", repeat: "<< repeat<< std::endl;
-  // }
 
   if (!predictStateStep(dt, tmp_ekf_for_no_update)) return false;
 

--- a/perception/multi_object_tracker/src/tracker/motion_model/motion_model_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/motion_model/motion_model_base.cpp
@@ -50,9 +50,15 @@ bool MotionModel::predictState(const rclcpp::Time & time)
     return true;
   }
 
-  if (!predictStateStep(dt, ekf_)) return false;
-
-  // update last_update_time_
+  // multi-step prediction
+  // if dt is too large, shorten dt and repeat prediction
+  const uint32_t repeat = std::floor(dt / dt_max_) + 1;
+  const double dt_ = dt / repeat;
+  for (uint32_t i = 0; i < repeat; ++i) {
+    if (!predictStateStep(dt_, ekf_)) return false;
+    last_update_time_ += rclcpp::Duration::from_seconds(dt_);
+  }
+  // reset the last_update_time_ to the prediction time
   last_update_time_ = time;
   return true;
 }
@@ -63,17 +69,23 @@ bool MotionModel::getPredictedState(
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  // copy the predicted state and covariance
-  KalmanFilter tmp_ekf_for_no_update = ekf_;
-
-  double dt = getDeltaTime(time);
-  if (dt < 0.0) {
-    // a naive way to handle the case when the required prediction time is in the past
-    dt = 0.0;
+  const double dt = getDeltaTime(time);
+  if (dt < 1e-6 /*1usec*/) {
+    // no prediction, return the current state
+    ekf_.getX(X);
+    ekf_.getP(P);
+    return true;
   }
 
-  if (!predictStateStep(dt, tmp_ekf_for_no_update)) return false;
-
+  // copy the predicted state and covariance
+  KalmanFilter tmp_ekf_for_no_update = ekf_;
+  // multi-step prediction
+  // if dt is too large, shorten dt and repeat prediction
+  const uint32_t repeat = std::floor(dt / dt_max_) + 1;
+  const double dt_ = dt / repeat;
+  for (uint32_t i = 0; i < repeat; ++i) {
+    if (!predictStateStep(dt_, tmp_ekf_for_no_update)) return false;
+  }
   tmp_ekf_for_no_update.getX(X);
   tmp_ekf_for_no_update.getP(P);
   return true;


### PR DESCRIPTION
## Description

The extended kalman filter update process was done in multiple-step when the given time-step is too large.
However, the implementation was not work as intended.

* multi-step prediction
```c++
// if dt is too large, shorten dt and repeat prediction
const uint32_t repeat = std::ceil(dt / dt_max_);
const double dt_ = dt / repeat;
for (uint32_t i = 0; i < repeat; ++i) {
  if (!predictStateStep(dt_, tmp_ekf_for_no_update)) {
    return false;
  }
}
```
The motion model prediction is linealization of non-linear motion model. The prediction step assumes the time difference is small enough. By keeping the prediction time step small, a maximum time step was set and the prediction is to be conducted in multiple times.

* Found symptom: the multi-step prediction is not working as intended. 
Until the reason is found, bring back to the one-step prediction.


## FOUND BUG and FIX
A bug was found on `predictStateStep` methods.
* intention: predict the future state of the variable Kalman filter `ekf`
* bug: using the member Kalman filter `ekf_`
* fix: get the state vector from the variable Kalman filter `ekf`

## Tests performed
Tested on recorded data replay recomputation. 

## Effects on system behavior
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
