### PR TITLE
fix(ground_segmentation launch): fix topic name conflict in additional_lidars option

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -281,7 +281,7 @@ class GroundSegmentationPipeline:
         use_additional = bool(additional_lidars)
         relay_topic = "all_lidars/pointcloud"
         common_pipeline_output = (
-            "single_frame/pointcloud" if use_additional or use_ransac else output_topic
+            "common/pointcloud" if use_additional or use_ransac else output_topic
         )
 
         components = self.create_common_pipeline(


### PR DESCRIPTION
## Description

- To rename `/perception/obstacle_segmentation/single_frame/pointcloud` which becomes conflict when `addition_lidars` or `ransac_input_topics` are used.

Current: 
![dai_proposal_diagram-Page-4](https://github.com/autowarefoundation/autoware.universe/assets/94814556/80921a82-96a7-47bc-b6f5-733314d9e2bb)

After: 
![dai_proposal_diagram-Page-5](https://github.com/autowarefoundation/autoware.universe/assets/94814556/a9db4081-735e-4b91-a028-6a24b82f81fd)


<!-- Write a brief description of this PR. -->
## Related link
- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03S84LDJGG/p1712897348252399)
## Tests performed

- Confirmed by `logging_simulator` there is no name confict:
  - Left lidar is used as additional_lidars: `additional_lidars: ["left"]`
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/6defef27-d1b2-4246-bfec-c497b22031bb)
  - Left lidar is used as ransac_input_topics: `ransac_input_topics: ["left"]`
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/85b310d6-6f6d-494b-9068-cd24163d0fbf)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
