### PR TITLE
refactor(static_centerline_optimizer): admit I/F for other sources of  centerline

### DIFF
--- a/planning/static_centerline_optimizer/config/static_centerline_optimizer.param.yaml
+++ b/planning/static_centerline_optimizer/config/static_centerline_optimizer.param.yaml
@@ -1,4 +1,5 @@
 /**:
   ros__parameters:
+    centerline_source: "optimization_trajectory_planning" # select from "optimization_trajectory_planning" and "ego_trajectory_from_bag"
     marker_color: ["FF0000", "00FF00", "0000FF"]
     marker_color_dist_thresh : [0.1, 0.2, 0.3]

--- a/planning/static_centerline_optimizer/config/static_centerline_optimizer.param.yaml
+++ b/planning/static_centerline_optimizer/config/static_centerline_optimizer.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    centerline_source: "optimization_trajectory_planning" # select from "optimization_trajectory_planning" and "ego_trajectory_from_bag"
+    centerline_source: "optimization_trajectory_base" # select from "optimization_trajectory_base" and "bag_ego_trajectory_base"
     marker_color: ["FF0000", "00FF00", "0000FF"]
     marker_color_dist_thresh : [0.1, 0.2, 0.3]

--- a/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
+++ b/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
@@ -44,6 +44,11 @@ public:
   void run();
 
 private:
+  struct CenterlineWithRoute
+  {
+    std::vector<TrajectoryPoint> centerline{};
+    std::vector<lanelet::Id> route_lane_ids{};
+  };
   // load map
   void load_map(const std::string & lanelet2_input_file_path);
   void on_load_map(
@@ -56,6 +61,7 @@ private:
     const PlanRoute::Request::SharedPtr request, const PlanRoute::Response::SharedPtr response);
 
   // plan path
+  CenterlineWithRoute generate_centerline_with_route();
   std::vector<TrajectoryPoint> plan_path(const std::vector<lanelet::Id> & route_lane_ids);
   std::vector<TrajectoryPoint> optimize_trajectory(const Path & raw_path) const;
   void on_plan_path(
@@ -65,8 +71,8 @@ private:
     const std::vector<lanelet::Id> & route_lane_ids,
     const std::vector<TrajectoryPoint> & optimized_traj_points);
   void save_map(
-    const std::string & lanelet2_output_file_path, const std::vector<lanelet::Id> & route_lane_ids,
-    const std::vector<TrajectoryPoint> & optimized_traj_points);
+    const std::string & lanelet2_output_file_path,
+    const CenterlineWithRoute & centerline_with_route);
 
   lanelet::LaneletMapPtr original_map_ptr_{nullptr};
   HADMapBin::ConstSharedPtr map_bin_ptr_{nullptr};
@@ -75,12 +81,13 @@ private:
 
   int traj_start_index_{0};
   int traj_end_index_{0};
-  struct MetaDataToSaveMap
-  {
-    std::vector<TrajectoryPoint> optimized_traj_points{};
-    std::vector<lanelet::Id> route_lane_ids{};
+  std::optional<CenterlineWithRoute> centerline_with_route_{std::nullopt};
+
+  enum class CenterlineSource {
+    OptimizationTrajectoryPlanning = 0,
+    EgoTrajectoryFromBag,
   };
-  std::optional<MetaDataToSaveMap> meta_data_to_save_map_{std::nullopt};
+  CenterlineSource centerline_source_;
 
   // publisher
   rclcpp::Publisher<HADMapBin>::SharedPtr pub_map_bin_{nullptr};

--- a/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
+++ b/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
@@ -84,8 +84,8 @@ private:
   std::optional<CenterlineWithRoute> centerline_with_route_{std::nullopt};
 
   enum class CenterlineSource {
-    OptimizationTrajectoryPlanning = 0,
-    EgoTrajectoryFromBag,
+    OptimizationTrajectoryBase = 0,
+    BagEgoTrajectoryBase,
   };
   CenterlineSource centerline_source_;
 

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -240,46 +240,43 @@ StaticCenterlineOptimizerNode::StaticCenterlineOptimizerNode(
   sub_traj_start_index_ = create_subscription<std_msgs::msg::Int32>(
     "/centerline_updater_helper/traj_start_index", rclcpp::QoS{1},
     [this](const std_msgs::msg::Int32 & msg) {
-      if (!meta_data_to_save_map_ || traj_end_index_ + 1 < msg.data) {
+      if (!centerline_with_route_ || traj_end_index_ + 1 < msg.data) {
         return;
       }
       traj_start_index_ = msg.data;
 
-      const auto & d = meta_data_to_save_map_;
-      const auto selected_optimized_traj_points = std::vector<TrajectoryPoint>(
-        d->optimized_traj_points.begin() + traj_start_index_,
-        d->optimized_traj_points.begin() + traj_end_index_ + 1);
+      const auto & c = *centerline_with_route_;
+      const auto selected_centerline = std::vector<TrajectoryPoint>(
+        c.centerline.begin() + traj_start_index_, c.centerline.begin() + traj_end_index_ + 1);
 
-      pub_optimized_centerline_->publish(motion_utils::convertToTrajectory(
-        selected_optimized_traj_points, createHeader(this->now())));
+      pub_optimized_centerline_->publish(
+        motion_utils::convertToTrajectory(selected_centerline, createHeader(this->now())));
     });
   sub_traj_end_index_ = create_subscription<std_msgs::msg::Int32>(
     "/centerline_updater_helper/traj_end_index", rclcpp::QoS{1},
     [this](const std_msgs::msg::Int32 & msg) {
-      if (!meta_data_to_save_map_ || msg.data + 1 < traj_start_index_) {
+      if (!centerline_with_route_ || msg.data + 1 < traj_start_index_) {
         return;
       }
       traj_end_index_ = msg.data;
 
-      const auto & d = meta_data_to_save_map_;
-      const auto selected_optimized_traj_points = std::vector<TrajectoryPoint>(
-        d->optimized_traj_points.begin() + traj_start_index_,
-        d->optimized_traj_points.begin() + traj_end_index_ + 1);
+      const auto & c = *centerline_with_route_;
+      const auto selected_centerline = std::vector<TrajectoryPoint>(
+        c.centerline.begin() + traj_start_index_, c.centerline.begin() + traj_end_index_ + 1);
 
-      pub_optimized_centerline_->publish(motion_utils::convertToTrajectory(
-        selected_optimized_traj_points, createHeader(this->now())));
+      pub_optimized_centerline_->publish(
+        motion_utils::convertToTrajectory(selected_centerline, createHeader(this->now())));
     });
   sub_save_map_ = create_subscription<std_msgs::msg::Bool>(
     "/centerline_updater_helper/save_map", rclcpp::QoS{1}, [this](const std_msgs::msg::Bool & msg) {
       const auto lanelet2_output_file_path =
         tier4_autoware_utils::getOrDeclareParameter<std::string>(
           *this, "lanelet2_output_file_path");
-      if (!meta_data_to_save_map_ || msg.data) {
-        const auto & d = meta_data_to_save_map_;
-        const auto selected_optimized_traj_points = std::vector<TrajectoryPoint>(
-          d->optimized_traj_points.begin() + traj_start_index_,
-          d->optimized_traj_points.begin() + traj_end_index_ + 1);
-        save_map(lanelet2_output_file_path, d->route_lane_ids, selected_optimized_traj_points);
+      if (!centerline_with_route_ || msg.data) {
+        const auto & c = *centerline_with_route_;
+        const auto selected_centerline = std::vector<TrajectoryPoint>(
+          c.centerline.begin() + traj_start_index_, c.centerline.begin() + traj_end_index_ + 1);
+        save_map(lanelet2_output_file_path, *centerline_with_route_);
       }
     });
 
@@ -306,6 +303,17 @@ StaticCenterlineOptimizerNode::StaticCenterlineOptimizerNode(
 
   // vehicle info
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
+
+  centerline_source_ = [&]() {
+    const auto centerline_source_param = declare_parameter<std::string>("centerline_source");
+    if (centerline_source_param == "optimization_trajectory_planning") {
+      return CenterlineSource::OptimizationTrajectoryPlanning;
+    } else if (centerline_source_param == "ego_trajectory_from_bag") {
+      return CenterlineSource::EgoTrajectoryFromBag;
+    }
+    throw std::logic_error(
+      "The centerline source is not supported in static_centerline_optimizer.");
+  }();
 }
 
 void StaticCenterlineOptimizerNode::run()
@@ -314,18 +322,31 @@ void StaticCenterlineOptimizerNode::run()
   const auto lanelet2_input_file_path = declare_parameter<std::string>("lanelet2_input_file_path");
   const auto lanelet2_output_file_path =
     declare_parameter<std::string>("lanelet2_output_file_path");
-  const lanelet::Id start_lanelet_id = declare_parameter<int64_t>("start_lanelet_id");
-  const lanelet::Id end_lanelet_id = declare_parameter<int64_t>("end_lanelet_id");
 
   // process
   load_map(lanelet2_input_file_path);
-  const auto route_lane_ids = plan_route(start_lanelet_id, end_lanelet_id);
-  const auto optimized_traj_points = plan_path(route_lane_ids);
+  const auto centerline_with_route = generate_centerline_with_route();
   traj_start_index_ = 0;
-  traj_end_index_ = optimized_traj_points.size() - 1;
-  save_map(lanelet2_output_file_path, route_lane_ids, optimized_traj_points);
+  traj_end_index_ = centerline_with_route.centerline.size() - 1;
+  save_map(lanelet2_output_file_path, centerline_with_route);
 
-  meta_data_to_save_map_ = MetaDataToSaveMap{optimized_traj_points, route_lane_ids};
+  centerline_with_route_ = centerline_with_route;
+}
+
+StaticCenterlineOptimizerNode::CenterlineWithRoute
+StaticCenterlineOptimizerNode::generate_centerline_with_route()
+{
+  if (centerline_source_ == CenterlineSource::OptimizationTrajectoryPlanning) {
+    const lanelet::Id start_lanelet_id = declare_parameter<int64_t>("start_lanelet_id");
+    const lanelet::Id end_lanelet_id = declare_parameter<int64_t>("end_lanelet_id");
+    const auto route_lane_ids = plan_route(start_lanelet_id, end_lanelet_id);
+    const auto optimized_traj_points = plan_path(route_lane_ids);
+    return CenterlineWithRoute{optimized_traj_points, route_lane_ids};
+  } else if (centerline_source_ == CenterlineSource::EgoTrajectoryFromBag) {
+    return CenterlineWithRoute{};
+  }
+
+  throw std::logic_error("The centerline source is not supported in static_centerline_optimizer.");
 }
 
 void StaticCenterlineOptimizerNode::load_map(const std::string & lanelet2_input_file_path)
@@ -741,17 +762,17 @@ void StaticCenterlineOptimizerNode::evaluate(
 }
 
 void StaticCenterlineOptimizerNode::save_map(
-  const std::string & lanelet2_output_file_path, const std::vector<lanelet::Id> & route_lane_ids,
-  const std::vector<TrajectoryPoint> & optimized_traj_points)
+  const std::string & lanelet2_output_file_path, const CenterlineWithRoute & centerline_with_route)
 {
   if (!route_handler_ptr_) {
     return;
   }
 
-  const auto route_lanelets = get_lanelets_from_ids(*route_handler_ptr_, route_lane_ids);
+  const auto & c = centerline_with_route;
+  const auto route_lanelets = get_lanelets_from_ids(*route_handler_ptr_, c.route_lane_ids);
 
   // update centerline in map
-  utils::update_centerline(*route_handler_ptr_, route_lanelets, optimized_traj_points);
+  utils::update_centerline(*route_handler_ptr_, route_lanelets, c.centerline);
   RCLCPP_INFO(get_logger(), "Updated centerline in map.");
 
   // save map with modified center line


### PR DESCRIPTION
## Description

Previously, only the optimization path planning was used for the source of the centerline.
With this PR, other sources are admitted as well.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
