### PR TITLE
fix(avoidance): don't avoid merging/deviating vehicle whose overhang distance is larger than threshold

### DIFF
--- a/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
+++ b/planning/behavior_path_avoidance_module/config/avoidance.param.yaml
@@ -132,6 +132,10 @@
           th_shiftable_ratio: 0.8                       # [-]
           min_road_shoulder_width: 0.5                  # [m] FOR DEVELOPER
 
+        # for merging/deviating vehicle
+        merging_vehicle:
+          th_overhang_distance: 0.0                     # [m]
+
         # params for avoidance of vehicle type objects that are ambiguous as to whether they are parked.
         avoidance_for_ambiguous_vehicle:
           enable: true                                  # [-]

--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/data_structs.hpp
@@ -189,6 +189,9 @@ struct AvoidanceParameters
   double time_threshold_for_ambiguous_vehicle{0.0};
   double distance_threshold_for_ambiguous_vehicle{0.0};
 
+  // for merging/deviating vehicle
+  double th_overhang_distance{0.0};
+
   // parameters for safety check area
   bool enable_safety_check{false};
   bool check_current_lane{false};

--- a/planning/behavior_path_avoidance_module/schema/avoidance.schema.json
+++ b/planning/behavior_path_avoidance_module/schema/avoidance.schema.json
@@ -681,6 +681,18 @@
               ],
               "additionalProperties": false
             },
+            "merging_vehicle": {
+              "type": "object",
+              "properties": {
+                "th_overhang_distance": {
+                  "type": "number",
+                  "description": "Distance threshold between overhang point and ego lane's centerline. If the nearest overhang point of merging/deviating vehicle is less than this param, the module never avoid it. (Basically, the ego stops behind of it.)",
+                  "default": 0.5
+                }
+              },
+              "required": ["th_overhang_distance"],
+              "additionalProperties": false
+            },
             "parked_vehicle": {
               "type": "object",
               "properties": {
@@ -803,6 +815,7 @@
             "object_check_return_pose_distance",
             "max_compensation_time",
             "detection_area",
+            "merging_vehicle",
             "parked_vehicle",
             "avoidance_for_ambiguous_vehicle",
             "intersection"

--- a/planning/behavior_path_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_avoidance_module/src/debug.cpp
@@ -578,6 +578,7 @@ MarkerArray createDebugMarkerArray(
     addObjects(data.other_objects, std::string("TooNearToGoal"));
     addObjects(data.other_objects, std::string("ParallelToEgoLane"));
     addObjects(data.other_objects, std::string("MergingToEgoLane"));
+    addObjects(data.other_objects, std::string("DeviatingFromEgoLane"));
     addObjects(data.other_objects, std::string("UnstableObject"));
     addObjects(data.other_objects, std::string("AmbiguousStoppedVehicle"));
     addObjects(data.other_objects, std::string("AmbiguousStoppedVehicle(wait-and-see)"));

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -576,6 +576,46 @@ bool isNeverAvoidanceTarget(
     }
   }
 
+  if (object.behavior == ObjectData::Behavior::MERGING) {
+    object.reason = "MergingToEgoLane";
+    if (
+      isOnRight(object) &&
+      object.overhang_points.front().first > parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(__func__),
+        "merging vehicle. but overhang distance is larger than threshold.");
+      return true;
+    }
+    if (
+      !isOnRight(object) &&
+      object.overhang_points.front().first < -1.0 * parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(__func__),
+        "merging vehicle. but overhang distance is larger than threshold.");
+      return true;
+    }
+  }
+
+  if (object.behavior == ObjectData::Behavior::DEVIATING) {
+    object.reason = "DeviatingFromEgoLane";
+    if (
+      isOnRight(object) &&
+      object.overhang_points.front().first > parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(__func__),
+        "deviating vehicle. but overhang distance is larger than threshold.");
+      return true;
+    }
+    if (
+      !isOnRight(object) &&
+      object.overhang_points.front().first < -1.0 * parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(__func__),
+        "deviating vehicle. but overhang distance is larger than threshold.");
+      return true;
+    }
+  }
+
   if (object.is_on_ego_lane) {
     const auto right_lane =
       planner_data->route_handler->getRightLanelet(object.overhang_lanelet, true, false);

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -579,7 +579,7 @@ bool isNeverAvoidanceTarget(
   if (object.behavior == ObjectData::Behavior::MERGING) {
     object.reason = "MergingToEgoLane";
     if (
-      isOnRight(object) &&
+      isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first > parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
         rclcpp::get_logger(__func__),
@@ -587,7 +587,7 @@ bool isNeverAvoidanceTarget(
       return true;
     }
     if (
-      !isOnRight(object) &&
+      !isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first < -1.0 * parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
         rclcpp::get_logger(__func__),
@@ -599,7 +599,7 @@ bool isNeverAvoidanceTarget(
   if (object.behavior == ObjectData::Behavior::DEVIATING) {
     object.reason = "DeviatingFromEgoLane";
     if (
-      isOnRight(object) &&
+      isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first > parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
         rclcpp::get_logger(__func__),
@@ -607,7 +607,7 @@ bool isNeverAvoidanceTarget(
       return true;
     }
     if (
-      !isOnRight(object) &&
+      !isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first < -1.0 * parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
         rclcpp::get_logger(__func__),

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -582,7 +582,7 @@ bool isNeverAvoidanceTarget(
       isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first > parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
-        rclcpp::get_logger(__func__),
+        rclcpp::get_logger(logger_namespace),
         "merging vehicle. but overhang distance is larger than threshold.");
       return true;
     }
@@ -590,7 +590,7 @@ bool isNeverAvoidanceTarget(
       !isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first < -1.0 * parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
-        rclcpp::get_logger(__func__),
+        rclcpp::get_logger(logger_namespace),
         "merging vehicle. but overhang distance is larger than threshold.");
       return true;
     }
@@ -602,7 +602,7 @@ bool isNeverAvoidanceTarget(
       isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first > parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
-        rclcpp::get_logger(__func__),
+        rclcpp::get_logger(logger_namespace),
         "deviating vehicle. but overhang distance is larger than threshold.");
       return true;
     }
@@ -610,7 +610,7 @@ bool isNeverAvoidanceTarget(
       !isOnRight(object) && !object.is_parked &&
       object.overhang_points.front().first < -1.0 * parameters->th_overhang_distance) {
       RCLCPP_DEBUG(
-        rclcpp::get_logger(__func__),
+        rclcpp::get_logger(logger_namespace),
         "deviating vehicle. but overhang distance is larger than threshold.");
       return true;
     }


### PR DESCRIPTION
## Description

Related PR: https://github.com/autowarefoundation/autoware_launch/pull/974
Related ticket: https://tier4.atlassian.net/browse/RT1-5553

Previous avoidance module creates avoidance path for merging/deviating vehicle. However, sometimes it caused unnatural behavior as follow. In this situation, perception module detected ghost deviationg vehicle and module tried to avoid it with huge leteral shift length. I think the ego should stop behind of the it even if it's not perception false positive because most of the rear of the vehicle is still in Ego's lane.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/45fbd4e0-33f0-4ef7-be8d-e0d2e9bb42f0)

In this PR, I fixed logic to check overhang distance and ignore such a vehicle.

```json
            "merging_vehicle": {
              "type": "object",
              "properties": {
                "th_overhang_distance": {
                  "type": "number",
                  "description": "Distance threshold between overhang point and ego lane's centerline. If the nearest overhang point of merging/deviating vehicle is less than this param, the module never avoid it. (Basically, the ego stops behind of it.)",
                  "default": 0.5
                }
              },
              "required": ["th_overhang_distance"],
              "additionalProperties": false
            }
```
![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/5e025955-8a1f-4459-9cb5-547ca2cd3836)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/5caaab91-a83a-57a7-90bb-3e1a1a660519?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve avoidance behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
