### PR TITLE
feat(auto_parking): automated valet parking implementation 

### DIFF
--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -23,6 +23,7 @@
   <depend>tier4_control_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_planning_msgs</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -25,6 +25,8 @@
 #include <QTableWidget>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_srvs/srv/set_bool.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/motion_state.hpp>
@@ -69,6 +71,8 @@ public Q_SLOTS:  // NOLINT for Qt
   void onClickLocal();
   void onClickRemote();
   void onClickAutowareControl();
+  void onClickEngageAutoPark();
+  void onClickDisengageAutoPark();
   void onClickDirectControl();
   void onClickClearRoute();
   void onClickInitByGnss();
@@ -80,6 +84,7 @@ protected:
   // Layout
   QGroupBox * makeOperationModeGroup();
   QGroupBox * makeControlModeGroup();
+  QGroupBox * makeAutoParkModeGroup();
   QGroupBox * makeRoutingGroup();
   QGroupBox * makeLocalizationGroup();
   QGroupBox * makeMotionGroup();
@@ -106,6 +111,7 @@ protected:
   QPushButton * remote_button_ptr_{nullptr};
 
   rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_auto_park_status_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_autonomous_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_stop_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_local_;
@@ -117,6 +123,13 @@ protected:
   QPushButton * disable_button_ptr_{nullptr};
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_autoware_control_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_direct_control_;
+
+  //// Auto Parking Mode
+  QLabel * park_mode_label_ptr_{nullptr};
+  QPushButton * p_enable_button_ptr_{nullptr};
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr client_auto_park_;
+  bool auto_park_running_;
+  void onAutoParkStatus(const std_msgs::msg::Bool::ConstSharedPtr msg);
 
   //// Functions
   void onOperationMode(const OperationModeState::ConstSharedPtr msg);

--- a/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
@@ -31,8 +31,28 @@
         <param from="$(var freespace_planner_param_path)"/>
         <extra_arg name="use_intra_process_comms" value="false"/>
       </composable_node>
-
       <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
     </node_container>
+  </group>
+
+  <!-- auto parking module -->
+  <group if="$(var launch_avp_module)">
+    <push-ros-namespace namespace="avp"/>
+      <node_container pkg="rclcpp_components" exec="component_container" name="auto_parking_container" namespace="">
+          <composable_node pkg="auto_parking" plugin="auto_parking::AutoParkingNode" name="auto_parking" namespace="">
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/occupancy_grid" to="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
+            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
+            <remap from="~/input/engage" to="/api/autoware/get/engage"/>
+            <remap from="~/service/engage" to="/api/autoware/set/engage"/>
+            <remap from="~/output/fixed_goal" to="/planning/mission_planning/goal"/>
+            <remap from="~/output/active_status" to="/planning/auto_parking/status"/>
+            <remap from="~/service/set_active" to="/planning/auto_parking/set_status"/>
+            <!-- params -->
+            <param from="$(var vehicle_param_file)"/>
+            <param from="$(var auto_parking_param_path)"/>
+          </composable_node>
+          <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
+      </node_container>
   </group>
 </launch>

--- a/planning/auto_parking/CMakeLists.txt
+++ b/planning/auto_parking/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+project(auto_parking)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(auto_parking_node SHARED
+  src/auto_parking/auto_parking_node.cpp
+)
+
+rclcpp_components_register_node(auto_parking_node
+  PLUGIN "auto_parking::AutoParkingNode"
+  EXECUTABLE auto_parking)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/planning/auto_parking/config/auto_parking.param.yaml
+++ b/planning/auto_parking/config/auto_parking.param.yaml
@@ -9,9 +9,9 @@
     # -- Configurations common to the all planners --
     # base configs
     time_limit: 30000.0
-    minimum_turning_radius: 9.0
+    minimum_turning_radius: 5.0
     maximum_turning_radius: 9.0
-    turning_radius_size: 1
+    turning_radius_size: 3
     # search configs
     theta_size: 144
     angle_goal_range: 6.0

--- a/planning/auto_parking/config/auto_parking.param.yaml
+++ b/planning/auto_parking/config/auto_parking.param.yaml
@@ -1,0 +1,31 @@
+/**:
+  ros__parameters:
+    # -- Auto Park Node Configurations --
+    th_arrived_distance_m: 1.0
+    th_parking_space_distance_m: 10.0
+    update_rate: 5.0
+    vehicle_shape_margin_m: 0.2
+
+    # -- Configurations common to the all planners --
+    # base configs
+    time_limit: 30000.0
+    minimum_turning_radius: 9.0
+    maximum_turning_radius: 9.0
+    turning_radius_size: 1
+    # search configs
+    theta_size: 144
+    angle_goal_range: 6.0
+    curve_weight: 1.2
+    reverse_weight: 2.0
+    lateral_goal_range: 0.5
+    longitudinal_goal_range: 2.0
+    # costmap configs
+    obstacle_threshold: 100
+
+    # -- A* search Configurations --
+    astar:
+      only_behind_solutions: false
+      use_back: true
+      use_curve_weight: false
+      use_complete_astar: true
+      distance_heuristic_weight: 1.0

--- a/planning/auto_parking/include/auto_parking/auto_parking_node.hpp
+++ b/planning/auto_parking/include/auto_parking/auto_parking_node.hpp
@@ -142,6 +142,7 @@ private:
   Pose parking_goal_;
   bool set_parking_lot_goal_;
   bool set_parking_space_goal_;
+  bool active_;
 
   bool is_engaged_;
 };

--- a/planning/auto_parking/include/auto_parking/auto_parking_node.hpp
+++ b/planning/auto_parking/include/auto_parking/auto_parking_node.hpp
@@ -1,0 +1,149 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright 2018-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AUTO_PARKING__AUTO_PARKING_NODE_HPP_
+#define AUTO_PARKING__AUTO_PARKING_NODE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <motion_utils/vehicle/vehicle_state_checker.hpp>
+#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include "tier4_autoware_utils/ros/logger_level_configure.hpp"
+
+#include <freespace_planning_algorithms/astar_search.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_routing/RoutingGraph.h>
+#include <lanelet2_traffic_rules/TrafficRules.h>
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
+#include <tier4_external_api_msgs/srv/engage.hpp>
+
+using Pose = geometry_msgs::msg::Pose;
+using PoseStamped = geometry_msgs::msg::PoseStamped;
+using geometry_msgs::msg::TransformStamped;
+
+using EngageMsg = autoware_auto_vehicle_msgs::msg::Engage;
+using EngageSrv = tier4_external_api_msgs::srv::Engage;
+
+using freespace_planning_algorithms::AbstractPlanningAlgorithm;
+using freespace_planning_algorithms::AstarParam;
+using freespace_planning_algorithms::AstarSearch;
+using freespace_planning_algorithms::PlannerCommonParam;
+using freespace_planning_algorithms::VehicleShape;
+using nav_msgs::msg::OccupancyGrid;
+
+namespace auto_parking
+{
+
+struct AutoParkParam
+{
+  double th_arrived_distance_m; // threshold to check arrival at goal 1.0
+  double th_parking_space_distance_m; // search for parking spaces within this radius 10
+  double update_rate; // Timer() update rate 2
+  double vehicle_shape_margin_m; // margin to add to vehicle dimensions for astar collision check, collision margin 0.2
+};
+
+class AutoParkingNode : public rclcpp::Node
+{
+public:
+  explicit AutoParkingNode(const rclcpp::NodeOptions & node_options);
+
+  void onMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
+  void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
+  void onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg);
+  void goalPublisher(const PoseStamped msg);
+  void reset();
+  void onTimer();
+  void filterGoalPoseinParkingLot(const lanelet::ConstLineString3d center_line, Pose& goal);
+  bool findParkingSpace();
+  //void getGoalToParkingSpace();
+  
+  bool isInParkingLot();
+  bool initAutoParking();
+  bool isArrived(const Pose& goal);
+
+  void onEngage(EngageMsg::ConstSharedPtr msg);
+  void engageAutonomous();
+
+  // functions used in the fpa constructor
+  PlannerCommonParam getPlannerCommonParam();
+  TransformStamped getTransform(const std::string & from, const std::string & to);
+
+private:
+  // ros
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<PoseStamped>::SharedPtr goal_pose_pub_;
+
+  nav_msgs::msg::Odometry::ConstSharedPtr odom_;
+  
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
+  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_lanelet_map_;
+  rclcpp::Subscription<EngageMsg>::SharedPtr engage_sub_;
+  rclcpp::Subscription<OccupancyGrid>::SharedPtr occupancy_grid_sub_;
+  rclcpp::Client<EngageSrv>::SharedPtr client_engage_;
+
+  std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
+  std::shared_ptr<lanelet::ConstPolygon3d> nearest_parking_lot_;
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules_ptr_;
+  lanelet::routing::RoutingGraphPtr routing_graph_ptr_;
+  lanelet::ConstLineStrings3d nearest_parking_spaces_;
+  lanelet::ConstLanelets parking_lot_lanelets_;
+  OccupancyGrid::ConstSharedPtr occupancy_grid_;
+
+  // fpa algo
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::unique_ptr<AbstractPlanningAlgorithm> algo_;
+
+  // params
+  AutoParkParam node_param_;
+  VehicleShape vehicle_shape_;
+
+  std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
+
+  PoseStamped current_goal_;
+  PoseStamped current_pose_;
+  lanelet::ConstLanelet current_lanelet_;
+  std::unique_ptr<motion_utils::VehicleStopCheckerBase> stop_checker_;
+  Pose parking_goal_;
+  bool set_parking_lot_goal_;
+  bool set_parking_space_goal_;
+
+  bool is_engaged_;
+};
+}  // namespace auto_parking
+#endif  // AUTO_PARKING__AUTO_PARKING_NODE_HPP_

--- a/planning/auto_parking/launch/auto_parking.launch.xml
+++ b/planning/auto_parking/launch/auto_parking.launch.xml
@@ -1,0 +1,26 @@
+<launch>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
+  <arg name="input_occupancy_grid" default="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
+  <arg name="input_lanelet_map_bin" default="/map/vector_map"/>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
+  <arg name="input_engage" default="/api/autoware/get/engage"/>
+
+  <arg name="output_engage" default="/api/autoware/set/engage"/>
+  <arg name="output_goal" default="/planning/mission_planning/goal"/>
+  
+
+  <arg name="param_file" default="$(find-pkg-share auto_parking)/config/auto_parking.param.yaml"/>
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml"/>
+
+  <node pkg="auto_parking" exec="auto_parking" name="auto_parking" output="screen">
+    <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/occupancy_grid" to="$(var input_occupancy_grid)"/>
+    <remap from="~/input/lanelet_map_bin" to="$(var input_lanelet_map_bin)"/>
+    <remap from="~/input/engage" to="$(var input_engage)"/>
+    <remap from="~/service/engage" to="$(var output_engage)"/>
+    <remap from="~/output/fixed_goal" to="$(var output_goal)"/>
+    <param from="$(var param_file)"/>
+    <param from="$(var vehicle_info_param_file)"/>
+  </node>
+</launch>

--- a/planning/auto_parking/launch/auto_parking.launch.xml
+++ b/planning/auto_parking/launch/auto_parking.launch.xml
@@ -2,11 +2,13 @@
   <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_occupancy_grid" default="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
   <arg name="input_lanelet_map_bin" default="/map/vector_map"/>
-  <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_engage" default="/api/autoware/get/engage"/>
 
   <arg name="output_engage" default="/api/autoware/set/engage"/>
   <arg name="output_goal" default="/planning/mission_planning/goal"/>
+  <arg name="output_status" default="/planning/auto_parking/status"/>
+
+  <arg name="srv_active" default="/planning/auto_parking/set_status"/>
   
 
   <arg name="param_file" default="$(find-pkg-share auto_parking)/config/auto_parking.param.yaml"/>
@@ -20,6 +22,8 @@
     <remap from="~/input/engage" to="$(var input_engage)"/>
     <remap from="~/service/engage" to="$(var output_engage)"/>
     <remap from="~/output/fixed_goal" to="$(var output_goal)"/>
+    <remap from="~/output/active_status" to="$(var output_status)"/>
+    <remap from="~/service/set_active" to="$(var srv_active)"/>
     <param from="$(var param_file)"/>
     <param from="$(var vehicle_info_param_file)"/>
   </node>

--- a/planning/auto_parking/package.xml
+++ b/planning/auto_parking/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>auto_parking</name>
+  <version>0.0.0</version>
+  <description>The auto_parking package</description>
+  <maintainer email="aswinvijay807@gmail.com">aswinvijay</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>tier4_autoware_utils</depend>
+  <depend>lanelet2_extension</depend>
+  <depend>motion_utils</depend>
+  <depend>tier4_external_api_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>freespace_planning_algorithms</depend>
+  <depend>nav_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/auto_parking/package.xml
+++ b/planning/auto_parking/package.xml
@@ -4,7 +4,7 @@
   <name>auto_parking</name>
   <version>0.0.0</version>
   <description>The auto_parking package</description>
-  <maintainer email="aswinvijay807@gmail.com">aswinvijay</maintainer>
+  <maintainer email="aswinvijay807@gmail.com">Aswin Vijay</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
@@ -22,6 +22,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/auto_parking/src/auto_parking/auto_parking_node.cpp
+++ b/planning/auto_parking/src/auto_parking/auto_parking_node.cpp
@@ -1,0 +1,498 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright 2015-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "auto_parking/auto_parking_node.hpp"
+
+#include <lanelet2_extension/utility/message_conversion.hpp>
+#include <lanelet2_extension/utility/query.hpp>
+
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/geometry/Point.h>
+#include <lanelet2_core/geometry/Polygon.h>
+
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
+using lanelet::utils::getId;
+using lanelet::utils::to2D;
+using Pose = geometry_msgs::msg::Pose;
+using PoseStamped = geometry_msgs::msg::PoseStamped;
+
+namespace 
+{
+
+std::shared_ptr<lanelet::ConstPolygon3d> filterNearestParkinglot(
+  const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr,
+  const lanelet::BasicPoint2d & current_position)
+{
+  const auto all_parking_lots = lanelet::utils::query::getAllParkingLots(lanelet_map_ptr);
+  const auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
+  *linked_parking_lot = *std::min_element(all_parking_lots.begin(), all_parking_lots.end(),
+    [&](const lanelet::ConstPolygon3d& p1, const lanelet::ConstPolygon3d& p2) {
+    const double dist_p1 = boost::geometry::distance(current_position, to2D(p1).basicPolygon());
+    const double dist_p2 = boost::geometry::distance(current_position, to2D(p2).basicPolygon());
+    return dist_p1 < dist_p2;
+  });
+  if (linked_parking_lot) {
+    return linked_parking_lot;
+  } else {
+    return {};
+  }
+}
+
+// bool isInLane(
+//   const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr,
+//   const geometry_msgs::msg::Point & current_pos)
+// {
+//   const auto & p = current_pos;
+//   const lanelet::Point3d search_point(lanelet::InvalId, p.x, p.y, p.z);
+
+//   std::vector<std::pair<double, lanelet::Lanelet>> nearest_lanelets =
+//     lanelet::geometry::findNearest(lanelet_map_ptr->laneletLayer, search_point.basicPoint2d(), 1);
+
+//   if (nearest_lanelets.empty()) {
+//     return false;
+//   }
+
+//   const auto nearest_lanelet = nearest_lanelets.front().second;
+
+//   return lanelet::geometry::within(search_point, nearest_lanelet.polygon3d());
+// }
+
+Pose transformPose(const Pose & pose, const TransformStamped & transform)
+{
+  PoseStamped transformed_pose;
+  PoseStamped orig_pose;
+  orig_pose.pose = pose;
+  tf2::doTransform(orig_pose, transformed_pose, transform);
+
+  return transformed_pose.pose;
+}
+}  // namespace
+
+namespace auto_parking
+{
+void AutoParkingNode::goalPublisher(const PoseStamped msg)
+{
+  goal_pose_pub_->publish(msg);
+}
+
+TransformStamped AutoParkingNode::getTransform(
+  const std::string & from, const std::string & to)
+{
+  TransformStamped tf;
+  try {
+    tf =
+      tf_buffer_->lookupTransform(from, to, rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_ERROR(get_logger(), "%s", ex.what());
+  }
+  return tf;
+}
+
+void AutoParkingNode::onMap(
+  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg)
+{
+  lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
+  lanelet::utils::conversion::fromBinMsg(
+    *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
+}
+
+void AutoParkingNode::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
+{
+  odom_ = msg;
+
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = msg->header;
+  twist.twist = msg->twist.twist;
+  stop_checker_->addTwist(twist);
+}
+
+void AutoParkingNode::onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg)
+{
+  occupancy_grid_ = msg;
+}
+
+PlannerCommonParam AutoParkingNode::getPlannerCommonParam()
+{
+  PlannerCommonParam p;
+
+  // search configs
+  p.time_limit = declare_parameter<double>("time_limit");
+  p.minimum_turning_radius = declare_parameter<double>("minimum_turning_radius");
+  p.maximum_turning_radius = declare_parameter<double>("maximum_turning_radius");
+  p.turning_radius_size = declare_parameter<int>("turning_radius_size");
+  p.maximum_turning_radius = std::max(p.maximum_turning_radius, p.minimum_turning_radius);
+  p.turning_radius_size = std::max(p.turning_radius_size, 1);
+
+  p.theta_size = declare_parameter<int>("theta_size");
+  p.angle_goal_range = declare_parameter<double>("angle_goal_range");
+  p.curve_weight = declare_parameter<double>("curve_weight");
+  p.reverse_weight = declare_parameter<double>("reverse_weight");
+  p.lateral_goal_range = declare_parameter<double>("lateral_goal_range");
+  p.longitudinal_goal_range = declare_parameter<double>("longitudinal_goal_range");
+
+  // costmap configs
+  p.obstacle_threshold = declare_parameter<int>("obstacle_threshold");
+
+  return p;
+}
+
+bool AutoParkingNode::isArrived(const Pose& goal)
+{
+  // Check distance to current goal
+  if (node_param_.th_arrived_distance_m < tier4_autoware_utils::calcDistance2d(current_pose_.pose, goal)) {
+    return false;
+  }
+  return true;
+}
+
+void AutoParkingNode::filterGoalPoseinParkingLot(const lanelet::ConstLineString3d center_line, 
+                                                 Pose& goal)
+{
+  for(size_t i = 0; i < center_line.size(); i++){
+    const lanelet::Point3d search_point(lanelet::InvalId, center_line[i].x(), center_line[i].y(), 0.0);
+    if(lanelet::geometry::within(search_point, nearest_parking_lot_->basicPolygon())){
+      goal.position.x = center_line[i].x();
+      goal.position.y = center_line[i].y();
+      goal.position.z = 0.0;
+      const auto yaw = std::atan2(
+        center_line[i+1].y() - center_line[i].y(), center_line[i+1].x() - center_line[i].x());
+      tf2::Quaternion q;
+      q.setRPY(0, 0, yaw);
+      goal.orientation = tf2::toMsg(q);
+      return;
+    }
+  }
+}
+
+bool AutoParkingNode::isInParkingLot()
+{
+  const auto & p = current_pose_.pose.position;
+  const lanelet::Point3d search_point(lanelet::InvalId, p.x, p.y, p.z);
+  if(lanelet::geometry::within(search_point, nearest_parking_lot_->basicPolygon())){
+    return true;
+  }
+  return false;
+}
+
+bool AutoParkingNode::initAutoParking()
+{
+  const auto & p = current_pose_.pose.position;
+  const lanelet::Point3d search_point(lanelet::InvalId, p.x, p.y, p.z);
+
+  nearest_parking_lot_ =
+    filterNearestParkinglot(lanelet_map_ptr_, search_point.basicPoint2d());
+  if(!nearest_parking_lot_){
+    RCLCPP_INFO(get_logger(), "No parking lot found!!");
+    return false;
+  }
+
+  const auto & all_parking_spaces_ = 
+    lanelet::utils::query::getAllParkingSpaces(lanelet_map_ptr_);
+
+  nearest_parking_spaces_ = 
+    lanelet::utils::query::getLinkedParkingSpaces(*nearest_parking_lot_, all_parking_spaces_);
+
+  const auto & all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
+  const auto & all_road_lanelets = lanelet::utils::query::roadLanelets(all_lanelets);
+
+  parking_lot_lanelets_ = 
+    lanelet::utils::query::getLinkedLanelets(*nearest_parking_lot_, all_road_lanelets);
+
+  // Get closest lanelet to ego-vehicle
+  if(!lanelet::utils::query::getClosestLanelet(all_road_lanelets, 
+      current_pose_.pose, &current_lanelet_)){
+    RCLCPP_INFO(get_logger(), "No close lanelet to vehicle found!!");
+    return false;
+  }
+
+  // Order parking lot lanelets by route length  
+  // - Sort lanelets
+  std::sort(parking_lot_lanelets_.begin(), parking_lot_lanelets_.end(), 
+      [&](const lanelet::ConstLanelet& l1, const lanelet::ConstLanelet& l2){ 
+      const auto l1_length = routing_graph_ptr_->shortestPath(current_lanelet_, l1, {}, false)->size();
+      const auto l2_length = routing_graph_ptr_->shortestPath(current_lanelet_, l2, {}, false)->size();
+      return ( l1_length < l2_length);
+      });
+
+  // Set parking lot goal, goal at exit of parking lot
+  // Assuming parking lot has one entry, longest route is from
+  // entry to exit.
+  lanelet::ConstLineString3d exit_llt_cline = 
+  parking_lot_lanelets_.back().centerline(); // final lanelet from sorted lanelets
+  filterGoalPoseinParkingLot(exit_llt_cline, parking_goal_);
+  
+  // print out sortet lanelet ID's for DEBUG.
+  // for (const auto & lanelet : parking_lot_lanelets_) {
+  //   // check if parking space is close to lanelet
+  //   RCLCPP_INFO(get_logger(),"LaneId: %li \n", getId(lanelet));
+  // }
+
+  return true;
+}
+
+bool AutoParkingNode::findParkingSpace()
+{
+  const auto & p = current_pose_.pose.position;
+  const lanelet::Point2d search_point(lanelet::InvalId, p.x, p.y);
+
+  // Set occupancy map and current pose
+  algo_->setMap(*occupancy_grid_);
+  const auto current_pose_in_costmap_frame = transformPose(
+  current_pose_.pose,
+  getTransform(occupancy_grid_->header.frame_id, current_pose_.header.frame_id));
+
+  // Cycle through parking spaces
+  for(const auto & parking_space : nearest_parking_spaces_){
+    const double dist = boost::geometry::distance(to2D(parking_space).basicLineString(), search_point);
+    // Check if parking space is nearby                                 
+    if(node_param_.th_parking_space_distance_m < dist){
+      continue;
+    }
+
+    // Compute two goal poses for each parking space
+    double distance_thresh = boost::geometry::distance(parking_space.front().basicPoint(), 
+                                                       parking_space.back().basicPoint()) / 4;
+    lanelet::ConstPoints3d p_space_fw_bk;
+    p_space_fw_bk.push_back(parking_space.back());
+    p_space_fw_bk.push_back(parking_space.front());
+
+    // Compute parking space poses, orientations i = 0 , 1 
+    // Check if freespace trajectory available then set parking space goal
+    // Check back to front pose first then opposite
+
+    for(auto i = 0; i < 2; i++){
+
+      auto in1 = i % 2;
+      auto in2 = (i + 1) % 2;
+
+      Eigen::Vector3d direction =
+        p_space_fw_bk[in2].basicPoint() - p_space_fw_bk[in1].basicPoint();
+      direction.normalize();
+
+      // Set pose 
+      const Eigen::Vector3d goal_pose = p_space_fw_bk[in1].basicPoint() + direction * distance_thresh;
+      const auto yaw = std::atan2(direction.y(), direction.x());
+      tf2::Quaternion q;
+      q.setRPY(0, 0, yaw);
+      
+      Pose goal;
+      goal.position.x = goal_pose.x();
+      goal.position.y = goal_pose.y();
+      goal.position.z = goal_pose.z();
+      goal.orientation = tf2::toMsg(q);
+
+      current_goal_.pose = goal;
+      current_goal_.header.frame_id = odom_->header.frame_id;
+      current_goal_.header.stamp = rclcpp::Time();
+
+      const auto goal_pose_in_costmap_frame = transformPose(
+      current_goal_.pose, 
+      getTransform(occupancy_grid_->header.frame_id, current_goal_.header.frame_id));
+      bool result = algo_->makePlan(current_pose_in_costmap_frame, goal_pose_in_costmap_frame);
+
+      if(result){
+        RCLCPP_INFO(get_logger(), "Found free parking space!");
+        return true;
+      }
+
+      continue;
+    }
+  }
+
+  // No free parking spaces found
+  return false;
+}
+
+void AutoParkingNode::onEngage(EngageMsg::ConstSharedPtr msg)
+{
+  is_engaged_ = msg->engage;
+}
+
+void AutoParkingNode::engageAutonomous()
+{
+  // engage
+  auto req = std::make_shared<EngageSrv::Request>();
+  req->engage = true;
+  RCLCPP_INFO(get_logger(), "auto-engage client request");
+  if (!client_engage_->service_is_ready()) {
+    RCLCPP_INFO(get_logger(), "auto-engage client is unavailable");
+    return;
+  }
+  client_engage_->async_send_request(
+    req, []([[maybe_unused]] rclcpp::Client<EngageSrv>::SharedFuture result) {});
+}
+
+void AutoParkingNode::reset()
+{
+  set_parking_lot_goal_ = false;
+  set_parking_space_goal_ = false;
+}
+
+void AutoParkingNode::onTimer()
+{
+  // Check all inputs are ready
+  if (!odom_ || !lanelet_map_ptr_ || !routing_graph_ptr_ ||
+      !engage_sub_ || !client_engage_) {
+    return;
+  }
+
+  current_pose_.pose = odom_->pose.pose;
+  current_pose_.header = odom_->header;
+
+  if (current_pose_.header.frame_id == "") {
+    return;
+  }
+
+  // Publish parking lot entrance goal
+  if(!set_parking_lot_goal_){
+    if(!initAutoParking()){ return; }
+    current_goal_.header.frame_id = odom_->header.frame_id;
+    current_goal_.header.stamp = rclcpp::Time();
+    current_goal_.pose = parking_goal_;
+    goalPublisher(current_goal_);
+    RCLCPP_INFO(get_logger(), "Publishing parking lot goal");
+    set_parking_lot_goal_ = true;
+  }
+
+  // If stopped replan: TODO
+  //const auto is_vehicle_stopped = stop_checker_->isVehicleStopped(1.0);
+
+  // Arrived at parking lot exit without finding parking space
+  if(set_parking_lot_goal_ && isArrived(parking_goal_)){
+    RCLCPP_INFO(get_logger(), "Auto-parking: failed to find parking space");
+    return;
+  }
+  
+  // Search parking spaces if inside parking lot
+  if(!set_parking_space_goal_ && 
+      isInParkingLot() && 
+      occupancy_grid_)
+  { 
+    RCLCPP_INFO(get_logger(), "Searching...");
+    if(findParkingSpace()){
+      goalPublisher(current_goal_);
+      RCLCPP_INFO(get_logger(), "Publishing parking space goal");
+      set_parking_space_goal_ = true;
+    }
+  }
+
+  // Engage autonomous once a goal is set
+  // For smooth transition remove vehicle stopping after publishing goal pose in freespace planner node
+  if(!is_engaged_ && !isArrived(current_goal_.pose)){
+    engageAutonomous();
+  }
+}
+
+AutoParkingNode::AutoParkingNode(const rclcpp::NodeOptions & node_options)
+: Node("auto_parking", node_options)
+{
+
+  // Auto-park params
+  {
+    auto & p = node_param_;
+    p.th_arrived_distance_m = declare_parameter<double>("th_arrived_distance_m");
+    p.th_parking_space_distance_m = declare_parameter<double>("th_parking_space_distance_m");
+    p.update_rate = declare_parameter<double>("update_rate");
+    p.vehicle_shape_margin_m = declare_parameter<double>("vehicle_shape_margin_m");
+  }
+
+  // set vehicle_info for astar
+  {
+    const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
+    vehicle_shape_.length = vehicle_info.vehicle_length_m + node_param_.vehicle_shape_margin_m;
+    vehicle_shape_.width = vehicle_info.vehicle_width_m + node_param_.vehicle_shape_margin_m;
+    vehicle_shape_.base2back = vehicle_info.rear_overhang_m + node_param_.vehicle_shape_margin_m / 2;
+  }
+
+  // Subscribers
+  {
+    sub_lanelet_map_ = this->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+    "~/input/lanelet_map_bin", rclcpp::QoS{10}.transient_local(),
+    std::bind(&AutoParkingNode::onMap, this, std::placeholders::_1));
+
+    sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    "~/input/odometry", rclcpp::QoS{100},
+    std::bind(&AutoParkingNode::onOdometry, this, std::placeholders::_1));
+
+    engage_sub_ = create_subscription<EngageMsg>(
+    "~/input/engage", rclcpp::QoS{5}, std::bind(&AutoParkingNode::onEngage, this, std::placeholders::_1));
+
+    occupancy_grid_sub_ = create_subscription<OccupancyGrid>(
+    "~/input/occupancy_grid", 10, std::bind(&AutoParkingNode::onOccupancyGrid, this, std::placeholders::_1));
+  }
+  
+  // Publishers
+  {
+    rclcpp::QoS qos{1};
+    qos.transient_local();  // latch
+    goal_pose_pub_ = this->create_publisher<PoseStamped>("~/output/fixed_goal", qos);
+  }
+  
+  // Client
+  {
+    client_engage_ = this->create_client<EngageSrv>("~/service/engage");
+  }
+
+  // TF
+  {
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  }
+
+  // Timer
+  {
+    const auto period_ns = rclcpp::Rate(node_param_.update_rate).period();
+    timer_ = rclcpp::create_timer(
+      this, get_clock(), period_ns, std::bind(&AutoParkingNode::onTimer, this));
+  }
+
+  // Initialize Freespace planning algorithm - astar
+  {
+    const auto planner_common_param = getPlannerCommonParam();
+    algo_ = std::make_unique<AstarSearch>(planner_common_param, vehicle_shape_, *this);
+  }
+
+  reset();
+  stop_checker_ = std::make_unique<motion_utils::VehicleStopCheckerBase>(this, 1.0 + 1.0);
+  logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
+}
+}
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(auto_parking::AutoParkingNode)


### PR DESCRIPTION
## Description

This PR contains the initial implementation for the avp module. 
The `auto_parking` module is made as a separate node under `planning`. The avp consists of two phases, 1) setting a goal to the nearest parking lot, driving to parking lot and 2) searching for a free parking space once inside the parking lot. The module publishes appropriate goal poses during the different phases. The following modules are required to be running for `auto_parking`:

- `freespace_planner` 
- `goal_planner` and `start_planner`
-  `scenario_selector`

and related modules. The `scenario_selector` directs either `freespace_planner`  or `goal_planner` and `start_planner` to generate trajectory based on goal pose published by `auto_parking`. 

Phase 1:
Depending on initial pose when the `auto_parking` feature is engaged, a goal pose is set at the exit of the parking lot. This pose is first found by getting nearest parking lot, parking spaces inside and lanelets inside the parking lot from the lanelet map. By ordering the lanelets based on routing distance from current position, the exit lanelet is found. Ideally the `auto_parking` feature should be engaged from outside parking lot so the ordering is proper. The ego vehicle then drives to parking lot exit lanelets, passing through the parking lot.

Phase 2:
Once inside the parking lot, while driving to exit lanelet goal, the algorithm searches for a free parking space using the astar algorithm. Once a free space is found a new goal is set and trajectory is generated by the `freespace_planner` as scenario is `PARKING`.

## Auto Park Node Configurations 
```
th_arrived_distance_m: 1.0 // threshold for arrival at goal
th_parking_space_distance_m: 10.0 // search parking spaces within this radius from ego
update_rate: 5.0 // AutoParking node timer rate per second
vehicle_shape_margin_m: 0.2 // Vehicle shape margin for astar search

# fpa configs
.
.
.
```

The `auto_parking` node is also integrated with rviz allowing you to trigger auto parking from the simulator interface. ENABLE activates the auto parking, clicking the STOP button disables it. 

![image](https://github.com/autowarefoundation/autoware.universe/assets/130948783/b522bee9-6e0e-4c55-a000-4872ba0dddce)

## Demo: 
- Multiple obstacles in parking space

[target.webm](https://github.com/autowarefoundation/autoware.universe/assets/130948783/c1191268-0f02-4b2f-8555-bfe0fa2df5a0)

- Costmap only sees one obstacle in the beginning

[target2.webm](https://github.com/autowarefoundation/autoware.universe/assets/130948783/38ee67a5-9154-46fe-8af5-3b31f4ba62ed)

- Dynamic avoidance when introducing sudden obstacles and re-planning

[target3.webm](https://github.com/autowarefoundation/autoware.universe/assets/130948783/4e7c8af4-5ae8-4edc-8052-13dfdcacf962)

 
## Related links

This PR requires the updated astar implementation, related PR's include:
- https://github.com/autowarefoundation/autoware.universe/pull/6526
- https://github.com/autowarefoundation/autoware_launch/pull/911
- https://github.com/autowarefoundation/autoware.universe/pull/6562
- https://github.com/autowarefoundation/autoware.universe/pull/6623

The implementation working is also described here: 
- https://tier4.atlassian.net/wiki/spaces/~117245171/pages/3072525734/Automated+Parking+Implementation+using+improved+free-space+planner 

## Tests performed

Tested on multiple start pose cases inside and outside parking lot. Multiple patterns of obstacles also tested. The rviz panel also accounts for when start pose is not initialized and shows right state after finishing autoparking.

## Notes for reviewers

All PR's in related links are pre-requisites for this PR.

## Interface changes

New services, topics added for `auto_parking`. `tier4_state_rviz_plugin` modified.

## Effects on system behavior

Allows automated parking from a valid start pose.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
