### PR TITLE
feat(perception_online_evaluator): count objects within specific range

### DIFF
--- a/evaluator/perception_online_evaluator/README.md
+++ b/evaluator/perception_online_evaluator/README.md
@@ -30,7 +30,7 @@ This module allows for the evaluation of how accurately perception results are g
 | `smoothing_window_size`           | Integer      | Determines the window size for smoothing path, should be an odd number.                          |
 | `prediction_time_horizons`        | list[double] | Time horizons for prediction evaluation in seconds.                                              |
 | `stopped_velocity_threshold`      | double       | threshold velocity to check if vehicle is stopped                                                |
-| `detection_range`                 | double       | Detection range for objects to be evaluated.(used for objects count only)                        |
+| `detection_radius`                 | double       | Detection radius for objects to be evaluated.(used for objects count only)                        |
 | `detection_height`                | double       | Detection height for objects to be evaluated. (used for objects count only)                      |
 | `target_object.*.check_deviation` | bool         | Whether to check deviation for specific object types (car, truck, etc.).                         |
 | `debug_marker.*`                  | bool         | Debugging parameters for marker visualization (history path, predicted path, etc.).              |

--- a/evaluator/perception_online_evaluator/README.md
+++ b/evaluator/perception_online_evaluator/README.md
@@ -30,8 +30,8 @@ This module allows for the evaluation of how accurately perception results are g
 | `smoothing_window_size`           | Integer      | Determines the window size for smoothing path, should be an odd number.                          |
 | `prediction_time_horizons`        | list[double] | Time horizons for prediction evaluation in seconds.                                              |
 | `stopped_velocity_threshold`      | double       | threshold velocity to check if vehicle is stopped                                                |
-| `detection_range`                 | double       | Detection range for objects to be evaluated.                                                     |
-| `detection_height`                | double       | Detection height for objects to be evaluated.                                                    |
+| `detection_range`                 | double       | Detection range for objects to be evaluated.(used for objects count only)                        |
+| `detection_height`                | double       | Detection height for objects to be evaluated. (used for objects count only)                      |
 | `target_object.*.check_deviation` | bool         | Whether to check deviation for specific object types (car, truck, etc.).                         |
 | `debug_marker.*`                  | bool         | Debugging parameters for marker visualization (history path, predicted path, etc.).              |
 

--- a/evaluator/perception_online_evaluator/README.md
+++ b/evaluator/perception_online_evaluator/README.md
@@ -24,16 +24,17 @@ This module allows for the evaluation of how accurately perception results are g
 
 ## Parameters
 
-| Name                              | Type         | Description                                                                                      |
-| --------------------------------- | ------------ | ------------------------------------------------------------------------------------------------ |
-| `selected_metrics`                | List         | Metrics to be evaluated, such as lateral deviation, yaw deviation, and predicted path deviation. |
-| `smoothing_window_size`           | Integer      | Determines the window size for smoothing path, should be an odd number.                          |
-| `prediction_time_horizons`        | list[double] | Time horizons for prediction evaluation in seconds.                                              |
-| `stopped_velocity_threshold`      | double       | threshold velocity to check if vehicle is stopped                                                |
-| `detection_radius`                | double       | Detection radius for objects to be evaluated.(used for objects count only)                       |
-| `detection_height`                | double       | Detection height for objects to be evaluated. (used for objects count only)                      |
-| `target_object.*.check_deviation` | bool         | Whether to check deviation for specific object types (car, truck, etc.).                         |
-| `debug_marker.*`                  | bool         | Debugging parameters for marker visualization (history path, predicted path, etc.).              |
+| Name                              | Type         | Description                                                                                                                                     |
+| --------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selected_metrics`                | List         | Metrics to be evaluated, such as lateral deviation, yaw deviation, and predicted path deviation.                                                |
+| `smoothing_window_size`           | Integer      | Determines the window size for smoothing path, should be an odd number.                                                                         |
+| `prediction_time_horizons`        | list[double] | Time horizons for prediction evaluation in seconds.                                                                                             |
+| `stopped_velocity_threshold`      | double       | threshold velocity to check if vehicle is stopped                                                                                               |
+| `detection_radius`                | double       | Detection radius for objects to be evaluated.(used for objects count only)                                                                      |
+| `detection_height`                | double       | Detection height for objects to be evaluated. (used for objects count only)                                                                     |
+| `objects_count_window_seconds`    | double       | Time window for keeping object detection counts. The number of object detections within this time window is stored in `detection_count_vector_` |
+| `target_object.*.check_deviation` | bool         | Whether to check deviation for specific object types (car, truck, etc.).                                                                        |
+| `debug_marker.*`                  | bool         | Debugging parameters for marker visualization (history path, predicted path, etc.).                                                             |
 
 ## Assumptions / Known limits
 
@@ -45,5 +46,4 @@ It is assumed that the current positions of PredictedObjects are reasonably accu
 - Metrics for objects with strange physical behavior (e.g., going through a fence)
 - Metrics for splitting objects
 - Metrics for problems with objects that are normally stationary but move
-- Metrics for counting the number of objects per class within a specified time frame.
 - Disappearing object metrics

--- a/evaluator/perception_online_evaluator/README.md
+++ b/evaluator/perception_online_evaluator/README.md
@@ -30,7 +30,7 @@ This module allows for the evaluation of how accurately perception results are g
 | `smoothing_window_size`           | Integer      | Determines the window size for smoothing path, should be an odd number.                          |
 | `prediction_time_horizons`        | list[double] | Time horizons for prediction evaluation in seconds.                                              |
 | `stopped_velocity_threshold`      | double       | threshold velocity to check if vehicle is stopped                                                |
-| `detection_radius`                 | double       | Detection radius for objects to be evaluated.(used for objects count only)                        |
+| `detection_radius`                | double       | Detection radius for objects to be evaluated.(used for objects count only)                       |
 | `detection_height`                | double       | Detection height for objects to be evaluated. (used for objects count only)                      |
 | `target_object.*.check_deviation` | bool         | Whether to check deviation for specific object types (car, truck, etc.).                         |
 | `debug_marker.*`                  | bool         | Debugging parameters for marker visualization (history path, predicted path, etc.).              |

--- a/evaluator/perception_online_evaluator/README.md
+++ b/evaluator/perception_online_evaluator/README.md
@@ -11,7 +11,8 @@ This module allows for the evaluation of how accurately perception results are g
 - Calculates lateral deviation between the predicted path and the actual traveled trajectory.
 - Calculates lateral deviation between the smoothed traveled trajectory and the perceived position to evaluate the stability of lateral position recognition.
 - Calculates yaw deviation between the smoothed traveled trajectory and the perceived position to evaluate the stability of yaw recognition.
-- Calculates yaw rate based on the yaw of the object received in the previous cycle to evaluate the stability of the yaw rate recognition.
+- Calculates yaw rate based on the yaw of the stopped object received in the previous cycle to evaluate the stability of the yaw rate recognition.
+- Counts the number of detections for each object class within the specified detection range.
 
 ## Inputs / Outputs
 
@@ -29,6 +30,8 @@ This module allows for the evaluation of how accurately perception results are g
 | `smoothing_window_size`           | Integer      | Determines the window size for smoothing path, should be an odd number.                          |
 | `prediction_time_horizons`        | list[double] | Time horizons for prediction evaluation in seconds.                                              |
 | `stopped_velocity_threshold`      | double       | threshold velocity to check if vehicle is stopped                                                |
+| `detection_range`                 | double       | Detection range for objects to be evaluated.                                                     |
+| `detection_height`                | double       | Detection height for objects to be evaluated.                                                    |
 | `target_object.*.check_deviation` | bool         | Whether to check deviation for specific object types (car, truck, etc.).                         |
 | `debug_marker.*`                  | bool         | Debugging parameters for marker visualization (history path, predicted path, etc.).              |
 
@@ -42,4 +45,5 @@ It is assumed that the current positions of PredictedObjects are reasonably accu
 - Metrics for objects with strange physical behavior (e.g., going through a fence)
 - Metrics for splitting objects
 - Metrics for problems with objects that are normally stationary but move
+- Metrics for counting the number of objects per class within a specified time frame.
 - Disappearing object metrics

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/metric.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/metric.hpp
@@ -32,6 +32,7 @@ enum class Metric {
   yaw_deviation,
   predicted_path_deviation,
   yaw_rate,
+  objects_count,
   SIZE,
 };
 
@@ -41,20 +42,23 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"lateral_deviation", Metric::lateral_deviation},
   {"yaw_deviation", Metric::yaw_deviation},
   {"predicted_path_deviation", Metric::predicted_path_deviation},
-  {"yaw_rate", Metric::yaw_rate}};
+  {"yaw_rate", Metric::yaw_rate},
+  {"objects_count", Metric::objects_count}};
 
 static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::lateral_deviation, "lateral_deviation"},
   {Metric::yaw_deviation, "yaw_deviation"},
   {Metric::predicted_path_deviation, "predicted_path_deviation"},
-  {Metric::yaw_rate, "yaw_rate"}};
+  {Metric::yaw_rate, "yaw_rate"},
+  {Metric::objects_count, "objects_count"}};
 
 // Metrics descriptions
 static const std::unordered_map<Metric, std::string> metric_descriptions = {
   {Metric::lateral_deviation, "Lateral_deviation[m]"},
   {Metric::yaw_deviation, "Yaw_deviation[rad]"},
   {Metric::predicted_path_deviation, "Predicted_path_deviation[m]"},
-  {Metric::yaw_rate, "Yaw_rate[rad/s]"}};
+  {Metric::yaw_rate, "Yaw_rate[rad/s]"},
+  {Metric::objects_count, "objects_count"}};
 
 namespace details
 {

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -24,6 +24,7 @@
 
 #include <rclcpp/time.hpp>
 
+#include "autoware_auto_perception_msgs/msg/object_classification.hpp"
 #include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include <unique_identifier_msgs/msg/uuid.hpp>
@@ -115,14 +116,10 @@ private:
   DetectionCountMap initializeDetectionCountMap()
   {
     return {
-      {0, 0},  // UNKNOWN
-      {1, 0},  // CAR
-      {2, 0},  // TRUCK
-      {3, 0},  // BUS
-      {4, 0},  // TRAILER
-      {5, 0},  // MOTORCYCLE
-      {6, 0},  // BICYCLE
-      {7, 0},  // PEDESTRIAN
+      {ObjectClassification::UNKNOWN, 0}, {ObjectClassification::CAR, 0},
+      {ObjectClassification::TRUCK, 0},   {ObjectClassification::BUS, 0},
+      {ObjectClassification::TRAILER, 0}, {ObjectClassification::MOTORCYCLE, 0},
+      {ObjectClassification::BICYCLE, 0}, {ObjectClassification::PEDESTRIAN, 0},
     };
   }
 

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -127,6 +127,7 @@ private:
   }
 
   DetectionCountMap historical_detection_count_map_ = initializeDetectionCountMap();
+  DetectionCountMap current_detection_count_map_ = initializeDetectionCountMap();
 
   rclcpp::Time current_stamp_;
 

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -113,7 +113,7 @@ private:
   // Store predicted objects information and calculation results
   ObjectMap object_map_;
   HistoryPathMap history_path_map_;
-  DetectionCountMap initializeDetectionCountMap()
+  DetectionCountMap initializeDetectionCountMap() const
   {
     return {
       {ObjectClassification::UNKNOWN, 0}, {ObjectClassification::CAR, 0},
@@ -124,7 +124,7 @@ private:
   }
 
   DetectionCountMap historical_detection_count_map_ = initializeDetectionCountMap();
-  DetectionCountMap current_detection_count_map_ = initializeDetectionCountMap();
+  std::vector<std::pair<DetectionCountMap, rclcpp::Time>> detection_count_vector_;
 
   rclcpp::Time current_stamp_;
 

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -105,7 +105,6 @@ public:
 
   HistoryPathMap getHistoryPathMap() const { return history_path_map_; }
   ObjectDataMap getDebugObjectData() const { return debug_target_object_; }
-  DetectionCountMap getDetectionCountMap() const { return historical_detection_count_map_; }
 
 private:
   std::shared_ptr<Parameters> parameters_;
@@ -113,18 +112,10 @@ private:
   // Store predicted objects information and calculation results
   ObjectMap object_map_;
   HistoryPathMap history_path_map_;
-  DetectionCountMap initializeDetectionCountMap() const
-  {
-    return {
-      {ObjectClassification::UNKNOWN, 0}, {ObjectClassification::CAR, 0},
-      {ObjectClassification::TRUCK, 0},   {ObjectClassification::BUS, 0},
-      {ObjectClassification::TRAILER, 0}, {ObjectClassification::MOTORCYCLE, 0},
-      {ObjectClassification::BICYCLE, 0}, {ObjectClassification::PEDESTRIAN, 0},
-    };
-  }
 
   DetectionCountMap historical_detection_count_map_ = initializeDetectionCountMap();
-  std::vector<std::pair<DetectionCountMap, rclcpp::Time>> detection_count_vector_;
+  int objects_count_frame_ = 0;
+  std::vector<std::pair<DetectionCountMap, rclcpp::Time>> detection_count_vector_{};
 
   rclcpp::Time current_stamp_;
 
@@ -165,6 +156,16 @@ private:
   std::optional<std::pair<rclcpp::Time, PredictedObject>> getPreviousObjectByStamp(
     const std::string uuid, const rclcpp::Time stamp) const;
   PredictedObjects getObjectsByStamp(const rclcpp::Time stamp) const;
+
+  DetectionCountMap initializeDetectionCountMap() const
+  {
+    return {
+      {ObjectClassification::UNKNOWN, 0}, {ObjectClassification::CAR, 0},
+      {ObjectClassification::TRUCK, 0},   {ObjectClassification::BUS, 0},
+      {ObjectClassification::TRAILER, 0}, {ObjectClassification::MOTORCYCLE, 0},
+      {ObjectClassification::BICYCLE, 0}, {ObjectClassification::PEDESTRIAN, 0},
+    };
+  }
 
 };  // class MetricsCalculator
 

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/parameters.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/parameters.hpp
@@ -49,8 +49,9 @@ struct Parameters
   size_t smoothing_window_size{0};
   std::vector<double> prediction_time_horizons;
   double stopped_velocity_threshold{0.0};
-  double detection_range;
+  double detection_radius;
   double detection_height;
+  double objects_count_window_seconds;
   DebugMarkerParameter debug_marker_parameters;
   // parameters depend on object class
   std::unordered_map<uint8_t, ObjectParameter> object_parameters;

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/parameters.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/parameters.hpp
@@ -49,6 +49,8 @@ struct Parameters
   size_t smoothing_window_size{0};
   std::vector<double> prediction_time_horizons;
   double stopped_velocity_threshold{0.0};
+  double detection_range;
+  double detection_height;
   DebugMarkerParameter debug_marker_parameters;
   // parameters depend on object class
   std::unordered_map<uint8_t, ObjectParameter> object_parameters;

--- a/evaluator/perception_online_evaluator/param/perception_online_evaluator.defaults.yaml
+++ b/evaluator/perception_online_evaluator/param/perception_online_evaluator.defaults.yaml
@@ -13,8 +13,9 @@
     prediction_time_horizons: [1.0, 2.0, 3.0, 5.0]
 
     stopped_velocity_threshold: 1.0
-    detection_range: 100.0
+    detection_radius: 100.0
     detection_height: 10.0
+    objects_count_window_seconds: 3.0
 
     target_object:
       car:

--- a/evaluator/perception_online_evaluator/param/perception_online_evaluator.defaults.yaml
+++ b/evaluator/perception_online_evaluator/param/perception_online_evaluator.defaults.yaml
@@ -5,6 +5,7 @@
       - yaw_deviation
       - predicted_path_deviation
       - yaw_rate
+      - objects_count
 
     # this should be an odd number, because it includes the target point
     smoothing_window_size: 11
@@ -12,6 +13,8 @@
     prediction_time_horizons: [1.0, 2.0, 3.0, 5.0]
 
     stopped_velocity_threshold: 1.0
+    detection_range: 100.0
+    detection_height: 10.0
 
     target_object:
       car:

--- a/evaluator/perception_online_evaluator/src/metrics_calculator.cpp
+++ b/evaluator/perception_online_evaluator/src/metrics_calculator.cpp
@@ -409,7 +409,12 @@ MetricStatMap MetricsCalculator::calcObjectsCountMetrics() const
   for (const auto & [label, count] : historical_detection_count_map_) {
     Stat<double> stat;
     stat.add(static_cast<double>(count));
-    metric_stat_map["objects_count_" + convertLabelToString(label)] = stat;
+    metric_stat_map["historical_objects_count_" + convertLabelToString(label)] = stat;
+  }
+  for (const auto & [label, count] : current_detection_count_map_) {
+    Stat<double> stat;
+    stat.add(static_cast<double>(count));
+    metric_stat_map["current_objects_count_" + convertLabelToString(label)] = stat;
   }
 
   return metric_stat_map;
@@ -447,6 +452,10 @@ void MetricsCalculator::updateObjectsCountMap(
               << "' to 'base_link': " << ex.what() << std::endl;
     return;
   }
+  // initialize the current_detection_count_map_ with 0
+  for (const auto & [label, count] : current_detection_count_map_) {
+    current_detection_count_map_[label] = 0;
+  }
 
   for (const auto & object : objects.objects) {
     const auto label = object_recognition_utils::getHighestProbLabel(object.classification);
@@ -465,8 +474,8 @@ void MetricsCalculator::updateObjectsCountMap(
       distance_to_pose < parameters_->detection_range &&
       pose_out.pose.position.z < parameters_->detection_height) {
       historical_detection_count_map_[label]++;
+      current_detection_count_map_[label]++;
     }
-
   }
 }
 

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -216,8 +216,9 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
 
   updateParam<size_t>(parameters, "smoothing_window_size", p->smoothing_window_size);
   updateParam<double>(parameters, "stopped_velocity_threshold", p->stopped_velocity_threshold);
-  updateParam<double>(parameters, "detection_range", p->detection_range);
+  updateParam<double>(parameters, "detection_radius", p->detection_radius);
   updateParam<double>(parameters, "detection_height", p->detection_height);
+  updateParam<double>(parameters, "objects_count_window_seconds", p->objects_count_window_seconds);
 
   // update metrics
   {
@@ -310,8 +311,10 @@ void PerceptionOnlineEvaluatorNode::initParameter()
     getOrDeclareParameter<std::vector<double>>(*this, "prediction_time_horizons");
   p->stopped_velocity_threshold =
     getOrDeclareParameter<double>(*this, "stopped_velocity_threshold");
-  p->detection_range = getOrDeclareParameter<double>(*this, "detection_range");
+  p->detection_radius = getOrDeclareParameter<double>(*this, "detection_radius");
   p->detection_height = getOrDeclareParameter<double>(*this, "detection_height");
+  p->objects_count_window_seconds =
+    getOrDeclareParameter<double>(*this, "objects_count_window_seconds");
 
   // set metrics
   const auto selected_metrics =

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -112,6 +112,7 @@ DiagnosticStatus PerceptionOnlineEvaluatorNode::generateDiagnosticStatus(
 void PerceptionOnlineEvaluatorNode::onObjects(const PredictedObjects::ConstSharedPtr objects_msg)
 {
   metrics_calculator_.setPredictedObjects(*objects_msg);
+  metrics_calculator_.updateObjectsCountMap(*objects_msg, *tf_buffer_);
   publishMetrics();
 }
 
@@ -215,6 +216,8 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
 
   updateParam<size_t>(parameters, "smoothing_window_size", p->smoothing_window_size);
   updateParam<double>(parameters, "stopped_velocity_threshold", p->stopped_velocity_threshold);
+  updateParam<double>(parameters, "detection_range", p->detection_range);
+  updateParam<double>(parameters, "detection_height", p->detection_height);
 
   // update metrics
   {
@@ -307,6 +310,8 @@ void PerceptionOnlineEvaluatorNode::initParameter()
     getOrDeclareParameter<std::vector<double>>(*this, "prediction_time_horizons");
   p->stopped_velocity_threshold =
     getOrDeclareParameter<double>(*this, "stopped_velocity_threshold");
+  p->detection_range = getOrDeclareParameter<double>(*this, "detection_range");
+  p->detection_height = getOrDeclareParameter<double>(*this, "detection_height");
 
   // set metrics
   const auto selected_metrics =


### PR DESCRIPTION
## Description

This PR enhances the perception_online_evaluator module by introducing two new functionalities: 
- Calculating the number of detections for each object class within the specified detection range in total/in the cycle

<!-- Write a brief description of this PR. -->

## Tests performed

cofirmed with psim
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/0d563dea-343c-4011-9eed-1081dfb07920)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
