### PR TITLE
feat(start_planner): output collided stop path

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -42,22 +42,23 @@ namespace motion_utils
  * @param points points of trajectory, path, ...
  */
 template <class T>
-void validateNonEmpty(const T & points)
+void validateNonEmpty(const T & points, const std::string caller_function)
 {
   if (points.empty()) {
     tier4_autoware_utils::print_backtrace();
-    throw std::invalid_argument("[motion_utils] validateNonEmpty(): Points is empty.");
+    throw std::invalid_argument(
+      "[motion_utils] [" + caller_function + "]: validateNonEmpty(): Points is empty.");
   }
 }
 
 extern template void validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
-  const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &);
+  const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &, const std::string);
 extern template void
 validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
-  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &);
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &, const std::string);
 extern template void
 validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
-  const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
+  const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &, const std::string);
 
 /**
  * @brief validate a point is in a non-sharp angle between two points or not
@@ -214,7 +215,7 @@ std::optional<size_t> searchZeroVelocityIndex(
   const T & points_with_twist, const size_t src_idx, const size_t dst_idx)
 {
   try {
-    validateNonEmpty(points_with_twist);
+    validateNonEmpty(points_with_twist, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -246,7 +247,7 @@ template <class T>
 std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t src_idx)
 {
   try {
-    validateNonEmpty(points_with_twist);
+    validateNonEmpty(points_with_twist, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -289,7 +290,7 @@ searchZeroVelocityIndex<std::vector<autoware_auto_planning_msgs::msg::Trajectory
 template <class T>
 size_t findNearestIndex(const T & points, const geometry_msgs::msg::Point & point)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   double min_dist = std::numeric_limits<double>::max();
   size_t min_idx = 0;
@@ -336,7 +337,7 @@ std::optional<size_t> findNearestIndex(
   const double max_yaw = std::numeric_limits<double>::max())
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -420,10 +421,10 @@ double calcLongitudinalOffsetToSegment(
   const auto overlap_removed_points = removeOverlapPoints(points, seg_idx);
 
   if (throw_exception) {
-    validateNonEmpty(overlap_removed_points);
+    validateNonEmpty(overlap_removed_points, __func__);
   } else {
     try {
-      validateNonEmpty(overlap_removed_points);
+      validateNonEmpty(overlap_removed_points, __func__);
     } catch (const std::exception & e) {
       log_error(e.what());
       return std::nan("");
@@ -581,10 +582,10 @@ double calcLateralOffset(
   const auto overlap_removed_points = removeOverlapPoints(points, 0);
 
   if (throw_exception) {
-    validateNonEmpty(overlap_removed_points);
+    validateNonEmpty(overlap_removed_points, __func__);
   } else {
     try {
-      validateNonEmpty(overlap_removed_points);
+      validateNonEmpty(overlap_removed_points, __func__);
     } catch (const std::exception & e) {
       log_error(
         std::string(e.what()) +
@@ -653,10 +654,10 @@ double calcLateralOffset(
   const auto overlap_removed_points = removeOverlapPoints(points, 0);
 
   if (throw_exception) {
-    validateNonEmpty(overlap_removed_points);
+    validateNonEmpty(overlap_removed_points, __func__);
   } else {
     try {
-      validateNonEmpty(overlap_removed_points);
+      validateNonEmpty(overlap_removed_points, __func__);
     } catch (const std::exception & e) {
       log_error(
         std::string(e.what()) +
@@ -709,7 +710,7 @@ template <class T>
 double calcSignedArcLength(const T & points, const size_t src_idx, const size_t dst_idx)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return 0.0;
@@ -752,7 +753,7 @@ std::vector<double> calcSignedArcLengthPartialSum(
   const T & points, const size_t src_idx, const size_t dst_idx)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -804,7 +805,7 @@ double calcSignedArcLength(
   const T & points, const geometry_msgs::msg::Point & src_point, const size_t dst_idx)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return 0.0;
@@ -847,7 +848,7 @@ double calcSignedArcLength(
   const T & points, const size_t src_idx, const geometry_msgs::msg::Point & dst_point)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return 0.0;
@@ -886,7 +887,7 @@ double calcSignedArcLength(
   const geometry_msgs::msg::Point & dst_point)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return 0.0;
@@ -926,7 +927,7 @@ template <class T>
 double calcArcLength(const T & points)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return 0.0;
@@ -1035,7 +1036,7 @@ std::optional<double> calcDistanceToForwardStopPoint(
   const T & points_with_twist, const size_t src_idx = 0)
 {
   try {
-    validateNonEmpty(points_with_twist);
+    validateNonEmpty(points_with_twist, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -1069,7 +1070,7 @@ std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const T & points, const size_t src_idx, const double offset, const bool throw_exception = false)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -1151,7 +1152,7 @@ std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error("Failed to calculate longitudinal offset: " + std::string(e.what()));
     return {};
@@ -1199,7 +1200,7 @@ std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const bool set_orientation_from_position_direction = true, const bool throw_exception = false)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error("Failed to calculate longitudinal offset: " + std::string(e.what()));
     return {};
@@ -1302,7 +1303,7 @@ std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const bool set_orientation_from_position_direction = true)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -1348,7 +1349,7 @@ std::optional<size_t> insertTargetPoint(
   const double overlap_threshold = 1e-3)
 {
   try {
-    validateNonEmpty(points);
+    validateNonEmpty(points, __func__);
   } catch (const std::exception & e) {
     log_error(e.what());
     return {};
@@ -1450,7 +1451,7 @@ std::optional<size_t> insertTargetPoint(
   const double insert_point_length, const geometry_msgs::msg::Point & p_target, T & points,
   const double overlap_threshold = 1e-3)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   if (insert_point_length < 0.0) {
     return std::nullopt;
@@ -1505,7 +1506,7 @@ std::optional<size_t> insertTargetPoint(
   const size_t src_segment_idx, const double insert_point_length, T & points,
   const double overlap_threshold = 1e-3)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   if (src_segment_idx >= points.size() - 1) {
     return std::nullopt;
@@ -1582,7 +1583,7 @@ std::optional<size_t> insertTargetPoint(
   const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   if (insert_point_length < 0.0) {
     return std::nullopt;
@@ -1633,7 +1634,7 @@ std::optional<size_t> insertStopPoint(
   const size_t src_segment_idx, const double distance_to_stop_point, T & points_with_twist,
   const double overlap_threshold = 1e-3)
 {
-  validateNonEmpty(points_with_twist);
+  validateNonEmpty(points_with_twist, __func__);
 
   if (distance_to_stop_point < 0.0 || src_segment_idx >= points_with_twist.size() - 1) {
     return std::nullopt;
@@ -1680,7 +1681,7 @@ template <class T>
 std::optional<size_t> insertStopPoint(
   const double distance_to_stop_point, T & points_with_twist, const double overlap_threshold = 1e-3)
 {
-  validateNonEmpty(points_with_twist);
+  validateNonEmpty(points_with_twist, __func__);
 
   if (distance_to_stop_point < 0.0) {
     return std::nullopt;
@@ -1736,7 +1737,7 @@ std::optional<size_t> insertStopPoint(
   T & points_with_twist, const double max_dist = std::numeric_limits<double>::max(),
   const double max_yaw = std::numeric_limits<double>::max(), const double overlap_threshold = 1e-3)
 {
-  validateNonEmpty(points_with_twist);
+  validateNonEmpty(points_with_twist, __func__);
 
   if (distance_to_stop_point < 0.0) {
     return std::nullopt;
@@ -1943,7 +1944,7 @@ double calcSignedArcLength(
   const T & points, const geometry_msgs::msg::Point & src_point, const size_t src_seg_idx,
   const geometry_msgs::msg::Point & dst_point, const size_t dst_seg_idx)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   const double signed_length_on_traj = calcSignedArcLength(points, src_seg_idx, dst_seg_idx);
   const double signed_length_src_offset =
@@ -1986,7 +1987,7 @@ double calcSignedArcLength(
   const T & points, const geometry_msgs::msg::Point & src_point, const size_t src_seg_idx,
   const size_t dst_idx)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   const double signed_length_on_traj = calcSignedArcLength(points, src_seg_idx, dst_idx);
   const double signed_length_src_offset =
@@ -2024,7 +2025,7 @@ double calcSignedArcLength(
   const T & points, const size_t src_idx, const geometry_msgs::msg::Point & dst_point,
   const size_t dst_seg_idx)
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   const double signed_length_on_traj = calcSignedArcLength(points, src_idx, dst_seg_idx);
   const double signed_length_dst_offset =
@@ -2064,7 +2065,7 @@ size_t findFirstNearestIndexWithSoftConstraints(
   const double dist_threshold = std::numeric_limits<double>::max(),
   const double yaw_threshold = std::numeric_limits<double>::max())
 {
-  validateNonEmpty(points);
+  validateNonEmpty(points, __func__);
 
   {  // with dist and yaw thresholds
     const double squared_dist_threshold = dist_threshold * dist_threshold;
@@ -2229,7 +2230,7 @@ std::optional<double> calcDistanceToForwardStopPoint(
   const double max_yaw = std::numeric_limits<double>::max())
 {
   try {
-    validateNonEmpty(points_with_twist);
+    validateNonEmpty(points_with_twist, __func__);
   } catch (const std::exception & e) {
     log_error("Failed to calculate stop distance" + std::string(e.what()));
     return {};
@@ -2410,10 +2411,10 @@ double calcYawDeviation(
   const auto overlap_removed_points = removeOverlapPoints(points, 0);
 
   if (throw_exception) {
-    validateNonEmpty(overlap_removed_points);
+    validateNonEmpty(overlap_removed_points, __func__);
   } else {
     try {
-      validateNonEmpty(overlap_removed_points);
+      validateNonEmpty(overlap_removed_points, __func__);
     } catch (const std::exception & e) {
       log_error(e.what());
       return 0.0;

--- a/common/motion_utils/src/trajectory/path_with_lane_id.cpp
+++ b/common/motion_utils/src/trajectory/path_with_lane_id.cpp
@@ -64,11 +64,11 @@ size_t findNearestIndexFromLaneId(
     const size_t start_idx = opt_range->first;
     const size_t end_idx = opt_range->second;
 
-    validateNonEmpty(path.points);
+    validateNonEmpty(path.points, __func__);
 
     const auto sub_points = std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>{
       path.points.begin() + start_idx, path.points.begin() + end_idx + 1};
-    validateNonEmpty(sub_points);
+    validateNonEmpty(sub_points, __func__);
 
     return start_idx + findNearestIndex(sub_points, pos);
   }

--- a/common/motion_utils/src/trajectory/trajectory.cpp
+++ b/common/motion_utils/src/trajectory/trajectory.cpp
@@ -19,11 +19,11 @@ namespace motion_utils
 
 //
 template void validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::PathPoint>>(
-  const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &);
+  const std::vector<autoware_auto_planning_msgs::msg::PathPoint> &, const std::string);
 template void validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>>(
-  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &);
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> &, const std::string);
 template void validateNonEmpty<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>(
-  const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &);
+  const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> &, const std::string);
 
 //
 template std::optional<bool>

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -97,11 +97,11 @@ TEST(trajectory, validateNonEmpty)
   using motion_utils::validateNonEmpty;
 
   // Empty
-  EXPECT_THROW(validateNonEmpty(Trajectory{}.points), std::invalid_argument);
+  EXPECT_THROW(validateNonEmpty(Trajectory{}.points, " "), std::invalid_argument);
 
   // Non-empty
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
-  EXPECT_NO_THROW(validateNonEmpty(traj.points));
+  EXPECT_NO_THROW(validateNonEmpty(traj.points, " "));
 }
 
 TEST(trajectory, validateNonSharpAngle_DefaultThreshold)

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -88,7 +88,7 @@ geometry_msgs::msg::Polygon toMsg(const tier4_autoware_utils::Polygon2d & polygo
 template <class T>
 size_t findFirstNearestIndex(const T & points, const geometry_msgs::msg::Point & point)
 {
-  motion_utils::validateNonEmpty(points);
+  motion_utils::validateNonEmpty(points, "");
 
   double min_dist = std::numeric_limits<double>::max();
   size_t min_idx = 0;
@@ -139,7 +139,7 @@ double calcSignedArcLengthToFirstNearestPoint(
   const geometry_msgs::msg::Point & dst_point)
 {
   try {
-    motion_utils::validateNonEmpty(points);
+    motion_utils::validateNonEmpty(points, "");
   } catch (const std::exception & e) {
     std::cerr << e.what() << std::endl;
     return 0.0;

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -312,6 +312,7 @@ private:
    */
   void deleteExpiredModules(SceneModulePtr & module_ptr) const
   {
+    std::cerr << "Module to be killed! " << module_ptr->name() << "\n";
     module_ptr->onExit();
     module_ptr->publishRTCStatus();
     module_ptr->publishObjectsOfInterestMarker();
@@ -356,6 +357,8 @@ private:
   void clearCandidateModules()
   {
     std::for_each(candidate_module_ptrs_.begin(), candidate_module_ptrs_.end(), [this](auto & m) {
+      std::cerr << "0xxx Module " << m->name() << " killed in func " << __func__ << " \n";
+
       deleteExpiredModules(m);
     });
     candidate_module_ptrs_.clear();

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -179,7 +179,11 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
       /**
        * STEP7: if the candidate module is approved, push the module into approved_module_ptrs_
        */
+      std::cerr << "highest_priority_module before " << highest_priority_module->name() << "\n";
       addApprovedModule(highest_priority_module);
+      std::cerr << "highest_priority_module after " << highest_priority_module->name() << "\n";
+
+      std::cerr << "clear CandidateModules() called 0\n";
       clearCandidateModules();
       debug_info_.emplace_back(highest_priority_module, Action::ADD, "To Approval");
 
@@ -557,11 +561,14 @@ std::pair<SceneModulePtr, BehaviorModuleOutput> PlannerManager::runRequestModule
   {
     const auto remove_expired_modules = [this](auto & m) {
       if (m->getCurrentStatus() == ModuleStatus::FAILURE) {
+        std::cerr << "0 Module " << m->name() << " killed in func " << __func__ << " \n";
         deleteExpiredModules(m);
         return true;
       }
 
       if (m->getCurrentStatus() == ModuleStatus::SUCCESS) {
+        std::cerr << "1 Module " << m->name() << " killed in func " << __func__ << " \n";
+
         deleteExpiredModules(m);
         return true;
       }
@@ -581,6 +588,8 @@ std::pair<SceneModulePtr, BehaviorModuleOutput> PlannerManager::runRequestModule
    * return null data if valid candidate module doesn't exist.
    */
   if (executable_modules.empty()) {
+    std::cerr << "clear CandidateModules() called 1\n";
+
     clearCandidateModules();
     return std::make_pair(nullptr, BehaviorModuleOutput{});
   }
@@ -711,6 +720,8 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
       [](const auto & m) { return m->isWaitingApproval(); });
 
     if (waiting_approval_modules_itr != approved_module_ptrs_.end()) {
+      std::cerr << "clear CandidateModules() called 2\n";
+
       clearCandidateModules();
       candidate_module_ptrs_.push_back(*waiting_approval_modules_itr);
 
@@ -738,6 +749,8 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
 
     std::for_each(itr, approved_module_ptrs_.end(), [this](auto & m) {
       debug_info_.emplace_back(m, Action::DELETE, "From Approved");
+      std::cerr << "2 Module " << m->name() << " killed in func " << __func__ << " \n";
+
       deleteExpiredModules(m);
     });
 
@@ -745,6 +758,8 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
       manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->updateObserver(); });
 
     if (itr != approved_module_ptrs_.end()) {
+      std::cerr << "clear CandidateModules() called 3\n";
+
       clearCandidateModules();
     }
 
@@ -808,6 +823,8 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
 
     std::for_each(itr, approved_module_ptrs_.end(), [&](auto & m) {
       debug_info_.emplace_back(m, Action::DELETE, "From Approved");
+      std::cerr << "3 Module " << m->name() << " killed in func " << __func__ << " \n";
+
       deleteExpiredModules(m);
     });
 
@@ -838,6 +855,8 @@ void PlannerManager::updateCandidateModules(
   {
     const auto candidate_to_remove = [&](auto & itr) {
       if (!exist(itr, request_modules)) {
+        std::cerr << "4 Module " << itr->name() << " killed in func " << __func__ << " \n";
+
         deleteExpiredModules(itr);
         return true;
       }

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -386,6 +386,7 @@ private:
       }
 
       if (canTransitFailureState()) {
+        std::cerr << name() << " has transited to failure!\n";
         log_debug_throttled("transiting from RUNNING to FAILURE");
         return ModuleStatus::FAILURE;
       }

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -63,9 +63,11 @@ public:
   virtual PlannerType getPlannerType() const = 0;
   virtual std::optional<PullOutPath> plan(const Pose & start_pose, const Pose & goal_pose) = 0;
 
-protected:
+  bool hasBestCollidedPath() { return best_collided_path_.has_value(); }
+  std::optional<PullOutPath> getBestCollidedPath() { return best_collided_path_; }
+
   bool isPullOutPathCollided(
-    behavior_path_planner::PullOutPath & pull_out_path,
+    const behavior_path_planner::PullOutPath & pull_out_path,
     double collision_check_distance_from_end) const
   {
     // check for collisions
@@ -97,6 +99,7 @@ protected:
   LinearRing2d vehicle_footprint_;
   StartPlannerParameters parameters_;
   double collision_check_margin_;
+  std::optional<PullOutPath> best_collided_path_;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -63,7 +63,8 @@ struct PullOutStatus
   PathWithLaneId backward_path{};
   bool found_pull_out_path{false};      // current path is safe against static objects
   bool is_safe_dynamic_objects{false};  // current path is safe against dynamic objects
-  bool driving_forward{false};          // if ego is driving on backward path, this is set to false
+  bool is_safe_static_objects{false};
+  bool driving_forward{false};  // if ego is driving on backward path, this is set to false
   bool backward_driving_complete{
     false};  // after backward driving is complete, this is set to true (warning: this is set to
              // false at next cycle after backward driving is complete)
@@ -78,6 +79,14 @@ struct PullOutStatus
   PullOutStatus() {}
 };
 
+struct CollidedPullOutStatus
+{
+  std::optional<PullOutPath> best_collided_path;
+  size_t best_collided_path_index;
+  double best_collided_path_collision_check_margin;
+  bool best_collided_path_requires_backwards;
+  behavior_path_planner::PlannerType best_collided_path_planner_type;
+};
 class StartPlannerModule : public SceneModuleInterface
 {
 public:
@@ -243,10 +252,12 @@ private:
     const PullOutPath & path, const behavior_path_planner::PlannerType & planner_type);
   void updateStatusWithCurrentPath(
     const behavior_path_planner::PullOutPath & path, const Pose & start_pose,
-    const behavior_path_planner::PlannerType & planner_type);
+    const behavior_path_planner::PlannerType & planner_type,
+    const bool is_safe_static_objects = true);
   void updateStatusWithNextPath(
     const behavior_path_planner::PullOutPath & path, const Pose & start_pose,
-    const behavior_path_planner::PlannerType & planner_type);
+    const behavior_path_planner::PlannerType & planner_type,
+    const bool is_safe_static_objects = true);
   void updateStatusIfNoSafePathFound();
 
   std::shared_ptr<StartPlannerParameters> parameters_;

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/util.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/util.hpp
@@ -53,6 +53,8 @@ Pose getBackedPose(
   const Pose & current_pose, const double & yaw_shoulder_lane, const double & back_distance);
 std::optional<PathWithLaneId> extractCollisionCheckSection(
   const PullOutPath & path, const double collision_check_distance_from_end);
+bool backwardsMovementIsNecessary(
+  const Pose & start_pose_candidate, const Pose & refined_start_pose);
 }  // namespace behavior_path_planner::start_planner_utils
 
 #endif  // BEHAVIOR_PATH_START_PLANNER_MODULE__UTIL_HPP_

--- a/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -115,6 +115,9 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
 
   if (isPullOutPathCollided(output, parameters_.geometric_collision_check_distance_from_end)) {
+    if (!best_collided_path_.has_value()) {
+      best_collided_path_ = output;
+    }
     return {};
   }
 

--- a/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -135,6 +135,9 @@ std::optional<PullOutPath> ShiftPullOut::plan(const Pose & start_pose, const Pos
     shift_path.header = planner_data_->route_handler->getRouteHeader();
 
     if (isPullOutPathCollided(pull_out_path, parameters_.shift_collision_check_distance_from_end)) {
+      if (!best_collided_path_.has_value()) {
+        best_collided_path_ = pull_out_path;
+      }
       continue;
     }
 

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -638,10 +638,10 @@ BehaviorModuleOutput StartPlannerModule::plan()
       // Insert stop point in the path if needed
       const std::string stop_point_reason = std::invoke([&]() {
         if (status_.is_safe_static_objects)
-          return "Insert stop point in the path because of dynamic objects";
+          return "Insert stop point in the path because of dynamic objects.";
         if (status_.is_safe_dynamic_objects)
           return "All path candidates cause a collision with static objects. Outputting best path "
-                 "with a stop point";
+                 "with a stop point.";
         return "Collision with dynamic objects and static objects. A stop point is inserted for "
                "safety.";
       });

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -623,7 +623,7 @@ BehaviorModuleOutput StartPlannerModule::plan()
 
     if (status_.stop_pose) {
       // Delete stop point if conditions are met
-      if (status_.is_safe_dynamic_objects && isStopped()) {
+      if (status_.is_safe_dynamic_objects && status_.is_safe_static_objects && isStopped()) {
         status_.stop_pose = std::nullopt;
       }
       stop_pose_ = status_.stop_pose;
@@ -1066,7 +1066,10 @@ void StartPlannerModule::updatePullOutStatus()
   const PathWithLaneId start_pose_candidates_path = calcBackwardPathFromStartPose();
   const auto refined_start_pose = calcLongitudinalOffsetPose(
     start_pose_candidates_path.points, planner_data_->self_odometry->pose.pose.position, 0.0);
-  if (!refined_start_pose) return;
+  if (!refined_start_pose) {
+    std::cerr << "IS THIS GUY GUILTY?\n";
+    return;
+  }
 
   // search pull out start candidates backward
   const std::vector<Pose> start_pose_candidates = std::invoke([&]() -> std::vector<Pose> {

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -852,15 +852,16 @@ void StartPlannerModule::planWithPriority(
     debug_data_.selected_start_pose_candidate_index = cps.best_collided_path_index;
     debug_data_.margin_for_start_pose_candidate = cps.best_collided_path_collision_check_margin;
     const auto & start_pose_candidate = start_pose_candidates.at(cps.best_collided_path_index);
+    constexpr bool is_path_without_static_collisions = false;
     if (cps.best_collided_path_requires_backwards) {
       updateStatusWithNextPath(
         cps.best_collided_path.value(), start_pose_candidate, cps.best_collided_path_planner_type,
-        false);
+        is_path_without_static_collisions);
       return;
     }
     updateStatusWithCurrentPath(
       cps.best_collided_path.value(), start_pose_candidate, cps.best_collided_path_planner_type,
-      false);
+      is_path_without_static_collisions);
     return;
   }
 
@@ -898,8 +899,6 @@ bool StartPlannerModule::findPullOutPath(
   const Pose & start_pose_candidate, const std::shared_ptr<PullOutPlannerBase> & planner,
   const Pose & refined_start_pose, const Pose & goal_pose, const double collision_check_margin)
 {
-  // if start_pose_candidate is far from refined_start_pose, backward driving is necessary
-
   const bool backward_is_necessary =
     start_planner_utils::backwardsMovementIsNecessary(start_pose_candidate, refined_start_pose);
 

--- a/planning/behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_start_planner_module/src/util.cpp
@@ -72,6 +72,14 @@ PathWithLaneId getBackwardPath(
   return backward_path;
 }
 
+bool backwardsMovementIsNecessary(
+  const Pose & start_pose_candidate, const Pose & refined_start_pose)
+{
+  // if start_pose_candidate is far from refined_start_pose, backward driving is necessary
+  constexpr double epsilon = 0.01;
+  return tier4_autoware_utils::calcDistance2d(start_pose_candidate, refined_start_pose) > epsilon;
+}
+
 Pose getBackedPose(
   const Pose & current_pose, const double & yaw_shoulder_lane, const double & back_distance)
 {


### PR DESCRIPTION
## Description

Sometimes, when the ego vehicle is surrounded by other vehicles/objects, the start planner is unable to find a pull out path that does not collide with other objects and instead outputs a stop path (a path with 2 points and 0 speed). However, if the surrounding vehicles move, or the ego vehicle is moved manually, as in a driver moves the vehicle to a place were it should be able to take off from, the start planner does not output a new path and, instead, the start and goal poses must be set again so the start planner can output a valid path. 

With this PR, if the start planner does not find a non-collided path, it outputs the "best collided path" with a stop point on the ego's current position, and periodically checks if the stop point can be removed (either because the ego was moved manually by a driver or because the surrounding obstacles disappeared), which can be very beneficial when running Autoware on real vehicles. 

Examples: 

1)The start planner outputs a geometric path, but, since it is surrounded by other vehicles a stop point is inserted, once the other vehicles are removed, the ego can move:

https://github.com/autowarefoundation/autoware.universe/assets/25967964/5e6c7966-0b84-46f2-9211-607290408e84

2) The ego outputs a collided path with stop point when it is surrounded by other objects:

-  First, I move the ego position (as if a driver moved the vehicle manually) to a new point in the path where the ego can continue -> the path turns green and the ego can proceed
- Second, same situation, but I eliminate the surrounding vehicles and the ego can proceed.

https://github.com/autowarefoundation/autoware.universe/assets/25967964/d85031d1-7a9e-4efd-99b2-97aeaa8568ea


Limitations: 
Paths with backward movements are not fully supported: 
Since the output paths with backward movement are "divided in several parts" it is difficult at the moment to check in which part of the path the ego vehicle is in order to re-check for collisions with static objects, the result is that, if the driver takes manually and moves the ego to a different position, the "active path" will still be the backward path and the ego wont move.

## Related links

Related Ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-5261)
Conversation:  [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QW0GU6P7/p1701153915688299?thread_ts=1701152695.782779&cid=C03QW0GU6P7)
## Tests performed

PSim
Evaluator: [TIER IVs INTERNAL LINK](https://evaluation.ci.tier4.jp/evaluation/reports/54318455-998c-5918-bb69-ec1bae497c95?project_id=prd_jt)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
