### PR TITLE
feat(perception_online_evaluator): unify debug markers instead of separating for each object

### DIFF
--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/marker_utils.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/marker_utils.hpp
@@ -63,8 +63,8 @@ MarkerArray createPoseMarkerArray(
   const float & b);
 
 MarkerArray createPosesMarkerArray(
-  const std::vector<Pose> poses, std::string && ns, const float & r, const float & g,
-  const float & b, const float & x_scale = 0.5, const float & y_scale = 0.2,
+  const std::vector<Pose> poses, std::string && ns, const int32_t & first_id, const float & r,
+  const float & g, const float & b, const float & x_scale = 0.5, const float & y_scale = 0.2,
   const float & z_scale = 0.2);
 
 std_msgs::msg::ColorRGBA createColorFromString(const std::string & str);
@@ -75,7 +75,7 @@ MarkerArray createObjectPolygonMarkerArray(
 
 MarkerArray createDeviationLines(
   const std::vector<Pose> poses1, const std::vector<Pose> poses2, const std::string & ns,
-  const float r, const float g, const float b);
+  const int32_t & first_id, const float r, const float g, const float b);
 
 }  // namespace marker_utils
 

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -132,50 +132,76 @@ void PerceptionOnlineEvaluatorNode::publishDebugMarker()
     tier4_autoware_utils::appendMarkerArray(added, &marker);
   };
 
-  const auto history_path_map = metrics_calculator_.getHistoryPathMap();
   const auto & p = parameters_->debug_marker_parameters;
 
-  for (const auto & [uuid, history_path] : history_path_map) {
-    {
-      const auto c = createColorFromString(uuid + "_raw");
-      if (p.show_history_path) {
-        add(createPointsMarkerArray(history_path.first, "history_path_" + uuid, 0, c.r, c.g, c.b));
+  // visualize history path
+  {
+    const auto history_path_map = metrics_calculator_.getHistoryPathMap();
+    int32_t history_path_first_id = 0;
+    int32_t smoothed_history_path_first_id = 0;
+    size_t i = 0;
+    for (auto it = history_path_map.begin(); it != history_path_map.end(); ++it) {
+      const auto & [uuid, history_path] = *it;
+      {
+        const auto c = createColorFromString(uuid + "_raw");
+        if (p.show_history_path) {
+          add(createPointsMarkerArray(history_path.first, "history_path", i, c.r, c.g, c.b));
+        }
+        if (p.show_history_path_arrows) {
+          add(createPosesMarkerArray(
+            history_path.first, "history_path_arrows", history_path_first_id, c.r, c.g, c.b, 0.1,
+            0.05, 0.05));
+          history_path_first_id += history_path.first.size();
+        }
       }
-      if (p.show_history_path_arrows) {
-        add(createPosesMarkerArray(
-          history_path.first, "history_path_arrows_" + uuid, c.r, c.g, c.b, 0.1, 0.05, 0.05));
+      {
+        const auto c = createColorFromString(uuid);
+        if (p.show_smoothed_history_path) {
+          add(createPointsMarkerArray(
+            history_path.second, "smoothed_history_path", i, c.r, c.g, c.b));
+        }
+        if (p.show_smoothed_history_path_arrows) {
+          add(createPosesMarkerArray(
+            history_path.second, "smoothed_history_path_arrows", smoothed_history_path_first_id,
+            c.r, c.g, c.b, 0.1, 0.05, 0.05));
+          smoothed_history_path_first_id += history_path.second.size();
+        }
       }
-    }
-    {
-      const auto c = createColorFromString(uuid);
-      if (p.show_smoothed_history_path) {
-        add(createPointsMarkerArray(
-          history_path.second, "smoothed_history_path_" + uuid, 0, c.r, c.g, c.b));
-      }
-      if (p.show_smoothed_history_path_arrows) {
-        add(createPosesMarkerArray(
-          history_path.second, "smoothed_history_path_arrows_" + uuid, c.r, c.g, c.b, 0.1, 0.05,
-          0.05));
-      }
+      i++;
     }
   }
-  const auto object_data_map = metrics_calculator_.getDebugObjectData();
-  for (const auto & [uuid, object_data] : object_data_map) {
-    const auto c = createColorFromString(uuid);
-    const auto predicted_path = object_data.getPredictedPath();
-    const auto history_path = object_data.getHistoryPath();
-    if (p.show_predicted_path) {
-      add(createPosesMarkerArray(predicted_path, "predicted_path_" + uuid, 0, 0, 1));
-    }
-    if (p.show_predicted_path_gt) {
-      add(createPosesMarkerArray(history_path, "predicted_path_gt_" + uuid, 1, 0, 0));
-    }
-    if (p.show_deviation_lines) {
-      add(createDeviationLines(predicted_path, history_path, "deviation_lines_" + uuid, 1, 1, 1));
-    }
-    if (p.show_object_polygon) {
-      add(createObjectPolygonMarkerArray(
-        object_data.object, "object_polygon_" + uuid, 0, c.r, c.g, c.b));
+
+  // visualize predicted path of past objects
+  {
+    int32_t predicted_path_first_id = 0;
+    int32_t history_path_first_id = 0;
+    int32_t deviation_lines_first_id = 0;
+    size_t i = 0;
+    const auto object_data_map = metrics_calculator_.getDebugObjectData();
+    for (auto it = object_data_map.begin(); it != object_data_map.end(); ++it) {
+      const auto & [uuid, object_data] = *it;
+      const auto c = createColorFromString(uuid);
+      const auto predicted_path = object_data.getPredictedPath();
+      const auto history_path = object_data.getHistoryPath();
+      if (p.show_predicted_path) {
+        add(createPosesMarkerArray(
+          predicted_path, "predicted_path", predicted_path_first_id, 0, 0, 1));
+        predicted_path_first_id += predicted_path.size();
+      }
+      if (p.show_predicted_path_gt) {
+        add(createPosesMarkerArray(
+          history_path, "predicted_path_gt", history_path_first_id, 1, 0, 0));
+        history_path_first_id += history_path.size();
+      }
+      if (p.show_deviation_lines) {
+        add(createDeviationLines(
+          predicted_path, history_path, "deviation_lines", deviation_lines_first_id, 1, 1, 1));
+        deviation_lines_first_id += predicted_path.size();
+      }
+      if (p.show_object_polygon) {
+        add(createObjectPolygonMarkerArray(object_data.object, "object_polygon", i, c.r, c.g, c.b));
+      }
+      i++;
     }
   }
 

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -140,8 +140,7 @@ void PerceptionOnlineEvaluatorNode::publishDebugMarker()
     int32_t history_path_first_id = 0;
     int32_t smoothed_history_path_first_id = 0;
     size_t i = 0;
-    for (auto it = history_path_map.begin(); it != history_path_map.end(); ++it) {
-      const auto & [uuid, history_path] = *it;
+    for (const auto & [uuid, history_path] : history_path_map) {
       {
         const auto c = createColorFromString(uuid + "_raw");
         if (p.show_history_path) {
@@ -178,8 +177,7 @@ void PerceptionOnlineEvaluatorNode::publishDebugMarker()
     int32_t deviation_lines_first_id = 0;
     size_t i = 0;
     const auto object_data_map = metrics_calculator_.getDebugObjectData();
-    for (auto it = object_data_map.begin(); it != object_data_map.end(); ++it) {
-      const auto & [uuid, object_data] = *it;
+    for (const auto & [uuid, object_data] : object_data_map) {
       const auto c = createColorFromString(uuid);
       const auto predicted_path = object_data.getPredictedPath();
       const auto history_path = object_data.getHistoryPath();

--- a/evaluator/perception_online_evaluator/src/utils/marker_utils.cpp
+++ b/evaluator/perception_online_evaluator/src/utils/marker_utils.cpp
@@ -111,14 +111,14 @@ MarkerArray createPointsMarkerArray(
 
 MarkerArray createDeviationLines(
   const std::vector<Pose> poses1, const std::vector<Pose> poses2, const std::string & ns,
-  const float r, const float g, const float b)
+  const int32_t & first_id, const float r, const float g, const float b)
 {
   MarkerArray msg;
 
   const size_t max_idx = std::min(poses1.size(), poses2.size());
   for (size_t i = 0; i < max_idx; ++i) {
     auto marker = createDefaultMarker(
-      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, i, Marker::LINE_STRIP,
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, first_id + i, Marker::LINE_STRIP,
       createMarkerScale(0.005, 0.0, 0.0), createMarkerColor(r, g, b, 0.5));
     marker.points.push_back(poses1.at(i).position);
     marker.points.push_back(poses2.at(i).position);
@@ -144,14 +144,15 @@ MarkerArray createPoseMarkerArray(
 }
 
 MarkerArray createPosesMarkerArray(
-  const std::vector<Pose> poses, std::string && ns, const float & r, const float & g,
-  const float & b, const float & x_scale, const float & y_scale, const float & z_scale)
+  const std::vector<Pose> poses, std::string && ns, const int32_t & first_id, const float & r,
+  const float & g, const float & b, const float & x_scale, const float & y_scale,
+  const float & z_scale)
 {
   MarkerArray msg;
 
   for (size_t i = 0; i < poses.size(); ++i) {
     Marker marker = createDefaultMarker(
-      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, i, Marker::ARROW,
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, first_id + i, Marker::ARROW,
       createMarkerScale(x_scale, y_scale, z_scale), createMarkerColor(r, g, b, 0.5));
     marker.pose = poses.at(i);
     msg.markers.push_back(marker);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

making debug marker for each uuid objects is heavy, so unify the markers.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/bcc6e0ac-891f-44a5-a951-77c49696ca46)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/de4b4811-42a5-47bd-8fab-378c21d3eecc)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
