### PR TITLE
fix(tier4_autoware_utils): fix `-Werror=unused-parameter`

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -38,7 +38,8 @@ public:
     noexec_subscription_options.callback_group = noexec_callback_group;
 
     subscriber_ = node->create_subscription<T>(
-      topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },
+      topic_name, rclcpp::QoS{1},
+      [node]([[maybe_unused]] const typename T::ConstSharedPtr msg) { assert(false); },
       noexec_subscription_options);
   };
   bool updateLatestData()


### PR DESCRIPTION
## Description

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/6702

Fix following build error.

```
--- stderr: obstacle_cruise_planner                                                                                                                                                                                                                                                                                                                                                                                             
In file included from /home/satoshi/pilot-auto/src/autoware/universe/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp:24,                                                                                                                                                                                                                                                                              
                 from /home/satoshi/pilot-auto/src/autoware/universe/planning/obstacle_cruise_planner/src/node.cpp:15:                                                                                                                                                                                                                                                                                                          
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp: In instantiation of ‘tier4_autoware_utils::InterProcessPollingSubscriber<T>::InterProcessPollingSubscriber(rclcpp::Node*, const string&) [with T = nav_msgs::msg::Odometry_<std::allocator<void> >; std::string = std::__cxx11::basic_string<char>]’:                                                            
/home/satoshi/pilot-auto/src/autoware/universe/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp:143:29:   required from here                                                                                                                                                                                                                                                                           
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp:41:75: error: unused parameter ‘msg’ [-Werror=unused-parameter]                                                                                                                                                                                                                                                   
   41 |       topic_name, rclcpp::QoS{1}, [node](const typename T::ConstSharedPtr msg) { assert(false); },                                                                                                                                                                                                                                                                                                                      
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                                                                                                                                                                                                                                                                                           
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp: In instantiation of ‘tier4_autoware_utils::InterProcessPollingSubscriber<T>::InterProcessPollingSubscriber(rclcpp::Node*, const string&) [with T = autoware_auto_perception_msgs::msg::PredictedObjects_<std::allocator<void> >; std::string = std::__cxx11::basic_string<char>]’:                               
/home/satoshi/pilot-auto/src/autoware/universe/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp:145:28:   required from here                                                                                                                                                                                                                                                                           
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp:41:75: error: unused parameter ‘msg’ [-Werror=unused-parameter]                                                                                                                                                                                                                                                   
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp: In instantiation of ‘tier4_autoware_utils::InterProcessPollingSubscriber<T>::InterProcessPollingSubscriber(rclcpp::Node*, const string&) [with T = geometry_msgs::msg::AccelWithCovarianceStamped_<std::allocator<void> >; std::string = std::__cxx11::basic_string<char>]’:                                     
/home/satoshi/pilot-auto/src/autoware/universe/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp:147:33:   required from here                                                                                                                                                                                                                                                                           
/home/satoshi/pilot-auto/install/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp:41:75: error: unused parameter ‘msg’ [-Werror=unused-parameter]                                                                                                                                                                                                                                                   
cc1plus: all warnings being treated as errors                                                                                                                                                                                                                                                                                                                                                                                   
gmake[2]: *** [CMakeFiles/obstacle_cruise_planner_core.dir/build.make:76: CMakeFiles/obstacle_cruise_planner_core.dir/src/node.cpp.o] Error 1                                                                                                                                                                                                                                                                                   
gmake[1]: *** [CMakeFiles/Makefile2:159: CMakeFiles/obstacle_cruise_planner_core.dir/all] Error 2                                                                                                                                                                                                                                                                                                                               
gmake: *** [Makefile:146: all] Error 2                                                                                                                                                                                                                                                                                                                                                                                          
---                                                                                                                                                                                                                                                                                                                                                                                                                             
Failed   <<< obstacle_cruise_planner [1min 0s, exited with code 2]
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Pass build.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
