### PR TITLE
revert(goal_planner): fix non-thread-safe access in goal_planner (#6740)

### DIFF
--- a/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/geometric_pull_over.hpp
+++ b/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/geometric_pull_over.hpp
@@ -16,6 +16,7 @@
 #define BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GEOMETRIC_PULL_OVER_HPP_
 
 #include "behavior_path_goal_planner_module/pull_over_planner_base.hpp"
+#include "behavior_path_planner_common/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.hpp"
 #include "behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp"
 
 #include <lane_departure_checker/lane_departure_checker.hpp>
@@ -33,7 +34,9 @@ class GeometricPullOver : public PullOverPlannerBase
 public:
   GeometricPullOver(
     rclcpp::Node & node, const GoalPlannerParameters & parameters,
-    const LaneDepartureChecker & lane_departure_checker, const bool is_forward);
+    const LaneDepartureChecker & lane_departure_checker,
+    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
+    const bool is_forward);
 
   PullOverPlannerType getPlannerType() const override
   {
@@ -58,6 +61,7 @@ public:
 protected:
   ParallelParkingParameters parallel_parking_parameters_;
   LaneDepartureChecker lane_departure_checker_{};
+  std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map_;
   bool is_forward_{true};
   bool left_side_parking_{true};
 

--- a/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_searcher.hpp
+++ b/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_searcher.hpp
@@ -29,45 +29,33 @@ using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
 class GoalSearcher : public GoalSearcherBase
 {
 public:
-  GoalSearcher(const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint);
+  GoalSearcher(
+    const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint,
+    const std::shared_ptr<OccupancyGridBasedCollisionDetector> & occupancy_grid_map);
 
-  GoalCandidates search(
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) override;
-  void update(
-    GoalCandidates & goal_candidates,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const override;
+  GoalCandidates search() override;
+  void update(GoalCandidates & goal_candidates) const override;
 
   // todo(kosuke55): Functions for this specific use should not be in the interface,
   // so it is better to consider interface design when we implement other goal searchers.
   GoalCandidate getClosetGoalCandidateAlongLanes(
-    const GoalCandidates & goal_candidates,
-    const std::shared_ptr<const PlannerData> & planner_data) const override;
+    const GoalCandidates & goal_candidates) const override;
   bool isSafeGoalWithMarginScaleFactor(
-    const GoalCandidate & goal_candidate, const double margin_scale_factor,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const override;
+    const GoalCandidate & goal_candidate, const double margin_scale_factor) const override;
 
 private:
   void countObjectsToAvoid(
-    GoalCandidates & goal_candidates, const PredictedObjects & objects,
-    const std::shared_ptr<const PlannerData> & planner_data) const;
-  void createAreaPolygons(
-    std::vector<Pose> original_search_poses,
-    const std::shared_ptr<const PlannerData> & planner_data);
-  bool checkCollision(
-    const Pose & pose, const PredictedObjects & objects,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map) const;
+    GoalCandidates & goal_candidates, const PredictedObjects & objects) const;
+  void createAreaPolygons(std::vector<Pose> original_search_poses);
+  bool checkCollision(const Pose & pose, const PredictedObjects & objects) const;
   bool checkCollisionWithLongitudinalDistance(
-    const Pose & ego_pose, const PredictedObjects & objects,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const;
+    const Pose & ego_pose, const PredictedObjects & objects) const;
   BasicPolygons2d getNoParkingAreaPolygons(const lanelet::ConstLanelets & lanes) const;
   BasicPolygons2d getNoStoppingAreaPolygons(const lanelet::ConstLanelets & lanes) const;
   bool isInAreas(const LinearRing2d & footprint, const BasicPolygons2d & areas) const;
 
   LinearRing2d vehicle_footprint_{};
+  std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map_{};
   bool left_side_parking_{true};
 };
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_searcher_base.hpp
+++ b/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/goal_searcher_base.hpp
@@ -17,7 +17,6 @@
 
 #include "behavior_path_goal_planner_module/goal_planner_parameters.hpp"
 #include "behavior_path_planner_common/data_manager.hpp"
-#include "behavior_path_planner_common/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.hpp"
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
@@ -50,29 +49,23 @@ public:
   {
     reference_goal_pose_ = reference_goal_pose;
   }
-  const Pose & getReferenceGoal() const { return reference_goal_pose_; }
 
-  MultiPolygon2d getAreaPolygons() const { return area_polygons_; }
-  virtual GoalCandidates search(
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) = 0;
-  virtual void update(
-    [[maybe_unused]] GoalCandidates & goal_candidates,
-    [[maybe_unused]] const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    [[maybe_unused]] const std::shared_ptr<const PlannerData> & planner_data) const
+  void setPlannerData(const std::shared_ptr<const PlannerData> & planner_data)
   {
-    return;
+    planner_data_ = planner_data;
   }
+
+  MultiPolygon2d getAreaPolygons() { return area_polygons_; }
+  virtual GoalCandidates search() = 0;
+  virtual void update([[maybe_unused]] GoalCandidates & goal_candidates) const { return; }
   virtual GoalCandidate getClosetGoalCandidateAlongLanes(
-    const GoalCandidates & goal_candidates,
-    const std::shared_ptr<const PlannerData> & planner_data) const = 0;
+    const GoalCandidates & goal_candidates) const = 0;
   virtual bool isSafeGoalWithMarginScaleFactor(
-    const GoalCandidate & goal_candidate, const double margin_scale_factor,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const = 0;
+    const GoalCandidate & goal_candidate, const double margin_scale_factor) const = 0;
 
 protected:
   GoalPlannerParameters parameters_{};
+  std::shared_ptr<const PlannerData> planner_data_{nullptr};
   Pose reference_goal_pose_{};
   MultiPolygon2d area_polygons_{};
 };

--- a/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/shift_pull_over.hpp
+++ b/planning/behavior_path_goal_planner_module/include/behavior_path_goal_planner_module/shift_pull_over.hpp
@@ -16,6 +16,7 @@
 #define BEHAVIOR_PATH_GOAL_PLANNER_MODULE__SHIFT_PULL_OVER_HPP_
 
 #include "behavior_path_goal_planner_module/pull_over_planner_base.hpp"
+#include "behavior_path_planner_common/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.hpp"
 
 #include <lane_departure_checker/lane_departure_checker.hpp>
 
@@ -33,7 +34,9 @@ class ShiftPullOver : public PullOverPlannerBase
 public:
   ShiftPullOver(
     rclcpp::Node & node, const GoalPlannerParameters & parameters,
-    const LaneDepartureChecker & lane_departure_checker);
+    const LaneDepartureChecker & lane_departure_checker,
+    const std::shared_ptr<OccupancyGridBasedCollisionDetector> & occupancy_grid_map);
+
   PullOverPlannerType getPlannerType() const override { return PullOverPlannerType::SHIFT; };
   std::optional<PullOverPath> plan(const Pose & goal_pose) override;
 
@@ -54,6 +57,7 @@ protected:
     const Pose & start_pose, const Pose & end_pose, const double resample_interval);
 
   LaneDepartureChecker lane_departure_checker_{};
+  std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map_{};
 
   bool left_side_parking_{true};
 };

--- a/planning/behavior_path_goal_planner_module/src/geometric_pull_over.cpp
+++ b/planning/behavior_path_goal_planner_module/src/geometric_pull_over.cpp
@@ -27,10 +27,13 @@ namespace behavior_path_planner
 {
 GeometricPullOver::GeometricPullOver(
   rclcpp::Node & node, const GoalPlannerParameters & parameters,
-  const LaneDepartureChecker & lane_departure_checker, const bool is_forward)
+  const LaneDepartureChecker & lane_departure_checker,
+  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
+  const bool is_forward)
 : PullOverPlannerBase{node, parameters},
   parallel_parking_parameters_{parameters.parallel_parking_parameters},
   lane_departure_checker_{lane_departure_checker},
+  occupancy_grid_map_{occupancy_grid_map},
   is_forward_{is_forward},
   left_side_parking_{parameters.parking_policy == ParkingPolicy::LEFT_SIDE}
 {

--- a/planning/behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -90,35 +90,35 @@ struct SortByWeightedDistance
 };
 
 GoalSearcher::GoalSearcher(
-  const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint)
+  const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint,
+  const std::shared_ptr<OccupancyGridBasedCollisionDetector> & occupancy_grid_map)
 : GoalSearcherBase{parameters},
   vehicle_footprint_{vehicle_footprint},
+  occupancy_grid_map_{occupancy_grid_map},
   left_side_parking_{parameters.parking_policy == ParkingPolicy::LEFT_SIDE}
 {
 }
 
-GoalCandidates GoalSearcher::search(
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data)
+GoalCandidates GoalSearcher::search()
 {
   GoalCandidates goal_candidates{};
 
-  const auto & route_handler = planner_data->route_handler;
+  const auto & route_handler = planner_data_->route_handler;
   const double forward_length = parameters_.forward_goal_search_length;
   const double backward_length = parameters_.backward_goal_search_length;
   const double margin_from_boundary = parameters_.margin_from_boundary;
   const double lateral_offset_interval = parameters_.lateral_offset_interval;
   const double max_lateral_offset = parameters_.max_lateral_offset;
   const double ignore_distance_from_lane_start = parameters_.ignore_distance_from_lane_start;
-  const double vehicle_width = planner_data->parameters.vehicle_width;
-  const double base_link2front = planner_data->parameters.base_link2front;
-  const double base_link2rear = planner_data->parameters.base_link2rear;
+  const double vehicle_width = planner_data_->parameters.vehicle_width;
+  const double base_link2front = planner_data_->parameters.base_link2front;
+  const double base_link2rear = planner_data_->parameters.base_link2rear;
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, parameters_.backward_goal_search_length,
     parameters_.forward_goal_search_length);
   auto lanes = utils::getExtendedCurrentLanes(
-    planner_data, backward_length, forward_length,
+    planner_data_, backward_length, forward_length,
     /*forward_only_in_route*/ false);
   lanes.insert(lanes.end(), pull_over_lanes.begin(), pull_over_lanes.end());
 
@@ -193,18 +193,17 @@ GoalCandidates GoalSearcher::search(
       goal_candidates.push_back(goal_candidate);
     }
   }
-  createAreaPolygons(original_search_poses, planner_data);
+  createAreaPolygons(original_search_poses);
 
-  update(goal_candidates, occupancy_grid_map, planner_data);
+  update(goal_candidates);
 
   return goal_candidates;
 }
 
 void GoalSearcher::countObjectsToAvoid(
-  GoalCandidates & goal_candidates, const PredictedObjects & objects,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+  GoalCandidates & goal_candidates, const PredictedObjects & objects) const
 {
-  const auto & route_handler = planner_data->route_handler;
+  const auto & route_handler = planner_data_->route_handler;
   const double forward_length = parameters_.forward_goal_search_length;
   const double backward_length = parameters_.backward_goal_search_length;
 
@@ -226,7 +225,7 @@ void GoalSearcher::countObjectsToAvoid(
 
   // generate current lane center line path to check collision with objects
   const auto current_lanes = utils::getExtendedCurrentLanes(
-    planner_data, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
+    planner_data_, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
     /*forward_only_in_route*/ false);
   const auto current_center_line_path = std::invoke([&]() -> PathWithLaneId {
     const double s_start =
@@ -265,19 +264,16 @@ void GoalSearcher::countObjectsToAvoid(
   }
 }
 
-void GoalSearcher::update(
-  GoalCandidates & goal_candidates,
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+void GoalSearcher::update(GoalCandidates & goal_candidates) const
 {
   const auto pull_over_lane_stop_objects =
     goal_planner_utils::extractStaticObjectsInExpandedPullOverLanes(
-      *(planner_data->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
+      *(planner_data_->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
       parameters_.forward_goal_search_length, parameters_.detection_bound_offset,
-      *(planner_data->dynamic_object), parameters_.th_moving_object_velocity);
+      *(planner_data_->dynamic_object), parameters_.th_moving_object_velocity);
 
   if (parameters_.prioritize_goals_before_objects) {
-    countObjectsToAvoid(goal_candidates, pull_over_lane_stop_objects, planner_data);
+    countObjectsToAvoid(goal_candidates, pull_over_lane_stop_objects);
   }
 
   if (parameters_.goal_priority == "minimum_weighted_distance") {
@@ -297,7 +293,7 @@ void GoalSearcher::update(
     const Pose goal_pose = goal_candidate.goal_pose;
 
     // check collision with footprint
-    if (checkCollision(goal_pose, pull_over_lane_stop_objects, occupancy_grid_map)) {
+    if (checkCollision(goal_pose, pull_over_lane_stop_objects)) {
       goal_candidate.is_safe = false;
       continue;
     }
@@ -305,10 +301,9 @@ void GoalSearcher::update(
     // check longitudinal margin with pull over lane objects
     constexpr bool filter_inside = true;
     const auto target_objects = goal_planner_utils::filterObjectsByLateralDistance(
-      goal_pose, planner_data->parameters.vehicle_width, pull_over_lane_stop_objects,
+      goal_pose, planner_data_->parameters.vehicle_width, pull_over_lane_stop_objects,
       parameters_.object_recognition_collision_check_hard_margins.back(), filter_inside);
-    if (checkCollisionWithLongitudinalDistance(
-          goal_pose, target_objects, occupancy_grid_map, planner_data)) {
+    if (checkCollisionWithLongitudinalDistance(goal_pose, target_objects)) {
       goal_candidate.is_safe = false;
       continue;
     }
@@ -321,9 +316,7 @@ void GoalSearcher::update(
 // current planner_data_ and margin scale factor.
 // And is_safe is not updated in this function.
 bool GoalSearcher::isSafeGoalWithMarginScaleFactor(
-  const GoalCandidate & goal_candidate, const double margin_scale_factor,
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+  const GoalCandidate & goal_candidate, const double margin_scale_factor) const
 {
   if (!parameters_.use_object_recognition) {
     return true;
@@ -333,9 +326,9 @@ bool GoalSearcher::isSafeGoalWithMarginScaleFactor(
 
   const auto pull_over_lane_stop_objects =
     goal_planner_utils::extractStaticObjectsInExpandedPullOverLanes(
-      *(planner_data->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
+      *(planner_data_->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
       parameters_.forward_goal_search_length, parameters_.detection_bound_offset,
-      *(planner_data->dynamic_object), parameters_.th_moving_object_velocity);
+      *(planner_data_->dynamic_object), parameters_.th_moving_object_velocity);
 
   const double margin =
     parameters_.object_recognition_collision_check_hard_margins.back() * margin_scale_factor;
@@ -348,26 +341,23 @@ bool GoalSearcher::isSafeGoalWithMarginScaleFactor(
   // check longitudinal margin with pull over lane objects
   constexpr bool filter_inside = true;
   const auto target_objects = goal_planner_utils::filterObjectsByLateralDistance(
-    goal_pose, planner_data->parameters.vehicle_width, pull_over_lane_stop_objects, margin,
+    goal_pose, planner_data_->parameters.vehicle_width, pull_over_lane_stop_objects, margin,
     filter_inside);
-  if (checkCollisionWithLongitudinalDistance(
-        goal_pose, target_objects, occupancy_grid_map, planner_data)) {
+  if (checkCollisionWithLongitudinalDistance(goal_pose, target_objects)) {
     return false;
   }
 
   return true;
 }
 
-bool GoalSearcher::checkCollision(
-  const Pose & pose, const PredictedObjects & objects,
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map) const
+bool GoalSearcher::checkCollision(const Pose & pose, const PredictedObjects & objects) const
 {
   if (parameters_.use_occupancy_grid_for_goal_search) {
-    const Pose pose_grid_coords = global2local(occupancy_grid_map->getMap(), pose);
+    const Pose pose_grid_coords = global2local(occupancy_grid_map_->getMap(), pose);
     const auto idx = pose2index(
-      occupancy_grid_map->getMap(), pose_grid_coords, occupancy_grid_map->getParam().theta_size);
+      occupancy_grid_map_->getMap(), pose_grid_coords, occupancy_grid_map_->getParam().theta_size);
     const bool check_out_of_range = false;
-    if (occupancy_grid_map->detectCollision(idx, check_out_of_range)) {
+    if (occupancy_grid_map_->detectCollision(idx, check_out_of_range)) {
       return true;
     }
   }
@@ -383,9 +373,7 @@ bool GoalSearcher::checkCollision(
 }
 
 bool GoalSearcher::checkCollisionWithLongitudinalDistance(
-  const Pose & ego_pose, const PredictedObjects & objects,
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+  const Pose & ego_pose, const PredictedObjects & objects) const
 {
   if (
     parameters_.use_occupancy_grid_for_goal_search &&
@@ -397,22 +385,22 @@ bool GoalSearcher::checkCollisionWithLongitudinalDistance(
     // check forward collision
     const Pose ego_pose_moved_forward = calcOffsetPose(ego_pose, offset, 0, 0);
     const Pose forward_pose_grid_coords =
-      global2local(occupancy_grid_map->getMap(), ego_pose_moved_forward);
+      global2local(occupancy_grid_map_->getMap(), ego_pose_moved_forward);
     const auto forward_idx = pose2index(
-      occupancy_grid_map->getMap(), forward_pose_grid_coords,
-      occupancy_grid_map->getParam().theta_size);
-    if (occupancy_grid_map->detectCollision(forward_idx, check_out_of_range)) {
+      occupancy_grid_map_->getMap(), forward_pose_grid_coords,
+      occupancy_grid_map_->getParam().theta_size);
+    if (occupancy_grid_map_->detectCollision(forward_idx, check_out_of_range)) {
       return true;
     }
 
     // check backward collision
     const Pose ego_pose_moved_backward = calcOffsetPose(ego_pose, -offset, 0, 0);
     const Pose backward_pose_grid_coords =
-      global2local(occupancy_grid_map->getMap(), ego_pose_moved_backward);
+      global2local(occupancy_grid_map_->getMap(), ego_pose_moved_backward);
     const auto backward_idx = pose2index(
-      occupancy_grid_map->getMap(), backward_pose_grid_coords,
-      occupancy_grid_map->getParam().theta_size);
-    if (occupancy_grid_map->detectCollision(backward_idx, check_out_of_range)) {
+      occupancy_grid_map_->getMap(), backward_pose_grid_coords,
+      occupancy_grid_map_->getParam().theta_size);
+    if (occupancy_grid_map_->detectCollision(backward_idx, check_out_of_range)) {
       return true;
     }
   }
@@ -420,24 +408,23 @@ bool GoalSearcher::checkCollisionWithLongitudinalDistance(
   if (parameters_.use_object_recognition) {
     if (
       utils::calcLongitudinalDistanceFromEgoToObjects(
-        ego_pose, planner_data->parameters.base_link2front, planner_data->parameters.base_link2rear,
-        objects) < parameters_.longitudinal_margin) {
+        ego_pose, planner_data_->parameters.base_link2front,
+        planner_data_->parameters.base_link2rear, objects) < parameters_.longitudinal_margin) {
       return true;
     }
   }
   return false;
 }
 
-void GoalSearcher::createAreaPolygons(
-  std::vector<Pose> original_search_poses, const std::shared_ptr<const PlannerData> & planner_data)
+void GoalSearcher::createAreaPolygons(std::vector<Pose> original_search_poses)
 {
   using tier4_autoware_utils::MultiPolygon2d;
   using tier4_autoware_utils::Point2d;
   using tier4_autoware_utils::Polygon2d;
 
-  const double vehicle_width = planner_data->parameters.vehicle_width;
-  const double base_link2front = planner_data->parameters.base_link2front;
-  const double base_link2rear = planner_data->parameters.base_link2rear;
+  const double vehicle_width = planner_data_->parameters.vehicle_width;
+  const double base_link2front = planner_data_->parameters.base_link2front;
+  const double base_link2rear = planner_data_->parameters.base_link2rear;
   const double max_lateral_offset = parameters_.max_lateral_offset;
 
   const auto appendPointToPolygon =
@@ -519,11 +506,10 @@ bool GoalSearcher::isInAreas(const LinearRing2d & footprint, const BasicPolygons
 }
 
 GoalCandidate GoalSearcher::getClosetGoalCandidateAlongLanes(
-  const GoalCandidates & goal_candidates,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+  const GoalCandidates & goal_candidates) const
 {
   const auto current_lanes = utils::getExtendedCurrentLanes(
-    planner_data, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
+    planner_data_, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
     /*forward_only_in_route*/ false);
 
   // Define a lambda function to compute the arc length for a given goal candidate.

--- a/planning/behavior_path_goal_planner_module/src/shift_pull_over.cpp
+++ b/planning/behavior_path_goal_planner_module/src/shift_pull_over.cpp
@@ -28,9 +28,11 @@ namespace behavior_path_planner
 {
 ShiftPullOver::ShiftPullOver(
   rclcpp::Node & node, const GoalPlannerParameters & parameters,
-  const LaneDepartureChecker & lane_departure_checker)
+  const LaneDepartureChecker & lane_departure_checker,
+  const std::shared_ptr<OccupancyGridBasedCollisionDetector> & occupancy_grid_map)
 : PullOverPlannerBase{node, parameters},
   lane_departure_checker_{lane_departure_checker},
+  occupancy_grid_map_{occupancy_grid_map},
   left_side_parking_{parameters.parking_policy == ParkingPolicy::LEFT_SIDE}
 {
 }


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/6740/files

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

none

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
