### PR TITLE
fix(pose_initializer): added "user_defined_initial_pose" to dummy localization

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -127,6 +127,8 @@
   <!-- Dummy localization -->
   <group if="$(var launch_dummy_localization)">
     <include file="$(find-pkg-share pose_initializer)/launch/pose_initializer.launch.xml">
+      <arg name="user_defined_initial_pose/enable" value="false"/>
+      <arg name="user_defined_initial_pose/pose" value="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]"/>
       <arg name="ndt_enabled" value="false"/>
       <arg name="gnss_enabled" value="false"/>
       <arg name="ekf_enabled" value="false"/>


### PR DESCRIPTION
## Description
Fixed an issue where planning_simulator was stuck on the following pull request

* https://github.com/autowarefoundation/autoware.universe/pull/6692

## Tests performed

- [x] unit test of ndt_scan_matcher in autoware.universe
- [x] logging_simulator (sample-rosbag)
- [x] logging_simulator (AWSIM-rosbag) single map with comparing to GT Pose
- [x] logging_simulator (AWSIM-rosbag) divided map with comparing to GT Pose
- [x] driving_log_replayer
- [x] AWSIM
- [x] planning_simulator

## Effects on system behavior

planning_simulator will work

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
