### PR TITLE
feat(multi_object_tracker): reduce publish delay

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
@@ -58,7 +58,11 @@ private:
     tracked_objects_pub_;
   rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
     detected_object_sub_;
-  rclcpp::TimerBase::SharedPtr publish_timer_;  // publish timer
+
+  // publish timer
+  rclcpp::TimerBase::SharedPtr publish_timer_;
+  rclcpp::Time last_published_time_;
+  double publisher_period_;
 
   // debugger class
   std::unique_ptr<TrackerDebugger> debugger_;
@@ -79,14 +83,14 @@ private:
   std::unique_ptr<DataAssociation> data_association_;
 
   void checkTrackerLifeCycle(
-    std::list<std::shared_ptr<Tracker>> & list_tracker, const rclcpp::Time & time,
-    const geometry_msgs::msg::Transform & self_transform);
+    std::list<std::shared_ptr<Tracker>> & list_tracker, const rclcpp::Time & time);
   void sanitizeTracker(
     std::list<std::shared_ptr<Tracker>> & list_tracker, const rclcpp::Time & time);
   std::shared_ptr<Tracker> createNewTracker(
     const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) const;
 
+  void checkAndPublish(const rclcpp::Time & time);
   void publish(const rclcpp::Time & time) const;
   inline bool shouldTrackerPublish(const std::shared_ptr<const Tracker> tracker) const;
 };

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -207,7 +207,7 @@ void MultiObjectTracker::onMeasurement(
     publish(measurement_time);
   } else {
     // Publish if the next publish time is close
-    const double minimum_publish_interval = publisher_period_ * 0.7;  // 70% of the period
+    const double minimum_publish_interval = publisher_period_ * 0.70;  // 70% of the period
     if ((this->now() - last_published_time_).seconds() > minimum_publish_interval) {
       checkAndPublish(this->now());
     }
@@ -247,8 +247,8 @@ void MultiObjectTracker::onTimer()
   // check the publish period
   const auto elapsed_time = (current_time - last_published_time_).seconds();
   // if the elapsed time is over the period, publish objects with prediction
-  constexpr double latency_ratio = 1.11;  // 11% margin
-  const double maximum_publish_latency = publisher_period_ * latest_publish_latency_ratio;
+  constexpr double maximum_latency_ratio = 1.11;  // 11% margin
+  const double maximum_publish_latency = publisher_period_ * maximum_latency_ratio;
   if (elapsed_time > maximum_publish_latency) {
     checkAndPublish(current_time);
   }


### PR DESCRIPTION
## Description

This PR suggests a new method to reduce latency about 100 ms.

### Background: 
Current multi_object_tracker publishes the tracked object triggered by a timer. This timer ensures the topic is published in target frequency. The delay is compensated by predict the tracked objects motion.
However, the input (merged objects from multiple detectors) frequency is unstable (see the following plots, name of `input_latency_ms`). The instability of the detection latency is absorbed by the multi_object_tracker and adds latency about one cycle (100 ms of TIER IV configuration). 

### The new method:
there is two triggers to publish the tracked object
1) on measurement : When the publishing frequency is in the target window, publish right after the process is done. The publishing object will be compensated the delay from the measurement to the publishing time.
2) on timer : When the input is late, publish tracked object with delay compensation. 

### Side effect: 
The publishing frequency will not be kept precisely. (see the following plots, name of `cycle_time_ms` )

## Related links

[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT1-5741)

## Tests performed

Current
![MOT_timing_now](https://github.com/autowarefoundation/autoware.universe/assets/42434141/db718fe7-eae3-47c6-b233-e24b91df8cb1)

Improved
![MOT_timing_proposal](https://github.com/autowarefoundation/autoware.universe/assets/42434141/cbecfeab-ec44-4b2a-99a7-c62f407e9857)


## Notes for reviewers

This PR will be merged after 
PR https://github.com/autowarefoundation/autoware.universe/pull/6706
PR https://github.com/autowarefoundation/autoware.universe/pull/6757
PR https://github.com/autowarefoundation/autoware.universe/pull/6775

This PR is an alternative work of PR https://github.com/autowarefoundation/autoware.universe/pull/6687

TODO: improve input (merged object) stability

## Interface changes
N/A

## Effects on system behavior
It may reduces overall latency about one cycle of the perception (100 ms).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
