### PR TITLE
perf(static_centerline_optimizer): cleanup the package dependencies

### DIFF
--- a/planning/static_centerline_optimizer/CMakeLists.txt
+++ b/planning/static_centerline_optimizer/CMakeLists.txt
@@ -7,8 +7,6 @@ find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED)
 
 rosidl_generate_interfaces(
   static_centerline_optimizer
@@ -25,16 +23,6 @@ ament_auto_add_executable(main
   src/main.cpp
   src/static_centerline_optimizer_node.cpp
   src/utils.cpp
-)
-
-target_include_directories(main
-  SYSTEM PUBLIC
-    ${OpenCV_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIR}
-)
-
-target_link_libraries(main
-  ${OpenCV_LIBRARIES}
 )
 
 if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)

--- a/planning/static_centerline_optimizer/package.xml
+++ b/planning/static_centerline_optimizer/package.xml
@@ -18,8 +18,7 @@
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>behavior_path_planner</depend>
-  <depend>behavior_velocity_planner</depend>
+  <depend>behavior_path_planner_common</depend>
   <depend>geometry_msgs</depend>
   <depend>global_parameter_loader</depend>
   <depend>interpolation</depend>
@@ -43,6 +42,8 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>behavior_path_planner</test_depend>
+  <test_depend>behavior_velocity_planner</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
I found the build time of `static_centerline_optimizer` to be too long and maybe this PR will help.
It simply removes some unused dependencies (opencv and eigen) and moves the `behavior_*_planner`  dependencies to `test_dependencies` (for build we only need `behavior_path_planner_common`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
