### PR TITLE
revert(lane_change): disable terminal path

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -136,8 +136,7 @@ BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
 {
   *prev_approved_path_ = getPreviousModuleOutput().path;
 
-  BehaviorModuleOutput out;
-  out = module_type_->getTerminalLaneChangePath();
+  BehaviorModuleOutput out = getPreviousModuleOutput();
   module_type_->insertStopPoint(module_type_->getLaneChangeStatus().current_lanes, out.path);
   out.turn_signal_info =
     getCurrentTurnSignalInfo(out.path, getPreviousModuleOutput().turn_signal_info);


### PR DESCRIPTION
## Description

Terminal path logic is currently causing node dying.
So this PR  will temporarily revert the function.
Once the issue is identified, it will be enabled again.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
