### PR TITLE
fix(multi_object_tracker): mot timer bug fix

### DIFF
--- a/perception/multi_object_tracker/src/debugger.cpp
+++ b/perception/multi_object_tracker/src/debugger.cpp
@@ -18,12 +18,7 @@
 
 #include <memory>
 
-TrackerDebugger::TrackerDebugger(rclcpp::Node & node)
-: diagnostic_updater_(&node),
-  node_(node),
-  last_input_stamp_(node.now()),
-  stamp_process_start_(node.now()),
-  stamp_publish_output_(node.now())
+TrackerDebugger::TrackerDebugger(rclcpp::Node & node) : diagnostic_updater_(&node), node_(node)
 {
   // declare debug parameters to decide whether to publish debug topics
   loadParameters();
@@ -39,7 +34,15 @@ TrackerDebugger::TrackerDebugger(rclcpp::Node & node)
         "debug/tentative_objects", rclcpp::QoS{1});
   }
 
-  // initialize stop watch and diagnostics
+  // initialize timestamps
+  const rclcpp::Time now = node_.now();
+  last_input_stamp_ = now;
+  stamp_process_start_ = now;
+  stamp_process_end_ = now;
+  stamp_publish_start_ = now;
+  stamp_publish_output_ = now;
+
+  // setup diagnostics
   setupDiagnostics();
 }
 

--- a/perception/multi_object_tracker/src/debugger.cpp
+++ b/perception/multi_object_tracker/src/debugger.cpp
@@ -73,7 +73,11 @@ void TrackerDebugger::loadParameters()
 
 void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  const double delay = pipeline_latency_ms_;  // [s]
+  if (!is_initialized_) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Measurement time is not set.");
+    return;
+  }
+  const double & delay = pipeline_latency_ms_;  // [s]
 
   if (delay == 0.0) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Detection delay is not calculated.");
@@ -127,18 +131,21 @@ void TrackerDebugger::startPublishTime(const rclcpp::Time & now)
 
 void TrackerDebugger::endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time)
 {
-  const auto current_time = now;
+  // if the measurement time is not set, do not publish debug information
+  if (!is_initialized_) return;
+
   // pipeline latency: time from sensor measurement to publish, used for 'checkDelay'
-  pipeline_latency_ms_ = (current_time - last_input_stamp_).seconds() * 1e3;
-  if (debug_settings_.publish_processing_time && is_initialized_) {
+  pipeline_latency_ms_ = (now - last_input_stamp_).seconds() * 1e3;
+
+  if (debug_settings_.publish_processing_time) {
     // processing latency: time between input and publish
-    double processing_latency_ms = ((current_time - stamp_process_start_).seconds()) * 1e3;
+    double processing_latency_ms = ((now - stamp_process_start_).seconds()) * 1e3;
     // processing time: only the time spent in the tracking processes
-    double processing_time_ms = ((current_time - stamp_publish_start_).seconds() +
+    double processing_time_ms = ((now - stamp_publish_start_).seconds() +
                                  (stamp_process_end_ - stamp_process_start_).seconds()) *
                                 1e3;
     // cycle time: time between two consecutive publish
-    double cyclic_time_ms = (current_time - stamp_publish_output_).seconds() * 1e3;
+    double cyclic_time_ms = (now - stamp_publish_output_).seconds() * 1e3;
     // measurement to tracked-object time: time from the sensor measurement to the publishing object
     // time If there is not latency compensation, this value is zero
     double measurement_to_object_ms = (object_time - last_input_stamp_).seconds() * 1e3;
@@ -155,5 +162,5 @@ void TrackerDebugger::endPublishTime(const rclcpp::Time & now, const rclcpp::Tim
     processing_time_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
       "debug/meas_to_tracked_object_ms", measurement_to_object_ms);
   }
-  stamp_publish_output_ = current_time;
+  stamp_publish_output_ = now;
 }

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -135,10 +135,14 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 void MultiObjectTracker::onMeasurement(
   const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_objects_msg)
 {
+  // Get the time of the measurement
+  const rclcpp::Time measurement_time =
+    rclcpp::Time(input_objects_msg->header.stamp, this->now().get_clock_type());
+
   /* keep the latest input stamp and check transform*/
-  debugger_->startMeasurementTime(this->now(), rclcpp::Time(input_objects_msg->header.stamp));
-  const auto self_transform = getTransformAnonymous(
-    tf_buffer_, "base_link", world_frame_id_, input_objects_msg->header.stamp);
+  debugger_->startMeasurementTime(this->now(), measurement_time);
+  const auto self_transform =
+    getTransformAnonymous(tf_buffer_, "base_link", world_frame_id_, measurement_time);
   if (!self_transform) {
     return;
   }
@@ -150,7 +154,6 @@ void MultiObjectTracker::onMeasurement(
     return;
   }
   /* tracker prediction */
-  const rclcpp::Time measurement_time = input_objects_msg->header.stamp;
   for (auto itr = list_tracker_.begin(); itr != list_tracker_.end(); ++itr) {
     (*itr)->predict(measurement_time);
   }


### PR DESCRIPTION
## Description

In some simulation configuration, the MOT had crash.

```
[openscenario_interpreter_node-3] [multi_object_tracker-52] terminate called after throwing an instance of 'std::runtime_error'
[openscenario_interpreter_node-3] [multi_object_tracker-52]   what():  can't subtract times with different time sources [2 != 1]
[openscenario_interpreter_node-3] [multi_object_tracker-52] *** Aborted at 1712577962 (unix time) try "date -d @1712577962" if you are using GNU date ***
[openscenario_interpreter_node-3] [multi_object_tracker-52] PC: @                0x0 (unknown)
[openscenario_interpreter_node-3] [multi_object_tracker-52] *** SIGABRT (@0x3e800003010) received by PID 12304 (TID 0x7f0786116380) from PID 12304; stack trace: ***
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f0784bb2046 (unknown)
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07863f2520 (unknown)
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07864469fc pthread_kill
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07863f2476 raise
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07863d87f3 abort
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f078669db9e (unknown)
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07866a920c (unknown)
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07866a9277 std::terminate()
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07866a94d8 __cxa_throw
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07869b57ae _ZNK6rclcpp4TimemiERKS0_.cold
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f0784e4ab22 TrackerDebugger::endPublishTime()
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f0784de1e6d MultiObjectTracker::publish()
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f0784de2acd MultiObjectTracker::onTimer()
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f0784de6515 rclcpp::GenericTimer<>::execute_callback()
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07869d3ffe rclcpp::Executor::execute_any_executable()
[openscenario_interpreter_node-3] [WARN] [1712577963.230491202] [simulation.openscenario_interpreter]: Your machine is not powerful enough to run the scenario at the specified frame rate (30 Hz). We recommend that you reduce the frame rate to 2.99401 or less.
[openscenario_interpreter_node-3] [INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/default_ad_api/node/motion' in container '/default_ad_api/container'
[openscenario_interpreter_node-3] [INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/map/lanelet2_map_loader' in container '/map/map_container'
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07869dac90 rclcpp::executors::SingleThreadedExecutor::spin()
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x55a167a7043e main
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07863d9d90 (unknown)
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x7f07863d9e40 __libc_start_main
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @     0x55a167a70df5 _start
[openscenario_interpreter_node-3] [multi_object_tracker-52]     @                0x0 (unknown)
```

```
what():  can't subtract times with different time sources [2 != 1]
```


1. Newly introduced timestamps for the debug time calculation was not initialized.
2. Even the input was not come, the timer triggered the debug time publisher.
3. The debug timer publisher calculated with non-initialized or not-updated timestamps and got error.

[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT1-5741)

## Tests performed

[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/829f3bda-3148-5933-83f6-43d59c71f04a?project_id=prd_jt)

## Effects on system behavior

Initial behavior of the MOT will be fixed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
