### PR TITLE
fix(avoidance): fix invalid road bound distance calculation

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -872,8 +872,7 @@ double getRoadShoulderDistance(
       }
 
       {
-        const auto p2 =
-          calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -100.0 : 100.0), 0.0).position;
+        const auto p2 = calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -1.0 : 1.0), 0.0).position;
         const auto opt_intersect =
           tier4_autoware_utils::intersect(p1.second, p2, bound.at(i - 1), bound.at(i));
 


### PR DESCRIPTION
## Background

The avoidance module calculates distance to drivable bound by using `tier4_autoware_utils::intersection` with following step.

1. check object offset direction based on current path. (fig: on left)
2. calculate overhang point (=p1). (fig: black point)
3. calculate offset point (=p2) based on overhang points by using `tier4_autoware_utils::calcOffsetPose`.
4. calculate intersect point (=p3) between line p1-p2 and drivable bound.
5. calculate distance (=`D`) p1 to p3.

In most case (fig: nominal case), we can find intersect by following logic. But, in edge case, we can't.

```c++
        const auto p2 =
          calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? 100.0 : -100.0), 0.0).position;
        const auto opt_intersect =
          tier4_autoware_utils::intersect(p1.second, p2, bound.at(i - 1), bound.at(i));
```

Then, there is following logic as well to calculate `D'`.

```c++
        const auto p2 =
          calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -100.0 : 100.0), 0.0).position;
        const auto opt_intersect =
          tier4_autoware_utils::intersect(p1.second, p2, bound.at(i - 1), bound.at(i));
```

![IMG_0043](https://github.com/autowarefoundation/autoware.universe/assets/44889564/47ded4df-deb4-494c-b3e9-0c4973c0ec0b)

## Description

BUG: The module couldn't calculate distance to drivable bound properly. As a result, the module didn't create avoidance path even when there was enough space to avoid.

![Screenshot from 2024-04-09 11-28-17](https://github.com/autowarefoundation/autoware.universe/assets/44889564/f0e77701-0d01-4e49-b835-18594df0acba)

This issue caused by unexpected intersetion point calculation in following logic. And, I decreased the hard coded value to 1m in order not to get unexpected intersection point.

```c++
        const auto p2 =
          calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -100.0 : 100.0), 0.0).position;
        const auto opt_intersect =
          tier4_autoware_utils::intersect(p1.second, p2, bound.at(i - 1), bound.at(i));
```

![IMG_0044](https://github.com/autowarefoundation/autoware.universe/assets/44889564/ec65c356-e143-4169-b799-02f0d98d619d)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
https://github.com/autowarefoundation/autoware.universe/assets/44889564/892447d8-2844-44f4-993c-9af831869bc6

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/c2d865f1-f4c3-50e2-a5df-4d6fcf174c8a?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix bug.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
