### PR TITLE
fix(tier4_autoware_utils): clang-tidy errors for published_time_publisher

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/published_time_publisher.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/published_time_publisher.hpp
@@ -24,6 +24,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 namespace tier4_autoware_utils
 {
@@ -32,9 +33,9 @@ class PublishedTimePublisher
 {
 public:
   explicit PublishedTimePublisher(
-    rclcpp::Node * node, const std::string & publisher_topic_suffix = "/debug/published_time",
+    rclcpp::Node * node, std::string publisher_topic_suffix = "/debug/published_time",
     const rclcpp::QoS & qos = rclcpp::QoS(1))
-  : node_(node), publisher_topic_suffix_(publisher_topic_suffix), qos_(qos)
+  : node_(node), publisher_topic_suffix_(std::move(publisher_topic_suffix)), qos_(qos)
   {
   }
 
@@ -46,16 +47,16 @@ public:
     // if the publisher is not in the map, create a new publisher for published time
     ensure_publisher_exists(gid_key, publisher->get_topic_name());
 
-    const auto & pub_published_time_ = publishers_[gid_key];
+    const auto & pub_published_time = publishers_[gid_key];
 
     // Check if there are any subscribers, otherwise don't do anything
-    if (pub_published_time_->get_subscription_count() > 0) {
+    if (pub_published_time->get_subscription_count() > 0) {
       PublishedTime published_time;
 
       published_time.header.stamp = stamp;
       published_time.published_stamp = rclcpp::Clock().now();
 
-      pub_published_time_->publish(published_time);
+      pub_published_time->publish(published_time);
     }
   }
 
@@ -67,16 +68,16 @@ public:
     // if the publisher is not in the map, create a new publisher for published time
     ensure_publisher_exists(gid_key, publisher->get_topic_name());
 
-    const auto & pub_published_time_ = publishers_[gid_key];
+    const auto & pub_published_time = publishers_[gid_key];
 
     // Check if there are any subscribers, otherwise don't do anything
-    if (pub_published_time_->get_subscription_count() > 0) {
+    if (pub_published_time->get_subscription_count() > 0) {
       PublishedTime published_time;
 
       published_time.header = header;
       published_time.published_stamp = rclcpp::Clock().now();
 
-      pub_published_time_->publish(published_time);
+      pub_published_time->publish(published_time);
     }
   }
 


### PR DESCRIPTION
## Description

Fixes some clang-tidy errors on this code.

Related:
- https://github.com/autowarefoundation/autoware.universe/pull/6647
- https://github.com/autowarefoundation/autoware.universe/pull/6641
- https://github.com/autowarefoundation/autoware.universe/pull/6440

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
