### PR TITLE
feat(obstacle_avoidance_planner): sanitize reference points

### DIFF
--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
@@ -129,6 +129,8 @@ ReferencePoint convertToReferencePoint(const TrajectoryPoint & traj_point);
 std::vector<ReferencePoint> convertToReferencePoints(
   const std::vector<TrajectoryPoint> & traj_points);
 
+std::vector<ReferencePoint> sanitizePoints(const std::vector<ReferencePoint> & points);
+
 void compensateLastPose(
   const PathPoint & last_path_point, std::vector<TrajectoryPoint> & traj_points,
   const double delta_dist_threshold, const double delta_yaw_threshold);

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -567,6 +567,9 @@ std::vector<ReferencePoint> MPTOptimizer::calcReferencePoints(
   ref_points = motion_utils::cropPoints(
     ref_points, p.ego_pose.position, ego_seg_idx, forward_traj_length + tmp_margin,
     backward_traj_length + tmp_margin);
+
+  // remove repeated points
+  ref_points = trajectory_utils::sanitizePoints(ref_points);
   SplineInterpolationPoints2d ref_points_spline(ref_points);
   ego_seg_idx = trajectory_utils::findEgoSegmentIndex(ref_points, p.ego_pose, ego_nearest_param_);
 
@@ -586,6 +589,7 @@ std::vector<ReferencePoint> MPTOptimizer::calcReferencePoints(
   // NOTE: This must be after backward cropping.
   //       New start point may be added and resampled. Spline calculation is required.
   updateFixedPoint(ref_points);
+  ref_points = trajectory_utils::sanitizePoints(ref_points);
   ref_points_spline = SplineInterpolationPoints2d(ref_points);
 
   // 6. update bounds

--- a/planning/obstacle_avoidance_planner/src/utils/trajectory_utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/trajectory_utils.cpp
@@ -91,8 +91,8 @@ std::vector<ReferencePoint> sanitizePoints(const std::vector<ReferencePoint> & p
         std::fabs(current_pos.y - prev_pos.y) < 1e-6) {
         continue;
       }
-      output.push_back(points.at(i));
     }
+    output.push_back(points.at(i));
   }
   return output;
 }

--- a/planning/obstacle_avoidance_planner/src/utils/trajectory_utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/trajectory_utils.cpp
@@ -79,6 +79,24 @@ std::vector<ReferencePoint> convertToReferencePoints(
   return ref_points;
 }
 
+std::vector<ReferencePoint> sanitizePoints(const std::vector<ReferencePoint> & points)
+{
+  std::vector<ReferencePoint> output;
+  for (size_t i = 0; i < points.size(); i++) {
+    if (i > 0) {
+      const auto & current_pos = points.at(i).pose.position;
+      const auto & prev_pos = points.at(i - 1).pose.position;
+      if (
+        std::fabs(current_pos.x - prev_pos.x) < 1e-6 &&
+        std::fabs(current_pos.y - prev_pos.y) < 1e-6) {
+        continue;
+      }
+      output.push_back(points.at(i));
+    }
+  }
+  return output;
+}
+
 void compensateLastPose(
   const PathPoint & last_path_point, std::vector<TrajectoryPoint> & traj_points,
   const double delta_dist_threshold, const double delta_yaw_threshold)


### PR DESCRIPTION
## Description

If the reference path on the mpt_optimizer has points that are too close to each other, or are the same, calling the creation of the spline like this: 

`ref_points_spline = SplineInterpolationPoints2d(ref_points);`

generates a spline with less points than the reference path, which causes a crash in autoware when the method obstacle_avoidance_planner::MPTOptimizer::updateOrientation() is called, as it happened here: [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/d8425419-b7ae-50b1-ad5e-6cc2a76f7247/tests/29422684-1dde-5fef-bb5e-61ad8e74662b/08bb5129-f242-52f7-8f82-5cac9dfb8b64/a36b3372-1789-5fcf-9647-e325df1ab847?project_id=prd_jt) 

This PR adds a sanitize function to prevent that from happening with the MPTOptimizer::calcReferencePoints method.  The sanitize function is basically used to eliminate the duplicated points before the spline is created, assuring the spline and ref path have the same size. 
## Related links

## Tests performed

PSIM
Evaluator: [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/a3f48935-9879-577d-ad7b-efeffc58a202?project_id=prd_jt)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
