### PR TITLE
fix(ar_tag_based_localizer): added 1 second wait to test

### DIFF
--- a/localization/landmark_based_localizer/ar_tag_based_localizer/test/test.cpp
+++ b/localization/landmark_based_localizer/ar_tag_based_localizer/test/test.cpp
@@ -56,7 +56,9 @@ protected:
 TEST_F(TestArTagBasedLocalizer, test_setup)  // NOLINT
 {
   // Check if the constructor finishes successfully
-  EXPECT_TRUE(true);
+  // For some unknown reason, the test sometimes fails to terminate normally and results in failure
+  // unless a 1-second wait is implemented.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Added a 1 second wait to the test to address the issue below.

https://github.com/autowarefoundation/autoware.universe/issues/6619

## Tests performed

It has been confirmed that the following command succeeds more than 200 times.

```
colcon test --packages-select ar_tag_based_localizer --event-handlers console_cohesion+
```

## Effects on system behavior

There are no effects on system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
