### PR TITLE
refactor(dynamic_obstacle_stop): change log level for processing time

### DIFF
--- a/planning/behavior_velocity_dynamic_obstacle_stop_module/src/scene_dynamic_obstacle_stop.cpp
+++ b/planning/behavior_velocity_dynamic_obstacle_stop_module/src/scene_dynamic_obstacle_stop.cpp
@@ -121,7 +121,7 @@ bool DynamicObstacleStopModule::modifyPathVelocity(PathWithLaneId * path, StopRe
   }
 
   const auto total_time_us = stopwatch.toc();
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     logger_,
     "Total time = %2.2fus\n\tpreprocessing = %2.2fus\n\tfootprints = "
     "%2.2fus\n\tcollisions = %2.2fus\n",


### PR DESCRIPTION
## Description

Refactor of the unnesessary logging information which is enabled in this https://github.com/autowarefoundation/autoware.universe/pull/6683

<!-- Write a brief description of this PR. -->


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
without this change, following output is shown in the terminal
```
[INFO 1711879593.700843163] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.dynamic_obstacle_stop_module]: Total time = 7.00us
1711879593.7013659 [component_container_mt-30] 	preprocessing = 5.00us
1711879593.7014267 [component_container_mt-30] 	footprints = 0.00us
1711879593.7014904 [component_container_mt-30] 	collisions = 0.00us
```
with this change, the output is not shown in the teminal

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
