### PR TITLE
fix(vehicle_cmd_gate): fix publisher HZ in the unit test

### DIFF
--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -388,15 +388,25 @@ TEST_P(TestFixture, CheckFilterForSinCmd)
   //           << ")" << std::endl;
 
   for (size_t i = 0; i < 100; ++i) {
+    auto start_time = std::chrono::steady_clock::now();
+
     const bool reset_clock = (i == 0);
     const auto cmd = cmd_generator_.calcSinWaveCommand(reset_clock);
     pub_sub_node_.publishControlCommand(cmd);
     pub_sub_node_.publishDefaultTopicsNoSpin();
-    for (int i = 0; i < 20; ++i) {
+    for (int j = 0; j < 20; ++j) {
       rclcpp::spin_some(pub_sub_node_.get_node_base_interface());
       rclcpp::spin_some(vehicle_cmd_gate_node_->get_node_base_interface());
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds{10LL});
+
+    auto end_time = std::chrono::steady_clock::now();
+    std::chrono::milliseconds elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+
+    std::chrono::milliseconds sleep_duration = std::chrono::milliseconds{10} - elapsed;
+    if (sleep_duration.count() > 0) {
+      std::this_thread::sleep_for(sleep_duration);
+    }
   }
 
   std::cerr << "received cmd num = " << pub_sub_node_.cmd_received_times_.size() << std::endl;


### PR DESCRIPTION
## Description

Related to https://github.com/autowarefoundation/autoware.universe/issues/6612.
Based on the following analysis and suggestion by @xmfcx, the unit test in the vehicle_cmd_gate uses more precise 100Hz publisher.
https://github.com/autowarefoundation/autoware.universe/issues/6612#issuecomment-1994770127

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
