### PR TITLE
feat(multi_object_tracker): separate timer usage from enable delay compensation flag

### DIFF
--- a/perception/multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -13,6 +13,7 @@
     publish_rate: 10.0
     world_frame_id: map
     enable_delay_compensation: false
+    timer_based_constant_publish_rate: false
 
     # debug parameters
     publish_processing_time: false

--- a/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
@@ -98,6 +98,7 @@ private:
   rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
     detected_object_sub_;
   rclcpp::TimerBase::SharedPtr publish_timer_;  // publish timer
+  rclcpp::Time last_published_time_;
 
   // debugger class
   std::unique_ptr<TrackerDebugger> debugger_;

--- a/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
@@ -97,8 +97,14 @@ private:
     tracked_objects_pub_;
   rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
     detected_object_sub_;
+  bool enable_delay_compensation_;
+  // timer control
   rclcpp::TimerBase::SharedPtr publish_timer_;  // publish timer
   rclcpp::Time last_published_time_;
+  constexpr static double min_publish_interval_ =
+    0.02;  // minimum interval to prevent too many publish[sec]
+  constexpr static double max_publish_delay_ =
+    0.02;  // maximum delay allowed for publisher from input[sec]
 
   // debugger class
   std::unique_ptr<TrackerDebugger> debugger_;
@@ -121,6 +127,7 @@ private:
     const geometry_msgs::msg::Transform & self_transform);
   void sanitizeTracker(
     std::list<std::shared_ptr<Tracker>> & list_tracker, const rclcpp::Time & time);
+  void fixTimerPhase();
   std::shared_ptr<Tracker> createNewTracker(
     const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) const;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR tries to separate timer usage and delay compensation.

- add `timer_based_constant_publish_rate` parameter to utilize timer (default is `false`)
- conventional delay compensation will not use timer to prevent large processing delay

### Problem statement

Previously, `enable_delay_compensation` mode used timer to control publish timing and compensate processing delay.
In this mode, subscription and topic publish is asynchronous. So, there is a problem that it can cause large processing delay depending the phase.

![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/98321eb7-0cb0-4e03-95c5-37774cb05aec)

In the worst case, we got almost 100ms delay! 
![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/dc3d1116-273c-41fd-a3a9-1838be880756)

However, fixing timer publish phase was difficult since the tracking process often does not perform in constant time.
Keep constant publishing rate while controlling publish timing seems unrealistic, so I want to separate those objective and its implementation. 


## Related links

https://tier4.atlassian.net/browse/RT1-5741?atlOrigin=eyJpIjoiOWMwZWRkN2FjZDM0NDlmMzliZjQwZWFiYmE2OGUwYTQiLCJwIjoiaiJ9

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
