### PR TITLE
ci(build-and-test-differential): bring back clang-tidy-differential job

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -76,13 +76,16 @@ jobs:
         run: df -h
 
   clang-tidy-differential:
-    runs-on: [self-hosted, linux, X64]
+    runs-on: ubuntu-latest
     container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt-cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Show disk space before the tasks
+        run: df -h
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -74,3 +74,37 @@ jobs:
 
       - name: Show disk space after the tasks
         run: df -h
+
+  clang-tidy-differential:
+    runs-on: [self-hosted, linux, X64]
+    container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt-cuda
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Remove exec_depend
+        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
+
+      - name: Get modified packages
+        id: get-modified-packages
+        uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
+
+      - name: Get modified files
+        id: get-modified-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.cpp
+            **/*.hpp
+
+      - name: Run clang-tidy
+        if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
+        uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
+        with:
+          rosdistro: humble
+          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
+          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
+          build-depends-repos: build_depends.repos


### PR DESCRIPTION
## Description

- This was removed with:
  - https://github.com/autowarefoundation/autoware.universe/pull/6507
- Now that the essential tasks are running on the github public runners, we can bring this job back

Related PR:
- https://github.com/autowarefoundation/autoware.universe/pull/6641

## Tests performed

I will add a small bug to test if it could catch that.

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
