### PR TITLE
fix(behavior_velocity_run_out): construct predicted path up to max pr…

### DIFF
--- a/planning/behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
@@ -26,6 +26,7 @@
 #include <pcl/filters/voxel_grid.h>
 
 #include <algorithm>
+#include <limits>
 #include <string>
 
 namespace behavior_velocity_planner

--- a/planning/behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
@@ -324,6 +324,15 @@ std::vector<geometry_msgs::msg::Pose> createPathToPredictionTime(
   // Calculate the number of poses to include based on the prediction time and the time step between
   // poses
   const double time_step_seconds = convertDurationToDouble(predicted_path.time_step);
+  if (time_step_seconds < std::numeric_limits<double>::epsilon()) {
+    // Handle the case where time_step_seconds is zero or too close to zero
+    RCLCPP_WARN_STREAM(
+      rclcpp::get_logger("run_out: createPathToPredictionTime"),
+      "time_step of the path is too close to zero. Use the input path");
+    const std::vector<geometry_msgs::msg::Pose> input_path(
+      predicted_path.path.begin(), predicted_path.path.end());
+    return input_path;
+  }
   const size_t poses_to_include =
     std::min(static_cast<size_t>(prediction_time / time_step_seconds), predicted_path.path.size());
 

--- a/planning/behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
@@ -312,6 +312,31 @@ void calculateMinAndMaxVelFromCovariance(
   dynamic_obstacle.max_velocity_mps = max_velocity;
 }
 
+double convertDurationToDouble(const builtin_interfaces::msg::Duration & duration)
+{
+  return duration.sec + duration.nanosec / 1e9;
+}
+
+// Create a path leading up to a specified prediction time
+std::vector<geometry_msgs::msg::Pose> createPathToPredictionTime(
+  const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path, double prediction_time)
+{
+  // Calculate the number of poses to include based on the prediction time and the time step between
+  // poses
+  const double time_step_seconds = convertDurationToDouble(predicted_path.time_step);
+  const size_t poses_to_include =
+    std::min(static_cast<size_t>(prediction_time / time_step_seconds), predicted_path.path.size());
+
+  // Construct the path to the specified prediction time
+  std::vector<geometry_msgs::msg::Pose> path_to_prediction_time;
+  path_to_prediction_time.reserve(poses_to_include);
+  for (size_t i = 0; i < poses_to_include; ++i) {
+    path_to_prediction_time.push_back(predicted_path.path[i]);
+  }
+
+  return path_to_prediction_time;
+}
+
 }  // namespace
 
 DynamicObstacleCreatorForObject::DynamicObstacleCreatorForObject(
@@ -343,8 +368,7 @@ std::vector<DynamicObstacle> DynamicObstacleCreatorForObject::createDynamicObsta
     for (const auto & path : predicted_object.kinematics.predicted_paths) {
       PredictedPath predicted_path;
       predicted_path.confidence = path.confidence;
-      predicted_path.path.resize(path.path.size());
-      std::copy(path.path.cbegin(), path.path.cend(), predicted_path.path.begin());
+      predicted_path.path = createPathToPredictionTime(path, param_.max_prediction_time);
 
       dynamic_obstacle.predicted_paths.emplace_back(predicted_path);
     }


### PR DESCRIPTION
## Description
The parameter of `max_prediction_time` was not applied when `Object` method is used, so I fixed this.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
[Scenario Test](https://evaluation.tier4.jp/evaluation/reports/45a25d04-09a3-5bc9-b25d-d77a44bd8a92?project_id=prd_jt) 2791/2811


PSim
`max_prediction_time` = 10.0 (default value)

https://github.com/autowarefoundation/autoware.universe/assets/11865769/fb8bcbe3-a3a9-4a79-b7f5-ed25b0247260

`max_prediction_time` = 3.0

https://github.com/autowarefoundation/autoware.universe/assets/11865769/ca50ca32-be8c-42de-b875-4c2bceae4b7e


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
