### PR TITLE
feat(perception_online_evaluator): ignore reversal of orientation from yaw_rate calculation

### DIFF
--- a/evaluator/perception_online_evaluator/src/metrics_calculator.cpp
+++ b/evaluator/perception_online_evaluator/src/metrics_calculator.cpp
@@ -381,12 +381,17 @@ MetricStatMap MetricsCalculator::calcYawRateMetrics(const ClassObjectsMap & clas
       if (time_diff < 0.01) {
         continue;
       }
-      const auto current_yaw =
+      const double current_yaw =
         tf2::getYaw(object.kinematics.initial_pose_with_covariance.pose.orientation);
-      const auto previous_yaw =
+      const double previous_yaw =
         tf2::getYaw(previous_object.kinematics.initial_pose_with_covariance.pose.orientation);
-      const auto yaw_rate =
-        std::abs(tier4_autoware_utils::normalizeRadian(current_yaw - previous_yaw) / time_diff);
+      const double yaw_diff =
+        std::abs(tier4_autoware_utils::normalizeRadian(current_yaw - previous_yaw));
+      // if yaw_diff is close to PI, reversal of orientation is likely occurring, so ignore it
+      if (std::abs(M_PI - yaw_diff) < 0.1) {
+        continue;
+      }
+      const auto yaw_rate = yaw_diff / time_diff;
       stat.add(yaw_rate);
     }
     metric_stat_map["yaw_rate_" + convertLabelToString(label)] = stat;

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -214,6 +214,7 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
   auto & p = parameters_;
 
   updateParam<size_t>(parameters, "smoothing_window_size", p->smoothing_window_size);
+  updateParam<double>(parameters, "stopped_velocity_threshold", p->stopped_velocity_threshold);
 
   // update metrics
   {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Some objects will have their orientation reversed, so ignore them from the yaw_rate.
Detection of those objects requires other metrics

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

drving log replayer

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
