### PR TITLE
perf(autoware_auto_perception_rviz_plugin): add simple_visualization_mode for predicted path

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -160,7 +160,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_predicted_path_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const std_msgs::msg::ColorRGBA & predicted_path_color, const bool is_simple = false);
+  const std_msgs::msg::ColorRGBA & predicted_path_color, const int simple_visualize_mode = 0);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_path_confidence_marker_ptr(
@@ -224,7 +224,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_polygon_bottom_line_lis
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_path_line_list(
   const autoware_auto_perception_msgs::msg::PredictedPath & paths,
-  std::vector<geometry_msgs::msg::Point> & points, const bool is_simple = false);
+  std::vector<geometry_msgs::msg::Point> & points, const int simple_visualize_mode = 0);
 
 /// \brief Convert Point32 to Point
 /// \param val Point32 to be converted

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -104,6 +104,7 @@ public:
       "Visualization Type", "Normal", "Simplicity of the polygon to display object.", this);
     m_simple_visualize_mode_property->addOption("Normal", 0);
     m_simple_visualize_mode_property->addOption("Simple", 1);
+    m_simple_visualize_mode_property->addOption("Simple2", 2);
     // Confidence interval property
     m_confidence_interval_property = new rviz_common::properties::EnumProperty(
       "Confidence Interval", "95%", "Confidence interval of state estimations.", this);
@@ -361,7 +362,7 @@ protected:
       const std_msgs::msg::ColorRGBA predicted_path_color = get_color_from_uuid(uuid_str);
       return detail::get_predicted_path_marker_ptr(
         shape, predicted_path, predicted_path_color,
-        m_simple_visualize_mode_property->getOptionInt() == 1);
+        m_simple_visualize_mode_property->getOptionInt());
     } else {
       return std::nullopt;
     }


### PR DESCRIPTION
## Description

- Background
  - FPS on rviz decreases from 30 fps to 5~15 fps when many objects appears due to drawing predicted paths
  - Existing "Simple" mode improves the FPS, but it still less than 30 fps in some cases so more improvement is needed
- Changes
  - This PR adds "Simple2" mode to lighten the rendering process

## Tests performed

### Appearance

- Normal
  - ![image](https://github.com/autowarefoundation/autoware.universe/assets/11009876/a01d25d2-be2c-4a69-9ffd-a9b92cee2f79)
- Simple <- existing
  - ![image](https://github.com/autowarefoundation/autoware.universe/assets/11009876/bf87503b-3660-4b42-9643-283d0aa9b012)
- Simple2   <- New!!
  - ![image](https://github.com/autowarefoundation/autoware.universe/assets/11009876/ae239add-499d-4bfd-a86a-d97b7aee3d2f)



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/