### PR TITLE
feat(time_synchronizer_nodelet): set input_offsets zero if it was not defined

### DIFF
--- a/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
@@ -83,7 +83,12 @@ PointCloudDataSynchronizerComponent::PointCloudDataSynchronizerComponent(
     timeout_sec_ = static_cast<double>(declare_parameter("timeout_sec", 0.1));
 
     input_offset_ = declare_parameter("input_offset", std::vector<double>{});
-    if (!input_offset_.empty() && input_topics_.size() != input_offset_.size()) {
+
+    // If input_offset_ is not defined, set all offsets to 0
+    if (input_offset_.empty()) {
+      input_offset_.resize(input_topics_.size(), 0.0);
+      RCLCPP_INFO(get_logger(), "Input offset is not defined. Set all offsets to 0.0.");
+    } else if (input_topics_.size() != input_offset_.size()) {
       RCLCPP_ERROR(get_logger(), "The number of topics does not match the number of offsets.");
       return;
     }


### PR DESCRIPTION
## Description
Partially fixes #6575 
<!-- Write a brief description of this PR. -->
In `time_synchronizer_nodelet`, It has timer cancel and reset functionalities when the input point cloud messages were not set successfully. However, if the `input_offsets` were not set as parameter, nodelet can not operate fully because of the `offset_map_.size() > 0 ` always false:
https://github.com/autowarefoundation/autoware.universe/blob/872cbddd7fea8ef7387ec514e3803a76eb69e457/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp#L527-L537

To avoid this behavior, added another code snippet to set zero offset if it was not defined.

## Tests performed
Tested with `e2e_simulator`, behavior was not observed in #6575 while running pipeline with `time_synchronizer_nodelet`.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
