### PR TITLE
feat(ndt_scan_matcher): fix first update map

### DIFF
--- a/localization/ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/ndt_scan_matcher/src/map_update_module.cpp
@@ -48,7 +48,8 @@ MapUpdateModule::MapUpdateModule(
 bool MapUpdateModule::should_update_map(const geometry_msgs::msg::Point & position)
 {
   if (last_update_position_ == std::nullopt) {
-    return false;
+    need_rebuild_ = true;
+    return true;
   }
 
   const double dx = position.x - last_update_position_.value().x;


### PR DESCRIPTION
## Description


Since `service_ndt_align` needed to be called after startup for the map point cloud to be loaded,
there was an issue when not performing initial position estimation with NDT.

In particular, with [the PR directly passing the initial position](https://github.com/autowarefoundation/autoware.universe/pull/6692), there was an issue where the map point cloud was not being loaded.

So, I have fixed this issue.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

LSim works.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
