### PR TITLE
fix(multi_object_tracker): make sure smallest unknown footprint is 0.3

### DIFF
--- a/common/object_recognition_utils/include/object_recognition_utils/matching.hpp
+++ b/common/object_recognition_utils/include/object_recognition_utils/matching.hpp
@@ -65,6 +65,12 @@ inline double getUnionArea(const Polygon2d & source_polygon, const Polygon2d & t
 template <class T1, class T2>
 double get2dIoU(const T1 source_object, const T2 target_object, const double min_union_area = 0.01)
 {
+  if (
+    source_object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON &&
+    source_object.shape.footprint.points.size() < 3) {
+    return 0.0;
+  }
+
   const auto source_polygon = tier4_autoware_utils::toPolygon2d(source_object);
   const auto target_polygon = tier4_autoware_utils::toPolygon2d(target_object);
 


### PR DESCRIPTION
## Description

Related issue:
- https://github.com/autowarefoundation/autoware.universe/issues/6617

When unknown object polygon has only one point which is 0,0,0 , the node dies.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

Fixes: https://github.com/autowarefoundation/autoware.universe/issues/6617

## Tests performed

<!-- Describe how you have tested this PR. -->

Confirmed on logging simulator.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

There are two places where this error occurs, on `data_association.cpp` and `multi_object_tracker_core.cpp`. The fix was added those.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
