### PR TITLE
feat(tier4_autoware_utils, obstacle_cruise): change to read topic by polling

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
@@ -43,8 +43,8 @@ public:
   {
     rclcpp::MessageInfo message_info;
     T tmp;
-    // "while" is required for the case of Queue size (QoS) is 2 or lager
-    while (subscriber->take(tmp, message_info)) {
+    // The queue size (QoS) must be 1 to get the last message data.
+    if (subscriber->take(tmp, message_info)) {
       data = tmp;
     }
   };

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
@@ -27,6 +27,7 @@ private:
   typename rclcpp::Subscription<T>::SharedPtr subscriber;
 
 public:
+  std::optional<T> data;
   explicit InterProcessPollingReceiver(rclcpp::Node * node, const std::string & topic_name)
   {
     auto noexec_callback_group =
@@ -38,8 +39,7 @@ public:
       topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },
       noexec_subscription_options);
   };
-
-  void takeLastData(std::optional<T> & data)
+  bool takeLatestData()
   {
     rclcpp::MessageInfo message_info;
     T tmp;
@@ -47,6 +47,7 @@ public:
     if (subscriber->take(tmp, message_info)) {
       data = tmp;
     }
+    return data.has_value();
   };
 };
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
@@ -1,0 +1,55 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__ROS__POLLING_RECIEVER_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__POLLING_RECIEVER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace tier4_autoware_utils
+{
+
+template <typename T>
+class InterProcessPollingReciever
+{
+private:
+  typename rclcpp::Subscription<T>::SharedPtr subscriber;
+
+public:
+  explicit InterProcessPollingReciever(rclcpp::Node * node, const std::string & topic_name)
+  {
+    auto noexec_callback_group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    auto noexec_subscription_options = rclcpp::SubscriptionOptions();
+    noexec_subscription_options.callback_group = noexec_callback_group;
+
+    subscriber = node->create_subscription<T>(
+      topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },
+      noexec_subscription_options);
+  };
+
+  void takeLastData(std::optional<T> & data)
+  {
+    rclcpp::MessageInfo message_info;
+    T tmp;
+    // "while" is required for the case of Queue size (QoS) is 2 or lager
+    while (subscriber->take(tmp, message_info)) {
+      data = tmp;
+    }
+  };
+};
+
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__ROS__POLLING_RECIEVER_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_reciever.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TIER4_AUTOWARE_UTILS__ROS__POLLING_RECIEVER_HPP_
-#define TIER4_AUTOWARE_UTILS__ROS__POLLING_RECIEVER_HPP_
+#ifndef TIER4_AUTOWARE_UTILS__ROS__POLLING_RECEIVER_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__POLLING_RECEIVER_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -21,13 +21,13 @@ namespace tier4_autoware_utils
 {
 
 template <typename T>
-class InterProcessPollingReciever
+class InterProcessPollingReceiver
 {
 private:
   typename rclcpp::Subscription<T>::SharedPtr subscriber;
 
 public:
-  explicit InterProcessPollingReciever(rclcpp::Node * node, const std::string & topic_name)
+  explicit InterProcessPollingReceiver(rclcpp::Node * node, const std::string & topic_name)
   {
     auto noexec_callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
@@ -52,4 +52,4 @@ public:
 
 }  // namespace tier4_autoware_utils
 
-#endif  // TIER4_AUTOWARE_UTILS__ROS__POLLING_RECIEVER_HPP_
+#endif  // TIER4_AUTOWARE_UTILS__ROS__POLLING_RECEIVER_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -21,14 +21,14 @@ namespace tier4_autoware_utils
 {
 
 template <typename T>
-class InterProcessPollingReceiver
+class InterProcessPollingSubscriber
 {
 private:
   typename rclcpp::Subscription<T>::SharedPtr subscriber;
+  std::optional<T> data;
 
 public:
-  std::optional<T> data;
-  explicit InterProcessPollingReceiver(rclcpp::Node * node, const std::string & topic_name)
+  explicit InterProcessPollingSubscriber(rclcpp::Node * node, const std::string & topic_name)
   {
     auto noexec_callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
@@ -39,7 +39,7 @@ public:
       topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },
       noexec_subscription_options);
   };
-  bool takeLatestData()
+  std::optional<T> takeLatestData()
   {
     rclcpp::MessageInfo message_info;
     T tmp;
@@ -47,10 +47,10 @@ public:
     if (subscriber->take(tmp, message_info)) {
       data = tmp;
     }
-    return data.has_value();
+    return data;
   };
 };
 
 }  // namespace tier4_autoware_utils
 
-#endif  // TIER4_AUTOWARE_UTILS__ROS__POLLING_RECEIVER_HPP_
+#endif  // TIER4_AUTOWARE_UTILS__ROS__POLLING_SUBSCRIBER_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -17,6 +17,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <string>
+
 namespace tier4_autoware_utils
 {
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -49,7 +49,13 @@ public:
     }
     return data.has_value();
   };
-  const std::optional<T> & getData() const { return data; };
+  const T & getData() const
+  {
+    if (!data.has_value()) {
+      throw std::runtime_error("Bad_optional_access in class InterProcessPollingSubscriber");
+    }
+    return data.value();
+  };
 };
 
 }  // namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -24,8 +24,8 @@ template <typename T>
 class InterProcessPollingSubscriber
 {
 private:
-  typename rclcpp::Subscription<T>::SharedPtr subscriber;
-  std::optional<T> data;
+  typename rclcpp::Subscription<T>::SharedPtr subscriber_;
+  std::optional<T> data_;
 
 public:
   explicit InterProcessPollingSubscriber(rclcpp::Node * node, const std::string & topic_name)
@@ -35,7 +35,7 @@ public:
     auto noexec_subscription_options = rclcpp::SubscriptionOptions();
     noexec_subscription_options.callback_group = noexec_callback_group;
 
-    subscriber = node->create_subscription<T>(
+    subscriber_ = node->create_subscription<T>(
       topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },
       noexec_subscription_options);
   };
@@ -44,17 +44,17 @@ public:
     rclcpp::MessageInfo message_info;
     T tmp;
     // The queue size (QoS) must be 1 to get the last message data.
-    if (subscriber->take(tmp, message_info)) {
-      data = tmp;
+    if (subscriber_->take(tmp, message_info)) {
+      data_ = tmp;
     }
-    return data.has_value();
+    return data_.has_value();
   };
   const T & getData() const
   {
-    if (!data.has_value()) {
+    if (!data_.has_value()) {
       throw std::runtime_error("Bad_optional_access in class InterProcessPollingSubscriber");
     }
-    return data.value();
+    return data_.value();
   };
 };
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TIER4_AUTOWARE_UTILS__ROS__POLLING_RECEIVER_HPP_
-#define TIER4_AUTOWARE_UTILS__ROS__POLLING_RECEIVER_HPP_
+#ifndef TIER4_AUTOWARE_UTILS__ROS__POLLING_SUBSCRIBER_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__POLLING_SUBSCRIBER_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -39,7 +39,7 @@ public:
       topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },
       noexec_subscription_options);
   };
-  std::optional<T> takeLatestData()
+  bool updateLatestData()
   {
     rclcpp::MessageInfo message_info;
     T tmp;
@@ -47,8 +47,9 @@ public:
     if (subscriber->take(tmp, message_info)) {
       data = tmp;
     }
-    return data;
+    return data.has_value();
   };
+  const std::optional<T> & getData() const { return data; };
 };
 
 }  // namespace tier4_autoware_utils

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -145,10 +145,6 @@ private:
     this, "~/input/objects"};
   tier4_autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> acc_sub_{
     this, "~/input/acceleration"};
-    
-  std::optional<Odometry> ego_odom_opt_;
-  std::optional<PredictedObjects> objects_opt_;
-  std::optional<AccelWithCovarianceStamped> acc_opt_;
 
   // Vehicle Parameters
   VehicleInfo vehicle_info_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -139,35 +139,12 @@ private:
 
   // subscriber
   rclcpp::Subscription<Trajectory>::SharedPtr traj_sub_;
-  class PollingInputTopics
-  {
-  private:
-    tier4_autoware_utils::InterProcessPollingReceiver<Odometry> ego_odom_sub_;
-    tier4_autoware_utils::InterProcessPollingReceiver<PredictedObjects> objects_sub_;
-    tier4_autoware_utils::InterProcessPollingReceiver<AccelWithCovarianceStamped> acc_sub_;
-
-  public:
-    PollingInputTopics(rclcpp::Node * node)
-    : ego_odom_sub_(node, "~/input/odometry"),
-      objects_sub_(node, "~/input/objects"),
-      acc_sub_(node, "~/input/acceleration")
-    {
-    }
-    std::optional<Odometry> ego_odom_opt;
-    std::optional<PredictedObjects> objects_opt;
-    std::optional<AccelWithCovarianceStamped> ego_accel_opt;
-    bool takeData()
-    {
-      ego_odom_sub_.takeLastData(ego_odom_opt);
-      objects_sub_.takeLastData(objects_opt);
-      acc_sub_.takeLastData(ego_accel_opt);
-
-      if (!ego_odom_opt.has_value() || !objects_opt.has_value() || !ego_accel_opt.has_value()) {
-        return false;
-      }
-      return true;
-    };
-  } polling_topics_{this};
+  tier4_autoware_utils::InterProcessPollingReceiver<Odometry> ego_odom_sub_{
+    this, "~/input/odometry"};
+  tier4_autoware_utils::InterProcessPollingReceiver<PredictedObjects> objects_sub_{
+    this, "~/input/objects"};
+  tier4_autoware_utils::InterProcessPollingReceiver<AccelWithCovarianceStamped> acc_sub_{
+    this, "~/input/acceleration"};
 
   // Vehicle Parameters
   VehicleInfo vehicle_info_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -21,7 +21,7 @@
 #include "obstacle_cruise_planner/type_alias.hpp"
 #include "signal_processing/lowpass_filter_1d.hpp"
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
-#include "tier4_autoware_utils/ros/polling_reciever.hpp"
+#include "tier4_autoware_utils/ros/polling_subscriber.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -139,12 +139,16 @@ private:
 
   // subscriber
   rclcpp::Subscription<Trajectory>::SharedPtr traj_sub_;
-  tier4_autoware_utils::InterProcessPollingReceiver<Odometry> ego_odom_sub_{
+  tier4_autoware_utils::InterProcessPollingSubscriber<Odometry> ego_odom_sub_{
     this, "~/input/odometry"};
-  tier4_autoware_utils::InterProcessPollingReceiver<PredictedObjects> objects_sub_{
+  tier4_autoware_utils::InterProcessPollingSubscriber<PredictedObjects> objects_sub_{
     this, "~/input/objects"};
-  tier4_autoware_utils::InterProcessPollingReceiver<AccelWithCovarianceStamped> acc_sub_{
+  tier4_autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> acc_sub_{
     this, "~/input/acceleration"};
+    
+  std::optional<Odometry> ego_odom_opt_;
+  std::optional<PredictedObjects> objects_opt_;
+  std::optional<AccelWithCovarianceStamped> acc_opt_;
 
   // Vehicle Parameters
   VehicleInfo vehicle_info_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -142,9 +142,9 @@ private:
   class PollingInputTopics
   {
   private:
-    tier4_autoware_utils::InterProcessPollingReciever<Odometry> ego_odom_sub_;
-    tier4_autoware_utils::InterProcessPollingReciever<PredictedObjects> objects_sub_;
-    tier4_autoware_utils::InterProcessPollingReciever<AccelWithCovarianceStamped> acc_sub_;
+    tier4_autoware_utils::InterProcessPollingReceiver<Odometry> ego_odom_sub_;
+    tier4_autoware_utils::InterProcessPollingReceiver<PredictedObjects> objects_sub_;
+    tier4_autoware_utils::InterProcessPollingReceiver<AccelWithCovarianceStamped> acc_sub_;
 
   public:
     PollingInputTopics(rclcpp::Node * node)

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -38,7 +38,6 @@
 
 namespace motion_planning
 {
-
 class ObstacleCruisePlannerNode : public rclcpp::Node
 {
 public:
@@ -50,8 +49,6 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
   void onTrajectory(const Trajectory::ConstSharedPtr msg);
   void onSmoothedTrajectory(const Trajectory::ConstSharedPtr msg);
-
-  void takeData();
 
   // main functions
   std::vector<Polygon2d> createOneStepPolygons(

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -605,11 +605,11 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
 {
   stop_watch_.tic(__func__);
 
-  const auto obj_stamp = rclcpp::Time(objects_sub_.getData()->header.stamp);
+  const auto obj_stamp = rclcpp::Time(objects_sub_.getData().header.stamp);
   const auto & p = behavior_determination_param_;
 
   std::vector<Obstacle> target_obstacles;
-  for (const auto & predicted_object : objects_sub_.getData()->objects) {
+  for (const auto & predicted_object : objects_sub_.getData().objects) {
     const auto & object_id =
       tier4_autoware_utils::toHexString(predicted_object.object_id).substr(0, 4);
     const auto & current_obstacle_pose =
@@ -628,7 +628,7 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
 
     // 2. Check if the obstacle is in front of the ego.
     const size_t ego_idx =
-      ego_nearest_param_.findIndex(traj_points, ego_odom_sub_.getData()->pose.pose);
+      ego_nearest_param_.findIndex(traj_points, ego_odom_sub_.getData().pose.pose);
     const auto ego_to_obstacle_distance =
       calcDistanceToFrontVehicle(traj_points, ego_idx, current_obstacle_pose.pose.position);
     if (!ego_to_obstacle_distance) {
@@ -724,7 +724,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   // calculated decimated trajectory points and trajectory polygon
   const auto decimated_traj_points = decimateTrajectoryPoints(traj_points);
   const auto decimated_traj_polys =
-    createOneStepPolygons(decimated_traj_points, vehicle_info_, ego_odom_sub_.getData()->pose.pose);
+    createOneStepPolygons(decimated_traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose);
   debug_data_ptr_->detection_polygons = decimated_traj_polys;
 
   // determine ego's behavior from stop, cruise and slow down
@@ -782,8 +782,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   slow_down_condition_counter_.removeCounterUnlessUpdated();
 
   // Check target obstacles' consistency
-  checkConsistency(
-    objects_sub_.getData()->header.stamp, objects_sub_.getData().value(), stop_obstacles);
+  checkConsistency(objects_sub_.getData().header.stamp, objects_sub_.getData(), stop_obstacles);
 
   // update previous obstacles
   prev_stop_obstacles_ = stop_obstacles;
@@ -805,7 +804,7 @@ std::vector<TrajectoryPoint> ObstacleCruisePlannerNode::decimateTrajectoryPoints
 
   // trim trajectory
   const size_t ego_seg_idx =
-    ego_nearest_param_.findSegmentIndex(traj_points, ego_odom_sub_.getData()->pose.pose);
+    ego_nearest_param_.findSegmentIndex(traj_points, ego_odom_sub_.getData().pose.pose);
   const size_t traj_start_point_idx = ego_seg_idx;
   const auto trimmed_traj_points =
     std::vector<TrajectoryPoint>(traj_points.begin() + traj_start_point_idx, traj_points.end());
@@ -1189,7 +1188,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
 
   // calculate collision points with trajectory with lateral stop margin
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_sub_.getData()->pose.pose, p.max_lat_margin_for_stop);
+    traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose, p.max_lat_margin_for_stop);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
     traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);
@@ -1259,7 +1258,7 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   // calculate collision points with trajectory with lateral stop margin
   // NOTE: For additional margin, hysteresis is not divided by two.
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_sub_.getData()->pose.pose,
+    traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose,
     p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down);
 
   std::vector<Polygon2d> front_collision_polygons;
@@ -1422,8 +1421,8 @@ double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
   const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & traj_points, const bool is_driving_forward) const
 {
-  const auto & ego_pose = ego_odom_sub_.getData()->pose.pose;
-  const double ego_vel = ego_odom_sub_.getData()->twist.twist.linear.x;
+  const auto & ego_pose = ego_odom_sub_.getData().pose.pose;
+  const double ego_vel = ego_odom_sub_.getData().twist.twist.linear.x;
 
   const double time_to_reach_collision_point = [&]() {
     const double abs_ego_offset = is_driving_forward
@@ -1455,9 +1454,9 @@ PlannerData ObstacleCruisePlannerNode::createPlannerData(
   PlannerData planner_data;
   planner_data.current_time = now();
   planner_data.traj_points = traj_points;
-  planner_data.ego_pose = ego_odom_sub_.getData()->pose.pose;
-  planner_data.ego_vel = ego_odom_sub_.getData()->twist.twist.linear.x;
-  planner_data.ego_acc = acc_sub_.getData()->accel.accel.linear.x;
+  planner_data.ego_pose = ego_odom_sub_.getData().pose.pose;
+  planner_data.ego_vel = ego_odom_sub_.getData().twist.twist.linear.x;
+  planner_data.ego_acc = acc_sub_.getData().accel.accel.linear.x;
   planner_data.is_driving_forward = is_driving_forward_;
   return planner_data;
 }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -357,13 +357,6 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
   traj_sub_ = create_subscription<Trajectory>(
     "~/input/trajectory", rclcpp::QoS{1},
     std::bind(&ObstacleCruisePlannerNode::onTrajectory, this, _1));
-  objects_sub_ = create_subscription<PredictedObjects>(
-    "~/input/objects", rclcpp::QoS{1},
-    [this](const PredictedObjects::ConstSharedPtr msg) { objects_ptr_ = msg; });
-
-  acc_sub_ = create_subscription<AccelWithCovarianceStamped>(
-    "~/input/acceleration", rclcpp::QoS{1},
-    [this](const AccelWithCovarianceStamped::ConstSharedPtr msg) { ego_accel_ptr_ = msg; });
 
   // publisher
   trajectory_pub_ = create_publisher<Trajectory>("~/output/trajectory", 1);
@@ -491,14 +484,13 @@ rcl_interfaces::msg::SetParametersResult ObstacleCruisePlannerNode::onParam(
 
 void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr msg)
 {
-  ego_odom_sub_.updateLastData();
+  if (!polling_topics_.takeData()) {
+    return;
+  }
 
   const auto traj_points = motion_utils::convertToTrajectoryPointArray(*msg);
-
   // check if subscribed variables are ready
-  if (
-    traj_points.empty() || !ego_odom_sub_.getData().has_value() || !ego_accel_ptr_ ||
-    !objects_ptr_) {
+  if (traj_points.empty()) {
     return;
   }
 
@@ -611,11 +603,11 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
 {
   stop_watch_.tic(__func__);
 
-  const auto obj_stamp = rclcpp::Time(objects_ptr_->header.stamp);
+  const auto obj_stamp = rclcpp::Time(polling_topics_.objects_opt->header.stamp);
   const auto & p = behavior_determination_param_;
 
   std::vector<Obstacle> target_obstacles;
-  for (const auto & predicted_object : objects_ptr_->objects) {
+  for (const auto & predicted_object : polling_topics_.objects_opt->objects) {
     const auto & object_id =
       tier4_autoware_utils::toHexString(predicted_object.object_id).substr(0, 4);
     const auto & current_obstacle_pose =
@@ -634,7 +626,7 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
 
     // 2. Check if the obstacle is in front of the ego.
     const size_t ego_idx =
-      ego_nearest_param_.findIndex(traj_points, ego_odom_sub_.getData().value().pose.pose);
+      ego_nearest_param_.findIndex(traj_points, polling_topics_.ego_odom_opt->pose.pose);
     const auto ego_to_obstacle_distance =
       calcDistanceToFrontVehicle(traj_points, ego_idx, current_obstacle_pose.pose.position);
     if (!ego_to_obstacle_distance) {
@@ -730,7 +722,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   // calculated decimated trajectory points and trajectory polygon
   const auto decimated_traj_points = decimateTrajectoryPoints(traj_points);
   const auto decimated_traj_polys = createOneStepPolygons(
-    decimated_traj_points, vehicle_info_, ego_odom_sub_.getData().value().pose.pose);
+    decimated_traj_points, vehicle_info_, polling_topics_.ego_odom_opt->pose.pose);
   debug_data_ptr_->detection_polygons = decimated_traj_polys;
 
   // determine ego's behavior from stop, cruise and slow down
@@ -788,7 +780,8 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   slow_down_condition_counter_.removeCounterUnlessUpdated();
 
   // Check target obstacles' consistency
-  checkConsistency(objects_ptr_->header.stamp, *objects_ptr_, stop_obstacles);
+  checkConsistency(
+    polling_topics_.objects_opt->header.stamp, *polling_topics_.objects_opt, stop_obstacles);
 
   // update previous obstacles
   prev_stop_obstacles_ = stop_obstacles;
@@ -810,7 +803,7 @@ std::vector<TrajectoryPoint> ObstacleCruisePlannerNode::decimateTrajectoryPoints
 
   // trim trajectory
   const size_t ego_seg_idx =
-    ego_nearest_param_.findSegmentIndex(traj_points, ego_odom_sub_.getData().value().pose.pose);
+    ego_nearest_param_.findSegmentIndex(traj_points, polling_topics_.ego_odom_opt->pose.pose);
   const size_t traj_start_point_idx = ego_seg_idx;
   const auto trimmed_traj_points =
     std::vector<TrajectoryPoint>(traj_points.begin() + traj_start_point_idx, traj_points.end());
@@ -1194,8 +1187,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
 
   // calculate collision points with trajectory with lateral stop margin
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_sub_.getData().value().pose.pose,
-    p.max_lat_margin_for_stop);
+    traj_points, vehicle_info_, polling_topics_.ego_odom_opt->pose.pose, p.max_lat_margin_for_stop);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
     traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);
@@ -1265,7 +1257,7 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   // calculate collision points with trajectory with lateral stop margin
   // NOTE: For additional margin, hysteresis is not divided by two.
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_sub_.getData().value().pose.pose,
+    traj_points, vehicle_info_, polling_topics_.ego_odom_opt->pose.pose,
     p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down);
 
   std::vector<Polygon2d> front_collision_polygons;
@@ -1428,8 +1420,8 @@ double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
   const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & traj_points, const bool is_driving_forward) const
 {
-  const auto & ego_pose = ego_odom_sub_.getData().value().pose.pose;
-  const double ego_vel = ego_odom_sub_.getData().value().twist.twist.linear.x;
+  const auto & ego_pose = polling_topics_.ego_odom_opt->pose.pose;
+  const double ego_vel = polling_topics_.ego_odom_opt->twist.twist.linear.x;
 
   const double time_to_reach_collision_point = [&]() {
     const double abs_ego_offset = is_driving_forward
@@ -1461,9 +1453,9 @@ PlannerData ObstacleCruisePlannerNode::createPlannerData(
   PlannerData planner_data;
   planner_data.current_time = now();
   planner_data.traj_points = traj_points;
-  planner_data.ego_pose = ego_odom_sub_.getData().value().pose.pose;
-  planner_data.ego_vel = ego_odom_sub_.getData().value().twist.twist.linear.x;
-  planner_data.ego_acc = ego_accel_ptr_->accel.accel.linear.x;
+  planner_data.ego_pose = polling_topics_.ego_odom_opt->pose.pose;
+  planner_data.ego_vel = polling_topics_.ego_odom_opt->twist.twist.linear.x;
+  planner_data.ego_acc = polling_topics_.ego_accel_opt->accel.accel.linear.x;
   planner_data.is_driving_forward = is_driving_forward_;
   return planner_data;
 }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -484,11 +484,9 @@ rcl_interfaces::msg::SetParametersResult ObstacleCruisePlannerNode::onParam(
 
 void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr msg)
 {
-  ego_odom_opt_ = ego_odom_sub_.takeLatestData();
-  objects_opt_ = objects_sub_.takeLatestData();
-  acc_opt_ = acc_sub_.takeLatestData();
-
-  if (!ego_odom_opt_ || !objects_opt_ || !acc_opt_) {
+  if (
+    !ego_odom_sub_.updateLatestData() || !objects_sub_.updateLatestData() ||
+    !acc_sub_.updateLatestData()) {
     return;
   }
 
@@ -607,11 +605,11 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
 {
   stop_watch_.tic(__func__);
 
-  const auto obj_stamp = rclcpp::Time(objects_opt_->header.stamp);
+  const auto obj_stamp = rclcpp::Time(objects_sub_.getData()->header.stamp);
   const auto & p = behavior_determination_param_;
 
   std::vector<Obstacle> target_obstacles;
-  for (const auto & predicted_object : objects_opt_->objects) {
+  for (const auto & predicted_object : objects_sub_.getData()->objects) {
     const auto & object_id =
       tier4_autoware_utils::toHexString(predicted_object.object_id).substr(0, 4);
     const auto & current_obstacle_pose =
@@ -629,7 +627,8 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
     }
 
     // 2. Check if the obstacle is in front of the ego.
-    const size_t ego_idx = ego_nearest_param_.findIndex(traj_points, ego_odom_opt_->pose.pose);
+    const size_t ego_idx =
+      ego_nearest_param_.findIndex(traj_points, ego_odom_sub_.getData()->pose.pose);
     const auto ego_to_obstacle_distance =
       calcDistanceToFrontVehicle(traj_points, ego_idx, current_obstacle_pose.pose.position);
     if (!ego_to_obstacle_distance) {
@@ -725,7 +724,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   // calculated decimated trajectory points and trajectory polygon
   const auto decimated_traj_points = decimateTrajectoryPoints(traj_points);
   const auto decimated_traj_polys =
-    createOneStepPolygons(decimated_traj_points, vehicle_info_, ego_odom_opt_->pose.pose);
+    createOneStepPolygons(decimated_traj_points, vehicle_info_, ego_odom_sub_.getData()->pose.pose);
   debug_data_ptr_->detection_polygons = decimated_traj_polys;
 
   // determine ego's behavior from stop, cruise and slow down
@@ -783,7 +782,8 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   slow_down_condition_counter_.removeCounterUnlessUpdated();
 
   // Check target obstacles' consistency
-  checkConsistency(objects_opt_->header.stamp, objects_opt_.value(), stop_obstacles);
+  checkConsistency(
+    objects_sub_.getData()->header.stamp, objects_sub_.getData().value(), stop_obstacles);
 
   // update previous obstacles
   prev_stop_obstacles_ = stop_obstacles;
@@ -805,7 +805,7 @@ std::vector<TrajectoryPoint> ObstacleCruisePlannerNode::decimateTrajectoryPoints
 
   // trim trajectory
   const size_t ego_seg_idx =
-    ego_nearest_param_.findSegmentIndex(traj_points, ego_odom_opt_->pose.pose);
+    ego_nearest_param_.findSegmentIndex(traj_points, ego_odom_sub_.getData()->pose.pose);
   const size_t traj_start_point_idx = ego_seg_idx;
   const auto trimmed_traj_points =
     std::vector<TrajectoryPoint>(traj_points.begin() + traj_start_point_idx, traj_points.end());
@@ -1189,7 +1189,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
 
   // calculate collision points with trajectory with lateral stop margin
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_opt_->pose.pose, p.max_lat_margin_for_stop);
+    traj_points, vehicle_info_, ego_odom_sub_.getData()->pose.pose, p.max_lat_margin_for_stop);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
     traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);
@@ -1259,7 +1259,7 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   // calculate collision points with trajectory with lateral stop margin
   // NOTE: For additional margin, hysteresis is not divided by two.
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_opt_->pose.pose,
+    traj_points, vehicle_info_, ego_odom_sub_.getData()->pose.pose,
     p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down);
 
   std::vector<Polygon2d> front_collision_polygons;
@@ -1422,8 +1422,8 @@ double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
   const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & traj_points, const bool is_driving_forward) const
 {
-  const auto & ego_pose = ego_odom_opt_->pose.pose;
-  const double ego_vel = ego_odom_opt_->twist.twist.linear.x;
+  const auto & ego_pose = ego_odom_sub_.getData()->pose.pose;
+  const double ego_vel = ego_odom_sub_.getData()->twist.twist.linear.x;
 
   const double time_to_reach_collision_point = [&]() {
     const double abs_ego_offset = is_driving_forward
@@ -1455,9 +1455,9 @@ PlannerData ObstacleCruisePlannerNode::createPlannerData(
   PlannerData planner_data;
   planner_data.current_time = now();
   planner_data.traj_points = traj_points;
-  planner_data.ego_pose = ego_odom_opt_->pose.pose;
-  planner_data.ego_vel = ego_odom_opt_->twist.twist.linear.x;
-  planner_data.ego_acc = acc_opt_->accel.accel.linear.x;
+  planner_data.ego_pose = ego_odom_sub_.getData()->pose.pose;
+  planner_data.ego_vel = ego_odom_sub_.getData()->twist.twist.linear.x;
+  planner_data.ego_acc = acc_sub_.getData()->accel.accel.linear.x;
   planner_data.is_driving_forward = is_driving_forward_;
   return planner_data;
 }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -484,7 +484,9 @@ rcl_interfaces::msg::SetParametersResult ObstacleCruisePlannerNode::onParam(
 
 void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr msg)
 {
-  if (!polling_topics_.takeData()) {
+  if (
+    !ego_odom_sub_.takeLatestData() || !objects_sub_.takeLatestData() ||
+    !acc_sub_.takeLatestData()) {
     return;
   }
 
@@ -603,11 +605,11 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
 {
   stop_watch_.tic(__func__);
 
-  const auto obj_stamp = rclcpp::Time(polling_topics_.objects_opt->header.stamp);
+  const auto obj_stamp = rclcpp::Time(objects_sub_.data->header.stamp);
   const auto & p = behavior_determination_param_;
 
   std::vector<Obstacle> target_obstacles;
-  for (const auto & predicted_object : polling_topics_.objects_opt->objects) {
+  for (const auto & predicted_object : objects_sub_.data->objects) {
     const auto & object_id =
       tier4_autoware_utils::toHexString(predicted_object.object_id).substr(0, 4);
     const auto & current_obstacle_pose =
@@ -625,8 +627,7 @@ std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
     }
 
     // 2. Check if the obstacle is in front of the ego.
-    const size_t ego_idx =
-      ego_nearest_param_.findIndex(traj_points, polling_topics_.ego_odom_opt->pose.pose);
+    const size_t ego_idx = ego_nearest_param_.findIndex(traj_points, ego_odom_sub_.data->pose.pose);
     const auto ego_to_obstacle_distance =
       calcDistanceToFrontVehicle(traj_points, ego_idx, current_obstacle_pose.pose.position);
     if (!ego_to_obstacle_distance) {
@@ -721,8 +722,8 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
 
   // calculated decimated trajectory points and trajectory polygon
   const auto decimated_traj_points = decimateTrajectoryPoints(traj_points);
-  const auto decimated_traj_polys = createOneStepPolygons(
-    decimated_traj_points, vehicle_info_, polling_topics_.ego_odom_opt->pose.pose);
+  const auto decimated_traj_polys =
+    createOneStepPolygons(decimated_traj_points, vehicle_info_, ego_odom_sub_.data->pose.pose);
   debug_data_ptr_->detection_polygons = decimated_traj_polys;
 
   // determine ego's behavior from stop, cruise and slow down
@@ -780,8 +781,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   slow_down_condition_counter_.removeCounterUnlessUpdated();
 
   // Check target obstacles' consistency
-  checkConsistency(
-    polling_topics_.objects_opt->header.stamp, *polling_topics_.objects_opt, stop_obstacles);
+  checkConsistency(objects_sub_.data->header.stamp, objects_sub_.data.value(), stop_obstacles);
 
   // update previous obstacles
   prev_stop_obstacles_ = stop_obstacles;
@@ -803,7 +803,7 @@ std::vector<TrajectoryPoint> ObstacleCruisePlannerNode::decimateTrajectoryPoints
 
   // trim trajectory
   const size_t ego_seg_idx =
-    ego_nearest_param_.findSegmentIndex(traj_points, polling_topics_.ego_odom_opt->pose.pose);
+    ego_nearest_param_.findSegmentIndex(traj_points, ego_odom_sub_.data->pose.pose);
   const size_t traj_start_point_idx = ego_seg_idx;
   const auto trimmed_traj_points =
     std::vector<TrajectoryPoint>(traj_points.begin() + traj_start_point_idx, traj_points.end());
@@ -1187,7 +1187,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
 
   // calculate collision points with trajectory with lateral stop margin
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, polling_topics_.ego_odom_opt->pose.pose, p.max_lat_margin_for_stop);
+    traj_points, vehicle_info_, ego_odom_sub_.data->pose.pose, p.max_lat_margin_for_stop);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
     traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);
@@ -1257,7 +1257,7 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   // calculate collision points with trajectory with lateral stop margin
   // NOTE: For additional margin, hysteresis is not divided by two.
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, polling_topics_.ego_odom_opt->pose.pose,
+    traj_points, vehicle_info_, ego_odom_sub_.data->pose.pose,
     p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down);
 
   std::vector<Polygon2d> front_collision_polygons;
@@ -1420,8 +1420,8 @@ double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
   const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & traj_points, const bool is_driving_forward) const
 {
-  const auto & ego_pose = polling_topics_.ego_odom_opt->pose.pose;
-  const double ego_vel = polling_topics_.ego_odom_opt->twist.twist.linear.x;
+  const auto & ego_pose = ego_odom_sub_.data->pose.pose;
+  const double ego_vel = ego_odom_sub_.data->twist.twist.linear.x;
 
   const double time_to_reach_collision_point = [&]() {
     const double abs_ego_offset = is_driving_forward
@@ -1453,9 +1453,9 @@ PlannerData ObstacleCruisePlannerNode::createPlannerData(
   PlannerData planner_data;
   planner_data.current_time = now();
   planner_data.traj_points = traj_points;
-  planner_data.ego_pose = polling_topics_.ego_odom_opt->pose.pose;
-  planner_data.ego_vel = polling_topics_.ego_odom_opt->twist.twist.linear.x;
-  planner_data.ego_acc = polling_topics_.ego_accel_opt->accel.accel.linear.x;
+  planner_data.ego_pose = ego_odom_sub_.data->pose.pose;
+  planner_data.ego_vel = ego_odom_sub_.data->twist.twist.linear.x;
+  planner_data.ego_acc = acc_sub_.data->accel.accel.linear.x;
   planner_data.is_driving_forward = is_driving_forward_;
   return planner_data;
 }


### PR DESCRIPTION
## Description
change to read topic by polling instead of best_effort callback


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
psim test and tier4 internal tests were performed

If we access to getData() without any call of updatelatestDate() following message will be shown
[component_container_mt-31] terminate called after throwing an instance of 'std::runtime_error'
[component_container_mt-31]   what():  Bad_optional_access in class InterProcessPollingSubscriber
[component_container_mt-31] *** Aborted at 1712130709 (unix time) try "date -d @1712130709" if you are using GNU date ***
[component_container_mt-31] PC: @                0x0 (unknown)
[component_container_mt-31] *** SIGABRT (@0x3e8002983f9) received by PID 2720761 (TID 0x7fe1de7ec640) from PID 2720761; stack trace: ***
[component_container_mt-31]     @     0x7fe1d84b6046 (unknown)
[component_container_mt-31]     @     0x7fe2136fb520 (unknown)
[component_container_mt-31]     @     0x7fe21374f9fc pthread_kill
[component_container_mt-31]     @     0x7fe2136fb476 raise
[component_container_mt-31]     @     0x7fe2136e17f3 abort
[component_container_mt-31]     @     0x7fe2139a3b9e (unknown)
[component_container_mt-31]     @     0x7fe2139af20c (unknown)
[component_container_mt-31]     @     0x7fe2139af277 std::terminate()
[component_container_mt-31]     @     0x7fe2139af4d8 __cxa_throw
[component_container_mt-31]     @     0x7fe20067cf8c _ZNK15motion_planning25ObstacleCruisePlannerNode18convertToObstaclesERKSt6vectorIN27autoware_auto_planning_msgs3msg16TrajectoryPoint_ISaIvEEESaIS6_EE.cold
[component_container_mt-31]     @     0x7fe2006ace54 motion_planning::ObstacleCruisePlannerNode::onTrajectory()
[component_container_mt-31]     @     0x7fe2006d7627 std::_Function_handler<>::_M_invoke()
[component_container_mt-31]     @     0x7fe2006d6462 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN27autoware_auto_planning_msgs3msg11Trajectory_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_
[component_container_mt-31]     @     0x7fe20075029a rclcpp::Subscription<>::handle_message()
[component_container_mt-31]     @     0x7fe213ccaba0 rclcpp::Executor::execute_subscription()
[component_container_mt-31]     @     0x7fe213ccc10e rclcpp::Executor::execute_any_executable()
[component_container_mt-31]     @     0x7fe213cd2432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-31]     @     0x7fe2139dd253 (unknown)
[component_container_mt-31]     @     0x7fe21374dac3 (unknown)
[component_container_mt-31]     @     0x7fe2137dfa40 (unknown)
[component_container_mt-31]     @                0x0 (unknown)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
