### PR TITLE
feat(dynamic_obstacle_stop): use a time buffer for each dynamic objects

### DIFF
--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/README.md
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/README.md
@@ -27,8 +27,6 @@ In addition to these 4 steps, 2 mechanisms are in place to make the stop point o
 The `hysteresis` parameter is used when a stop point was already being inserted in the previous iteration
 and it increases the range where dynamic objects are considered close enough to the ego path to be used by the module.
 
-The `decision_duration_buffer` parameter defines the duration when the module will keep inserted the previous stop point, even after no collisions were found.
-
 #### Filter dynamic objects
 
 ![filtering example](docs/DynamicObstacleStop-Filtering.drawio.svg)
@@ -75,6 +73,15 @@ If a stop point was inserted in the previous iteration of the module, its arc le
 Finally,
 the stop point arc length is calculated to be the arc length of the previously found collision point minus the `stop_distance_buffer` and the ego vehicle longitudinal offset, clamped between the minimum and maximum values.
 
+#### Duration buffer
+
+To prevent chatter caused by noisy perception, two duration parameters are used.
+
+- `add_stop_duration_buffer` represents the duration of consecutive collision detection with an object for the corresponding stop point to be added.
+- `remove_stop_duration_buffer` represents the duration of consecutive non-detection of collision with an object for the corresponding stop point to be removed.
+
+Timers and collision points are tracked for each dynamic object independently.
+
 ### Module Parameters
 
 | Parameter                               | Type   | Description                                                                                                        |
@@ -84,6 +91,7 @@ the stop point arc length is calculated to be the arc length of the previously f
 | `stop_distance_buffer`                  | double | [m] extra distance to add between the stop point and the collision point                                           |
 | `time_horizon`                          | double | [s] time horizon used for collision checks                                                                         |
 | `hysteresis`                            | double | [m] once a collision has been detected, this hysteresis is used on the collision detection                         |
-| `decision_duration_buffer`              | double | [s] duration between no collision being detected and the stop decision being cancelled                             |
+| `add_stop_duration_buffer`              | double | [s] duration where a collision must be continuously detected before a stop decision is added                       |
+| `remove_stop_duration_buffer`           | double | [s] duration between no collision being detected and the stop decision being remove                                |
 | `minimum_object_distance_from_ego_path` | double | [m] minimum distance between the footprints of ego and an object to consider for collision                         |
 | `ignore_unavoidable_collisions`         | bool   | [-] if true, ignore collisions that cannot be avoided by stopping (assuming the obstacle continues going straight) |

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/config/dynamic_obstacle_stop.param.yaml
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/config/dynamic_obstacle_stop.param.yaml
@@ -6,6 +6,7 @@
       stop_distance_buffer: 0.5  # [m] extra distance to add between the stop point and the collision point
       time_horizon: 5.0  # [s] time horizon used for collision checks
       hysteresis: 1.0  # [m] once a collision has been detected, this hysteresis is used on the collision detection
-      decision_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being cancelled
+      add_stop_duration_buffer : 0.5  # [s] duration where a collision must be continuously detected before a stop decision is added
+      remove_stop_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being remove
       minimum_object_distance_from_ego_path: 1.0  # [m] minimum distance between the footprints of ego and an object to consider for collision
       ignore_unavoidable_collisions : true  # if true, ignore collisions that cannot be avoided by stopping (assuming the obstacle continues going straight)

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.cpp
@@ -16,56 +16,68 @@
 
 #include <motion_utils/trajectory/trajectory.hpp>
 #include <tier4_autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <tier4_autoware_utils/ros/uuid_helper.hpp>
 
 #include <boost/geometry.hpp>
 
+#include <limits>
 #include <optional>
 #include <vector>
 
 namespace behavior_velocity_planner::dynamic_obstacle_stop
 {
 
-std::optional<geometry_msgs::msg::Point> find_earliest_collision(
-  const EgoData & ego_data,
-  const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & objects,
-  const tier4_autoware_utils::MultiPolygon2d & obstacle_forward_footprints, DebugData & debug_data)
+std::optional<geometry_msgs::msg::Point> find_closest_collision_point(
+  const EgoData & ego_data, const geometry_msgs::msg::Pose & object_pose,
+  const tier4_autoware_utils::Polygon2d & object_footprint)
 {
-  auto earliest_idx = ego_data.path_footprints.size();
-  auto earliest_arc_length = motion_utils::calcArcLength(ego_data.path.points);
-  std::optional<geometry_msgs::msg::Point> earliest_collision_point;
-  debug_data.collisions.clear();
+  std::optional<geometry_msgs::msg::Point> closest_collision_point;
+  auto closest_dist = std::numeric_limits<double>::max();
   std::vector<BoxIndexPair> rough_collisions;
-  for (auto obstacle_idx = 0UL; obstacle_idx < objects.size(); ++obstacle_idx) {
-    rough_collisions.clear();
-    const auto & obstacle_pose = objects[obstacle_idx].kinematics.initial_pose_with_covariance.pose;
-    const auto & obstacle_footprint = obstacle_forward_footprints[obstacle_idx];
-    ego_data.rtree.query(
-      boost::geometry::index::intersects(obstacle_footprint), std::back_inserter(rough_collisions));
-    for (const auto & rough_collision : rough_collisions) {
-      const auto path_idx = rough_collision.second;
-      const auto & ego_footprint = ego_data.path_footprints[path_idx];
-      const auto & ego_pose = ego_data.path.points[ego_data.first_path_idx + path_idx].point.pose;
-      const auto angle_diff = tier4_autoware_utils::normalizeRadian(
-        tf2::getYaw(ego_pose.orientation) - tf2::getYaw(obstacle_pose.orientation));
-      if (path_idx <= earliest_idx && std::abs(angle_diff) > (M_PI_2 + M_PI_4)) {
-        tier4_autoware_utils::MultiPoint2d collision_points;
-        boost::geometry::intersection(
-          obstacle_footprint.outer(), ego_footprint.outer(), collision_points);
-        earliest_idx = path_idx;
-        for (const auto & coll_p : collision_points) {
-          auto p = geometry_msgs::msg::Point().set__x(coll_p.x()).set__y(coll_p.y());
-          const auto arc_length =
-            motion_utils::calcSignedArcLength(ego_data.path.points, ego_data.first_path_idx, p);
-          if (arc_length < earliest_arc_length) {
-            earliest_arc_length = arc_length;
-            debug_data.collisions = {obstacle_footprint, ego_footprint};
-            earliest_collision_point = p;
-          }
+  ego_data.rtree.query(
+    boost::geometry::index::intersects(object_footprint), std::back_inserter(rough_collisions));
+  for (const auto & rough_collision : rough_collisions) {
+    const auto path_idx = rough_collision.second;
+    const auto & ego_footprint = ego_data.path_footprints[path_idx];
+    const auto & ego_pose = ego_data.path.points[path_idx].point.pose;
+    const auto angle_diff = tier4_autoware_utils::normalizeRadian(
+      tf2::getYaw(ego_pose.orientation) - tf2::getYaw(object_pose.orientation));
+    if (std::abs(angle_diff) > (M_PI_2 + M_PI_4)) {  // TODO(Maxime): make this angle a parameter
+      tier4_autoware_utils::MultiPoint2d collision_points;
+      boost::geometry::intersection(
+        object_footprint.outer(), ego_footprint.outer(), collision_points);
+      for (const auto & coll_p : collision_points) {
+        auto p = geometry_msgs::msg::Point().set__x(coll_p.x()).set__y(coll_p.y());
+        const auto dist_to_ego =
+          motion_utils::calcSignedArcLength(ego_data.path.points, ego_data.pose.position, p);
+        if (dist_to_ego < closest_dist) {
+          closest_dist = dist_to_ego;
+          closest_collision_point = p;
         }
       }
     }
   }
-  return earliest_collision_point;
+  return closest_collision_point;
+}
+
+std::vector<Collision> find_collisions(
+  const EgoData & ego_data,
+  const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & objects,
+  const tier4_autoware_utils::MultiPolygon2d & object_forward_footprints)
+{
+  std::vector<Collision> collisions;
+  for (auto object_idx = 0UL; object_idx < objects.size(); ++object_idx) {
+    const auto & object_pose = objects[object_idx].kinematics.initial_pose_with_covariance.pose;
+    const auto & object_footprint = object_forward_footprints[object_idx];
+    const auto collision = find_closest_collision_point(ego_data, object_pose, object_footprint);
+    if (collision) {
+      Collision c;
+      c.object_uuid = tier4_autoware_utils::toHexString(objects[object_idx].object_id);
+      c.point = *collision;
+      collisions.push_back(c);
+    }
+  }
+  return collisions;
 }
 
 }  // namespace behavior_velocity_planner::dynamic_obstacle_stop

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.hpp
@@ -22,17 +22,24 @@
 
 namespace behavior_velocity_planner::dynamic_obstacle_stop
 {
+/// @brief find the first collision along an object footprint and the ego path
+/// @param [in] ego_data ego data including its path and footprint
+/// @param [in] object_pose pose of the dynamic object
+/// @param [in] object_footprint footprint of the object used for finding a collision
+/// @return the first collision point along the object footprint (if any)
+std::optional<geometry_msgs::msg::Point> find_first_collision_point(
+  const EgoData & ego_data, const geometry_msgs::msg::Pose & object_pose,
+  const tier4_autoware_utils::Polygon2d & object_footprint);
 
 /// @brief find the earliest collision along the ego path and an obstacle footprint
 /// @param [in] ego_data ego data including its path and footprint
 /// @param [in] objects obstacles
 /// @param [in] obstacle_forward_footprints obstacle footprints
-/// @param [in] debug_data debug data
 /// @return the point of earliest collision along the ego path
-std::optional<geometry_msgs::msg::Point> find_earliest_collision(
+std::vector<Collision> find_collisions(
   const EgoData & ego_data,
   const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & objects,
-  const tier4_autoware_utils::MultiPolygon2d & obstacle_forward_footprints, DebugData & debug_data);
+  const tier4_autoware_utils::MultiPolygon2d & obstacle_forward_footprints);
 
 }  // namespace behavior_velocity_planner::dynamic_obstacle_stop
 

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/collision.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,19 +22,19 @@
 
 namespace behavior_velocity_planner::dynamic_obstacle_stop
 {
-/// @brief find the first collision along an object footprint and the ego path
-/// @param [in] ego_data ego data including its path and footprint
+/// @brief find the collision point closest to ego along an object footprint
+/// @param [in] ego_data ego data including its path and footprints used for finding a collision
 /// @param [in] object_pose pose of the dynamic object
 /// @param [in] object_footprint footprint of the object used for finding a collision
-/// @return the first collision point along the object footprint (if any)
-std::optional<geometry_msgs::msg::Point> find_first_collision_point(
+/// @return the collision point closest to ego (if any)
+std::optional<geometry_msgs::msg::Point> find_closest_collision_point(
   const EgoData & ego_data, const geometry_msgs::msg::Pose & object_pose,
   const tier4_autoware_utils::Polygon2d & object_footprint);
 
-/// @brief find the earliest collision along the ego path and an obstacle footprint
+/// @brief find the earliest collision along the ego path
 /// @param [in] ego_data ego data including its path and footprint
 /// @param [in] objects obstacles
-/// @param [in] obstacle_forward_footprints obstacle footprints
+/// @param [in] obstacle_forward_footprints obstacle footprints to check for collisions
 /// @return the point of earliest collision along the ego path
 std::vector<Collision> find_collisions(
   const EgoData & ego_data,

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.cpp
@@ -14,6 +14,8 @@
 
 #include "debug.hpp"
 
+#include "types.hpp"
+
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 
 #include <visualization_msgs/msg/marker.hpp>
@@ -36,22 +38,46 @@ std::vector<visualization_msgs::msg::Marker> make_delete_markers(
   return markers;
 }
 
-std::vector<visualization_msgs::msg::Marker> make_dynamic_obstacle_markers(
-  const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & obstacles)
+void add_markers(
+  visualization_msgs::msg::MarkerArray & array, size_t & prev_nb,
+  const std::vector<visualization_msgs::msg::Marker> & markers, const std::string & ns)
+{
+  array.markers.insert(array.markers.end(), markers.begin(), markers.end());
+  const auto delete_markers = debug::make_delete_markers(markers.size(), prev_nb, ns);
+  array.markers.insert(array.markers.end(), delete_markers.begin(), delete_markers.end());
+  prev_nb = markers.size();
+}
+
+std::vector<visualization_msgs::msg::Marker> make_collision_markers(
+  const ObjectStopDecisionMap & object_map, const std::string & ns, const double z,
+  const rclcpp::Time & now)
 {
   std::vector<visualization_msgs::msg::Marker> markers;
   visualization_msgs::msg::Marker marker;
   marker.header.frame_id = "map";
   marker.header.stamp = rclcpp::Time(0);
-  marker.ns = "dynamic_obstacles";
+  marker.ns = ns;
   marker.id = 0;
-  marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.scale = tier4_autoware_utils::createMarkerScale(1.0, 1.0, 1.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(1.0, 0.1, 0.1, 1.0);
-  marker.text = "dynamic obstacle";
-  for (const auto & obstacle : obstacles) {
-    marker.pose = obstacle.kinematics.initial_pose_with_covariance.pose;
+  marker.scale = tier4_autoware_utils::createMarkerScale(0.2, 0.2, 0.5);
+  marker.color = tier4_autoware_utils::createMarkerColor(0.6, 0.0, 0.6, 1.0);
+  for (const auto & [object_uuid, decision] : object_map) {
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.text = object_uuid.substr(0, 5) + "\n";
+    if (decision.should_be_avoided()) {
+      marker.text += "avoiding\nlast detection = ";
+      marker.text += std::to_string((now - *decision.last_stop_decision_time).seconds());
+      marker.text += "s\n";
+    } else {
+      marker.text += "first detection = ";
+      marker.text += std::to_string((now - *decision.start_detection_time).seconds());
+      marker.text += "s\n";
+    }
+    marker.pose.position = decision.collision_point;
+    marker.pose.position.z = z;
+    markers.push_back(marker);
+    ++marker.id;
+    marker.type = visualization_msgs::msg::Marker::SPHERE;
     markers.push_back(marker);
     ++marker.id;
   }

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.hpp
@@ -17,10 +17,12 @@
 
 #include "types.hpp"
 
+#include <rclcpp/time.hpp>
 #include <tier4_autoware_utils/geometry/boost_geometry.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_object.hpp>
 #include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <string>
 #include <vector>
@@ -29,12 +31,14 @@ namespace behavior_velocity_planner::dynamic_obstacle_stop::debug
 {
 std::vector<visualization_msgs::msg::Marker> make_delete_markers(
   const size_t from, const size_t to, const std::string & ns);
-std::vector<visualization_msgs::msg::Marker> make_dynamic_obstacle_markers(
-  const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & obstacles);
+void add_markers(
+  visualization_msgs::msg::MarkerArray & array, size_t & prev_nb,
+  const std::vector<visualization_msgs::msg::Marker> & markers, const std::string & ns);
+std::vector<visualization_msgs::msg::Marker> make_collision_markers(
+  const ObjectStopDecisionMap & object_map, const std::string & ns, const double z,
+  const rclcpp::Time & now);
 std::vector<visualization_msgs::msg::Marker> make_polygon_markers(
   const tier4_autoware_utils::MultiPolygon2d & footprints, const std::string & ns, const double z);
-std::vector<visualization_msgs::msg::Marker> make_collision_markers(
-  const tier4_autoware_utils::MultiPoint2d & collisions, const double z);
 }  // namespace behavior_velocity_planner::dynamic_obstacle_stop::debug
 
 #endif  // DEBUG_HPP_

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/debug.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DEBUG_HPP_
 #define DEBUG_HPP_
 
+#include "object_stop_decision.hpp"
 #include "types.hpp"
 
 #include <rclcpp/time.hpp>

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/manager.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/manager.cpp
@@ -35,8 +35,9 @@ DynamicObstacleStopModuleManager::DynamicObstacleStopModuleManager(rclcpp::Node 
   pp.stop_distance_buffer = getOrDeclareParameter<double>(node, ns + ".stop_distance_buffer");
   pp.time_horizon = getOrDeclareParameter<double>(node, ns + ".time_horizon");
   pp.hysteresis = getOrDeclareParameter<double>(node, ns + ".hysteresis");
-  pp.decision_duration_buffer =
-    getOrDeclareParameter<double>(node, ns + ".decision_duration_buffer");
+  pp.add_duration_buffer = getOrDeclareParameter<double>(node, ns + ".add_stop_duration_buffer");
+  pp.remove_duration_buffer =
+    getOrDeclareParameter<double>(node, ns + ".remove_stop_duration_buffer");
   pp.minimum_object_distance_from_ego_path =
     getOrDeclareParameter<double>(node, ns + ".minimum_object_distance_from_ego_path");
   pp.ignore_unavoidable_collisions =

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_stop_decision.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_stop_decision.cpp
@@ -1,0 +1,69 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "object_stop_decision.hpp"
+
+#include <motion_utils/trajectory/trajectory.hpp>
+
+#include <limits>
+
+namespace behavior_velocity_planner::dynamic_obstacle_stop
+{
+void update_object_map(
+  ObjectStopDecisionMap & object_map, const std::vector<Collision> & collisions,
+  const rclcpp::Time & now,
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & path_points,
+  const PlannerParam & params)
+{
+  for (auto & [object, decision] : object_map) decision.collision_detected = false;
+  for (const auto & collision : collisions) {
+    if (auto search = object_map.find(collision.object_uuid); search != object_map.end()) {
+      search->second.collision_detected = true;
+      const auto is_closer_collision_point =
+        motion_utils::calcSignedArcLength(
+          path_points, search->second.collision_point, collision.point) < 0.0;
+      if (is_closer_collision_point) search->second.collision_point = collision.point;
+    } else {
+      object_map[collision.object_uuid].collision_point = collision.point;
+    }
+  }
+  for (auto it = object_map.begin(); it != object_map.end();) {
+    auto & decision = it->second;
+    decision.update_timers(now, params.add_duration_buffer, params.remove_duration_buffer);
+    if (decision.is_inactive())
+      it = object_map.erase(it);
+    else
+      ++it;
+  }
+}
+
+std::optional<geometry_msgs::msg::Point> find_earliest_collision(
+  const ObjectStopDecisionMap & object_map, const EgoData & ego_data)
+{
+  std::optional<geometry_msgs::msg::Point> earliest_collision;
+  double earliest_collision_arc_length = std::numeric_limits<double>::max();
+  for (auto & [object_uuid, decision] : object_map) {
+    if (decision.should_be_avoided()) {
+      const auto arc_length = motion_utils::calcSignedArcLength(
+        ego_data.path.points, ego_data.pose.position, decision.collision_point);
+      if (arc_length < earliest_collision_arc_length) {
+        earliest_collision_arc_length = arc_length;
+        earliest_collision = decision.collision_point;
+      }
+    }
+  }
+  return earliest_collision;
+}
+
+}  // namespace behavior_velocity_planner::dynamic_obstacle_stop

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_stop_decision.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/object_stop_decision.hpp
@@ -1,0 +1,76 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OBJECT_STOP_DECISION_HPP_
+#define OBJECT_STOP_DECISION_HPP_
+
+#include "types.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace behavior_velocity_planner::dynamic_obstacle_stop
+{
+/// @brief representation of a decision to stop for a dynamic object
+struct ObjectStopDecision
+{
+  geometry_msgs::msg::Point collision_point{};
+  bool collision_detected = true;
+  std::optional<rclcpp::Time> start_detection_time{};
+  std::optional<rclcpp::Time> last_stop_decision_time{};
+
+public:
+  void update_timers(const rclcpp::Time & now, const double add_buffer, const double remove_buffer)
+  {
+    if (collision_detected) {
+      if (!start_detection_time) start_detection_time = now;
+      if ((now - *start_detection_time).seconds() >= add_buffer) last_stop_decision_time = now;
+    } else if (
+      !last_stop_decision_time || (now - *last_stop_decision_time).seconds() >= remove_buffer) {
+      start_detection_time.reset();
+    }
+  }
+  bool should_be_avoided() const { return start_detection_time && last_stop_decision_time; }
+  bool is_inactive() const { return !start_detection_time; }
+};
+using ObjectStopDecisionMap = std::unordered_map<std::string, ObjectStopDecision>;
+
+/// @brief update an object map with the given detected collisions
+/// @details update the collision point of each object in the map (keep the closest one) and its
+/// timers, remove inactive objects and add new ones
+/// @param [inout] object_map object map to update
+/// @param [in] collisions detected collisions (used to update the objects' collision points)
+/// @param [in] now current time (used to update the objects' timers)
+/// @param [in] path_points ego path points (used to determine the closest collision points)
+/// @param [in] params planner parameters
+void update_object_map(
+  ObjectStopDecisionMap & object_map, const std::vector<Collision> & collisions,
+  const rclcpp::Time & now,
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & path_points,
+  const PlannerParam & params);
+
+/// @brief find the earliest collision requiring a stop along the ego path
+/// @param object_map map with the objects to avoid and their corresponding collision points
+/// @param ego_data ego data
+/// @return the earliest collision point (if any)
+std::optional<geometry_msgs::msg::Point> find_earliest_collision(
+  const ObjectStopDecisionMap & object_map, const EgoData & ego_data);
+
+}  // namespace behavior_velocity_planner::dynamic_obstacle_stop
+
+#endif  // OBJECT_STOP_DECISION_HPP_

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/scene_dynamic_obstacle_stop.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/scene_dynamic_obstacle_stop.hpp
@@ -15,6 +15,7 @@
 #ifndef SCENE_DYNAMIC_OBSTACLE_STOP_HPP_
 #define SCENE_DYNAMIC_OBSTACLE_STOP_HPP_
 
+#include "object_stop_decision.hpp"
 #include "types.hpp"
 
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/scene_dynamic_obstacle_stop.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/scene_dynamic_obstacle_stop.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,8 +48,7 @@ public:
 
 private:
   PlannerParam params_;
-  rclcpp::Time prev_stop_decision_time_;
-  std::optional<geometry_msgs::msg::Pose> current_stop_pose_;
+  ObjectStopDecisionMap object_map_;
 
 protected:
   int64_t module_id_{};

--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/types.hpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/types.hpp
@@ -26,7 +26,6 @@
 
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -85,29 +84,6 @@ struct Collision
   geometry_msgs::msg::Point point;
   std::string object_uuid;
 };
-
-struct ObjectStopDecision
-{
-  geometry_msgs::msg::Point collision_point{};
-  bool collision_detected = true;
-  std::optional<rclcpp::Time> start_detection_time{};
-  std::optional<rclcpp::Time> last_stop_decision_time{};
-
-public:
-  void update_timers(const rclcpp::Time & now, const double add_buffer, const double remove_buffer)
-  {
-    if (collision_detected) {
-      if (!start_detection_time) start_detection_time = now;
-      if ((now - *start_detection_time).seconds() >= add_buffer) last_stop_decision_time = now;
-    } else if (
-      !last_stop_decision_time || (now - *last_stop_decision_time).seconds() >= remove_buffer) {
-      start_detection_time.reset();
-    }
-  }
-  bool should_be_avoided() const { return start_detection_time && last_stop_decision_time; }
-  bool is_inactive() const { return !start_detection_time; }
-};
-using ObjectStopDecisionMap = std::unordered_map<std::string, ObjectStopDecision>;
 }  // namespace behavior_velocity_planner::dynamic_obstacle_stop
 
 #endif  // TYPES_HPP_


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Add a time buffer for each dynamic object to add/remove the decision to stop.
Also improve debug markers to clearly show the state of the markers of each dynamic object.
Required launch PR: https://github.com/autowarefoundation/autoware_launch/pull/933

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
