### PR TITLE
feat(start_planner): add validation check to prevent over cropped paths

### DIFF
--- a/planning/behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -27,6 +27,7 @@
       shift_collision_check_distance_from_end: -10.0
       minimum_shift_pull_out_distance: 0.0
       deceleration_interval: 15.0
+      maximum_longitudinal_deviation: 1.0 # Note, should be the same or less than planning validator's "longitudinal_distance_deviation"
       lateral_jerk: 0.5
       lateral_acceleration_sampling_num: 3
       minimum_lateral_acc: 0.15

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/data_structs.hpp
@@ -84,6 +84,7 @@ struct StartPlannerParameters
   double minimum_lateral_acc{0.0};
   double maximum_curvature{0.0};  // maximum curvature considered in the path generation
   double deceleration_interval{0.0};
+  double maximum_longitudinal_deviation{0.0};
   // geometric pull out
   bool enable_geometric_pull_out{false};
   double geometric_collision_check_distance_from_end;

--- a/planning/behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_start_planner_module/src/manager.cpp
@@ -88,6 +88,8 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   p.minimum_lateral_acc = node->declare_parameter<double>(ns + "minimum_lateral_acc");
   p.maximum_curvature = node->declare_parameter<double>(ns + "maximum_curvature");
   p.deceleration_interval = node->declare_parameter<double>(ns + "deceleration_interval");
+  p.maximum_longitudinal_deviation =
+    node->declare_parameter<double>(ns + "maximum_longitudinal_deviation");
   // geometric pull out
   p.enable_geometric_pull_out = node->declare_parameter<bool>(ns + "enable_geometric_pull_out");
   p.geometric_collision_check_distance_from_end =
@@ -424,6 +426,8 @@ void StartPlannerModuleManager::updateModuleParams(
     updateParam<double>(parameters, ns + "minimum_lateral_acc", p->minimum_lateral_acc);
     updateParam<double>(parameters, ns + "maximum_curvature", p->maximum_curvature);
     updateParam<double>(parameters, ns + "deceleration_interval", p->deceleration_interval);
+    updateParam<double>(
+      parameters, ns + "maximum_longitudinal_deviation", p->maximum_longitudinal_deviation);
     updateParam<bool>(parameters, ns + "enable_geometric_pull_out", p->enable_geometric_pull_out);
     updateParam<bool>(parameters, ns + "divide_pull_out_path", p->divide_pull_out_path);
     updateParam<double>(

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -111,6 +111,21 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
     const auto cropped_path = lane_departure_checker_->cropPointsOutsideOfLanes(
       lanelet_map_ptr, shift_path, start_segment_idx);
     if (cropped_path.points.empty()) continue;
+
+    auto validate_cropped_path = [&](const auto & cropped_path) -> bool {
+      if (cropped_path.points.size() < 2) return false;
+      const size_t start_segment_idx_after_crop =
+        motion_utils::findFirstNearestIndexWithSoftConstraints(cropped_path.points, start_pose);
+      if (start_segment_idx_after_crop != 0) return true;
+
+      const auto long_offset_to_closest_point = motion_utils::calcLongitudinalOffsetToSegment(
+        cropped_path.points, start_segment_idx_after_crop, start_pose.position);
+      const auto long_offset_to_next_point = motion_utils::calcLongitudinalOffsetToSegment(
+        cropped_path.points, start_segment_idx_after_crop + 1, start_pose.position);
+      return std::abs(long_offset_to_closest_point - long_offset_to_next_point) < 1.0;
+    };
+
+    if (!validate_cropped_path(cropped_path)) continue;
     shift_path.points = cropped_path.points;
     shift_path.header = planner_data_->route_handler->getRouteHeader();
 

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -114,6 +114,7 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
 
     auto validate_cropped_path = [&](const auto & cropped_path) -> bool {
       if (cropped_path.points.size() < 2) return false;
+      constexpr double max_long_offset = 1.0;
       const size_t start_segment_idx_after_crop =
         motion_utils::findFirstNearestIndexWithSoftConstraints(cropped_path.points, start_pose);
       if (start_segment_idx_after_crop != 0) return true;
@@ -122,7 +123,7 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
         cropped_path.points, start_segment_idx_after_crop, start_pose.position);
       const auto long_offset_to_next_point = motion_utils::calcLongitudinalOffsetToSegment(
         cropped_path.points, start_segment_idx_after_crop + 1, start_pose.position);
-      return std::abs(long_offset_to_closest_point - long_offset_to_next_point) < 1.0;
+      return std::abs(long_offset_to_closest_point - long_offset_to_next_point) < max_long_offset;
     };
 
     if (!validate_cropped_path(cropped_path)) continue;

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -112,11 +112,15 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
       lanelet_map_ptr, shift_path, start_segment_idx);
     if (cropped_path.points.empty()) continue;
 
+    // check that the path is not cropped in excess and there is not excessive longitudinal
+    // deviation between the first 2 points
     auto validate_cropped_path = [&](const auto & cropped_path) -> bool {
       if (cropped_path.points.size() < 2) return false;
-      constexpr double max_long_offset = 1.0;
+      const double max_long_offset = parameters_.maximum_longitudinal_deviation;
       const size_t start_segment_idx_after_crop =
         motion_utils::findFirstNearestIndexWithSoftConstraints(cropped_path.points, start_pose);
+
+      // if the start segment id after crop is not 0, then the cropping is not excessive
       if (start_segment_idx_after_crop != 0) return true;
 
       const auto long_offset_to_closest_point = motion_utils::calcLongitudinalOffsetToSegment(


### PR DESCRIPTION
## Description

Sometimes, backwards path cropping may cause the starting point on the output path to have a big longitudinal offset between the last point of the backward path and the starting point of pull out, like here: https://evaluation.ci.tier4.jp/evaluation/reports/d982b5c4-0306-5ec0-be4d-4c0720090edb/tests/a6f3baf6-627c-5a6e-bd08-4f04dfe24559/eff3a61a-55fd-547e-b968-4acd7288a7eb/93168fc7-5735-5005-9745-465e76e192d0?project_id=prd_jt

This distance causes  problems with the planning validator when PlanningValidator::checkValidLongitudinalDistanceDeviation() is called.

This PR solves the issue by checking the distance between said points and eliminating the paths that dont comply with it. 

Note, requires launch changes: https://github.com/autowarefoundation/autoware_launch/pull/942
## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

internal discussion
https://star4.slack.com/archives/C03QW0GU6P7/p1711962608419269

## Tests performed
https://evaluation.ci.tier4.jp/evaluation/reports/76c102bd-0fa1-5da3-b315-3b851f302916?project_id=prd_jt
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
