### PR TITLE
fix(lane_change): do not return empty path if no valid path

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -104,10 +104,6 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   resetPathCandidate();
   resetPathReference();
 
-  if (!module_type_->isValidPath()) {
-    return {};
-  }
-
   auto output = module_type_->generateOutput();
   path_reference_ = std::make_shared<PathWithLaneId>(output.reference_path);
   *prev_approved_path_ = getPreviousModuleOutput().path;

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -195,7 +195,7 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
 {
   BehaviorModuleOutput output;
 
-  if(!status_.is_valid_path){
+  if (!status_.is_valid_path) {
     output.path = prev_module_path_;
     output.reference_path = prev_module_reference_path_;
     output.drivable_area_info = prev_drivable_area_info_;

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -195,6 +195,14 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
 {
   BehaviorModuleOutput output;
 
+  if(!status_.is_valid_path){
+    output.path = prev_module_path_;
+    output.reference_path = prev_module_reference_path_;
+    output.drivable_area_info = prev_drivable_area_info_;
+    output.turn_signal_info = prev_turn_signal_info_;
+    return output;
+  }
+
   if (isAbortState() && abort_path_) {
     output.path = abort_path_->path;
     output.reference_path = prev_module_reference_path_;


### PR DESCRIPTION
## Description

When lane change plans for lane changing path, when there is no valid path, it will return empty path. When the empty path is sent to the next module, it causes the module to die. In this case, it is the Avoidance  module.
```
[component_container_mt-73]     @     0x7f7a1aa8f7f3 abort
[component_container_mt-73]     @     0x7f7a1aaf0676 (unknown)
[component_container_mt-73]     @     0x7f7a1ab07cfc (unknown)
[component_container_mt-73]     @     0x7f7a1ab09a44 (unknown)
[component_container_mt-73]     @     0x7f7a1ab0c453 free
[component_container_mt-73]     @     0x7f79eddf7dad autoware_auto_planning_msgs::msg::PathWithLaneId_<>::operator=()
[component_container_mt-73]     @     0x7f79eddf4998 behavior_path_planner::AvoidanceModule::updateData()
[component_container_mt-73]     @     0x7f79eddf5348 behavior_path_planner::SceneModuleInterface::run()
[component_container_mt-73]     @     0x7f7a145776af behavior_path_planner::PlannerManager::run()
[component_container_mt-73]     @     0x7f7a14536a4a behavior_path_planner::PlannerManager::runApprovedModules()
[component_container_mt-73]     @     0x7f7a1453bb99 _ZZN21behavior_path_planner14PlannerManager3runERKSt10shared_ptrINS_11PlannerDataEEENKUlvE0_clEv
[component_container_mt-73]     @     0x7f7a1453ca36 behavior_path_planner::PlannerManager::run()
[component_container_mt-73]     @     0x7f7a1458f91a behavior_path_planner::BehaviorPathPlannerNode::run()
[component_container_mt-73]     @     0x7f7a14598b95 rclcpp::GenericTimer<>::execute_callback()
[component_container_mt-73]     @     0x7f7a1b07dffe rclcpp::Executor::execute_any_executable()
[component_container_mt-73]     @     0x7f7a1b084432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-73]     @     0x7f7a1ad8c253 (unknown)
[component_container_mt-73]     @     0x7f7a1aafbac3 (unknown)
[component_container_mt-73]     @     0x7f7a1ab8d850 (unknown)
```

This PR aims to fix this by returning previous module's path if there no no valid lane change path.

## Tests performed

Tested with Odaiba  reference drive `67357a3d-1cd8-4014-9556-e17dae11b0e3_2024-03-14-13-54-05_p0900`. Initially the node dies, with the PR, there is node dying.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
