### PR TITLE
fix(static_centerline_optimizer): fix latlon values of generated LL2 map

### DIFF
--- a/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
+++ b/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
@@ -22,6 +22,8 @@
 #include "static_centerline_optimizer/type_alias.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
+#include <geography_utils/lanelet2_projector.hpp>
+
 #include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/int32.hpp"
 
@@ -69,6 +71,7 @@ private:
   lanelet::LaneletMapPtr original_map_ptr_{nullptr};
   HADMapBin::ConstSharedPtr map_bin_ptr_{nullptr};
   std::shared_ptr<RouteHandler> route_handler_ptr_{nullptr};
+  std::unique_ptr<lanelet::Projector> map_projector_{nullptr};
 
   int traj_start_index_{0};
   int traj_end_index_{0};

--- a/planning/static_centerline_optimizer/package.xml
+++ b/planning/static_centerline_optimizer/package.xml
@@ -19,11 +19,15 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>behavior_path_planner_common</depend>
+  <depend>behavior_path_planner</depend>
+  <depend>behavior_velocity_planner</depend>
+  <depend>geography_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>global_parameter_loader</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
   <depend>map_loader</depend>
+  <depend>map_projection_loader</depend>
   <depend>mission_planner</depend>
   <depend>motion_utils</depend>
   <depend>obstacle_avoidance_planner</depend>

--- a/planning/static_centerline_optimizer/package.xml
+++ b/planning/static_centerline_optimizer/package.xml
@@ -19,8 +19,6 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>behavior_path_planner_common</depend>
-  <depend>behavior_path_planner</depend>
-  <depend>behavior_velocity_planner</depend>
   <depend>geography_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>global_parameter_loader</depend>

--- a/planning/static_centerline_optimizer/scripts/tmp/run.sh
+++ b/planning/static_centerline_optimizer/scripts/tmp/run.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# ros2 launch static_centerline_optimizer static_centerline_optimizer.launch.xml run_background:=false lanelet2_input_file_path:="$HOME/autoware_map/sample_map/lanelet2_map.osm" start_lanelet_id:=125 end_lanelet_id:=132 vehicle_model:=lexus
-ros2 launch static_centerline_optimizer static_centerline_optimizer.launch.xml run_background:=false lanelet2_input_file_path:="$HOME/autoware_map/odaiba_beta/lanelet2_map.osm" start_lanelet_id:=168 end_lanelet_id:=74 vehicle_model:=lexus
+ros2 launch static_centerline_optimizer static_centerline_optimizer.launch.xml run_background:=false lanelet2_input_file_path:="$HOME/autoware_map/sample_map/lanelet2_map.osm" start_lanelet_id:=125 end_lanelet_id:=132 vehicle_model:=lexus

--- a/planning/static_centerline_optimizer/scripts/tmp/run.sh
+++ b/planning/static_centerline_optimizer/scripts/tmp/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-ros2 launch static_centerline_optimizer static_centerline_optimizer.launch.xml run_background:=false lanelet2_input_file_path:="$HOME/autoware_map/sample_map/lanelet2_map.osm" start_lanelet_id:=125 end_lanelet_id:=132 vehicle_model:=lexus
+# ros2 launch static_centerline_optimizer static_centerline_optimizer.launch.xml run_background:=false lanelet2_input_file_path:="$HOME/autoware_map/sample_map/lanelet2_map.osm" start_lanelet_id:=125 end_lanelet_id:=132 vehicle_model:=lexus
+ros2 launch static_centerline_optimizer static_centerline_optimizer.launch.xml run_background:=false lanelet2_input_file_path:="$HOME/autoware_map/odaiba_beta/lanelet2_map.osm" start_lanelet_id:=168 end_lanelet_id:=74 vehicle_model:=lexus

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -340,9 +340,9 @@ void StaticCenterlineOptimizerNode::load_map(const std::string & lanelet2_input_
       return nullptr;
     }
 
+    // NOTE: generate map projector for lanelet::write().
+    //       Without this, lat/lon of the generated LL2 map will be wrong.
     map_projector_ = geography_utils::get_lanelet2_projector(map_projector_info);
-    // const auto lanelet2_output_file_path = "/tmp/lanelet2_map.osm";
-    // lanelet::write(lanelet2_output_file_path, *map_ptr, *projector);
 
     // NOTE: The original map is stored here since the various ids in the lanelet map will change
     //       after lanelet::utils::overwriteLaneletCenterline, and saving map will fail.

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -339,11 +339,10 @@ void StaticCenterlineOptimizerNode::load_map(const std::string & lanelet2_input_
     if (!map_ptr) {
       return nullptr;
     }
-    const auto lanelet2_output_file_path = "/tmp/lanelet2_map.osm";
 
-    std::unique_ptr<lanelet::Projector> projector =
-      geography_utils::get_lanelet2_projector(map_projector_info);
-    lanelet::write(lanelet2_output_file_path, *map_ptr, *projector);
+    map_projector_ = geography_utils::get_lanelet2_projector(map_projector_info);
+    // const auto lanelet2_output_file_path = "/tmp/lanelet2_map.osm";
+    // lanelet::write(lanelet2_output_file_path, *map_ptr, *projector);
 
     // NOTE: The original map is stored here since the various ids in the lanelet map will change
     //       after lanelet::utils::overwriteLaneletCenterline, and saving map will fail.
@@ -351,7 +350,7 @@ void StaticCenterlineOptimizerNode::load_map(const std::string & lanelet2_input_
       Lanelet2MapLoaderNode::load_map(lanelet2_input_file_path, map_projector_info);
 
     // overwrite more dense centerline
-    // lanelet::utils::overwriteLaneletsCenterline(map_ptr, 5.0, false);
+    lanelet::utils::overwriteLaneletsCenterline(map_ptr, 5.0, false);
 
     // create map bin msg
     const auto map_bin_msg =
@@ -752,20 +751,11 @@ void StaticCenterlineOptimizerNode::save_map(
   const auto route_lanelets = get_lanelets_from_ids(*route_handler_ptr_, route_lane_ids);
 
   // update centerline in map
-  // utils::update_centerline(*route_handler_ptr_, route_lanelets, optimized_traj_points);
+  utils::update_centerline(*route_handler_ptr_, route_lanelets, optimized_traj_points);
   RCLCPP_INFO(get_logger(), "Updated centerline in map.");
 
   // save map with modified center line
-  // lanelet::write(lanelet2_output_file_path, *original_map_ptr_);
+  lanelet::write(lanelet2_output_file_path, *original_map_ptr_, *map_projector_);
   RCLCPP_INFO(get_logger(), "Saved map.");
-
-  /*
-  const auto lanelet2_input_file_path = "/home/takayuki/autoware_map/sample_map/lanelet2_map.osm";
-  tier4_map_msgs::msg::MapProjectorInfo map_projector_info;
-  map_projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
-  const auto map_ptr =
-    Lanelet2MapLoaderNode::load_map(lanelet2_input_file_path, map_projector_info);
-  lanelet::write(lanelet2_output_file_path, *map_ptr);
-  */
 }
 }  // namespace static_centerline_optimizer


### PR DESCRIPTION
## Description

Without this PR, the lat/lon of the generated LL2 map has an issue of becoming around 0.
This PR fixes the issue by giving a correct projector to `lanelet::write` function
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Test with the tmp/run.sh script.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
