### PR TITLE
fix(avoidance): fix logic to check if it is parked vehicle

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -421,7 +421,7 @@ bool isParkedVehicle(
     const auto most_left_lanelet = [&]() {
       const auto same_direction_lane =
         route_handler->getMostLeftLanelet(object.overhang_lanelet, true, true);
-      const lanelet::Attribute sub_type =
+      const lanelet::Attribute & sub_type =
         same_direction_lane.attribute(lanelet::AttributeName::Subtype);
       if (sub_type == "road_shoulder") {
         return same_direction_lane;
@@ -442,7 +442,7 @@ bool isParkedVehicle(
     double object_shiftable_distance =
       center_to_left_boundary - 0.5 * object.object.shape.dimensions.y;
 
-    const lanelet::Attribute sub_type =
+    const lanelet::Attribute & sub_type =
       most_left_lanelet.attribute(lanelet::AttributeName::Subtype);
     if (sub_type == "road_shoulder") {
       // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
@@ -469,7 +469,7 @@ bool isParkedVehicle(
     const auto most_right_lanelet = [&]() {
       const auto same_direction_lane =
         route_handler->getMostRightLanelet(object.overhang_lanelet, true, true);
-      const lanelet::Attribute sub_type =
+      const lanelet::Attribute & sub_type =
         same_direction_lane.attribute(lanelet::AttributeName::Subtype);
       if (sub_type == "road_shoulder") {
         return same_direction_lane;
@@ -490,7 +490,7 @@ bool isParkedVehicle(
     double object_shiftable_distance =
       center_to_right_boundary - 0.5 * object.object.shape.dimensions.y;
 
-    const lanelet::Attribute sub_type =
+    const lanelet::Attribute & sub_type =
       most_right_lanelet.attribute(lanelet::AttributeName::Subtype);
     if (sub_type == "road_shoulder") {
       // assuming it's parked vehicle if its CoG is within road shoulder lanelet.

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -418,8 +418,23 @@ bool isParkedVehicle(
 
   bool is_left_side_parked_vehicle = false;
   if (!isOnRight(object)) {
-    const auto most_left_lanelet =
-      route_handler->getMostLeftLanelet(object.overhang_lanelet, true, true);
+    const auto most_left_lanelet = [&]() {
+      const auto same_direction_lane =
+        route_handler->getMostLeftLanelet(object.overhang_lanelet, true, true);
+      const lanelet::Attribute sub_type =
+        same_direction_lane.attribute(lanelet::AttributeName::Subtype);
+      if (sub_type == "road_shoulder") {
+        return same_direction_lane;
+      }
+
+      const auto opposite_lanes = route_handler->getLeftOppositeLanelets(same_direction_lane);
+      if (opposite_lanes.empty()) {
+        return same_direction_lane;
+      }
+
+      return static_cast<lanelet::ConstLanelet>(opposite_lanes.front().invert());
+    }();
+
     const auto center_to_left_boundary = distance2d(
       to2D(most_left_lanelet.leftBound().basicLineString()),
       to2D(toLaneletPoint(centerline_pos)).basicPoint());
@@ -451,8 +466,23 @@ bool isParkedVehicle(
 
   bool is_right_side_parked_vehicle = false;
   if (isOnRight(object)) {
-    const auto most_right_lanelet =
-      route_handler->getMostRightLanelet(object.overhang_lanelet, true, true);
+    const auto most_right_lanelet = [&]() {
+      const auto same_direction_lane =
+        route_handler->getMostRightLanelet(object.overhang_lanelet, true, true);
+      const lanelet::Attribute sub_type =
+        same_direction_lane.attribute(lanelet::AttributeName::Subtype);
+      if (sub_type == "road_shoulder") {
+        return same_direction_lane;
+      }
+
+      const auto opposite_lanes = route_handler->getRightOppositeLanelets(same_direction_lane);
+      if (opposite_lanes.empty()) {
+        return same_direction_lane;
+      }
+
+      return static_cast<lanelet::ConstLanelet>(opposite_lanes.front().invert());
+    }();
+
     const auto center_to_right_boundary = distance2d(
       to2D(most_right_lanelet.rightBound().basicLineString()),
       to2D(toLaneletPoint(centerline_pos)).basicPoint());

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -418,33 +418,26 @@ bool isParkedVehicle(
 
   bool is_left_side_parked_vehicle = false;
   if (!isOnRight(object)) {
-    auto [object_shiftable_distance, sub_type] = [&]() {
-      const auto most_left_road_lanelet =
-        route_handler->getMostLeftLanelet(object.overhang_lanelet);
-      const auto most_left_lanelet_candidates =
-        route_handler->getLaneletMapPtr()->laneletLayer.findUsages(
-          most_left_road_lanelet.leftBound());
+    const auto most_left_lanelet =
+      route_handler->getMostLeftLanelet(object.overhang_lanelet, true, true);
+    const auto center_to_left_boundary = distance2d(
+      to2D(most_left_lanelet.leftBound().basicLineString()),
+      to2D(toLaneletPoint(centerline_pos)).basicPoint());
 
-      lanelet::ConstLanelet most_left_lanelet = most_left_road_lanelet;
-      const lanelet::Attribute sub_type =
-        most_left_lanelet.attribute(lanelet::AttributeName::Subtype);
+    double object_shiftable_distance =
+      center_to_left_boundary - 0.5 * object.object.shape.dimensions.y;
 
-      for (const auto & ll : most_left_lanelet_candidates) {
-        const lanelet::Attribute sub_type = ll.attribute(lanelet::AttributeName::Subtype);
-        if (sub_type.value() == "road_shoulder") {
-          most_left_lanelet = ll;
-        }
+    const lanelet::Attribute sub_type =
+      most_left_lanelet.attribute(lanelet::AttributeName::Subtype);
+    if (sub_type == "road_shoulder") {
+      // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
+      if (boost::geometry::within(
+            to2D(toLaneletPoint(object_pos)).basicPoint(),
+            most_left_lanelet.polygon2d().basicPolygon())) {
+        return true;
       }
-
-      const auto center_to_left_boundary = distance2d(
-        to2D(most_left_lanelet.leftBound().basicLineString()),
-        to2D(toLaneletPoint(centerline_pos)).basicPoint());
-
-      return std::make_pair(
-        center_to_left_boundary - 0.5 * object.object.shape.dimensions.y, sub_type);
-    }();
-
-    if (sub_type.value() != "road_shoulder") {
+    } else {
+      // assuming there is 0.5m road shoulder even if it's not defined explicitly in HDMap.
       object_shiftable_distance += parameters->object_check_min_road_shoulder_width;
     }
 
@@ -458,33 +451,26 @@ bool isParkedVehicle(
 
   bool is_right_side_parked_vehicle = false;
   if (isOnRight(object)) {
-    auto [object_shiftable_distance, sub_type] = [&]() {
-      const auto most_right_road_lanelet =
-        route_handler->getMostRightLanelet(object.overhang_lanelet);
-      const auto most_right_lanelet_candidates =
-        route_handler->getLaneletMapPtr()->laneletLayer.findUsages(
-          most_right_road_lanelet.rightBound());
+    const auto most_right_lanelet =
+      route_handler->getMostRightLanelet(object.overhang_lanelet, true, true);
+    const auto center_to_right_boundary = distance2d(
+      to2D(most_right_lanelet.rightBound().basicLineString()),
+      to2D(toLaneletPoint(centerline_pos)).basicPoint());
 
-      lanelet::ConstLanelet most_right_lanelet = most_right_road_lanelet;
-      const lanelet::Attribute sub_type =
-        most_right_lanelet.attribute(lanelet::AttributeName::Subtype);
+    double object_shiftable_distance =
+      center_to_right_boundary - 0.5 * object.object.shape.dimensions.y;
 
-      for (const auto & ll : most_right_lanelet_candidates) {
-        const lanelet::Attribute sub_type = ll.attribute(lanelet::AttributeName::Subtype);
-        if (sub_type.value() == "road_shoulder") {
-          most_right_lanelet = ll;
-        }
+    const lanelet::Attribute sub_type =
+      most_right_lanelet.attribute(lanelet::AttributeName::Subtype);
+    if (sub_type == "road_shoulder") {
+      // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
+      if (boost::geometry::within(
+            to2D(toLaneletPoint(object_pos)).basicPoint(),
+            most_right_lanelet.polygon2d().basicPolygon())) {
+        return true;
       }
-
-      const auto center_to_right_boundary = distance2d(
-        to2D(most_right_lanelet.rightBound().basicLineString()),
-        to2D(toLaneletPoint(centerline_pos)).basicPoint());
-
-      return std::make_pair(
-        center_to_right_boundary - 0.5 * object.object.shape.dimensions.y, sub_type);
-    }();
-
-    if (sub_type.value() != "road_shoulder") {
+    } else {
+      // assuming there is 0.5m road shoulder even if it's not defined explicitly in HDMap.
       object_shiftable_distance += parameters->object_check_min_road_shoulder_width;
     }
 

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -419,7 +419,7 @@ bool isParkedVehicle(
   bool is_left_side_parked_vehicle = false;
   if (!isOnRight(object)) {
     const auto most_left_lanelet = [&]() {
-      const auto same_direction_lane =
+      auto same_direction_lane =
         route_handler->getMostLeftLanelet(object.overhang_lanelet, true, true);
       const lanelet::Attribute & sub_type =
         same_direction_lane.attribute(lanelet::AttributeName::Subtype);
@@ -467,7 +467,7 @@ bool isParkedVehicle(
   bool is_right_side_parked_vehicle = false;
   if (isOnRight(object)) {
     const auto most_right_lanelet = [&]() {
-      const auto same_direction_lane =
+      auto same_direction_lane =
         route_handler->getMostRightLanelet(object.overhang_lanelet, true, true);
       const lanelet::Attribute & sub_type =
         same_direction_lane.attribute(lanelet::AttributeName::Subtype);


### PR DESCRIPTION
## Description

There are two issues in the logic to judge parked vehicle.

**BUG**: Return unexpected result for vehicle on opposite lane as follow. Previously, the module used `most_right_lanelet_candidates` data only when it was road shoulder lanes. But it should use opposite lane info even when it's not road shoulder lane so that it can judge if it's parked vehicle properly in following situation.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/f8a1499e-061c-4195-8c65-db4bc467cae0)

```c++
      const auto most_right_road_lanelet =
        route_handler->getMostRightLanelet(object.overhang_lanelet);
      const auto most_right_lanelet_candidates =
        route_handler->getLaneletMapPtr()->laneletLayer.findUsages(
          most_right_road_lanelet.rightBound());

      lanelet::ConstLanelet most_right_lanelet = most_right_road_lanelet;
      const lanelet::Attribute sub_type =
        most_right_lanelet.attribute(lanelet::AttributeName::Subtype);

      for (const auto & ll : most_right_lanelet_candidates) {
        const lanelet::Attribute sub_type = ll.attribute(lanelet::AttributeName::Subtype);
        if (sub_type.value() == "road_shoulder") { <- BUG
          most_right_lanelet = ll;
        }
      }
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/bcafdc0a-3070-4ce6-bdce-deaeec2a7db7)

Additionally, I modified the parked vhehicle check condition. If the vehicle CoG is in road shoulder lanelet, the module judge it as parked vhehicle.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/5caaab91-a83a-57a7-90bb-3e1a1a660519?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Bug fix.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
