### PR TITLE
feat(perception_online_evaluator): extract moving object for deviation check

### DIFF
--- a/evaluator/perception_online_evaluator/param/perception_online_evaluator.defaults.yaml
+++ b/evaluator/perception_online_evaluator/param/perception_online_evaluator.defaults.yaml
@@ -11,7 +11,7 @@
 
     prediction_time_horizons: [1.0, 2.0, 3.0, 5.0]
 
-    stopped_velocity_threshold: 0.3
+    stopped_velocity_threshold: 1.0
 
     target_object:
       car:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

1. extract moving objects to check 
- predicted path deviation
- yaw deviation
- lateral deviation
because these deviation of stopped object is noisy.
yaw rate for stopped objects is checked by
https://github.com/autowarefoundation/autoware.universe/pull/6667

2. make smoothing path stable.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- psim with perception replyer

before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/5e6b361b-2a35-4497-8c6e-06df45df8d3d)


after

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/ddc6ab28-4003-4e2e-bc8c-874af7b85054)

- unit test


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
