### PR TITLE
fix(avoidance): bug in the logic to judge whether it's a parked vehicle

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/utils.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/utils.hpp
@@ -85,10 +85,6 @@ lanelet::ConstLanelets getAdjacentLane(
   const std::shared_ptr<const PlannerData> & planner_data,
   const std::shared_ptr<AvoidanceParameters> & parameters, const bool is_right_shift);
 
-lanelet::ConstLanelets getTargetLanelets(
-  const std::shared_ptr<const PlannerData> & planner_data, lanelet::ConstLanelets & route_lanelets,
-  const double left_offset, const double right_offset);
-
 lanelet::ConstLanelets getCurrentLanesFromPath(
   const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data);
 

--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -318,7 +318,6 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   using utils::avoidance::fillAvoidanceNecessity;
   using utils::avoidance::fillObjectStoppableJudge;
   using utils::avoidance::filterTargetObjects;
-  using utils::avoidance::getTargetLanelets;
   using utils::avoidance::separateObjectsByPath;
   using utils::avoidance::updateRoadShoulderDistance;
   using utils::traffic_light::calcDistanceToRedTrafficLight;


### PR DESCRIPTION
## Description

The avoidance module couldn't create avoidance path in following situation. The module makes avoidance path for object on the ego's lane only when it's a parked vehicle. And, it assumed there is no parked vehicle on ego's lane if the lane has both right and left adjacent lane. 

On the other hand, if the right or left lane is a road shoulder lane, there is a possibility that there is parked vehicle on ego's lane. (if it is a large vehicle and the road should is narrow, maybe the vehicles position is on ego's lane.)

However, since previous avoidance module considered the road shoudler lanes as road lanes, the module didn't create avoidance path in following situation.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/6ceb73f5-a9fb-4828-97f6-14836734ec6b)

In this PR, I fixed the argument in order not to get adjacent road shoulder lanelet in following function.

```c++
    const auto right_lane =
      planner_data->route_handler->getRightLanelet(object.overhang_lanelet, true, false);
    const auto left_lane =
      planner_data->route_handler->getLeftLanelet(object.overhang_lanelet, true, false);
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/c58155ef-bb9e-4da4-ae05-fbcfde413291)

Additionally, this PR includes small refactoring as well (remove unused function `getTargetLanelets`).

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/1198676d-8e04-542b-ad61-a487af6fbafe?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix bug.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
