### PR TITLE
feat(start_planner): fix non-thread-safe access

### DIFF
--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -51,7 +51,7 @@ public:
   }
   virtual ~PullOutPlannerBase() = default;
 
-  void setPlannerData(std::shared_ptr<const PlannerData> & planner_data)
+  void setPlannerData(const std::shared_ptr<const PlannerData> & planner_data)
   {
     planner_data_ = planner_data;
   }

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -155,6 +155,24 @@ public:
   bool isFreespacePlanning() const { return status_.planner_type == PlannerType::FREESPACE; }
 
 private:
+  struct StartPlannerData
+  {
+    StartPlannerParameters parameters;
+    PlannerData planner_data;
+    ModuleStatus current_status;
+    PullOutStatus main_thread_pull_out_status;
+    bool is_stopped;
+
+    StartPlannerData clone() const;
+    void update(
+      const StartPlannerParameters & parameters, const PlannerData & planner_data,
+      const ModuleStatus & current_status, const PullOutStatus & pull_out_status,
+      const bool is_stopped);
+  };
+  std::optional<PullOutStatus> freespace_thread_status_{std::nullopt};
+  std::optional<StartPlannerData> sp_planner_data_{std::nullopt};
+  std::mutex sp_planner_data_mutex_;
+
   // Flag class for managing whether a certain callback is running in multi-threading
   class ScopedFlag
   {
@@ -307,7 +325,9 @@ private:
   SafetyCheckParams createSafetyCheckParams() const;
   // freespace planner
   void onFreespacePlannerTimer();
-  bool planFreespacePath();
+  std::optional<PullOutStatus> planFreespacePath(
+    const StartPlannerParameters & parameters,
+    const std::shared_ptr<const PlannerData> & planner_data, const PullOutStatus & pull_out_status);
 
   void setDebugData();
   void logPullOutStatus(rclcpp::Logger::Level log_level = rclcpp::Logger::Level::Info) const;

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -170,8 +170,8 @@ private:
       const bool is_stopped);
   };
   std::optional<PullOutStatus> freespace_thread_status_{std::nullopt};
-  std::optional<StartPlannerData> sp_planner_data_{std::nullopt};
-  std::mutex sp_planner_data_mutex_;
+  std::optional<StartPlannerData> start_planner_data_{std::nullopt};
+  std::mutex start_planner_data_mutex_;
 
   // Flag class for managing whether a certain callback is running in multi-threading
   class ScopedFlag

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -308,7 +308,6 @@ private:
   bool hasFinishedBackwardDriving() const;
   bool hasCollisionWithDynamicObjects() const;
   bool isStopped();
-  bool isStuck();
   bool hasFinishedCurrentPath();
   void updateSafetyCheckTargetObjectsData(
     const PredictedObjects & filtered_objects, const TargetObjectsOnLane & target_objects_on_lane,

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1739,11 +1739,11 @@ void StartPlannerModule::StartPlannerData::update(
   /*
     auto route_handler_self = planner_data.route_handler;
     planner_data = planner_data_; // sync planer_data to planner_data_, planner_data.route_handler
-    is once repointed
+    is once re-pointed
 
     if (!planner_data_->is_route_handler_updated && route_handler_self != nullptr) {
       // we do not need to sync planner_data.route_handler with that of planner_data_
-      // repoint to the original again
+      // re-point to the original again
       planner_data.route_handler = route_handler_self;
     } else {
       // this is actually heavy if the lanelet_map is HUGE

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -134,9 +134,9 @@ void StartPlannerModule::onFreespacePlannerTimer()
     return;
   }
 
-  if (
-    is_stopped && pull_out_status.planner_type == PlannerType::STOP &&
-    !pull_out_status.found_pull_out_path) {
+  const bool is_stuck = is_stopped && pull_out_status.planner_type == PlannerType::STOP &&
+                        !pull_out_status.found_pull_out_path;
+  if (is_stuck) {
     const auto free_space_status =
       planFreespacePath(parameters, local_planner_data, pull_out_status);
     if (free_space_status) {
@@ -1192,19 +1192,6 @@ bool StartPlannerModule::needToPrepareBlinkerBeforeStartDrivingForward() const
   const double elapsed =
     rclcpp::Duration(clock_->now() - first_engaged_and_driving_forward_time).seconds();
   return elapsed < parameters_->prepare_time_before_start;
-}
-
-bool StartPlannerModule::isStuck()
-{
-  if (!isStopped()) {
-    return false;
-  }
-
-  if (status_.planner_type == PlannerType::STOP || !status_.found_pull_out_path) {
-    return true;
-  }
-
-  return false;
 }
 
 bool StartPlannerModule::hasFinishedCurrentPath()

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -205,14 +205,14 @@ void StartPlannerModule::updateData()
   // The method PlannerManager::run() calls SceneModuleInterface::setData and
   // SceneModuleInterface::setPreviousModuleOutput() before this module's run() method is called
   // with module_ptr->run(). Then module_ptr->run() invokes StartPlannerModule::updateData and,
-  // finally, planWaitingApproval()/plan(), so we can copy latest current_status to
-  // start_planner_data_ here
+  // finally, the planWaitingApproval()/plan() methods are called by run(). So we can copy the
+  // latest current_status to start_planner_data_ here for later usage.
 
   // NOTE: onFreespacePlannerTimer copies start_planner_data to its thread local variable, so we
   // need to lock start_planner_data_ here to avoid data race. But the following clone process is
   // lightweight because most of the member variables of PlannerData/RouteHandler is
   // shared_ptrs/bool
-  // begin of critical section
+  // making a local copy of thread sensitive data
   {
     std::lock_guard<std::mutex> guard(start_planner_data_mutex_);
     if (!start_planner_data_) {
@@ -236,7 +236,7 @@ void StartPlannerModule::updateData()
       }
     }
   }
-  // end of critical section
+  // finish copying thread sensitive data
 
   if (receivedNewRoute()) {
     resetStatus();


### PR DESCRIPTION
## Description

related work for https://github.com/autowarefoundation/autoware.universe/pull/6740

following variables are copied to thread local variable for thread-safety
- planner_data_
- getCurrentStatus() result
- parameters_
- isStopped() result
- `status_` (PullOutStatus)

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/6718

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/51d9494d-0cb2-5726-bd8e-80583125eb27?project_id=prd_jt

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
