### PR TITLE
chore(glog): add initialization check

### DIFF
--- a/common/glog_component/CMakeLists.txt
+++ b/common/glog_component/CMakeLists.txt
@@ -8,7 +8,7 @@ autoware_package()
 ament_auto_add_library(glog_component SHARED
   src/glog_component.cpp
 )
-target_link_libraries(glog_component glog)
+target_link_libraries(glog_component glog::glog)
 
 rclcpp_components_register_node(glog_component
   PLUGIN "GlogComponent"

--- a/common/glog_component/package.xml
+++ b/common/glog_component/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>libgoogle-glog-dev</depend>
+  <depend>glog</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/common/glog_component/src/glog_component.cpp
+++ b/common/glog_component/src/glog_component.cpp
@@ -17,8 +17,10 @@
 GlogComponent::GlogComponent(const rclcpp::NodeOptions & node_options)
 : Node("glog_component", node_options)
 {
-  google::InitGoogleLogging("glog_component");
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("glog_component");
+    google::InstallFailureSignalHandler();
+  }
 }
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/evaluator/perception_online_evaluator/CMakeLists.txt
+++ b/evaluator/perception_online_evaluator/CMakeLists.txt
@@ -6,8 +6,6 @@ autoware_package()
 
 find_package(pluginlib REQUIRED)
 
-find_package(glog REQUIRED)
-
 ament_auto_add_library(${PROJECT_NAME}_node SHARED
   src/metrics_calculator.cpp
   src/${PROJECT_NAME}_node.cpp

--- a/evaluator/perception_online_evaluator/package.xml
+++ b/evaluator/perception_online_evaluator/package.xml
@@ -21,8 +21,8 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>glog</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>motion_utils</depend>
   <depend>nav_msgs</depend>
   <depend>object_recognition_utils</depend>

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -43,8 +43,10 @@ PerceptionOnlineEvaluatorNode::PerceptionOnlineEvaluatorNode(
 {
   using std::placeholders::_1;
 
-  google::InitGoogleLogging("perception_online_evaluator_node");
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("perception_online_evaluator_node");
+    google::InstallFailureSignalHandler();
+  }
 
   objects_sub_ = create_subscription<PredictedObjects>(
     "~/input/objects", 1, std::bind(&PerceptionOnlineEvaluatorNode::onObjects, this, _1));

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -22,7 +22,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
-  <depend>libgoogle-glog-dev</depend>
+  <depend>glog</depend>
   <depend>libpcl-all-dev</depend>
   <depend>localization_util</depend>
   <depend>nav_msgs</depend>

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_node.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_node.cpp
@@ -20,8 +20,10 @@
 
 int main(int argc, char ** argv)
 {
-  google::InitGoogleLogging(argv[0]);  // NOLINT
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging(argv[0]);  // NOLINT
+    google::InstallFailureSignalHandler();
+  }
 
   rclcpp::init(argc, argv);
   auto ndt_scan_matcher = std::make_shared<NDTScanMatcher>();

--- a/localization/pose_estimator_arbiter/package.xml
+++ b/localization/pose_estimator_arbiter/package.xml
@@ -15,8 +15,8 @@
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>glog</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>magic_enum</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/pose_estimator_arbiter_node.cpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/pose_estimator_arbiter_node.cpp
@@ -18,8 +18,10 @@
 
 int main(int argc, char * argv[])
 {
-  google::InitGoogleLogging(argv[0]);
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging(argv[0]);
+    google::InstallFailureSignalHandler();
+  }
 
   rclcpp::init(argc, argv);
   auto node = std::make_shared<pose_estimator_arbiter::PoseEstimatorArbiter>();

--- a/localization/yabloc/yabloc_common/package.xml
+++ b/localization/yabloc/yabloc_common/package.xml
@@ -19,9 +19,9 @@
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
+  <depend>glog</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>

--- a/localization/yabloc/yabloc_common/src/ground_server/ground_server_node.cpp
+++ b/localization/yabloc/yabloc_common/src/ground_server/ground_server_node.cpp
@@ -18,8 +18,10 @@
 
 int main(int argc, char ** argv)
 {
-  google::InitGoogleLogging(argv[0]);
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging(argv[0]);
+    google::InstallFailureSignalHandler();
+  }
 
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<yabloc::ground_server::GroundServer>());

--- a/localization/yabloc/yabloc_particle_filter/src/camera_corrector/camera_particle_corrector_node.cpp
+++ b/localization/yabloc/yabloc_particle_filter/src/camera_corrector/camera_particle_corrector_node.cpp
@@ -18,8 +18,10 @@
 
 int main(int argc, char * argv[])
 {
-  google::InitGoogleLogging(argv[0]);
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging(argv[0]);
+    google::InstallFailureSignalHandler();
+  }
 
   namespace mpf = yabloc::modularized_particle_filter;
   rclcpp::init(argc, argv);

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -17,9 +17,9 @@
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>glog</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>motion_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -715,8 +715,10 @@ void replaceObjectYawWithLaneletsYaw(
 MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_options)
 : Node("map_based_prediction", node_options), debug_accumulated_time_(0.0)
 {
-  google::InitGoogleLogging("map_based_prediction_node");
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("map_based_prediction_node");
+    google::InstallFailureSignalHandler();
+  }
   enable_delay_compensation_ = declare_parameter<bool>("enable_delay_compensation");
   prediction_time_horizon_ = declare_parameter<double>("prediction_time_horizon");
   lateral_control_time_horizon_ =

--- a/perception/multi_object_tracker/CMakeLists.txt
+++ b/perception/multi_object_tracker/CMakeLists.txt
@@ -48,14 +48,11 @@ ament_auto_add_library(multi_object_tracker_node SHARED
 
 target_link_libraries(multi_object_tracker_node
   Eigen3::Eigen
+  glog::glog
 )
 
 ament_auto_add_executable(${PROJECT_NAME}
   src/multi_object_tracker_node.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  multi_object_tracker_node glog
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/perception/multi_object_tracker/package.xml
+++ b/perception/multi_object_tracker/package.xml
@@ -16,8 +16,8 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
+  <depend>glog</depend>
   <depend>kalman_filter</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>mussp</depend>
   <depend>object_recognition_utils</depend>
   <depend>rclcpp</depend>

--- a/perception/multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -20,8 +20,10 @@
 
 int main(int argc, char ** argv)
 {
-  google::InitGoogleLogging(argv[0]);  // NOLINT
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging(argv[0]);  // NOLINT
+    google::InstallFailureSignalHandler();
+  }
 
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions options;

--- a/perception/radar_object_tracker/package.xml
+++ b/perception/radar_object_tracker/package.xml
@@ -16,9 +16,9 @@
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>
+  <depend>glog</depend>
   <depend>kalman_filter</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>mussp</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>object_recognition_utils</depend>

--- a/perception/radar_object_tracker/src/radar_object_tracker_node/radar_object_tracker_node.cpp
+++ b/perception/radar_object_tracker/src/radar_object_tracker_node/radar_object_tracker_node.cpp
@@ -196,8 +196,10 @@ RadarObjectTrackerNode::RadarObjectTrackerNode(const rclcpp::NodeOptions & node_
   tf_listener_(tf_buffer_)
 {
   // glog for debug
-  google::InitGoogleLogging("radar_object_tracker");
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("radar_object_tracker");
+    google::InstallFailureSignalHandler();
+  }
 
   // Create publishers and subscribers
   detected_object_sub_ = create_subscription<autoware_auto_perception_msgs::msg::DetectedObjects>(

--- a/perception/tracking_object_merger/package.xml
+++ b/perception/tracking_object_merger/package.xml
@@ -15,7 +15,7 @@
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>
-  <depend>libgoogle-glog-dev</depend>
+  <depend>glog</depend>
   <depend>mussp</depend>
   <depend>object_recognition_utils</depend>
   <depend>rclcpp</depend>

--- a/perception/tracking_object_merger/src/decorative_tracker_merger.cpp
+++ b/perception/tracking_object_merger/src/decorative_tracker_merger.cpp
@@ -88,8 +88,10 @@ DecorativeTrackerMergerNode::DecorativeTrackerMergerNode(const rclcpp::NodeOptio
   tf_listener_(tf_buffer_)
 {
   // glog for debug
-  google::InitGoogleLogging("decorative_object_merger_node");
-  google::InstallFailureSignalHandler();
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("decorative_object_merger_node");
+    google::InstallFailureSignalHandler();
+  }
 
   // Subscriber
   sub_main_objects_ = create_subscription<TrackedObjects>(


### PR DESCRIPTION
## Description

Add `IsGoogleLoggingInitialized()` check before glog initialization as the multiple initializations terminate the process.

## Related links

Must be merged after
- https://github.com/autowarefoundation/autoware/pull/4614
- https://github.com/autowarefoundation/autoware.universe/pull/6952

## Tests performed

- Build 
- Run psim
- Confirm the glog works correctly as before
    - `kill -15 <pid>` should show the stack trace for the glog-installed process, e.g. `map_based_prediction`
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/7f4d0a5f-1764-4858-beb0-4be0bd10deab)

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
