### PR TITLE
refactor(system_monitor): rework parameters

### DIFF
--- a/system/system_monitor/README.md
+++ b/system/system_monitor/README.md
@@ -90,7 +90,7 @@ Every topic is published in 1 minute interval.
 
 ## ROS parameters
 
-See [ROS parameters](docs/ros_parameters.md).
+{{ json_to_markdown("system/system_monitor/schema/system_monitor.schema.json") }}
 
 ## Notes
 

--- a/system/system_monitor/config/hdd_monitor.param.yaml
+++ b/system/system_monitor/config/hdd_monitor.param.yaml
@@ -4,16 +4,16 @@
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:
-        name: /
-        temp_attribute_id: 0xC2
+        name: "/"
+        temp_attribute_id: "0xC2"
         temp_warn: 55.0
         temp_error: 70.0
-        power_on_hours_attribute_id: 0x09
+        power_on_hours_attribute_id: "0x09"
         power_on_hours_warn: 3000000
-        total_data_written_attribute_id: 0xF1
+        total_data_written_attribute_id: "0xF1"
         total_data_written_warn: 4915200   # =150TB (1unit=32MB)
         total_data_written_safety_factor: 0.05
-        recovered_error_attribute_id: 0xC3
+        recovered_error_attribute_id: "0xC3"
         recovered_error_warn: 1
         free_warn: 5120 # MB(8hour)
         free_error: 100 # MB(last 1 minute)

--- a/system/system_monitor/config/ntp_monitor.param.yaml
+++ b/system/system_monitor/config/ntp_monitor.param.yaml
@@ -1,6 +1,5 @@
 /**:
   ros__parameters:
-    server: ntp.nict.jp
     offset_warn: 0.1
     offset_error: 5.0
     timeout: 5  # The chronyc execution timeout will trigger a warning when this timer expires.

--- a/system/system_monitor/schema/system_monitor.schema.json
+++ b/system/system_monitor/schema/system_monitor.schema.json
@@ -1,0 +1,361 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for system monitor",
+  "type": "object",
+  "definitions": {
+    "cpu_monitor": {
+      "type": "object",
+      "properties": {
+        "usage_warn": {
+          "type": "number",
+          "default": 0.90,
+          "description": "Generates warning when CPU usage reaches a specified value or higher and last for usage_warn_count counts."
+        },
+        "usage_error": {
+          "type": "number",
+          "default": 1.00,
+          "description": "Generates error when CPU usage reaches a specified value or higher and last for usage_error_count counts."
+        },
+        "usage_warn_count": {
+          "type": "integer",
+          "default": 2,
+          "description": "Generates warning when CPU usage reaches usage_warn value or higher and last for a specified counts."
+        },
+        "usage_error_count": {
+          "type": "integer",
+          "default": 2,
+          "description": "Generates error when CPU usage reaches usage_error value or higher and last for a specified counts."
+        },
+        "usage_avg": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, the monitor will use the average CPU usage of all cores. If false, the monitor will use the CPU usage of the first core."
+        },
+        "msr_reader_port": {
+          "type": "integer",
+          "default": 7634,
+          "description": "Port number to connect to msr_reader."
+        }
+      },
+      "required": [
+        "usage_warn",
+        "usage_error",
+        "usage_warn_count",
+        "usage_error_count",
+        "usage_avg",
+        "msr_reader_port"
+      ],
+      "additionalProperties": false
+    },
+    "mem_monitor": {
+      "type": "object",
+      "properties": {
+        "available_size": {
+          "type": "integer",
+          "default": 1024,
+          "description": "Generates warning when available memory size is less than the specified value."
+        }
+      },
+      "required": [
+        "available_size"
+      ],
+      "additionalProperties": false
+    },
+    "net_monitor": {
+      "type": "object",
+      "properties": {
+        "device": {
+          "type": "array",
+          "default": ["*"],
+          "description": "The name of network interface to monitor. (e.g. eth0, * for all network interfaces)"
+        },
+        "monitor_program": {
+          "type": "string",
+          "default": "greengrass",
+          "description": "program name to be monitored by nethogs name."
+        },
+        "crc_error_check_duration": {
+          "type": "integer",
+          "default": 1,
+          "description": "CRC error check duration."
+        },
+        "crc_error_count_threshold": {
+          "type": "integer",
+          "default": 1,
+          "description": "Generates warning when count of CRC errors during CRC error check duration reaches a specified value or higher."
+        },
+        "reassembles_failed_check_duration": {
+          "type": "integer",
+          "default": 1,
+          "description": "IP packet reassembles failed check duration."
+        },
+        "reassembles_failed_check_count": {
+          "type": "integer",
+          "default": 1,
+          "description": "Generates warning when count of IP packet reassembles failed during IP packet reassembles failed check duration reaches a specified value or higher."
+        }
+      },
+      "required": [
+        "device",
+        "monitor_program",
+        "crc_error_check_duration",
+        "crc_error_count_threshold",
+        "reassembles_failed_check_duration",
+        "reassembles_failed_check_count"
+      ],
+      "additionalProperties": false
+    },
+    "ntp_monitor": {
+      "type": "object",
+      "properties": {
+        "offset_warn": {
+          "type": "number",
+          "default": 0.1,
+          "description": "Generates warning when NTP offset reaches a specified value or higher. (default is 100ms)"
+        },
+        "offset_error": {
+          "type": "number",
+          "default": 5.0,
+          "description": "Generates warning when NTP offset reaches a specified value or higher. (default is 5sec)"
+        },
+        "timeout": {
+          "type": "integer",
+          "default": 5,
+          "description": "Timeout for NTP query."
+        }
+      },
+      "required": [
+        "offset_warn",
+        "offset_error",
+        "timeout"
+      ],
+      "additionalProperties": false
+    },
+    "process_monitor": {
+      "type": "object",
+      "properties": {
+        "num_of_procs": {
+          "type": "integer",
+          "default": 5,
+          "description": "The number of processes to generate High-load Proc[0-9] and High-mem Proc[0-9]."
+        }
+      },
+      "required": [
+        "num_of_procs"
+      ],
+      "additionalProperties": false
+    },
+    "hdd_monitor": {
+      "type": "object",
+      "properties": {
+        "disks": {
+          "type": "object",
+          "properties": {
+            "disk0": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "default": "/",
+                  "description": "The disk name to monitor temperature. (e.g. /dev/sda)"
+                },
+                "temp_attribute_id": {
+                  "type": "string",
+                  "default": "0xC2",
+                  "description": "S.M.A.R.T attribute ID of temperature."
+                },
+                "temp_warn": {
+                  "type": "number",
+                  "default": 55.0,
+                  "description": "Generates warning when HDD temperature reaches a specified value or higher."
+                },
+                "temp_error": {
+                  "type": "number",
+                  "default": 70.0,
+                  "description": "Generates error when HDD temperature reaches a specified value or higher."
+                },
+                "power_on_hours_attribute_id": {
+                  "type": "string",
+                  "default": "0x09",
+                  "description": "S.M.A.R.T attribute ID of power-on hours."
+                },
+                "power_on_hours_warn": {
+                  "type": "integer",
+                  "default": 3000000,
+                  "description": "Generates warning when HDD power-on hours reaches a specified value or higher."
+                },
+                "total_data_written_attribute_id": {
+                  "type": "string",
+                  "default": "0xF1",
+                  "description": "S.M.A.R.T attribute ID of total data written."
+                },
+                "total_data_written_warn": {
+                  "type": "integer",
+                  "default": 4915200,
+                  "description": "Generates warning when HDD total data written reaches a specified value or higher."
+                },
+                "total_data_written_safety_factor": {
+                  "type": "number",
+                  "default": 0.05,
+                  "description": "Safety factor of HDD total data written."
+                },
+                "recovered_error_attribute_id": {
+                  "type": "string",
+                  "default": "0xC3",
+                  "description": "S.M.A.R.T attribute ID of recovered error."
+                },
+                "recovered_error_warn": {
+                  "type": "integer",
+                  "default": 1,
+                  "description": "Generates warning when HDD recovered error reaches a specified value or higher."
+                },
+                "free_warn": {
+                  "type": "integer",
+                  "default": 5120,
+                  "description": "Generates warning when HDD free space reaches a specified value or lower."
+                },
+                "free_error": {
+                  "type": "integer",
+                  "default": 100,
+                  "description": "Generates error when HDD free space reaches a specified value or lower."
+                },
+                "read_data_rate_warn": {
+                  "type": "number",
+                  "default": 360.0,
+                  "description": "Generates warning when HDD read data rate reaches a specified value or higher."
+                },
+                "write_data_rate_warn": {
+                  "type": "number",
+                  "default": 103.5,
+                  "description": "Generates warning when HDD write data rate reaches a specified value or higher."
+                },
+                "read_iops_warn": {
+                  "type": "number",
+                  "default": 63360.0,
+                  "description": "Generates warning when HDD read IOPS reaches a specified value or higher."
+                },
+                "write_iops_warn": {
+                  "type": "number",
+                  "default": 24120.0,
+                  "description": "Generates warning when HDD write IOPS reaches a specified value or higher."
+                }
+              },
+              "required": [
+                "name",
+                "temp_attribute_id",
+                "temp_warn",
+                "temp_error",
+                "power_on_hours_attribute_id",
+                "power_on_hours_warn",
+                "total_data_written_attribute_id",
+                "total_data_written_warn",
+                "total_data_written_safety_factor",
+                "recovered_error_attribute_id",
+                "recovered_error_warn",
+                "free_warn",
+                "free_error",
+                "read_data_rate_warn",
+                "write_data_rate_warn",
+                "read_iops_warn",
+                "write_iops_warn"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "disk0"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "disks"
+      ],
+      "additionalProperties": false
+    },
+    "gpu_monitor": {
+      "type": "object",
+      "properties": {
+        "temp_warn": {
+          "type": "number",
+          "default": 90.0,
+          "description": "Generates warning when GPU temperature reaches a specified value or higher."
+        },
+        "temp_error": {
+          "type": "number",
+          "default": 95.0,
+          "description": "Generates error when GPU temperature reaches a specified value or higher."
+        },
+        "gpu_usage_warn": {
+          "type": "number",
+          "default": 0.90,
+          "description": "Generates warning when GPU usage reaches a specified value or higher."
+        },
+        "gpu_usage_error": {
+          "type": "number",
+          "default": 1.00,
+          "description": "Generates error when GPU usage reaches a specified value or higher."
+        },
+        "memory_usage_warn": {
+          "type": "number",
+          "default": 0.95,
+          "description": "Generates warning when GPU memory usage reaches a specified value or higher."
+        },
+        "memory_usage_error": {
+          "type": "number",
+          "default": 0.99,
+          "description": "Generates error when GPU memory usage reaches a specified value or higher."
+        }
+      },
+      "required": [
+        "temp_warn",
+        "temp_error",
+        "gpu_usage_warn",
+        "gpu_usage_error",
+        "memory_usage_warn",
+        "memory_usage_error"
+      ],
+      "additionalProperties": false
+    },
+    "voltage_monitor": {
+      "type": "object",
+      "properties": {
+        "cmos_battery_warn": {
+          "type": "number",
+          "default": 2.90,
+          "description": "Generates warning when voltage of CMOS Battery is lower."
+        },
+        "cmos_battery_error": {
+          "type": "number",
+          "default": 2.70,
+          "description": "Generates error when voltage of CMOS Battery is lower."
+        },
+        "cmos_battery_label": {
+          "type": "string",
+          "default": "",
+          "description": "voltage string in sensors command outputs. if empty no voltage will be checked."
+        }
+      },
+      "required": [
+        "cmos_battery_warn",
+        "cmos_battery_error",
+        "cmos_battery_label"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/system_monitor"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/system/system_monitor/schema/system_monitor.schema.json
+++ b/system/system_monitor/schema/system_monitor.schema.json
@@ -8,12 +8,12 @@
       "properties": {
         "usage_warn": {
           "type": "number",
-          "default": 0.90,
+          "default": 0.9,
           "description": "Generates warning when CPU usage reaches a specified value or higher and last for usage_warn_count counts."
         },
         "usage_error": {
           "type": "number",
-          "default": 1.00,
+          "default": 1.0,
           "description": "Generates error when CPU usage reaches a specified value or higher and last for usage_error_count counts."
         },
         "usage_warn_count": {
@@ -56,9 +56,7 @@
           "description": "Generates warning when available memory size is less than the specified value."
         }
       },
-      "required": [
-        "available_size"
-      ],
+      "required": ["available_size"],
       "additionalProperties": false
     },
     "net_monitor": {
@@ -124,11 +122,7 @@
           "description": "Timeout for NTP query."
         }
       },
-      "required": [
-        "offset_warn",
-        "offset_error",
-        "timeout"
-      ],
+      "required": ["offset_warn", "offset_error", "timeout"],
       "additionalProperties": false
     },
     "process_monitor": {
@@ -140,9 +134,7 @@
           "description": "The number of processes to generate High-load Proc[0-9] and High-mem Proc[0-9]."
         }
       },
-      "required": [
-        "num_of_procs"
-      ],
+      "required": ["num_of_procs"],
       "additionalProperties": false
     },
     "hdd_monitor": {
@@ -262,15 +254,11 @@
               "additionalProperties": false
             }
           },
-          "required": [
-            "disk0"
-          ],
+          "required": ["disk0"],
           "additionalProperties": false
         }
       },
-      "required": [
-        "disks"
-      ],
+      "required": ["disks"],
       "additionalProperties": false
     },
     "gpu_monitor": {
@@ -288,12 +276,12 @@
         },
         "gpu_usage_warn": {
           "type": "number",
-          "default": 0.90,
+          "default": 0.9,
           "description": "Generates warning when GPU usage reaches a specified value or higher."
         },
         "gpu_usage_error": {
           "type": "number",
-          "default": 1.00,
+          "default": 1.0,
           "description": "Generates error when GPU usage reaches a specified value or higher."
         },
         "memory_usage_warn": {
@@ -322,12 +310,12 @@
       "properties": {
         "cmos_battery_warn": {
           "type": "number",
-          "default": 2.90,
+          "default": 2.9,
           "description": "Generates warning when voltage of CMOS Battery is lower."
         },
         "cmos_battery_error": {
           "type": "number",
-          "default": 2.70,
+          "default": 2.7,
           "description": "Generates error when voltage of CMOS Battery is lower."
         },
         "cmos_battery_label": {
@@ -336,11 +324,7 @@
           "description": "voltage string in sensors command outputs. if empty no voltage will be checked."
         }
       },
-      "required": [
-        "cmos_battery_warn",
-        "cmos_battery_error",
-        "cmos_battery_label"
-      ],
+      "required": ["cmos_battery_warn", "cmos_battery_error", "cmos_battery_label"],
       "additionalProperties": false
     }
   },

--- a/system/system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -45,11 +45,11 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   temps_(),
   freqs_(),
   mpstat_exists_(false),
-  usage_warn_(declare_parameter<float>("usage_warn", 0.96)),
-  usage_error_(declare_parameter<float>("usage_error", 0.96)),
-  usage_warn_count_(declare_parameter<int>("usage_warn_count", 1)),
-  usage_error_count_(declare_parameter<int>("usage_error_count", 2)),
-  usage_avg_(declare_parameter<bool>("usage_avg", true))
+  usage_warn_(declare_parameter<float>("usage_warn")),
+  usage_error_(declare_parameter<float>("usage_error")),
+  usage_warn_count_(declare_parameter<int>("usage_warn_count")),
+  usage_error_count_(declare_parameter<int>("usage_error_count")),
+  usage_avg_(declare_parameter<bool>("usage_avg"))
 {
   gethostname(hostname_, sizeof(hostname_));
   num_cores_ = boost::thread::hardware_concurrency();

--- a/system/system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
+++ b/system/system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
@@ -39,7 +39,7 @@ namespace fs = boost::filesystem;
 
 CPUMonitor::CPUMonitor(const rclcpp::NodeOptions & options) : CPUMonitorBase("cpu_monitor", options)
 {
-  msr_reader_port_ = declare_parameter<int>("msr_reader_port", 7634);
+  msr_reader_port_ = declare_parameter<int>("msr_reader_port");
 
   this->getTempNames();
   this->getFreqNames();

--- a/system/system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
+++ b/system/system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
@@ -27,12 +27,12 @@ GPUMonitorBase::GPUMonitorBase(const std::string & node_name, const rclcpp::Node
 : Node(node_name, options),
   updater_(this),
   hostname_{""},
-  temp_warn_(declare_parameter<float>("temp_warn", 90.0)),
-  temp_error_(declare_parameter<float>("temp_error", 95.0)),
-  gpu_usage_warn_(declare_parameter<float>("gpu_usage_warn", 0.90)),
-  gpu_usage_error_(declare_parameter<float>("gpu_usage_error", 1.00)),
-  memory_usage_warn_(declare_parameter<float>("memory_usage_warn", 0.95)),
-  memory_usage_error_(declare_parameter<float>("memory_usage_error", 0.99))
+  temp_warn_(declare_parameter<float>("temp_warn")),
+  temp_error_(declare_parameter<float>("temp_error")),
+  gpu_usage_warn_(declare_parameter<float>("gpu_usage_warn")),
+  gpu_usage_error_(declare_parameter<float>("gpu_usage_error")),
+  memory_usage_warn_(declare_parameter<float>("memory_usage_warn")),
+  memory_usage_error_(declare_parameter<float>("memory_usage_error"))
 {
   gethostname(hostname_, sizeof(hostname_));
 

--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -41,7 +41,7 @@ namespace bp = boost::process;
 HddMonitor::HddMonitor(const rclcpp::NodeOptions & options)
 : Node("hdd_monitor", options),
   updater_(this),
-  hdd_reader_port_(declare_parameter<int>("hdd_reader_port", 7635)),
+  hdd_reader_port_(declare_parameter<int>("hdd_reader_port")),
   last_hdd_stat_update_time_{0, 0, this->get_clock()->get_clock_type()}
 {
   using namespace std::literals::chrono_literals;
@@ -498,36 +498,36 @@ void HddMonitor::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & s
 
 void HddMonitor::getHddParams()
 {
-  const auto num_disks = this->declare_parameter("num_disks", 0);
+  const auto num_disks = this->declare_parameter<int>("num_disks");
   for (auto i = 0; i < num_disks; ++i) {
     const auto prefix = "disks.disk" + std::to_string(i);
-    const auto mount_point = declare_parameter<std::string>(prefix + ".name", "/");
+    const auto mount_point = declare_parameter<std::string>(prefix + ".name");
 
     HddParam param;
-    param.temp_warn_ = declare_parameter<float>(prefix + ".temp_warn", 55.0f);
-    param.temp_error_ = declare_parameter<float>(prefix + ".temp_error", 70.0f);
-    param.power_on_hours_warn_ = declare_parameter<int>(prefix + ".power_on_hours_warn", 3000000);
+    param.temp_warn_ = declare_parameter<float>(prefix + ".temp_warn");
+    param.temp_error_ = declare_parameter<float>(prefix + ".temp_error");
+    param.power_on_hours_warn_ = declare_parameter<int>(prefix + ".power_on_hours_warn");
     param.total_data_written_safety_factor_ =
-      declare_parameter<float>(prefix + ".total_data_written_safety_factor", 0.05f);
+      declare_parameter<float>(prefix + ".total_data_written_safety_factor");
     int64_t total_data_written_warn_org =
-      declare_parameter<int64_t>(prefix + ".total_data_written_warn", 4915200);
+      declare_parameter<int64_t>(prefix + ".total_data_written_warn");
     param.total_data_written_warn_ = static_cast<uint64_t>(
       total_data_written_warn_org * (1.0f - param.total_data_written_safety_factor_));
-    param.recovered_error_warn_ = declare_parameter<int>(prefix + ".recovered_error_warn", 1);
-    param.free_warn_ = declare_parameter<int>(prefix + ".free_warn", 5120);
-    param.free_error_ = declare_parameter<int>(prefix + ".free_error", 100);
-    param.read_data_rate_warn_ = declare_parameter<float>(prefix + ".read_data_rate_warn", 360.0);
-    param.write_data_rate_warn_ = declare_parameter<float>(prefix + ".write_data_rate_warn", 103.5);
-    param.read_iops_warn_ = declare_parameter<float>(prefix + ".read_iops_warn", 63360.0);
-    param.write_iops_warn_ = declare_parameter<float>(prefix + ".write_iops_warn", 24120.0);
+    param.recovered_error_warn_ = declare_parameter<int>(prefix + ".recovered_error_warn");
+    param.free_warn_ = declare_parameter<int>(prefix + ".free_warn");
+    param.free_error_ = declare_parameter<int>(prefix + ".free_error");
+    param.read_data_rate_warn_ = declare_parameter<float>(prefix + ".read_data_rate_warn");
+    param.write_data_rate_warn_ = declare_parameter<float>(prefix + ".write_data_rate_warn");
+    param.read_iops_warn_ = declare_parameter<float>(prefix + ".read_iops_warn");
+    param.write_iops_warn_ = declare_parameter<float>(prefix + ".write_iops_warn");
     param.temp_attribute_id_ =
-      static_cast<uint8_t>(declare_parameter<int>(prefix + ".temp_attribute_id", 0xC2));
+      static_cast<uint8_t>(std::stoi(declare_parameter<std::string>(prefix + ".temp_attribute_id"), nullptr, 16));
     param.power_on_hours_attribute_id_ =
-      static_cast<uint8_t>(declare_parameter<int>(prefix + ".power_on_hours_attribute_id", 0x09));
+      static_cast<uint8_t>(std::stoi(declare_parameter<std::string>(prefix + ".power_on_hours_attribute_id"), nullptr, 16));
     param.total_data_written_attribute_id_ = static_cast<uint8_t>(
-      declare_parameter<int>(prefix + ".total_data_written_attribute_id", 0xF1));
+      std::stoi(declare_parameter<std::string>(prefix + ".total_data_written_attribute_id"), nullptr, 16));
     param.recovered_error_attribute_id_ =
-      static_cast<uint8_t>(declare_parameter<int>(prefix + ".recovered_error_attribute_id", 0xC3));
+      static_cast<uint8_t>(std::stoi(declare_parameter<std::string>(prefix + ".recovered_error_attribute_id"), nullptr, 16));
 
     hdd_params_[mount_point] = param;
 

--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -520,14 +520,14 @@ void HddMonitor::getHddParams()
     param.write_data_rate_warn_ = declare_parameter<float>(prefix + ".write_data_rate_warn");
     param.read_iops_warn_ = declare_parameter<float>(prefix + ".read_iops_warn");
     param.write_iops_warn_ = declare_parameter<float>(prefix + ".write_iops_warn");
-    param.temp_attribute_id_ =
-      static_cast<uint8_t>(std::stoi(declare_parameter<std::string>(prefix + ".temp_attribute_id"), nullptr, 16));
-    param.power_on_hours_attribute_id_ =
-      static_cast<uint8_t>(std::stoi(declare_parameter<std::string>(prefix + ".power_on_hours_attribute_id"), nullptr, 16));
-    param.total_data_written_attribute_id_ = static_cast<uint8_t>(
-      std::stoi(declare_parameter<std::string>(prefix + ".total_data_written_attribute_id"), nullptr, 16));
-    param.recovered_error_attribute_id_ =
-      static_cast<uint8_t>(std::stoi(declare_parameter<std::string>(prefix + ".recovered_error_attribute_id"), nullptr, 16));
+    param.temp_attribute_id_ = static_cast<uint8_t>(
+      std::stoi(declare_parameter<std::string>(prefix + ".temp_attribute_id"), nullptr, 16));
+    param.power_on_hours_attribute_id_ = static_cast<uint8_t>(std::stoi(
+      declare_parameter<std::string>(prefix + ".power_on_hours_attribute_id"), nullptr, 16));
+    param.total_data_written_attribute_id_ = static_cast<uint8_t>(std::stoi(
+      declare_parameter<std::string>(prefix + ".total_data_written_attribute_id"), nullptr, 16));
+    param.recovered_error_attribute_id_ = static_cast<uint8_t>(std::stoi(
+      declare_parameter<std::string>(prefix + ".recovered_error_attribute_id"), nullptr, 16));
 
     hdd_params_[mount_point] = param;
 

--- a/system/system_monitor/src/mem_monitor/mem_monitor.cpp
+++ b/system/system_monitor/src/mem_monitor/mem_monitor.cpp
@@ -33,7 +33,7 @@ namespace bp = boost::process;
 MemMonitor::MemMonitor(const rclcpp::NodeOptions & options)
 : Node("mem_monitor", options),
   updater_(this),
-  available_size_(declare_parameter<int>("available_size", 1024) * 1024 * 1024)
+  available_size_(declare_parameter<int>("available_size") * 1024 * 1024)
 {
   gethostname(hostname_, sizeof(hostname_));
   updater_.setHardwareID(hostname_);

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -38,16 +38,14 @@ NetMonitor::NetMonitor(const rclcpp::NodeOptions & options)
   updater_(this),
   hostname_(),
   last_update_time_{0, 0, this->get_clock()->get_clock_type()},
-  device_params_(
-    declare_parameter<std::vector<std::string>>("devices")),
+  device_params_(declare_parameter<std::vector<std::string>>("devices")),
   getifaddrs_error_code_(0),
   monitor_program_(declare_parameter<std::string>("monitor_program")),
   socket_path_(declare_parameter("socket_path", traffic_reader_service::socket_path)),
   crc_error_check_duration_(declare_parameter<int>("crc_error_check_duration")),
   crc_error_count_threshold_(declare_parameter<int>("crc_error_count_threshold")),
   last_reassembles_failed_(0),
-  reassembles_failed_check_duration_(
-    declare_parameter<int>("reassembles_failed_check_duration")),
+  reassembles_failed_check_duration_(declare_parameter<int>("reassembles_failed_check_duration")),
   reassembles_failed_check_count_(declare_parameter<int>("reassembles_failed_check_count")),
   reassembles_failed_column_index_(0)
 {

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -39,16 +39,16 @@ NetMonitor::NetMonitor(const rclcpp::NodeOptions & options)
   hostname_(),
   last_update_time_{0, 0, this->get_clock()->get_clock_type()},
   device_params_(
-    declare_parameter<std::vector<std::string>>("devices", std::vector<std::string>())),
+    declare_parameter<std::vector<std::string>>("devices")),
   getifaddrs_error_code_(0),
-  monitor_program_(declare_parameter<std::string>("monitor_program", "greengrass")),
+  monitor_program_(declare_parameter<std::string>("monitor_program")),
   socket_path_(declare_parameter("socket_path", traffic_reader_service::socket_path)),
-  crc_error_check_duration_(declare_parameter<int>("crc_error_check_duration", 1)),
-  crc_error_count_threshold_(declare_parameter<int>("crc_error_count_threshold", 1)),
+  crc_error_check_duration_(declare_parameter<int>("crc_error_check_duration")),
+  crc_error_count_threshold_(declare_parameter<int>("crc_error_count_threshold")),
   last_reassembles_failed_(0),
   reassembles_failed_check_duration_(
-    declare_parameter<int>("reassembles_failed_check_duration", 1)),
-  reassembles_failed_check_count_(declare_parameter<int>("reassembles_failed_check_count", 1)),
+    declare_parameter<int>("reassembles_failed_check_duration")),
+  reassembles_failed_check_count_(declare_parameter<int>("reassembles_failed_check_count")),
   reassembles_failed_column_index_(0)
 {
   if (monitor_program_.empty()) {

--- a/system/system_monitor/src/ntp_monitor/ntp_monitor.cpp
+++ b/system/system_monitor/src/ntp_monitor/ntp_monitor.cpp
@@ -36,9 +36,9 @@ namespace fs = boost::filesystem;
 NTPMonitor::NTPMonitor(const rclcpp::NodeOptions & options)
 : Node("ntp_monitor", options),
   updater_(this),
-  offset_warn_(declare_parameter<float>("offset_warn", 0.1)),
-  offset_error_(declare_parameter<float>("offset_error", 5.0)),
-  timeout_(declare_parameter<int>("timeout", 5)),
+  offset_warn_(declare_parameter<float>("offset_warn")),
+  offset_error_(declare_parameter<float>("offset_error")),
+  timeout_(declare_parameter<int>("timeout")),
   timeout_expired_(false)
 {
   using namespace std::literals::chrono_literals;

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -33,7 +33,7 @@
 ProcessMonitor::ProcessMonitor(const rclcpp::NodeOptions & options)
 : Node("process_monitor", options),
   updater_(this),
-  num_of_procs_(declare_parameter<int>("num_of_procs", 5)),
+  num_of_procs_(declare_parameter<int>("num_of_procs")),
   is_top_error_(false),
   is_pipe2_error_(false)
 {

--- a/system/system_monitor/src/voltage_monitor/voltage_monitor.cpp
+++ b/system/system_monitor/src/voltage_monitor/voltage_monitor.cpp
@@ -48,9 +48,9 @@ VoltageMonitor::VoltageMonitor(const rclcpp::NodeOptions & options)
   rclcpp::QoS durable_qos{1};
   durable_qos.transient_local();
 
-  voltage_string_ = declare_parameter<std::string>("cmos_battery_label", "");
-  voltage_warn_ = declare_parameter<float>("cmos_battery_warn", 2.95);
-  voltage_error_ = declare_parameter<float>("cmos_battery_error", 2.75);
+  voltage_string_ = declare_parameter<std::string>("cmos_battery_label");
+  voltage_warn_ = declare_parameter<float>("cmos_battery_warn");
+  voltage_error_ = declare_parameter<float>("cmos_battery_error");
   bool sensors_exists = false;
   if (voltage_string_ == "") {
     sensors_exists = false;


### PR DESCRIPTION
## Description

Implement the ROS Node configuration layout described in https://github.com/orgs/autowarefoundation/discussions/3371 for the `system_monitor` package.

- Remove the default value from the source code in order to ensure all parameter values are passed from the parameter files.
- Use types that match the ones returned from declare_parameter() in order to prevent confusion and potential coding errors.
- Move the default parameter file to a standardized location. Use the JSON Schema for that.

## Related links

closes https://github.com/autowarefoundation/autoware.universe/issues/3239

## Tests performed

Only package built locally
## Notes for reviewers

- It is necessary to confirm that each monitor works with each device.(No environment to check)
- Since I could not figure out how to map hexadecimal types to the schema, I changed the parameters to be specified as strings.(about id in hdd monitor)
- It would be helpful if you could describe in detail what needs to be changed and what you would like to see changed.

## Interface changes

Parameter values are now required to be passed to the node when launched.

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/