### PR TITLE
feat(obstacle_cruise): ignore right beside objects

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -87,7 +87,7 @@
         obstacle_traj_angle_threshold : 1.22 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop
 
       stop:
-        max_lat_margin: 0.2 # lateral margin between obstacle and trajectory band with ego's width
+        max_lat_margin: 0.3 # lateral margin between obstacle and trajectory band with ego's width
         crossing_obstacle:
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -54,8 +54,7 @@ private:
   std::vector<Polygon2d> createOneStepPolygons(
     const std::vector<TrajectoryPoint> & traj_points,
     const vehicle_info_util::VehicleInfo & vehicle_info,
-    const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin = 0.0,
-    const double margin_exclusion_period = 0.0) const;
+    const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin = 0.0) const;
   std::vector<Obstacle> convertToObstacles(const std::vector<TrajectoryPoint> & traj_points) const;
   std::tuple<std::vector<StopObstacle>, std::vector<CruiseObstacle>, std::vector<SlowDownObstacle>>
   determineEgoBehaviorAgainstObstacles(

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -54,7 +54,8 @@ private:
   std::vector<Polygon2d> createOneStepPolygons(
     const std::vector<TrajectoryPoint> & traj_points,
     const vehicle_info_util::VehicleInfo & vehicle_info,
-    const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin = 0.0) const;
+    const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin = 0.0,
+    const double margin_exclusion_period = 0.0) const;
   std::vector<Obstacle> convertToObstacles(const std::vector<TrajectoryPoint> & traj_points) const;
   std::tuple<std::vector<StopObstacle>, std::vector<CruiseObstacle>, std::vector<SlowDownObstacle>>
   determineEgoBehaviorAgainstObstacles(

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -549,12 +549,10 @@ void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr ms
 std::vector<Polygon2d> ObstacleCruisePlannerNode::createOneStepPolygons(
   const std::vector<TrajectoryPoint> & traj_points,
   const vehicle_info_util::VehicleInfo & vehicle_info,
-  const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin) const
+  const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,
+  const double margin_exclusion_period) const
 {
   const auto & p = behavior_determination_param_;
-  const bool is_enable_current_pose_consideration = p.enable_to_consider_current_pose;
-  const double step_length = p.decimate_trajectory_step_length;
-  const double time_to_convergence = p.time_to_convergence;
 
   const size_t nearest_idx =
     motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose.position);
@@ -563,41 +561,52 @@ std::vector<Polygon2d> ObstacleCruisePlannerNode::createOneStepPolygons(
     tier4_autoware_utils::inverseTransformPose(current_ego_pose, nearest_pose);
   const double current_ego_lat_error = current_ego_pose_error.position.y;
   const double current_ego_yaw_error = tf2::getYaw(current_ego_pose_error.orientation);
-  double time_elapsed = 0.0;
+  double time_elapsed{0.0};
 
-  std::vector<Polygon2d> polygons;
-  std::vector<geometry_msgs::msg::Pose> last_poses = {traj_points.at(0).pose};
-  if (is_enable_current_pose_consideration) {
-    last_poses.push_back(current_ego_pose);
-  }
-
+  std::vector<Polygon2d> output_polygons;
+  Polygon2d tmp_polys{};
   for (size_t i = 0; i < traj_points.size(); ++i) {
     std::vector<geometry_msgs::msg::Pose> current_poses = {traj_points.at(i).pose};
 
     // estimate the future ego pose with assuming that the pose error against the reference path
     // will decrease to zero by the time_to_convergence
-    if (is_enable_current_pose_consideration && time_elapsed < time_to_convergence) {
-      const double rem_ratio = (time_to_convergence - time_elapsed) / time_to_convergence;
+    if (p.enable_to_consider_current_pose && time_elapsed < p.time_to_convergence) {
+      const double rem_ratio = (p.time_to_convergence - time_elapsed) / p.time_to_convergence;
       geometry_msgs::msg::Pose indexed_pose_err;
       indexed_pose_err.set__orientation(
         tier4_autoware_utils::createQuaternionFromYaw(current_ego_yaw_error * rem_ratio));
       indexed_pose_err.set__position(
         tier4_autoware_utils::createPoint(0.0, current_ego_lat_error * rem_ratio, 0.0));
-
       current_poses.push_back(
         tier4_autoware_utils::transformPose(indexed_pose_err, traj_points.at(i).pose));
-
-      if (traj_points.at(i).longitudinal_velocity_mps != 0.0) {
-        time_elapsed += step_length / std::abs(traj_points.at(i).longitudinal_velocity_mps);
-      } else {
-        time_elapsed = std::numeric_limits<double>::max();
-      }
     }
-    polygons.push_back(
-      polygon_utils::createOneStepPolygon(last_poses, current_poses, vehicle_info, lat_margin));
-    last_poses = current_poses;
+
+    Polygon2d idx_poly{};
+    const double indexed_lat_margin = time_elapsed < margin_exclusion_period ? 0.0 : lat_margin;
+    for (const auto & pose : current_poses) {
+      boost::geometry::append(
+        idx_poly, tier4_autoware_utils::toFootprint(
+                    pose, vehicle_info.max_longitudinal_offset_m, vehicle_info.rear_overhang_m,
+                    vehicle_info.vehicle_width_m + indexed_lat_margin * 2.0)
+                    .outer());
+    }
+
+    boost::geometry::append(tmp_polys, idx_poly.outer());
+    Polygon2d hull_polygon;
+    boost::geometry::convex_hull(tmp_polys, hull_polygon);
+    boost::geometry::correct(hull_polygon);
+
+    output_polygons.push_back(hull_polygon);
+    tmp_polys = std::move(idx_poly);
+
+    if (traj_points.at(i).longitudinal_velocity_mps != 0.0) {
+      time_elapsed +=
+        p.decimate_trajectory_step_length / std::abs(traj_points.at(i).longitudinal_velocity_mps);
+    } else {
+      time_elapsed = std::numeric_limits<double>::max();
+    }
   }
-  return polygons;
+  return output_polygons;
 }
 
 std::vector<Obstacle> ObstacleCruisePlannerNode::convertToObstacles(
@@ -1188,7 +1197,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
 
   // calculate collision points with trajectory with lateral stop margin
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose, p.max_lat_margin_for_stop);
+    traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose, p.max_lat_margin_for_stop, 0.5);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
     traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1197,7 +1197,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
 
   // calculate collision points with trajectory with lateral stop margin
   const auto traj_polys_with_lat_margin = createOneStepPolygons(
-    traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose, p.max_lat_margin_for_stop, 0.5);
+    traj_points, vehicle_info_, ego_odom_sub_.getData().pose.pose, p.max_lat_margin_for_stop, 0.3);
 
   const auto collision_point = polygon_utils::getCollisionPoint(
     traj_points, traj_polys_with_lat_margin, obstacle, is_driving_forward_, vehicle_info_);

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -104,38 +104,6 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> getCollisionIndex(
 
 namespace polygon_utils
 {
-Polygon2d createOneStepPolygon(
-  const std::vector<geometry_msgs::msg::Pose> & last_poses,
-  const std::vector<geometry_msgs::msg::Pose> & current_poses,
-  const vehicle_info_util::VehicleInfo & vehicle_info, const double lat_margin)
-{
-  Polygon2d polygon;
-
-  const double base_to_front = vehicle_info.max_longitudinal_offset_m;
-  const double width = vehicle_info.vehicle_width_m / 2.0 + lat_margin;
-  const double base_to_rear = vehicle_info.rear_overhang_m;
-
-  for (auto & pose : last_poses) {
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, base_to_front, width));
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, base_to_front, -width));
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, -base_to_rear, -width));
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, -base_to_rear, width));
-  }
-  for (auto & pose : current_poses) {
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, base_to_front, width));
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, base_to_front, -width));
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, -base_to_rear, -width));
-    appendPointToPolygon(polygon, calcOffsetPosition(pose, -base_to_rear, width));
-  }
-
-  bg::correct(polygon);
-
-  Polygon2d hull_polygon;
-  bg::convex_hull(polygon, hull_polygon);
-
-  return hull_polygon;
-}
-
 std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const Obstacle & obstacle, const bool is_driving_forward,

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -20,18 +20,6 @@
 
 namespace
 {
-void appendPointToPolygon(Polygon2d & polygon, const geometry_msgs::msg::Point & geom_point)
-{
-  Point2d point(geom_point.x, geom_point.y);
-  bg::append(polygon.outer(), point);
-}
-
-geometry_msgs::msg::Point calcOffsetPosition(
-  const geometry_msgs::msg::Pose & pose, const double offset_x, const double offset_y)
-{
-  return tier4_autoware_utils::calcOffsetPose(pose, offset_x, offset_y, 0.0).position;
-}
-
 PointWithStamp calcNearestCollisionPoint(
   const size_t first_within_idx, const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & decimated_traj_points, const bool is_driving_forward)


### PR DESCRIPTION
## Description
This PR makes the stop planning ignore right beside objects.
After this PR, the stop polygons are expanded only the in front of vehicle

![image](https://github.com/autowarefoundation/autoware.universe/assets/141538661/ba288a12-fd80-40d4-a748-192fa82c5641)

This PR corresponds to parameter change https://github.com/autowarefoundation/autoware_launch/pull/948

<!-- Write a brief description of this PR. -->

## Tests performed
psim and tier4 internal tests

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
