### PR TITLE
refactor(pointcloud_preprocessor): move roi_mode_map_ definition inside DualReturnOutlierFilterComponent class

### DIFF
--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/dual_return_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/dual_return_outlier_filter_nodelet.hpp
@@ -43,12 +43,6 @@ namespace pointcloud_preprocessor
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
 
-std::unordered_map<std::string, uint8_t> roi_mode_map_ = {
-  {"No_ROI", 0},
-  {"Fixed_xyz_ROI", 1},
-  {"Fixed_azimuth_ROI", 2},
-};
-
 class DualReturnOutlierFilterComponent : public pointcloud_preprocessor::Filter
 {
 protected:
@@ -85,6 +79,12 @@ private:
   float min_azimuth_deg_;
   float max_azimuth_deg_;
   float max_distance_;
+
+  std::unordered_map<std::string, uint8_t> roi_mode_map_ = {
+    {"No_ROI", 0},
+    {"Fixed_xyz_ROI", 1},
+    {"Fixed_azimuth_ROI", 2},
+  };
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW


### PR DESCRIPTION
## Description

This pull request encapsulates the roi_mode_map_ within the DualReturnOutlierFilterComponent class to improve the organization of the code and its maintainability. 
Previously, roi_mode_map_ was defined in the global namespace, which could potentially lead to naming conflicts.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
