### PR TITLE
perf(behavior_path_planner_common): simplify turn signal loop to support large maps

### DIFF
--- a/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -25,7 +25,6 @@
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/math/normalization.hpp>
 #include <tier4_autoware_utils/math/unit_conversion.hpp>
-#include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <limits>
 #include <queue>
@@ -87,12 +86,9 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
     extended_path.points, current_pose, nearest_dist_threshold, nearest_yaw_threshold);
 
   // Get closest intersection turn signal if exists
-  auto stop_watch = tier4_autoware_utils::StopWatch<std::chrono::milliseconds>();
   const auto intersection_turn_signal_info = getIntersectionTurnSignalInfo(
     extended_path, current_pose, current_vel, ego_seg_idx, *route_handler, nearest_dist_threshold,
     nearest_yaw_threshold);
-  const auto t = stop_watch.toc();
-  RCLCPP_WARN(logger_, "getIntersectionTurnSignalInfo = %2.2fms");
 
   if (intersection_turn_signal_info) {
     debug_data.intersection_turn_signal_info = *intersection_turn_signal_info;

--- a/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -254,28 +254,25 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
         desired_start_point_map_.erase(lane_id);
       }
       continue;
-    } else if (search_distance < dist_to_front_point) {
+    } else if (search_distance <= dist_to_front_point) {
       continue;
     }
-
     constexpr double stop_velocity_threshold = 0.1;
-    if (dist_to_front_point < search_distance) {
-      if (
-        lane_attribute == "right" || lane_attribute == "left" ||
-        (lane_attribute == "straight" && current_vel < stop_velocity_threshold)) {
-        // update map if necessary
-        if (desired_start_point_map_.find(lane_id) == desired_start_point_map_.end()) {
-          desired_start_point_map_.emplace(lane_id, current_pose);
-        }
-
-        TurnSignalInfo turn_signal_info{};
-        turn_signal_info.desired_start_point = desired_start_point_map_.at(lane_id);
-        turn_signal_info.required_start_point = lane_front_pose;
-        turn_signal_info.required_end_point = get_required_end_point(combined_lane.centerline3d());
-        turn_signal_info.desired_end_point = lane_back_pose;
-        turn_signal_info.turn_signal.command = g_signal_map.at(lane_attribute);
-        signal_queue.push(turn_signal_info);
+    if (
+      lane_attribute == "right" || lane_attribute == "left" ||
+      (lane_attribute == "straight" && current_vel < stop_velocity_threshold)) {
+      // update map if necessary
+      if (desired_start_point_map_.find(lane_id) == desired_start_point_map_.end()) {
+        desired_start_point_map_.emplace(lane_id, current_pose);
       }
+
+      TurnSignalInfo turn_signal_info{};
+      turn_signal_info.desired_start_point = desired_start_point_map_.at(lane_id);
+      turn_signal_info.required_start_point = lane_front_pose;
+      turn_signal_info.required_end_point = get_required_end_point(combined_lane.centerline3d());
+      turn_signal_info.desired_end_point = lane_back_pose;
+      turn_signal_info.turn_signal.command = g_signal_map.at(lane_attribute);
+      signal_queue.push(turn_signal_info);
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Improves the turn signal performances with large maps.
The performance issue was reported here first: https://github.com/orgs/autowarefoundation/discussions/4075

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim with large map generated with https://github.com/kminoda/large_lanelet2_generator/blob/main/hilbert_curve.ipynb
- Also added a `<tag k="turn_direction" v="left" />` to all lanelet relations.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Improved performance with very long routes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
