### PR TITLE
fix(out_of_lane): use bigger stop lines to cut predicted paths

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
@@ -86,10 +86,11 @@ void cut_predicted_path_beyond_red_lights(
 {
   const auto stop_line = find_next_stop_line(predicted_path, planner_data);
   if (stop_line) {
+    // we use a longer stop line to also cut predicted paths that slightly go around the stop line
     auto longer_stop_line = *stop_line;
     const auto diff = stop_line->back() - stop_line->front();
-    longer_stop_line.front() += diff * -2.0;
-    longer_stop_line.back() += diff * 2.0;
+    longer_stop_line.front() -= diff * 0.5;
+    longer_stop_line.back() += diff * 0.5;
     cut_predicted_path_beyond_line(predicted_path, longer_stop_line, object_front_overhang);
   }
 }

--- a/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
@@ -85,7 +85,13 @@ void cut_predicted_path_beyond_red_lights(
   const PlannerData & planner_data, const double object_front_overhang)
 {
   const auto stop_line = find_next_stop_line(predicted_path, planner_data);
-  if (stop_line) cut_predicted_path_beyond_line(predicted_path, *stop_line, object_front_overhang);
+  if (stop_line) {
+    auto longer_stop_line = *stop_line;
+    const auto diff = stop_line->back() - stop_line->front();
+    longer_stop_line.front() += diff * -2.0;
+    longer_stop_line.back() += diff * 2.0;
+    cut_predicted_path_beyond_line(predicted_path, longer_stop_line, object_front_overhang);
+  }
 }
 
 autoware_auto_perception_msgs::msg::PredictedObjects filter_predicted_objects(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fixes an edge case with the feature to cut predicted paths at red traffic lights.
In some case the predicted path goes slightly around the stop line and it is not correctly cut.
With this PR, the stop line is made longer to avoid this edge case.

- TIER IV INTERNAL LINK: https://tier4.atlassian.net/browse/RT1-5753

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
