### PR TITLE
fix(avoidance_by_lane_change): object filtering too conservative

### DIFF
--- a/planning/behavior_path_avoidance_by_lane_change_module/include/behavior_path_avoidance_by_lane_change_module/scene.hpp
+++ b/planning/behavior_path_avoidance_by_lane_change_module/include/behavior_path_avoidance_by_lane_change_module/scene.hpp
@@ -50,7 +50,7 @@ private:
   mutable ObjectDataArray stopped_objects_;
   std::shared_ptr<AvoidanceHelper> avoidance_helper_;
 
-  ObjectData createObjectData(
+  std::optional<ObjectData> createObjectData(
     const AvoidancePlanningData & data, const PredictedObject & object) const;
 
   void fillAvoidanceTargetObjects(AvoidancePlanningData & data, AvoidanceDebugData & debug) const;

--- a/planning/behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -205,7 +205,9 @@ std::optional<ObjectData> AvoidanceByLaneChange::createObjectData(
   object_data.to_centerline =
     lanelet::utils::getArcCoordinates(data.current_lanelets, object_pose).distance;
 
-  if( std::abs(object_data.to_centerline) < avoidance_parameters_->threshold_distance_object_is_on_center){
+  if (
+    std::abs(object_data.to_centerline) <
+    avoidance_parameters_->threshold_distance_object_is_on_center) {
     return std::nullopt;
   }
 

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -371,7 +371,7 @@ struct ObjectData  // avoidance target
   double distance_factor{0.0};
 
   // count up when object disappeared. Removed when it exceeds threshold.
-  rclcpp::Time last_seen;
+  rclcpp::Time last_seen{rclcpp::Clock(RCL_ROS_TIME).now()};
   double lost_time{0.0};
 
   // count up when object moved. Removed when it exceeds threshold.

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -80,13 +80,13 @@ void LaneChangeInterface::updateData()
     getPreviousModuleOutput().reference_path, getPreviousModuleOutput().path);
   module_type_->setPreviousDrivableAreaInfo(getPreviousModuleOutput().drivable_area_info);
   module_type_->setPreviousTurnSignalInfo(getPreviousModuleOutput().turn_signal_info);
+  module_type_->updateSpecialData();
 
   if (isWaitingApproval()) {
     module_type_->updateLaneChangeStatus();
   }
   updateDebugMarker();
 
-  module_type_->updateSpecialData();
   module_type_->resetStopPose();
 }
 


### PR DESCRIPTION
## Description

Avoidance by Lane Change's (AbLC) object filtering algorithm for activation condition, shares the same method as Avoidance module's filters. Due to this, there are many instances where AbLC couldn't be activated due to the differences between the parameter, and the expected behavior.

This PR aims to loosen the filtering condition, so that it is more easier to be activated.

### Before PR

Object in current lane is removed from being an target object, and avoidance or lane change will be activated instead.

https://github.com/autowarefoundation/autoware.universe/assets/93502286/78c2f0ce-2ddc-4a71-8372-1f7944af75fe

### After PR

Object in current lane is registered as target object, and AbLC is activated.

https://github.com/autowarefoundation/autoware.universe/assets/93502286/189b8303-eb22-4e99-a2ff-9905b1c7d472

## Related links

None

## Tests performed

Evaluator ([TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/3b695327-d71c-5aa6-8d03-711b4fbb4a5d?project_id=prd_jt))

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
