### PR TITLE
fix(ndt_scan_matcher): avoid passing nullptr in ndt

### DIFF
--- a/localization/ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/ndt_scan_matcher/src/map_update_module.cpp
@@ -88,7 +88,9 @@ void MapUpdateModule::update_map(const geometry_msgs::msg::Point & position)
       ndt_ptr_mutex_->unlock();
       return;
     }
-    ndt_ptr_->setInputSource(input_source);
+    if (input_source != nullptr) {
+      ndt_ptr_->setInputSource(input_source);
+    }
     ndt_ptr_mutex_->unlock();
     need_rebuild_ = false;
   } else {
@@ -107,7 +109,9 @@ void MapUpdateModule::update_map(const geometry_msgs::msg::Point & position)
     auto dummy_ptr = ndt_ptr_;
     auto input_source = ndt_ptr_->getInputSource();
     ndt_ptr_ = secondary_ndt_ptr_;
-    ndt_ptr_->setInputSource(input_source);
+    if (input_source != nullptr) {
+      ndt_ptr_->setInputSource(input_source);
+    }
     ndt_ptr_mutex_->unlock();
 
     dummy_ptr.reset();


### PR DESCRIPTION
## Description

The following PR for ndt_omp has been changed to now crash when a nullptr is passed to `MultiGridNormalDistributionsTransform::setInputSource`.

https://github.com/tier4/ndt_omp/pull/40/files

In this PR, Fixed the possibility of passing nullptr during initial position estimation in map_update_module.

This could occur in situations with low computing resources, such as on a laptop. This is because if there is no long range LiDAR in the concat point cloud, input pointcloud cannot be accepted and input_source remains as nullptr.

## Tests performed

* It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.

## Effects on system behavior

This will prevent the NDT node from crashing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
