### PR TITLE
fix(longitudinal_controller & shift_decider): stop check before changing the shift and correct the feedforward component

### DIFF
--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -41,6 +41,7 @@
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "visualization_msgs/msg/marker.hpp"
+#include "motion_utils/vehicle/vehicle_state_checker.hpp"
 
 #include <deque>
 #include <memory>
@@ -247,6 +248,8 @@ private:
   DiagnosticData m_diagnostic_data;
   void setupDiagnosticUpdater();
   void checkControlState(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  std::unique_ptr<motion_utils::VehicleStopChecker> vehicle_stop_checker_;
 
   /**
    * @brief set current and previous velocity with received message

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1064,14 +1064,7 @@ PidLongitudinalController::StateAfterDelay PidLongitudinalController::predictedS
 double PidLongitudinalController::applyVelocityFeedback(const ControlData & control_data)
 {
   // NOTE: Acceleration command is always positive even if the ego drives backward.
-  const double vel_sign = (control_data.shift == Shift::Forward)
-                            ? 1.0
-                            : (control_data.shift == Shift::Reverse ? -1.0 : 0.0);
-  const double current_vel = control_data.current_motion.vel;
-  const auto target_motion = Motion{
-    control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
-    control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};
-  const double diff_vel = (target_motion.vel - current_vel) * vel_sign;
+  const double diff_vel = target_motion.vel - current_vel;
   const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
                                 m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
 

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1064,6 +1064,8 @@ PidLongitudinalController::StateAfterDelay PidLongitudinalController::predictedS
 double PidLongitudinalController::applyVelocityFeedback(const ControlData & control_data)
 {
   const double diff_vel = target_motion.vel - current_vel;
+  std::cerr << "target_motion.vel: " << target_motion.vel << std::endl;
+  std::cerr << "current_vel: " << current_vel << std::endl;  
   const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
                                 m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
 
@@ -1096,7 +1098,12 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
 
   // NOTE: Acceleration command is always positive even if the ego drives backward.
   const double vel_sign = (shift == Shift::Forward) ? 1.0 : (shift == Shift::Reverse ? -1.0 : 0.0);
+  std::cerr << "desired_vel_sign: " << vel_sign << std::endl;
   const double feedback_acc = (ff_acc + pid_acc) * vel_sign;
+  std::cerr << "ff_acc_signed: " << ff_acc * vel_sign << std::endl;
+  std::cerr << "pid_acc_signed: " << pid_acc * vel_sign << std::endl;
+  std::cerr << "feedback_acc: " << feedback_acc << std::endl;
+  std::cerr << "----------------------" << std::endl;
 
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PID_APPLIED, feedback_acc);
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL_FILTERED, error_vel_filtered);

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -887,7 +887,7 @@ double PidLongitudinalController::getDt()
 enum PidLongitudinalController::Shift PidLongitudinalController::getCurrentShift(
   const ControlData & control_data) const
 {
-  constexpr double epsilon = 0.01;
+  constexpr double epsilon = 1e-5;
 
   const double target_vel =
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps;

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1069,8 +1069,6 @@ PidLongitudinalController::StateAfterDelay PidLongitudinalController::predictedS
 double PidLongitudinalController::applyVelocityFeedback(const ControlData & control_data)
 {
   const double diff_vel = target_motion.vel - current_vel;
-  std::cerr << "target_motion.vel: " << target_motion.vel << std::endl;
-  std::cerr << "current_vel: " << current_vel << std::endl;  
   const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
                                 m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
 
@@ -1103,12 +1101,7 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
 
   // NOTE: Acceleration command is always positive even if the ego drives backward.
   const double vel_sign = (shift == Shift::Forward) ? 1.0 : (shift == Shift::Reverse ? -1.0 : 0.0);
-  std::cerr << "desired_vel_sign: " << vel_sign << std::endl;
   const double feedback_acc = (ff_acc + pid_acc) * vel_sign;
-  std::cerr << "ff_acc_signed: " << ff_acc * vel_sign << std::endl;
-  std::cerr << "pid_acc_signed: " << pid_acc * vel_sign << std::endl;
-  std::cerr << "feedback_acc: " << feedback_acc << std::endl;
-  std::cerr << "----------------------" << std::endl;
 
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PID_APPLIED, feedback_acc);
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL_FILTERED, error_vel_filtered);

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -886,7 +886,7 @@ double PidLongitudinalController::getDt()
 enum PidLongitudinalController::Shift PidLongitudinalController::getCurrentShift(
   const ControlData & control_data) const
 {
-  constexpr double epsilon = 1e-5;
+  constexpr double epsilon = 0.01;
 
   const double target_vel =
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps;

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1063,7 +1063,6 @@ PidLongitudinalController::StateAfterDelay PidLongitudinalController::predictedS
 
 double PidLongitudinalController::applyVelocityFeedback(const ControlData & control_data)
 {
-  // NOTE: Acceleration command is always positive even if the ego drives backward.
   const double diff_vel = target_motion.vel - current_vel;
   const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
                                 m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
@@ -1095,7 +1094,9 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
   const double ff_acc =
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2 * ff_scale;
 
-  const double feedback_acc = ff_acc + pid_acc;
+  // NOTE: Acceleration command is always positive even if the ego drives backward.
+  const double vel_sign = (shift == Shift::Forward) ? 1.0 : (shift == Shift::Reverse ? -1.0 : 0.0);
+  const double feedback_acc = (ff_acc + pid_acc) * vel_sign;
 
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PID_APPLIED, feedback_acc);
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL_FILTERED, error_vel_filtered);

--- a/control/shift_decider/include/shift_decider/shift_decider.hpp
+++ b/control/shift_decider/include/shift_decider/shift_decider.hpp
@@ -21,6 +21,7 @@
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
+#include "motion_utils/vehicle/vehicle_state_checker.hpp"
 
 #include <memory>
 
@@ -36,6 +37,8 @@ private:
   void onCurrentGear(autoware_auto_vehicle_msgs::msg::GearReport::SharedPtr msg);
   void updateCurrentShiftCmd();
   void initTimer(double period_s);
+
+  std::unique_ptr<motion_utils::VehicleStopChecker> vehicle_stop_checker_;
 
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_cmd_;
   rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>motion_utils</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -80,10 +80,18 @@ void ShiftDecider::updateCurrentShiftCmd()
   if (autoware_state_->state == AutowareState::DRIVING) {
     if (control_cmd_->longitudinal.speed > vel_threshold) {
       shift_cmd_.command = GearCommand::DRIVE;
+      std::cerr << "shift_cmd: DRIVE" << std::endl;
     } else if (control_cmd_->longitudinal.speed < -vel_threshold) {
       shift_cmd_.command = GearCommand::REVERSE;
+      std::cerr << "shift_cmd: REVERSE" << std::endl;
     } else {
       shift_cmd_.command = prev_shift_command;
+      if (prev_shift_command == GearCommand::DRIVE) {
+        std::cerr << "shift_cmd: DRIVE" << std::endl;
+      }
+      if (prev_shift_command == GearCommand::REVERSE) {
+        std::cerr << "shift_cmd: REVERSE" << std::endl;
+      }
     }
   } else {
     if (

--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -77,10 +77,8 @@ void ShiftDecider::updateCurrentShiftCmd()
   using autoware_auto_vehicle_msgs::msg::GearCommand;
 
   const auto stopped = vehicle_stop_checker_->isVehicleStopped(0.0);
-  std::cerr << "stopped: " << stopped << std::endl;
   shift_cmd_.stamp = now();
   static constexpr double vel_threshold = 0.01;  // to prevent chattering
-  std::cerr << "longitudinal.speed: " << control_cmd_->longitudinal.speed << std::endl;
   if (autoware_state_->state == AutowareState::DRIVING) {
     if (stopped) {
       if (control_cmd_->longitudinal.speed > vel_threshold) {
@@ -102,13 +100,6 @@ void ShiftDecider::updateCurrentShiftCmd()
     }
   }
   prev_shift_command = shift_cmd_.command;
-  if (shift_cmd_.command == GearCommand::DRIVE) {
-    std::cerr << "ShiftDecider: DRIVE" << std::endl;
-  } else if (shift_cmd_.command == GearCommand::REVERSE) {
-      std::cerr << "ShiftDecider: REVERSE" << std::endl;
-  } else if (shift_cmd_.command == GearCommand::PARK) {
-      std::cerr << "ShiftDecider: PARK" << std::endl;
-  } 
 }
 
 void ShiftDecider::initTimer(double period_s)


### PR DESCRIPTION
## Description

This PR solves the following 2 issues in longitudinal_controller and shift_decider.

Fixed Issue 1.
A shift can only be changed when the car is stopped.
Therefore, the stopped checker is augmented before the car is changing its shift flag in longitudinal_controller and shift_decider.

Fixed Issue 2.
The feedforward part (ff_acc) in the PID controller is defined with a wrong sign.
This PR also fixes this issue.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

You may observe the relationship between the shift sign and the stop checker below.
(the debug information has been deleted before this PR)

![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/b5e2d79e-0577-449a-8e61-3121a269188d)

![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/a0d370ae-bb64-475f-94f6-cc41a6f4c7dc)
![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/a6e11f37-8ed3-4b82-bcac-c736a3d53478)
![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/bbe41417-3105-4357-a8c5-f14f4e5997b6)
![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/b9f46425-3173-46cf-a235-0598f0d0669b)
![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/acd2e832-ab18-4cef-bbe9-bc14398fc5a2)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
