### PR TITLE
feat(run_out): add motorcyles to run out module target obstacles

### DIFF
--- a/planning/behavior_velocity_run_out_module/README.md
+++ b/planning/behavior_velocity_run_out_module/README.md
@@ -2,7 +2,7 @@
 
 ### Role
 
-`run_out` is the module that decelerates and stops for dynamic obstacles such as pedestrians and bicycles.
+`run_out` is the module that decelerates and stops for dynamic obstacles such as pedestrians, bicycles and motorcycles.
 
 ![brief](./docs/run_out_overview.svg)
 
@@ -174,6 +174,7 @@ You can choose whether to use this feature by parameter of `slow_down_limit.enab
 | Parameter               | Type   | Description                                                                                                              |
 | ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
 | `detection_method`      | string | [-] candidate: Object, ObjectWithoutPath, Points                                                                         |
+| `target_obstacle_types`      | vector of string | [-] specifies which obstacle types will be considered by the module, if the obstacles classification type is not written here, it will be ignored. candidate: ["PEDESTRIAN", "BICYCLE","MOTORCYCLE"]                                                                     |
 | `use_partition_lanelet` | bool   | [-] whether to use partition lanelet map data                                                                            |
 | `specify_decel_jerk`    | bool   | [-] whether to specify jerk when ego decelerates                                                                         |
 | `stop_margin`           | double | [m] the vehicle decelerates to be able to stop with this margin                                                          |

--- a/planning/behavior_velocity_run_out_module/README.md
+++ b/planning/behavior_velocity_run_out_module/README.md
@@ -171,18 +171,18 @@ You can choose whether to use this feature by parameter of `slow_down_limit.enab
 
 ### Module Parameters
 
-| Parameter               | Type   | Description                                                                                                              |
-| ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `detection_method`      | string | [-] candidate: Object, ObjectWithoutPath, Points                                                                         |
-| `target_obstacle_types`      | vector of string | [-] specifies which obstacle types will be considered by the module, if the obstacles classification type is not written here, it will be ignored. candidate: ["PEDESTRIAN", "BICYCLE","MOTORCYCLE"]                                                                     |
-| `use_partition_lanelet` | bool   | [-] whether to use partition lanelet map data                                                                            |
-| `specify_decel_jerk`    | bool   | [-] whether to specify jerk when ego decelerates                                                                         |
-| `stop_margin`           | double | [m] the vehicle decelerates to be able to stop with this margin                                                          |
-| `passing_margin`        | double | [m] the vehicle begins to accelerate if the vehicle's front in predicted position is ahead of the obstacle + this margin |
-| `deceleration_jerk`     | double | [m/s^3] ego decelerates with this jerk when stopping for obstacles                                                       |
-| `detection_distance`    | double | [m] ahead distance from ego to detect the obstacles                                                                      |
-| `detection_span`        | double | [m] calculate collision with this span to reduce calculation time                                                        |
-| `min_vel_ego_kmph`      | double | [km/h] min velocity to calculate time to collision                                                                       |
+| Parameter               | Type             | Description                                                                                                                                                                                          |
+| ----------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `detection_method`      | string           | [-] candidate: Object, ObjectWithoutPath, Points                                                                                                                                                     |
+| `target_obstacle_types` | vector of string | [-] specifies which obstacle types will be considered by the module, if the obstacles classification type is not written here, it will be ignored. candidate: ["PEDESTRIAN", "BICYCLE","MOTORCYCLE"] |
+| `use_partition_lanelet` | bool             | [-] whether to use partition lanelet map data                                                                                                                                                        |
+| `specify_decel_jerk`    | bool             | [-] whether to specify jerk when ego decelerates                                                                                                                                                     |
+| `stop_margin`           | double           | [m] the vehicle decelerates to be able to stop with this margin                                                                                                                                      |
+| `passing_margin`        | double           | [m] the vehicle begins to accelerate if the vehicle's front in predicted position is ahead of the obstacle + this margin                                                                             |
+| `deceleration_jerk`     | double           | [m/s^3] ego decelerates with this jerk when stopping for obstacles                                                                                                                                   |
+| `detection_distance`    | double           | [m] ahead distance from ego to detect the obstacles                                                                                                                                                  |
+| `detection_span`        | double           | [m] calculate collision with this span to reduce calculation time                                                                                                                                    |
+| `min_vel_ego_kmph`      | double           | [km/h] min velocity to calculate time to collision                                                                                                                                                   |
 
 | Parameter /detection_area | Type   | Description                                  |
 | ------------------------- | ------ | -------------------------------------------- |

--- a/planning/behavior_velocity_run_out_module/config/run_out.param.yaml
+++ b/planning/behavior_velocity_run_out_module/config/run_out.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     run_out:
       detection_method: "Object"  # [-] candidate: Object, ObjectWithoutPath, Points
+      target_obstacle_types: ["PEDESTRIAN", "BICYCLE", "MOTORCYCLE"] # [-] Obstacle types considered by this module
       use_partition_lanelet: true # [-] whether to use partition lanelet map data
       suppress_on_crosswalk: true # [-] whether to suppress on crosswalk lanelet
       specify_decel_jerk: true    # [-] whether to specify jerk when ego decelerates

--- a/planning/behavior_velocity_run_out_module/package.xml
+++ b/planning/behavior_velocity_run_out_module/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_auto_planning_msgs</depend>
   <depend>behavior_velocity_crosswalk_module</depend>
   <depend>behavior_velocity_planner_common</depend>
+  <depend>object_recognition_utils</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/planning/behavior_velocity_run_out_module/package.xml
+++ b/planning/behavior_velocity_run_out_module/package.xml
@@ -23,12 +23,12 @@
   <depend>autoware_auto_planning_msgs</depend>
   <depend>behavior_velocity_crosswalk_module</depend>
   <depend>behavior_velocity_planner_common</depend>
-  <depend>object_recognition_utils</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>message_filters</depend>
   <depend>motion_utils</depend>
+  <depend>object_recognition_utils</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/planning/behavior_velocity_run_out_module/src/manager.cpp
+++ b/planning/behavior_velocity_run_out_module/src/manager.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace behavior_velocity_planner
 {

--- a/planning/behavior_velocity_run_out_module/src/manager.cpp
+++ b/planning/behavior_velocity_run_out_module/src/manager.cpp
@@ -57,6 +57,8 @@ RunOutModuleManager::RunOutModuleManager(rclcpp::Node & node)
   {
     auto & p = planner_param_.run_out;
     p.detection_method = getOrDeclareParameter<std::string>(node, ns + ".detection_method");
+    p.target_obstacle_types =
+      getOrDeclareParameter<std::vector<std::string>>(node, ns + ".target_obstacle_types");
     p.use_partition_lanelet = getOrDeclareParameter<bool>(node, ns + ".use_partition_lanelet");
     p.suppress_on_crosswalk = getOrDeclareParameter<bool>(node, ns + ".suppress_on_crosswalk");
     p.specify_decel_jerk = getOrDeclareParameter<bool>(node, ns + ".specify_decel_jerk");

--- a/planning/behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.cpp
@@ -335,7 +335,8 @@ std::vector<DynamicObstacle> RunOutModule::checkCollisionWithObstacles(
     // detect only pedestrian and bicycle
     if (
       classification != ObjectClassification::PEDESTRIAN &&
-      classification != ObjectClassification::BICYCLE) {
+      classification != ObjectClassification::BICYCLE &&
+      classification != ObjectClassification::MOTORCYCLE) {
       continue;
     }
 

--- a/planning/behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.cpp
@@ -324,22 +324,22 @@ std::vector<DynamicObstacle> RunOutModule::checkCollisionWithObstacles(
   std::vector<geometry_msgs::msg::Point> poly, const float travel_time,
   const std::vector<std::pair<int64_t, lanelet::ConstLanelet>> & crosswalk_lanelets) const
 {
+  using object_recognition_utils::convertLabelToString;
   const auto bg_poly_vehicle = run_out_utils::createBoostPolyFromMsg(poly);
 
   // check collision for each objects
   std::vector<DynamicObstacle> obstacles_collision;
   for (const auto & obstacle : dynamic_obstacles) {
     // get classification that has highest probability
-    const auto classification = run_out_utils::getHighestProbLabel(obstacle.classifications);
-
-    // detect only pedestrian and bicycle
-    if (
-      classification != ObjectClassification::PEDESTRIAN &&
-      classification != ObjectClassification::BICYCLE &&
-      classification != ObjectClassification::MOTORCYCLE) {
+    const auto classification =
+      convertLabelToString(run_out_utils::getHighestProbLabel(obstacle.classifications));
+    const auto & target_obstacle_types = planner_param_.run_out.target_obstacle_types;
+    // detect only pedestrians, bicycles or motorcycles
+    const auto it =
+      std::find(target_obstacle_types.begin(), target_obstacle_types.end(), classification);
+    if (it == target_obstacle_types.end()) {
       continue;
     }
-
     // calculate predicted obstacle pose for min velocity and max velocity
     const auto predicted_obstacle_pose_min_vel =
       calcPredictedObstaclePose(obstacle.predicted_paths, travel_time, obstacle.min_velocity_mps);

--- a/planning/behavior_velocity_run_out_module/src/scene.hpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.hpp
@@ -17,6 +17,7 @@
 
 #include "debug.hpp"
 #include "dynamic_obstacle.hpp"
+#include "object_recognition_utils/object_recognition_utils.hpp"
 #include "state_machine.hpp"
 #include "utils.hpp"
 

--- a/planning/behavior_velocity_run_out_module/src/utils.hpp
+++ b/planning/behavior_velocity_run_out_module/src/utils.hpp
@@ -53,6 +53,7 @@ struct CommonParam
 struct RunOutParam
 {
   std::string detection_method;
+  std::vector<std::string> target_obstacle_types;
   bool use_partition_lanelet;
   bool suppress_on_crosswalk;
   bool specify_decel_jerk;


### PR DESCRIPTION
## Description

Add motorcycles to run out module target obstacles: 
Reasoning: 
There are many situations in which object recognition misrepresents bicycles as motorcycles. It also makes little sense to say that if the ego vehicle needs to suddenly stop for a bicycle, why wouldn't it also stop for a motorcycle? 
## Related links
Ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-5643)

## Tests performed

PSim

## Notes for reviewers

Requires launch changes: https://github.com/autowarefoundation/autoware_launch/pull/936

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Run out module can activate for motorcycles too.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
