### PR TITLE
feat(lane_change): use external velocity limit in safety check

### DIFF
--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/scene.hpp
@@ -172,6 +172,8 @@ protected:
   bool isVehicleStuck(
     const lanelet::ConstLanelets & current_lanes, const double obstacle_check_distance) const;
 
+  double get_max_velocity_for_safety_check() const;
+
   bool isVehicleStuck(const lanelet::ConstLanelets & current_lanes) const;
 
   bool check_prepare_phase() const;

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -2064,14 +2064,15 @@ bool NormalLaneChange::isVehicleStuck(
 
 double NormalLaneChange::get_max_velocity_for_safety_check() const
 {
-  const auto extenal_velocity_limit_ptr = planner_data_->external_limit_max_velocity;
-  if (extenal_velocity_limit_ptr) {
+  const auto external_velocity_limit_ptr = planner_data_->external_limit_max_velocity;
+  if (external_velocity_limit_ptr) {
     return std::min(
-      static_cast<double>(extenal_velocity_limit_ptr->max_velocity), getCommonParam().max_vel);
+      static_cast<double>(external_velocity_limit_ptr->max_velocity), getCommonParam().max_vel);
   }
 
   return getCommonParam().max_vel;
 }
+
 bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lanes) const
 {
   if (current_lanes.empty()) {

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -1954,13 +1954,6 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
       target_objects.other_lane.end());
   }
 
-  const auto extenal_velocity_limit_ptr = planner_data_->external_limit_max_velocity;
-  const auto max_velocity_limit =
-    (extenal_velocity_limit_ptr)
-      ? std::min(
-          static_cast<double>(extenal_velocity_limit_ptr->max_velocity), getCommonParam().max_vel)
-      : getCommonParam().max_vel;
-
   const auto expanded_target_lanes = utils::lane_change::generateExpandedLanelets(
     lane_change_path.info.target_lanes, direction_,
     lane_change_parameters_->lane_expansion_left_offset,
@@ -1974,7 +1967,7 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
     for (const auto & obj_path : obj_predicted_paths) {
       const auto collided_polygons = utils::path_safety_checker::getCollidedPolygons(
         path, ego_predicted_path, obj, obj_path, common_parameters, rss_params, 1.0,
-        max_velocity_limit, current_debug_data.second);
+        get_max_velocity_for_safety_check(), current_debug_data.second);
 
       if (collided_polygons.empty()) {
         utils::path_safety_checker::updateCollisionCheckDebugMap(
@@ -2069,6 +2062,16 @@ bool NormalLaneChange::isVehicleStuck(
   return false;
 }
 
+double NormalLaneChange::get_max_velocity_for_safety_check() const
+{
+  const auto extenal_velocity_limit_ptr = planner_data_->external_limit_max_velocity;
+  if (extenal_velocity_limit_ptr) {
+    return std::min(
+      static_cast<double>(extenal_velocity_limit_ptr->max_velocity), getCommonParam().max_vel);
+  }
+
+  return getCommonParam().max_vel;
+}
 bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lanes) const
 {
   if (current_lanes.empty()) {

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -1954,10 +1954,13 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
       target_objects.other_lane.end());
   }
 
-  const auto expanded_target_lanes = utils::lane_change::generateExpandedLanelets(
-    lane_change_path.info.target_lanes, direction_,
-    lane_change_parameters_->lane_expansion_left_offset,
-    lane_change_parameters_->lane_expansion_right_offset);
+  const auto extenal_velocity_limit_ptr = planner_data_->external_limit_max_velocity;
+  const auto max_velocity_limit = (extenal_velocity_limit_ptr) ?  std::min(static_cast<double>(extenal_velocity_limit_ptr->max_velocity), getCommonParam().max_vel) : getCommonParam().max_vel;
+
+        const auto expanded_target_lanes = utils::lane_change::generateExpandedLanelets(
+          lane_change_path.info.target_lanes, direction_,
+          lane_change_parameters_->lane_expansion_left_offset,
+          lane_change_parameters_->lane_expansion_right_offset);
 
   for (const auto & obj : collision_check_objects) {
     auto current_debug_data = utils::path_safety_checker::createObjectDebug(obj);
@@ -1966,7 +1969,7 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
     auto is_safe = true;
     for (const auto & obj_path : obj_predicted_paths) {
       const auto collided_polygons = utils::path_safety_checker::getCollidedPolygons(
-        path, ego_predicted_path, obj, obj_path, common_parameters, rss_params, 1.0,
+                                                                                     path, ego_predicted_path, obj, obj_path, common_parameters, rss_params, 1.0, max_velocity_limit,
         current_debug_data.second);
 
       if (collided_polygons.empty()) {

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -1955,12 +1955,16 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
   }
 
   const auto extenal_velocity_limit_ptr = planner_data_->external_limit_max_velocity;
-  const auto max_velocity_limit = (extenal_velocity_limit_ptr) ?  std::min(static_cast<double>(extenal_velocity_limit_ptr->max_velocity), getCommonParam().max_vel) : getCommonParam().max_vel;
+  const auto max_velocity_limit =
+    (extenal_velocity_limit_ptr)
+      ? std::min(
+          static_cast<double>(extenal_velocity_limit_ptr->max_velocity), getCommonParam().max_vel)
+      : getCommonParam().max_vel;
 
-        const auto expanded_target_lanes = utils::lane_change::generateExpandedLanelets(
-          lane_change_path.info.target_lanes, direction_,
-          lane_change_parameters_->lane_expansion_left_offset,
-          lane_change_parameters_->lane_expansion_right_offset);
+  const auto expanded_target_lanes = utils::lane_change::generateExpandedLanelets(
+    lane_change_path.info.target_lanes, direction_,
+    lane_change_parameters_->lane_expansion_left_offset,
+    lane_change_parameters_->lane_expansion_right_offset);
 
   for (const auto & obj : collision_check_objects) {
     auto current_debug_data = utils::path_safety_checker::createObjectDebug(obj);
@@ -1969,8 +1973,8 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
     auto is_safe = true;
     for (const auto & obj_path : obj_predicted_paths) {
       const auto collided_polygons = utils::path_safety_checker::getCollidedPolygons(
-                                                                                     path, ego_predicted_path, obj, obj_path, common_parameters, rss_params, 1.0, max_velocity_limit,
-        current_debug_data.second);
+        path, ego_predicted_path, obj, obj_path, common_parameters, rss_params, 1.0,
+        max_velocity_limit, current_debug_data.second);
 
       if (collided_polygons.empty()) {
         utils::path_safety_checker::updateCollisionCheckDebugMap(

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -21,7 +21,6 @@
 #include "behavior_path_planner_common/interface/steering_factor_interface.hpp"
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
 
-#include <rclcpp/subscription.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
@@ -37,11 +36,11 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/approval.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
-#include <tier4_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 #include <tier4_planning_msgs/msg/path_change_module.hpp>
 #include <tier4_planning_msgs/msg/reroute_availability.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
+#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include <map>

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -21,6 +21,7 @@
 #include "behavior_path_planner_common/interface/steering_factor_interface.hpp"
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
 
+#include <rclcpp/subscription.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
@@ -36,6 +37,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/approval.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
+#include <tier4_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 #include <tier4_planning_msgs/msg/path_change_module.hpp>
 #include <tier4_planning_msgs/msg/reroute_availability.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
@@ -103,6 +105,8 @@ private:
   rclcpp::Publisher<PoseWithUuidStamped>::SharedPtr modified_goal_publisher_;
   rclcpp::Publisher<StopReasonArray>::SharedPtr stop_reason_publisher_;
   rclcpp::Publisher<RerouteAvailability>::SharedPtr reroute_availability_publisher_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr
+    external_limit_max_velocity_subscriber_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   std::map<std::string, rclcpp::Publisher<Path>::SharedPtr> path_candidate_publishers_;
@@ -142,6 +146,9 @@ private:
   void onRoute(const LaneletRoute::ConstSharedPtr route_msg);
   void onOperationMode(const OperationModeState::ConstSharedPtr msg);
   void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
+  void on_external_velocity_limiter(
+    const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 
   OnSetParametersCallbackHandle::SharedPtr m_set_param_res;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -826,6 +826,8 @@ void BehaviorPathPlannerNode::onOperationMode(const OperationModeState::ConstSha
 void BehaviorPathPlannerNode::on_external_velocity_limiter(
   const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg)
 {
+  // Note: Using this parameter during path planning might cause unexpected deceleration or jerk.
+  // Therefore, do not use it for anything other than safety checks.
   if (!msg) {
     return;
   }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -23,9 +23,7 @@
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <tier4_planning_msgs/msg/path_change_module_id.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 
-#include <functional>
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -22,8 +22,8 @@
 #include <tier4_autoware_utils/ros/update_param.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/path_change_module_id.hpp>
+#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 
 #include <functional>
 #include <memory>
@@ -828,7 +828,7 @@ void BehaviorPathPlannerNode::onOperationMode(const OperationModeState::ConstSha
 void BehaviorPathPlannerNode::on_external_velocity_limiter(
   const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg)
 {
-  if(!msg){
+  if (!msg) {
     return;
   }
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/data_manager.hpp
@@ -38,6 +38,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <limits>
@@ -65,6 +66,7 @@ using route_handler::RouteHandler;
 using tier4_planning_msgs::msg::LateralOffset;
 using PlanResult = PathWithLaneId::SharedPtr;
 using lanelet::TrafficLight;
+using tier4_planning_msgs::msg::VelocityLimit;
 using unique_identifier_msgs::msg::UUID;
 
 struct TrafficSignalStamped
@@ -161,6 +163,7 @@ struct PlannerData
   std::map<int64_t, TrafficSignalStamped> traffic_light_id_map;
   BehaviorPathPlannerParameters parameters{};
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
+  VelocityLimit::ConstSharedPtr external_limit_max_velocity{};
 
   mutable std::vector<geometry_msgs::msg::Pose> drivable_area_expansion_prev_path_poses{};
   mutable std::vector<double> drivable_area_expansion_prev_curvatures{};

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -141,7 +141,7 @@ std::vector<Polygon2d> getCollidedPolygons(
   const ExtendedPredictedObject & target_object,
   const PredictedPathWithPolygon & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const RSSparams & rss_parameters,
-  const double hysteresis_factor, CollisionCheckDebug & debug);
+  const double hysteresis_factor, const double max_velocity_limit, CollisionCheckDebug & debug);
 
 bool checkPolygonsIntersects(
   const std::vector<Polygon2d> & polys_1, const std::vector<Polygon2d> & polys_2);

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -25,6 +25,7 @@
 #include <boost/geometry/algorithms/overlaps.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
+
 #include <limits>
 
 namespace behavior_path_planner::utils::path_safety_checker

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -588,7 +588,7 @@ std::vector<Polygon2d> getCollidedPolygons(
     // get object information at current time
     const auto & obj_pose = obj_pose_with_poly.pose;
     const auto & obj_polygon = obj_pose_with_poly.poly;
-    const auto & object_velocity = obj_pose_with_poly.velocity;
+    const auto object_velocity = obj_pose_with_poly.velocity;
 
     // get ego information at current time
     // Note: we can create these polygons in advance. However, it can decrease the readability and
@@ -601,7 +601,7 @@ std::vector<Polygon2d> getCollidedPolygons(
     }
     const auto & ego_pose = interpolated_data->pose;
     const auto & ego_polygon = interpolated_data->poly;
-    const auto & ego_velocity = std::min(interpolated_data->velocity, max_velocity_limit);
+    const auto ego_velocity = std::min(interpolated_data->velocity, max_velocity_limit);
 
     // check overlap
     if (boost::geometry::overlaps(ego_polygon, obj_polygon)) {

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -25,6 +25,7 @@
 #include <boost/geometry/algorithms/overlaps.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
+#include <limits>
 
 namespace behavior_path_planner::utils::path_safety_checker
 {
@@ -560,7 +561,7 @@ bool checkCollision(
 {
   const auto collided_polygons = getCollidedPolygons(
     planned_path, predicted_ego_path, target_object, target_object_path, common_parameters,
-    rss_parameters, hysteresis_factor, debug);
+    rss_parameters, hysteresis_factor, std::numeric_limits<double>::max(), debug);
   return collided_polygons.empty();
 }
 
@@ -570,7 +571,7 @@ std::vector<Polygon2d> getCollidedPolygons(
   const ExtendedPredictedObject & target_object,
   const PredictedPathWithPolygon & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const RSSparams & rss_parameters,
-  double hysteresis_factor, CollisionCheckDebug & debug)
+  double hysteresis_factor, const double max_velocity_limit, CollisionCheckDebug & debug)
 {
   {
     debug.ego_predicted_path = predicted_ego_path;
@@ -599,7 +600,7 @@ std::vector<Polygon2d> getCollidedPolygons(
     }
     const auto & ego_pose = interpolated_data->pose;
     const auto & ego_polygon = interpolated_data->poly;
-    const auto & ego_velocity = interpolated_data->velocity;
+    const auto & ego_velocity = std::min(interpolated_data->velocity, max_velocity_limit);
 
     // check overlap
     if (boost::geometry::overlaps(ego_polygon, obj_polygon)) {


### PR DESCRIPTION
## Description

- Lane change doesn't subscribe to external velocity limiter.
- Therefore despite planning path with maximum velocity from common param[[1](https://github.com/autowarefoundation/autoware.universe/pull/6615)][[2](https://github.com/autowarefoundation/autoware.universe/pull/6734)], if user changes the maximum velocity via external velocity limiter, there will be mismatch between the path point's velocity, and the current limited velocity.
- Up until this point, when performing safety check, the path point's velocity is used to perform safety check. 
- This only happens in lane change module because it is the module that supports accelerating path at the moment. 
- However, because of the velocity mismatch, if the limited velocity is smaller than the path point's velocity, it might cause incorrect safety check results.

To avoid this mismatch, this PR aims to use the limited velocity only during the safety check.

![Proposal to lane change safety check issue](https://github.com/autowarefoundation/autoware.universe/assets/93502286/d3e7ce0d-91a3-4f17-80aa-fd0c156d9393)


### ⚠️⚠️⚠️ Additional note

We cannot use the external velocity limiter's limited velocity during path planning in the behavior path planner. This is because the velocity planning that takes the limited velocity into consideration is performed by the motion velocity smoother, a module that executes after both the behavior path and behavior velocity are completed. If the user applies the limited velocity in an earlier module, it might cause unexpected jerk and acceleration. Therefore, do not use this information to insert velocity during path planning. This issue might be resolved in the future.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

[TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/3a07cebe-5cf9-57cc-bb0a-f0d258bb8f2f?project_id=prd_jt)

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

We cannot use the external velocity limiter's limited velocity during path planning in the behavior path planner. This is because the velocity planning that takes the limited velocity into consideration is performed by the motion velocity smoother, a module that executes after both the behavior path and behavior velocity are completed. If the user applies the limited velocity in an earlier module, it might cause unexpected jerk and acceleration. Therefore, do not use this information to insert velocity during path planning. This issue might be resolved in the future.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
