### PR TITLE
fix(multi_object_tracker): debugger timers checks if the timer is initialized

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/debugger.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/debugger.hpp
@@ -41,7 +41,10 @@ public:
     const autoware_auto_perception_msgs::msg::TrackedObjects & tentative_objects) const;
   void startMeasurementTime(
     const rclcpp::Time & now, const rclcpp::Time & measurement_header_stamp);
+  void endMeasurementTime(const rclcpp::Time & now);
+  void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
+
   void setupDiagnostics();
   void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat);
   struct DEBUG_SETTINGS
@@ -56,12 +59,15 @@ public:
 
 private:
   void loadParameters();
+  bool is_initialized_ = false;
   rclcpp::Node & node_;
   rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
     debug_tentative_objects_pub_;
   std::unique_ptr<tier4_autoware_utils::DebugPublisher> processing_time_publisher_;
   rclcpp::Time last_input_stamp_;
   rclcpp::Time stamp_process_start_;
+  rclcpp::Time stamp_process_end_;
+  rclcpp::Time stamp_publish_start_;
   rclcpp::Time stamp_publish_output_;
 };
 

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -190,6 +190,10 @@ void MultiObjectTracker::onMeasurement(
     if (tracker) list_tracker_.push_back(tracker);
   }
 
+  // debugger time
+  debugger_->endMeasurementTime(this->now());
+
+  // Publish objects if the timer is not enabled
   if (publish_timer_ == nullptr) {
     publish(measurement_time);
   }
@@ -337,6 +341,7 @@ inline bool MultiObjectTracker::shouldTrackerPublish(
 
 void MultiObjectTracker::publish(const rclcpp::Time & time) const
 {
+  debugger_->startPublishTime(this->now());
   const auto subscriber_count = tracked_objects_pub_->get_subscription_count() +
                                 tracked_objects_pub_->get_intra_process_subscription_count();
   if (subscriber_count < 1) {


### PR DESCRIPTION
## Description

The previous debugger timer refactoring caused a large error on the initial processing_timing value.
1) Initial behavior of MOT: Even if there is no object input, it was publishing latency. A conditions for timing-related publishing is added. It will check if the first message has arrived.
2) Definition of measured time: Currently, the internal processing is divided into two parts, so the total time is defined as processing_time, and the time from input to output is defined as processing_latency.

## Tests performed

![Screenshot from 2024-04-08 11-53-38](https://github.com/autowarefoundation/autoware.universe/assets/42434141/399f501d-f8ed-4efa-9f10-dc2c44ddebf6)



## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
