### PR TITLE
fix(lane_change): fix terminal path not working in some case

### DIFF
--- a/planning/behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/utils.cpp
@@ -435,7 +435,8 @@ PathWithLaneId getReferencePathFromTargetLane(
       .get_child("getReferencePathFromTargetLane"),
     "start: %f, end: %f", s_start, s_end);
 
-  if (s_end - s_start < lane_changing_length) {
+  constexpr double epsilon = 1e-4;
+  if (s_end - s_start + epsilon < lane_changing_length) {
     return PathWithLaneId();
   }
 


### PR DESCRIPTION
## Description

When exceeding  certain distance, lane change terminal path is not generated. This PR aims  to fix this issue.

### Before PR

see after 0:36s

https://github.com/autowarefoundation/autoware.universe/assets/93502286/3d5b06e1-0bd4-4320-b5f7-1460ecd2eab6

### After PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/734b50b5-5fba-458f-b93d-bfbf2a5213b5

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
