### PR TITLE
feat: backwardcpp test

### DIFF
--- a/perception/map_based_prediction/CMakeLists.txt
+++ b/perception/map_based_prediction/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 find_package(Eigen3 REQUIRED)
+find_package(backward_ros REQUIRED)
 
 include_directories(
   SYSTEM

--- a/perception/map_based_prediction/CMakeLists.txt
+++ b/perception/map_based_prediction/CMakeLists.txt
@@ -6,8 +6,6 @@ autoware_package()
 
 find_package(Eigen3 REQUIRED)
 
-find_package(glog REQUIRED)
-
 include_directories(
   SYSTEM
     ${EIGEN3_INCLUDE_DIR}
@@ -18,8 +16,6 @@ ament_auto_add_library(map_based_prediction_node SHARED
   src/path_generator.cpp
   src/debug.cpp
 )
-
-target_link_libraries(map_based_prediction_node glog::glog)
 
 rclcpp_components_register_node(map_based_prediction_node
   PLUGIN "map_based_prediction::MapBasedPredictionNode"

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -19,7 +19,6 @@
   <depend>autoware_perception_msgs</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libgoogle-glog-dev</depend>
   <depend>motion_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -17,6 +17,7 @@
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>backward_ros</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
   <depend>motion_utils</depend>

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -42,8 +42,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-#include <glog/logging.h>
-
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -715,8 +713,6 @@ void replaceObjectYawWithLaneletsYaw(
 MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_options)
 : Node("map_based_prediction", node_options), debug_accumulated_time_(0.0)
 {
-  google::InitGoogleLogging("map_based_prediction_node");
-  google::InstallFailureSignalHandler();
   enable_delay_compensation_ = declare_parameter<bool>("enable_delay_compensation");
   prediction_time_horizon_ = declare_parameter<double>("prediction_time_horizon");
   lateral_control_time_horizon_ =

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -814,6 +814,23 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   stop_watch_ptr_ = std::make_unique<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
+
+  // crash in 10s
+  std::thread thread([]() {
+    const auto you_shall_not_pass = []() {
+      char * ptr = (char *)42;
+      int v = *ptr;
+      return v;
+    };
+    // print countdown
+    for (int i = 10; i > 0; i--) {
+      std::cout << "Countdown: " << i << std::endl;
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    int v = you_shall_not_pass();
+    std::cout << "v=" << v << std::endl;
+  });
+  thread.detach();
 }
 
 rcl_interfaces::msg::SetParametersResult MapBasedPredictionNode::onParam(


### PR DESCRIPTION
## Description

This is for demonstration of backward-cpp with backward_ros package with autoware.

Also recommended by [Nav 2 Guide](https://navigation.ros.org/tutorials/docs/get_backtrace.html#automatic-backtrace-on-crash) and [Davide Faconti](https://discourse.ros.org/t/ros-2-backtrace-tutorial-navigation2/15781/4) :smile:

@TakaHoribe this is continuation from:
- https://github.com/autowarefoundation/autoware.universe/pull/6792

**Please test in both branches:**
- https://github.com/autowarefoundation/autoware.universe/tree/feat/backwardcpp-test (PR branch)
- https://github.com/autowarefoundation/autoware.universe/tree/feat/backward-test-glog (glog test branch)

### glog

```bash
export AUTOWARE_DIR=~/workspace/autoware
cd $AUTOWARE_DIR/src/universe/autoware.universe
git checkout feat/backward-test-glog
cd $AUTOWARE_DIR
colcon build --symlink-install  --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=1  --packages-select  map_based_prediction

source $AUTOWARE_DIR/install/setup.bash
# map_based_prediction will crash in 10 seconds
# quickly put a vehicle and a goal with P and G keys in rviz to reduce unnecessary logs
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```
**Crash logs with glog:**
<details>
  <summary>Click to expand</summary>

```bash
[map_based_prediction-47] Countdown: 2
[map_based_prediction-47] Countdown: 1
[map_based_prediction-47] *** Aborted at 1712864144 (unix time) try "date -d @1712864144" if you are using GNU date ***
[map_based_prediction-47] PC: @                0x0 (unknown)
[map_based_prediction-47] *** SIGSEGV (@0x2a) received by PID 1423297 (TID 0x7a458e290640) from PID 42; stack trace: ***
[map_based_prediction-47]     @     0x7a4593377046 (unknown)
[map_based_prediction-47]     @     0x7a4594a42520 (unknown)
[map_based_prediction-47]     @     0x7a459393aa3b _ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJZN20map_based_prediction22MapBasedPredictionNodeC4ERKN6rclcpp11NodeOptionsEEUlvE_EEEEE6_M_runEv
[map_based_prediction-47]     @     0x7a4594edc253 (unknown)
[map_based_prediction-47]     @     0x7a4594a94ac3 (unknown)
[map_based_prediction-47]     @     0x7a4594b26850 (unknown)
[map_based_prediction-47]     @                0x0 (unknown)
```
</details>

### backward-cpp

```bash
export AUTOWARE_DIR=~/workspace/autoware
cd $AUTOWARE_DIR/src/universe/autoware.universe
git checkout feat/backwardcpp-test
cd $AUTOWARE_DIR

# do only once to make sure `ros-humble-backward-ros` is installed
rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO

colcon build --symlink-install  --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=1  --packages-select  map_based_prediction

source $AUTOWARE_DIR/install/setup.bash
# map_based_prediction will crash in 10 seconds
# quickly put a vehicle and a goal with P and G keys in rviz to reduce unnecessary logs
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```
**Crash logs with backward-cpp:**
<details>
  <summary>Click to expand</summary>

```bash
[map_based_prediction-47] Countdown: 2
[map_based_prediction-47] Countdown: 1
[map_based_prediction-47] Stack trace (most recent call last) in thread 1436033:
[map_based_prediction-47] #4    Object "", at 0xffffffffffffffff, in 
[map_based_prediction-47] #3    Source "../sysdeps/unix/sysv/linux/x86_64/clone3.S", line 81, in __clone3 [0x74d905b2684f]
[map_based_prediction-47] #2    Source "./nptl/pthread_create.c", line 442, in start_thread [0x74d905a94ac2]
[map_based_prediction-47] #1    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x74d905edc252, in 
[map_based_prediction-47] #0  | Source "/usr/include/c++/11/bits/std_thread.h", line 211, in operator()
[map_based_prediction-47]     |   210: 	void
[map_based_prediction-47]     | > 211: 	_M_run() { _M_func(); }
[map_based_prediction-47]     |   212:       };
[map_based_prediction-47]     | Source "/usr/include/c++/11/bits/std_thread.h", line 266, in _M_invoke<0>
[map_based_prediction-47]     |   264: 	  using _Indices
[map_based_prediction-47]     |   265: 	    = typename _Build_index_tuple<tuple_size<_Tuple>::value>::__type;
[map_based_prediction-47]     | > 266: 	  return _M_invoke(_Indices());
[map_based_prediction-47]     |   267: 	}
[map_based_prediction-47]     |   268:       };
[map_based_prediction-47]     | Source "/usr/include/c++/11/bits/std_thread.h", line 259, in __invoke<map_based_prediction::MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions&)::<lambda()> >
[map_based_prediction-47]     |   257: 	  typename __result<_Tuple>::type
[map_based_prediction-47]     |   258: 	  _M_invoke(_Index_tuple<_Ind...>)
[map_based_prediction-47]     | > 259: 	  { return std::__invoke(std::get<_Ind>(std::move(_M_t))...); }
[map_based_prediction-47]     |   260: 
[map_based_prediction-47]     |   261: 	typename __result<_Tuple>::type
[map_based_prediction-47]     | Source "/usr/include/c++/11/bits/invoke.h", line 96, in __invoke_impl<void, map_based_prediction::MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions&)::<lambda()> >
[map_based_prediction-47]     |    94:       using __type = typename __result::type;
[map_based_prediction-47]     |    95:       using __tag = typename __result::__invoke_type;
[map_based_prediction-47]     | >  96:       return std::__invoke_impl<__type>(__tag{}, std::forward<_Callable>(__fn),
[map_based_prediction-47]     |    97: 					std::forward<_Args>(__args)...);
[map_based_prediction-47]     |    98:     }
[map_based_prediction-47]     | Source "/usr/include/c++/11/bits/invoke.h", line 61, in operator()
[map_based_prediction-47]     |    59:     constexpr _Res
[map_based_prediction-47]     |    60:     __invoke_impl(__invoke_other, _Fn&& __f, _Args&&... __args)
[map_based_prediction-47]     | >  61:     { return std::forward<_Fn>(__f)(std::forward<_Args>(__args)...); }
[map_based_prediction-47]     |    62: 
[map_based_prediction-47]     |    63:   template<typename _Res, typename _MemFun, typename _Tp, typename... _Args>
[map_based_prediction-47]     | Source "/home/mfc/projects/autoware/src/universe/autoware.universe/perception/map_based_prediction/src/map_based_prediction_node.cpp", line 830, in operator()
[map_based_prediction-47]     |   828:       std::this_thread::sleep_for(std::chrono::seconds(1));
[map_based_prediction-47]     |   829:     }
[map_based_prediction-47]     | > 830:     int v = you_shall_not_pass();
[map_based_prediction-47]     |   831:     std::cout << "v=" << v << std::endl;
[map_based_prediction-47]     |   832:   });
[map_based_prediction-47]       Source "/home/mfc/projects/autoware/src/universe/autoware.universe/perception/map_based_prediction/src/map_based_prediction_node.cpp", line 822, in _M_run [0x74d9035f39fb]
[map_based_prediction-47]         819:   std::thread thread([]() {
[map_based_prediction-47]         820:     const auto you_shall_not_pass = []() {
[map_based_prediction-47]         821:       char * ptr = (char *)42;
[map_based_prediction-47]       > 822:       int v = *ptr;
[map_based_prediction-47]         823:       return v;
[map_based_prediction-47]         824:     };
[map_based_prediction-47]         825:     // print countdown
[map_based_prediction-47] Segmentation fault (Address not mapped to object [0x2a])
```
</details>

## Effects on system behavior

- When something crashes, you get **very detailed crash logs**.
- Almost no effort to include, no source code change is needed.
- There shouldn't be a performance hit but I didn't test it.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
