### PR TITLE
fix(vehicle_cmd_gate): fix publisher HZ in the unit test by introducing variable window length

### DIFF
--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -388,15 +388,25 @@ TEST_P(TestFixture, CheckFilterForSinCmd)
   //           << ")" << std::endl;
 
   for (size_t i = 0; i < 100; ++i) {
+    auto start_time = std::chrono::steady_clock::now();
+
     const bool reset_clock = (i == 0);
     const auto cmd = cmd_generator_.calcSinWaveCommand(reset_clock);
     pub_sub_node_.publishControlCommand(cmd);
     pub_sub_node_.publishDefaultTopicsNoSpin();
-    for (int i = 0; i < 20; ++i) {
+    for (int j = 0; j < 20; ++j) {
       rclcpp::spin_some(pub_sub_node_.get_node_base_interface());
       rclcpp::spin_some(vehicle_cmd_gate_node_->get_node_base_interface());
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds{10LL});
+
+    auto end_time = std::chrono::steady_clock::now();
+    std::chrono::milliseconds elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+
+    std::chrono::milliseconds sleep_duration = std::chrono::milliseconds{10} - elapsed;
+    if (sleep_duration.count() > 0) {
+      std::this_thread::sleep_for(sleep_duration);
+    }
   }
 
   std::cerr << "received cmd num = " << pub_sub_node_.cmd_received_times_.size() << std::endl;

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -249,6 +249,7 @@ public:
       // TODO(Horibe): prev_lat_acc should use the previous velocity, but use the current velocity
       // since the current filtering logic uses the current velocity.
       prev_tire_angle = cmd_start->lateral.steering_tire_angle;
+      lon_vel = cmd_start->longitudinal.speed;
       prev_lat_acc =
         calculate_lateral_acceleration(lon_vel, cmd_start->lateral.steering_tire_angle, wheelbase);
     }

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -80,7 +80,10 @@ public:
       [this](const AckermannControlCommand::ConstSharedPtr msg) {
         cmd_history_.push_back(msg);
         cmd_received_times_.push_back(now());
+        // check filter for varying last_x values to test the CI
+        checkFilter(2);
         checkFilter(3);
+        checkFilter(4);
       });
 
     rclcpp::QoS qos{1};
@@ -296,6 +299,7 @@ public:
     constexpr auto threshold_scale = 1.1;
     if (std::abs(lon_vel) > 0.01) {
       // Assert over averaged values against limits
+      PRINT_VALUES(last_x);
       ASSERT_LT_NEAR(std::abs(avg_lon_acc), max_lon_acc_lim, threshold_scale);
       ASSERT_LT_NEAR(std::abs(avg_lon_jerk), max_lon_jerk_lim, threshold_scale);
       ASSERT_LT_NEAR(std::abs(avg_lat_acc), max_lat_acc_lim, threshold_scale);

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -82,7 +82,6 @@ public:
         cmd_received_times_.push_back(now());
         // check filter for varying last_x values to test the CI
         checkFilter(4);
-        checkFilter(3);
       });
 
     rclcpp::QoS qos{1};

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -297,6 +297,8 @@ public:
     const auto max_lat_jerk_lim = *std::max_element(lat_jerk_lim.begin(), lat_jerk_lim.end());
 
     constexpr auto threshold_scale = 1.1;
+    // Output command must be smaller than maximum limit.
+    // TODO(Horibe): check for each velocity range.
     if (std::abs(lon_vel) > 0.01) {
       // Assert over averaged values against limits
       ASSERT_LT_NEAR(std::abs(avg_lon_acc), max_lon_acc_lim, threshold_scale) << "last_x was = " << last_x;

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -235,6 +235,7 @@ public:
     double lon_vel = 0.0;
     double prev_lon_acc = 0.0;
     double prev_lat_acc = 0.0;
+    // TODO(Horibe): Remove this variable when the filtering logic is fixed.
     double prev_tire_angle = 0.0;
 
     auto calculate_lateral_acceleration =
@@ -248,10 +249,10 @@ public:
       prev_lon_acc = cmd_start->longitudinal.acceleration;
       // TODO(Horibe): prev_lat_acc should use the previous velocity, but use the current velocity
       // since the current filtering logic uses the current velocity.
+      // when it's fixed, should be like this:
+      // prev_lat_acc = calculate_lateral_acceleration(cmd_start->longitudinal.speed,
+      // cmd_start->lateral.steering_tire_angle, wheelbase);
       prev_tire_angle = cmd_start->lateral.steering_tire_angle;
-      lon_vel = cmd_start->longitudinal.speed;
-      prev_lat_acc =
-        calculate_lateral_acceleration(lon_vel, cmd_start->lateral.steering_tire_angle, wheelbase);
     }
 
     for (size_t i = ind_start; i < history_size; ++i) {
@@ -269,6 +270,7 @@ public:
         calculate_lateral_acceleration(lon_vel, cmd->lateral.steering_tire_angle, wheelbase);
       // TODO(Horibe): prev_lat_acc should use the previous velocity, but use the current velocity
       // since the current filtering logic uses the current velocity.
+      // when it's fixed, it should be moved to the bottom of this loop.
       prev_lat_acc = calculate_lateral_acceleration(lon_vel, prev_tire_angle, wheelbase);
       const auto lat_jerk = (lat_acc - prev_lat_acc) / dt;
 
@@ -278,8 +280,7 @@ public:
       avg_lat_jerk += lat_jerk;
 
       prev_lon_acc = lon_acc;
-      // TODO(Horibe): prev_lat_acc should use the previous velocity, but use the current velocity
-      // since the current filtering logic uses the current velocity.
+      // TODO(Horibe): when the filtering logic is fixed, this line should be removed.
       prev_tire_angle = cmd->lateral.steering_tire_angle;
     }
 

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -81,7 +81,6 @@ public:
         cmd_history_.push_back(msg);
         cmd_received_times_.push_back(now());
         // check filter for varying last_x values to test the CI
-        checkFilter(2);
         checkFilter(3);
         checkFilter(4);
       });

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -81,8 +81,8 @@ public:
         cmd_history_.push_back(msg);
         cmd_received_times_.push_back(now());
         // check filter for varying last_x values to test the CI
-        checkFilter(3);
         checkFilter(4);
+        checkFilter(3);
       });
 
     rclcpp::QoS qos{1};
@@ -299,11 +299,10 @@ public:
     constexpr auto threshold_scale = 1.1;
     if (std::abs(lon_vel) > 0.01) {
       // Assert over averaged values against limits
-      PRINT_VALUES(last_x);
-      ASSERT_LT_NEAR(std::abs(avg_lon_acc), max_lon_acc_lim, threshold_scale);
-      ASSERT_LT_NEAR(std::abs(avg_lon_jerk), max_lon_jerk_lim, threshold_scale);
-      ASSERT_LT_NEAR(std::abs(avg_lat_acc), max_lat_acc_lim, threshold_scale);
-      ASSERT_LT_NEAR(std::abs(avg_lat_jerk), max_lat_jerk_lim, threshold_scale);
+      ASSERT_LT_NEAR(std::abs(avg_lon_acc), max_lon_acc_lim, threshold_scale) << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lon_jerk), max_lon_jerk_lim, threshold_scale) << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lat_acc), max_lat_acc_lim, threshold_scale) << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lat_jerk), max_lat_jerk_lim, threshold_scale) << "last_x was = " << last_x;
     }
   }
 };

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -80,7 +80,7 @@ public:
       [this](const AckermannControlCommand::ConstSharedPtr msg) {
         cmd_history_.push_back(msg);
         cmd_received_times_.push_back(now());
-        // check filter for varying last_x values to test the CI
+        // check the effectiveness of the filter for last x elements in the queue
         checkFilter(4);
       });
 

--- a/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp
@@ -301,10 +301,14 @@ public:
     // TODO(Horibe): check for each velocity range.
     if (std::abs(lon_vel) > 0.01) {
       // Assert over averaged values against limits
-      ASSERT_LT_NEAR(std::abs(avg_lon_acc), max_lon_acc_lim, threshold_scale) << "last_x was = " << last_x;
-      ASSERT_LT_NEAR(std::abs(avg_lon_jerk), max_lon_jerk_lim, threshold_scale) << "last_x was = " << last_x;
-      ASSERT_LT_NEAR(std::abs(avg_lat_acc), max_lat_acc_lim, threshold_scale) << "last_x was = " << last_x;
-      ASSERT_LT_NEAR(std::abs(avg_lat_jerk), max_lat_jerk_lim, threshold_scale) << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lon_acc), max_lon_acc_lim, threshold_scale)
+        << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lon_jerk), max_lon_jerk_lim, threshold_scale)
+        << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lat_acc), max_lat_acc_lim, threshold_scale)
+        << "last_x was = " << last_x;
+      ASSERT_LT_NEAR(std::abs(avg_lat_jerk), max_lat_jerk_lim, threshold_scale)
+        << "last_x was = " << last_x;
     }
   }
 };


### PR DESCRIPTION
## Description

Continuation from:
- https://github.com/autowarefoundation/autoware.universe/pull/6661

Attempts to fix:
- https://github.com/autowarefoundation/autoware.universe/issues/6612

@takayuki5168 -san, I've implemented this variable window length calculation to smooth out the control values.

https://github.com/autowarefoundation/autoware.universe/blob/9f319571cd7a4270aa67d8c07e812b4b569e301e/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp#L84-L86

`checkFilter(2)` should work same as the original implementation.

But higher values will will average over 3 or more values for buffering spiky test results.

## Tests performed

### Local machine

`colcon test --event-handlers console_cohesion+ --packages-select vehicle_cmd_gate` passes successfully with or without this PR.

### CI runners

#### Test with `checkFilter(2)` ❌, 👌

- https://github.com/autowarefoundation/autoware.universe/actions/runs/8381358377/job/22952704965?pr=6665#step:8:441

Ok, with `checkFilter(2)`, it has failed the same way as expected.
```
1: last_x:        2 
1: /__w/autoware.universe/autoware.universe/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp:304: Failure
1: Expected: (std::abs(avg_lon_jerk)) < (max_lon_jerk_lim * threshold_scale), actual: 1.59257 vs 1.54
```

Now removing the `checkFilter(2)`.

#### Test with `checkFilter(3) and checkFilter(4)` ✅

- https://github.com/autowarefoundation/autoware.universe/actions/runs/8381601303/job/22953511628?pr=6665#step:8:1537

It worked for the both tests 😄

Now will remove the redundant print line.

https://github.com/autowarefoundation/autoware.universe/blob/3e2f33b4c2e2c35274bc5e4ad36f887b7b74472c/control/vehicle_cmd_gate/test/src/test_filter_in_vehicle_cmd_gate_node.cpp#L301

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
