### PR TITLE
feat(behavior_path_planner_common): add general method for calculating turn signal for bpp modules

### DIFF
--- a/planning/behavior_path_planner_common/docs/behavior_path_planner_turn_signal_design.md
+++ b/planning/behavior_path_planner_common/docs/behavior_path_planner_turn_signal_design.md
@@ -4,7 +4,7 @@ Turn Signal decider determines necessary blinkers.
 
 ## Purpose / Role
 
-This module is responsible for activating a necessary blinker during driving. It uses rule-based algorithm to determine blinkers, and the details of this algorithm are described in the following sections. Note that this algorithm is strictly based on the Japanese Road Traffic Raw.
+This module is responsible for activating a necessary blinker during driving. It uses rule-based algorithm to determine blinkers, and the details of this algorithm are described in the following sections. Note that this algorithm is strictly based on the Japanese Road Traffic Law.
 
 ### Assumptions
 
@@ -16,7 +16,7 @@ Autoware has following order of priorities for turn signals.
 
 ### Limitations
 
-Currently, this algorithm can sometimes give unnatural (not wrong) blinkers in a complicated situations. This is because it tries to follow the road traffic raw and cannot solve `blinker conflicts` clearly in that environment.
+Currently, this algorithm can sometimes give unnatural (not wrong) blinkers in complicated situations. This is because it tries to follow the road traffic law and cannot solve `blinker conflicts` clearly in that environment.
 
 ## Parameters for turn signal decider
 
@@ -59,16 +59,16 @@ For left turn, right turn, avoidance, lane change, goal planner and pull out, we
 
 Turn signal decider checks each lanelet on the map if it has `turn_direction` information. If a lanelet has this information, it activates necessary blinker based on this information.
 
-- desired start point  
-  The `search_distance` for blinkers at intersections is `v * turn_signal_search_time + turn_signal_intersection_search_distance`. Then the start point becomes `search_distance` meters before the start point of the intersection lanelet(depicted in gree in the following picture), where `v` is the velocity of the ego vehicle. However, if we set `turn_signal_distance` in the lanelet, we use that length as search distance.
+- desired start point
+  The `search_distance` for blinkers at intersections is `v * turn_signal_search_time + turn_signal_intersection_search_distance`. Then the start point becomes `search_distance` meters before the start point of the intersection lanelet(depicted in green in the following picture), where `v` is the velocity of the ego vehicle. However, if we set `turn_signal_distance` in the lanelet, we use that length as search distance.
 
-- desired end point  
+- desired end point
   Terminal point of the intersection lanelet.
 
-- required start point  
+- required start point
   Initial point of the intersection lanelet.
 
-- required end point  
+- required end point
   The earliest point that satisfies the following condition. $\theta - \theta_{\textrm{end}} < \delta$, where $\theta_{\textrm{end}}$ is yaw angle of the terminal point of the lanelet, $\theta$ is the angle of a required end point and $\delta$ is the threshold defined by the user.
 
 ![section_turn_signal](../images/turn_signal_decider/left_right_turn.drawio.svg)
@@ -79,99 +79,99 @@ Avoidance can be separated into two sections, first section and second section. 
 
 First section
 
-- desired start point  
+- desired start point
   `v * turn_signal_search_time` meters before the start point of the avoidance shift path.
 
-- desired end point  
+- desired end point
   Shift complete point where the path shift is completed.
 
-- required start point  
+- required start point
   Avoidance start point.
 
-- required end point  
+- required end point
   Shift complete point same as the desired end point.
 
 ![section_first_avoidance](../images/turn_signal_decider/avoidance_first_section.drawio.svg)
 
 Second section
 
-- desired start point  
+- desired start point
   Shift complete point.
 
-- desired end point  
+- desired end point
   Avoidance terminal point
 
-- required start point  
+- required start point
   Shift complete point.
 
-- required end point  
+- required end point
   Avoidance terminal point.
 
 ![section_second_avoidance](../images/turn_signal_decider/avoidance_second_section.drawio.svg)
 
 #### 3. Lane Change
 
-- desired start point  
+- desired start point
   `v * turn_signal_search_time` meters before the start point of the lane change path.
 
-- desired end point  
+- desired end point
   Terminal point of the lane change path.
 
-- required start point  
+- required start point
   Initial point of the lane change path.
 
-- required end point  
+- required end point
   Cross point with lane change path and boundary line of the adjacent lane.
 
 ![section_lane_change](../images/turn_signal_decider/lane_change.drawio.svg)
 
 #### 4. Pull out
 
-- desired start point  
+- desired start point
   Start point of the path of pull out.
 
-- desired end point  
+- desired end point
   Terminal point of the path of pull out.
 
-- required start point  
+- required start point
   Start point of the path pull out.
 
-- required end point  
+- required end point
   Terminal point of the path of pull out.
 
 ![section_pull_out](../images/turn_signal_decider/pull_out.drawio.svg)
 
 #### 5. Goal Planner
 
-- desired start point  
+- desired start point
   `v * turn_signal_search_time` meters before the start point of the pull over path.
 
-- desired end point  
+- desired end point
   Terminal point of the path of pull over.
 
-- required start point  
+- required start point
   Start point of the path of pull over.
 
-- required end point  
+- required end point
   Terminal point of the path of pull over.
 
 ![section_pull_over](../images/turn_signal_decider/pull_over.drawio.svg)
 
 When it comes to handle several blinkers, it gives priority to the first blinker that comes first. However, this rule sometimes activate unnatural blinkers, so turn signal decider uses the following five rules to decide the necessary turn signal.
 
-- pattern1  
+- pattern1
   ![pattern1](../images/turn_signal_decider/pattern1.drawio.svg)
 
-- pattern2  
+- pattern2
   ![pattern2](../images/turn_signal_decider/pattern2.drawio.svg)
 
-- pattern3  
+- pattern3
   ![pattern3](../images/turn_signal_decider/pattern3.drawio.svg)
 
-- pattern4  
+- pattern4
   ![pattern4](../images/turn_signal_decider/pattern4.drawio.svg)
 
-- pattern5  
+- pattern5
   ![pattern5](../images/turn_signal_decider/pattern5.drawio.svg)
 
 Based on these five rules, turn signal decider can solve `blinker conflicts`. The following pictures show some examples of this kind of conflicts.

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/turn_signal_decider.hpp
@@ -15,14 +15,24 @@
 #ifndef BEHAVIOR_PATH_PLANNER_COMMON__TURN_SIGNAL_DECIDER_HPP_
 #define BEHAVIOR_PATH_PLANNER_COMMON__TURN_SIGNAL_DECIDER_HPP_
 
+#include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
+
 #include <behavior_path_planner_common/parameters.hpp>
+#include <behavior_path_planner_common/utils/path_shifter/path_shifter.hpp>
+#include <lanelet2_extension/utility/message_conversion.hpp>
 #include <route_handler/route_handler.hpp>
+#include <tier4_autoware_utils/geometry/boost_geometry.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <boost/geometry/algorithms/intersects.hpp>
 
 #include <lanelet2_core/Forward.h>
+#include <lanelet2_routing/RoutingGraphContainer.h>
 
 #include <limits>
 #include <map>
@@ -37,6 +47,7 @@ using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
+using nav_msgs::msg::Odometry;
 using route_handler::RouteHandler;
 
 const std::map<std::string, uint8_t> g_signal_map = {
@@ -100,6 +111,15 @@ public:
   std::pair<bool, bool> getIntersectionTurnSignalFlag();
   std::pair<Pose, double> getIntersectionPoseAndDistance();
 
+  std::pair<TurnSignalInfo, bool> getBehaviorTurnSignalInfo(
+    const ShiftedPath & path, const ShiftLine & shift_line,
+    const lanelet::ConstLanelets & current_lanelets,
+    const std::shared_ptr<RouteHandler> route_handler,
+    const BehaviorPathPlannerParameters & parameters, const Odometry::ConstSharedPtr self_odometry,
+    const double current_shift_length, const bool is_driving_forward,
+    const bool egos_lane_is_shifted, const bool override_ego_stopped_check = false,
+    const bool is_pull_out = false) const;
+
 private:
   std::optional<TurnSignalInfo> getIntersectionTurnSignalInfo(
     const PathWithLaneId & path, const Pose & current_pose, const double current_vel,
@@ -117,6 +137,132 @@ private:
     const TurnSignalInfo & intersection_turn_signal_info, const double nearest_dist_threshold,
     const double nearest_yaw_threshold);
   void initialize_intersection_info();
+
+  inline bool isAvoidShift(
+    const double start_shift_length, const double end_shift_length, const double threshold) const
+  {
+    return std::abs(start_shift_length) < threshold && std::abs(end_shift_length) > threshold;
+  };
+
+  inline bool isReturnShift(
+    const double start_shift_length, const double end_shift_length, const double threshold) const
+  {
+    return std::abs(start_shift_length) > threshold && std::abs(end_shift_length) < threshold;
+  };
+
+  inline bool isLeftMiddleShift(
+    const double start_shift_length, const double end_shift_length, const double threshold) const
+  {
+    return start_shift_length > threshold && end_shift_length > threshold;
+  };
+
+  inline bool isRightMiddleShift(
+    const double start_shift_length, const double end_shift_length, const double threshold) const
+  {
+    return start_shift_length < threshold && end_shift_length < threshold;
+  };
+
+  inline bool existShiftSideLane(
+    const double start_shift_length, const double end_shift_length, const bool no_left_lanes,
+    const bool no_right_lanes, const double threshold) const
+  {
+    const auto relative_shift_length = end_shift_length - start_shift_length;
+    if (isAvoidShift(start_shift_length, end_shift_length, threshold)) {
+      // Left avoid. But there is no adjacent lane. No need blinker.
+      if (relative_shift_length > 0.0 && no_left_lanes) {
+        return false;
+      }
+
+      // Right avoid. But there is no adjacent lane. No need blinker.
+      if (relative_shift_length < 0.0 && no_right_lanes) {
+        return false;
+      }
+    }
+
+    if (isReturnShift(start_shift_length, end_shift_length, threshold)) {
+      // Right return. But there is no adjacent lane. No need blinker.
+      if (relative_shift_length > 0.0 && no_right_lanes) {
+        return false;
+      }
+
+      // Left return. But there is no adjacent lane. No need blinker.
+      if (relative_shift_length < 0.0 && no_left_lanes) {
+        return false;
+      }
+    }
+
+    if (isLeftMiddleShift(start_shift_length, end_shift_length, threshold)) {
+      // Left avoid. But there is no adjacent lane. No need blinker.
+
+      if (relative_shift_length > 0.0 && no_left_lanes) {
+        return false;
+      }
+
+      // Left return. But there is no adjacent lane. No need blinker.
+      if (relative_shift_length < 0.0 && no_left_lanes) {
+        return false;
+      }
+    }
+
+    if (isRightMiddleShift(start_shift_length, end_shift_length, threshold)) {
+      // Right avoid. But there is no adjacent lane. No need blinker.
+
+      if (relative_shift_length < 0.0 && no_right_lanes) {
+        return false;
+      }
+
+      // Left avoid. But there is no adjacent lane. No need blinker.
+      if (relative_shift_length > 0.0 && no_right_lanes) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  inline bool straddleRoadBound(
+    const ShiftedPath & path, const ShiftLine & shift_line, const lanelet::ConstLanelets & lanes,
+    const vehicle_info_util::VehicleInfo & vehicle_info) const
+  {
+    using boost::geometry::intersects;
+    using tier4_autoware_utils::pose2transform;
+    using tier4_autoware_utils::transformVector;
+
+    const auto footprint = vehicle_info.createFootprint();
+
+    for (const auto & lane : lanes) {
+      for (size_t i = shift_line.start_idx; i < shift_line.end_idx; ++i) {
+        const auto transform = pose2transform(path.path.points.at(i).point.pose);
+        const auto shifted_vehicle_footprint = transformVector(footprint, transform);
+
+        if (intersects(lane.leftBound2d().basicLineString(), shifted_vehicle_footprint)) {
+          return true;
+        }
+
+        if (intersects(lane.rightBound2d().basicLineString(), shifted_vehicle_footprint)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
+  inline bool isNearEndOfShift(
+    const double start_shift_length, const double end_shift_length, const Point & ego_pos,
+    const lanelet::ConstLanelets & original_lanes, const double threshold) const
+  {
+    using boost::geometry::within;
+    using lanelet::utils::to2D;
+    using lanelet::utils::conversion::toLaneletPoint;
+
+    if (!isReturnShift(start_shift_length, end_shift_length, threshold)) {
+      return false;
+    }
+
+    return std::any_of(original_lanes.begin(), original_lanes.end(), [&ego_pos](const auto & lane) {
+      return within(to2D(toLaneletPoint(ego_pos)), lane.polygon2d().basicPolygon());
+    });
+  };
 
   geometry_msgs::msg::Quaternion calc_orientation(const Point & src_point, const Point & dst_point);
 


### PR DESCRIPTION
## Description

Add a general method to obtain the correct turnSignalInfo for all behavior path planner modules.
This PR implements only the method itself. The method has been tested with the start planner, goal planner, avoidance and lane change modules as depicted here: https://github.com/autowarefoundation/autoware.universe/pull/6622
This PR is 1 of 5 and the other PRs will depend on this one (to be linked)

Please see the Above link for further details

After approving this PR, the following PRs implement this method in the bpp modules: 

Avoidance: https://github.com/autowarefoundation/autoware.universe/pull/6626
Lane Change: https://github.com/autowarefoundation/autoware.universe/pull/6627
Start Planner: https://github.com/autowarefoundation/autoware.universe/pull/6628
Goal Planner: https://github.com/autowarefoundation/autoware.universe/pull/6629


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
