### PR TITLE
fix(planning_validator): calculate max lateral acceleration after resampling trajectory

### DIFF
--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -302,7 +302,6 @@ void PlanningValidator::validate(const Trajectory & trajectory)
   }
 
   s.is_valid_interval = checkValidInterval(trajectory);
-  s.is_valid_lateral_acc = checkValidLateralAcceleration(trajectory);
   s.is_valid_longitudinal_max_acc = checkValidMaxLongitudinalAcceleration(trajectory);
   s.is_valid_longitudinal_min_acc = checkValidMinLongitudinalAcceleration(trajectory);
   s.is_valid_velocity_deviation = checkValidVelocityDeviation(trajectory);
@@ -317,6 +316,7 @@ void PlanningValidator::validate(const Trajectory & trajectory)
 
   s.is_valid_relative_angle = checkValidRelativeAngle(resampled);
   s.is_valid_curvature = checkValidCurvature(resampled);
+  s.is_valid_lateral_acc = checkValidLateralAcceleration(resampled);
   s.is_valid_steering = checkValidSteering(resampled);
   s.is_valid_steering_rate = checkValidSteeringRate(resampled);
 


### PR DESCRIPTION
## Description
Related JIRA Ticket:  https://tier4.atlassian.net/browse/RT0-29352

In the planning validator, among other checks, the max lateral acceleration is calculated and checked whether it is larger than 1G [ms^2] or not from an input of trajectory. The lateral accelerations are calculated from longitudinal velocities and curvatures at every trajectory points.

The validation function in the planning validator includes two internal trajectory variables, namely `trajectory`, an input from the motion velocity smoother which is densely sampled near the ego and sparsely sampled otherwise with the policy explained [here](https://autowarefoundation.github.io/autoware.universe/main/planning/motion_velocity_smoother/#resample-trajectory) , and `resampled`, representing the same path as `trajectory` but wholly sparsely resampled with the interval of 1~2m.

This PR puts the lateral acceleration check process after resampling of trajectory for the purpose of numerically safer calculations of curvatures.
## Tests performed
I confirmed the normal operation with the latest version of Autoware in the planning simulation [here](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/).

## Effects on system behavior
Effects on the resulting max lateral accelerations would be small as the [curvature calcuation](https://github.com/autowarefoundation/autoware.universe/blob/e903d11d1fcba308325da3995a912d74bf0dcab2/planning/planning_validator/src/utils.cpp#L93-L154) is originally done after resampling the trajectory with the interval of about 1m.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
