### PR TITLE
feat(logger_level_configure): make it possible to change level of container logger

### DIFF
--- a/common/tier4_autoware_utils/CMakeLists.txt
+++ b/common/tier4_autoware_utils/CMakeLists.txt
@@ -18,6 +18,11 @@ ament_auto_add_library(tier4_autoware_utils SHARED
   src/system/backtrace.cpp
 )
 
+rclcpp_components_register_node(tier4_autoware_utils
+  PLUGIN "tier4_autoware_utils::LoggerLevelConfigureNode"
+  EXECUTABLE logger_level_configure_node
+)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_ros REQUIRED)
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/logger_level_configure.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/logger_level_configure.hpp
@@ -64,5 +64,10 @@ private:
     const ConfigLogger::Response::SharedPtr response);
 };
 
+class LoggerLevelConfigureNode : public rclcpp::Node, public LoggerLevelConfigure
+{
+public:
+  explicit LoggerLevelConfigureNode(const rclcpp::NodeOptions & node_options);
+};
 }  // namespace tier4_autoware_utils
 #endif  // TIER4_AUTOWARE_UTILS__ROS__LOGGER_LEVEL_CONFIGURE_HPP_

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -23,6 +23,7 @@
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tier4_debug_msgs</depend>

--- a/common/tier4_autoware_utils/src/ros/logger_level_configure.cpp
+++ b/common/tier4_autoware_utils/src/ros/logger_level_configure.cpp
@@ -58,4 +58,11 @@ void LoggerLevelConfigure::onLoggerConfigService(
   return;
 }
 
+LoggerLevelConfigureNode::LoggerLevelConfigureNode(const rclcpp::NodeOptions & node_options)
+: Node("logger_level_configure_node", node_options), LoggerLevelConfigure(this)
+{
+}
+
 }  // namespace tier4_autoware_utils
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(tier4_autoware_utils::LoggerLevelConfigureNode)

--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -31,12 +31,14 @@ Planning:
   behavior_path_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
       logger_name: tier4_autoware_utils
 
   behavior_path_planner_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning
+      logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance.utils
 
   behavior_path_planner_goal_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
@@ -57,7 +59,7 @@ Planning:
   behavior_velocity_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
       logger_name: tier4_autoware_utils
 
   behavior_velocity_planner_intersection:
@@ -67,13 +69,13 @@ Planning:
   motion_obstacle_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
       logger_name: planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner
-    - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/container_logger_configure
       logger_name: tier4_autoware_utils
 
   motion_velocity_smoother:
     - node_name: /planning/scenario_planning/motion_velocity_smoother
       logger_name: planning.scenario_planning.motion_velocity_smoother
-    - node_name: /planning/scenario_planning/motion_velocity_smoother
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/container_logger_configure
       logger_name: tier4_autoware_utils
 
 # ============================================================
@@ -83,19 +85,19 @@ Control:
   lateral_controller:
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: control.trajectory_follower.controller_node_exe.lateral_controller
-    - node_name: /control/trajectory_follower/controller_node_exe
+    - node_name: /control/container_logger_configure
       logger_name: tier4_autoware_utils
 
   longitudinal_controller:
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: control.trajectory_follower.controller_node_exe.longitudinal_controller
-    - node_name: /control/trajectory_follower/controller_node_exe
+    - node_name: /control/container_logger_configure
       logger_name: tier4_autoware_utils
 
   vehicle_cmd_gate:
     - node_name: /control/vehicle_cmd_gate
       logger_name: control.vehicle_cmd_gate
-    - node_name: /control/vehicle_cmd_gate
+    - node_name: /control/container_logger_configure
       logger_name: tier4_autoware_utils
 
 # ============================================================
@@ -104,17 +106,9 @@ Control:
 
 Common:
   tier4_autoware_utils:
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
       logger_name: tier4_autoware_utils
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/container_logger_configure
       logger_name: tier4_autoware_utils
-    - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
-      logger_name: tier4_autoware_utils
-    - node_name: /planning/scenario_planning/lane_driving/motion_planning/path_smoother
-      logger_name: tier4_autoware_utils
-    - node_name: /planning/scenario_planning/motion_velocity_smoother
-      logger_name: tier4_autoware_utils
-    - node_name: /control/trajectory_follower/controller_node_exe
-      logger_name: tier4_autoware_utils
-    - node_name: /control/vehicle_cmd_gate
+    - node_name: /control/container_logger_configure
       logger_name: tier4_autoware_utils

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -327,12 +327,6 @@ def launch_setup(context, *args, **kwargs):
         name="glog_component",
     )
 
-    logger_component = ComposableNode(
-        package="tier4_autoware_utils",
-        plugin="tier4_autoware_utils::LoggerLevelConfigureNode",
-        name="config_logger",
-    )
-
     # set container to run all required components in the same process
     container = ComposableNodeContainer(
         name="control_container",
@@ -340,7 +334,6 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
-            logger_component,
             controller_component,
             lane_departure_component,
             shift_decider_component,

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -327,6 +327,12 @@ def launch_setup(context, *args, **kwargs):
         name="glog_component",
     )
 
+    logger_component = ComposableNode(
+        package="tier4_autoware_utils",
+        plugin="tier4_autoware_utils::LoggerLevelConfigureNode",
+        name="config_logger",
+    )
+
     # set container to run all required components in the same process
     container = ComposableNodeContainer(
         name="control_container",
@@ -334,6 +340,7 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
+            logger_component,
             controller_component,
             lane_departure_component,
             shift_decider_component,
@@ -381,6 +388,12 @@ def launch_setup(context, *args, **kwargs):
                 package="rclcpp_components",
                 executable=LaunchConfiguration("container_executable"),
                 composable_node_descriptions=[
+                    ComposableNode(
+                        package="tier4_autoware_utils",
+                        plugin="tier4_autoware_utils::LoggerLevelConfigureNode",
+                        name="container_logger_configure",
+                        namespace="control_validator_container",
+                    ),
                     control_validator_component,
                     ComposableNode(
                         package="glog_component",

--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -13,8 +13,10 @@
 
   <exec_depend>external_cmd_converter</exec_depend>
   <exec_depend>external_cmd_selector</exec_depend>
+  <exec_depend>glog_component</exec_depend>
   <exec_depend>lane_departure_checker</exec_depend>
   <exec_depend>shift_decider</exec_depend>
+  <exec_depend>tier4_autoware_utils</exec_depend>
   <exec_depend>trajectory_follower_node</exec_depend>
   <exec_depend>vehicle_cmd_gate</exec_depend>
 

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -182,6 +182,7 @@
   <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="both">
+    <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="container_logger_configure" namespace=""/>
     <composable_node pkg="behavior_path_planner" plugin="behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
       <!-- topic remap -->
       <remap from="~/input/route" to="$(var input_route_topic_name)"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -6,6 +6,10 @@
     <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
   </node_container>
 
+  <load_composable_node target="/planning/scenario_planning/lane_driving/motion_planning/motion_planning_container">
+    <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="config_logger" namespace=""/>
+  </load_composable_node>
+
   <!-- path smoothing -->
   <group>
     <group if="$(eval &quot;'$(var motion_path_smoother_type)' == 'elastic_band'&quot;)">

--- a/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -27,6 +27,7 @@
     <!-- motion velocity smoother -->
     <group>
       <node_container pkg="rclcpp_components" exec="component_container" name="motion_velocity_smoother_container" namespace="">
+        <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="container_logger_configure" namespace=""/>
         <composable_node pkg="motion_velocity_smoother" plugin="motion_velocity_smoother::MotionVelocitySmootherNode" name="motion_velocity_smoother" namespace="">
           <param name="algorithm_type" value="$(var motion_velocity_smoother_type)"/>
           <param from="$(var common_param_path)"/>

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -74,6 +74,7 @@
   <exec_depend>planning_validator</exec_depend>
   <exec_depend>scenario_selector</exec_depend>
   <exec_depend>surround_obstacle_checker</exec_depend>
+  <exec_depend>tier4_autoware_utils</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -5,6 +5,7 @@
   <arg name="mission_planner_param_path" default="$(find-pkg-share mission_planner)/config/mission_planner.param.yaml"/>
 
   <node_container pkg="rclcpp_components" exec="component_container_mt" name="mission_planner_container" namespace="">
+    <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="container_logger_configure" namespace=""/>
     <composable_node pkg="mission_planner" plugin="mission_planner::MissionPlanner" name="mission_planner" namespace="">
       <param from="$(var mission_planner_param_path)"/>
       <remap from="~/input/modified_goal" to="$(var modified_goal_topic_name)"/>


### PR DESCRIPTION
## Description

- Related PR: 
  - https://github.com/autowarefoundation/autoware.universe/pull/5204
  - https://github.com/autowarefoundation/autoware.universe/pull/5101

We have to send service with container name when we change output level of stand alone logger `rclcpp::get_logger`. (08ece4cde68e48fc6061de20e928bc9b3db25885) Additionally, we need to load `logging_demo::LoggerConfig` node to the target container. (3089230a7fb58ae28b2b83a6927844021b8da577)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

```
$ ros2 service list | grep container_logger_configure
/control/control_validator_container/container_logger_configure/config_logger
/control/control_validator_container/container_logger_configure/describe_parameters
/control/control_validator_container/container_logger_configure/get_parameter_types
/control/control_validator_container/container_logger_configure/get_parameters
/control/control_validator_container/container_logger_configure/list_parameters
/control/control_validator_container/container_logger_configure/set_parameters
/control/control_validator_container/container_logger_configure/set_parameters_atomically
/planning/mission_planning/container_logger_configure/config_logger
/planning/mission_planning/container_logger_configure/describe_parameters
/planning/mission_planning/container_logger_configure/get_parameter_types
/planning/mission_planning/container_logger_configure/get_parameters
/planning/mission_planning/container_logger_configure/list_parameters
/planning/mission_planning/container_logger_configure/set_parameters
/planning/mission_planning/container_logger_configure/set_parameters_atomically
/planning/scenario_planning/container_logger_configure/config_logger
/planning/scenario_planning/container_logger_configure/describe_parameters
/planning/scenario_planning/container_logger_configure/get_parameter_types
/planning/scenario_planning/container_logger_configure/get_parameters
/planning/scenario_planning/container_logger_configure/list_parameters
/planning/scenario_planning/container_logger_configure/set_parameters
/planning/scenario_planning/container_logger_configure/set_parameters_atomically
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/config_logger
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/describe_parameters
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/get_parameter_types
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/get_parameters
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/list_parameters
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/set_parameters
/planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure/set_parameters_atomically
```

```
$ ros2 component list
/map/map_container
  1  /map/pointcloud_map_loader
  2  /map/lanelet2_map_loader
  3  /map/lanelet2_map_visualization
  4  /map/vector_map_tf_generator
/system/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_container
  1  /system/mrm_comfortable_stop_operator
/planning/scenario_planning/lane_driving/behavior_planning/behavior_planning_container
  1  /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
  2  /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
  3  /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
  4  /planning/scenario_planning/lane_driving/behavior_planning/glog_component
/perception/traffic_light_recognition/traffic_light_arbiter/container
  1  /perception/traffic_light_recognition/traffic_light_arbiter/arbiter
/planning/scenario_planning/parking/parking_container
No 'list_nodes' service response when listing components
/planning/scenario_planning/lane_driving/motion_planning/motion_planning_container
  1  /planning/scenario_planning/lane_driving/motion_planning/config_logger
  2  /planning/scenario_planning/lane_driving/motion_planning/glog_component
  3  /planning/scenario_planning/lane_driving/motion_planning/obstacle_velocity_limiter
  4  /planning/scenario_planning/lane_driving/motion_planning/elastic_band_smoother
  5  /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
  6  /planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker
  7  /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner
/control/control_validator_container
  1  /control/control_validator_container/container_logger_configure
  2  /control/control_validator
  3  /control/glog_validator_component
/default_ad_api/container
  1  /default_ad_api/node/autoware_state
  2  /default_ad_api/node/fail_safe
  3  /default_ad_api/node/interface
  4  /default_ad_api/node/localization
  5  /default_ad_api/node/motion
  6  /default_ad_api/node/operation_mode
  7  /default_ad_api/node/perception
  8  /default_ad_api/node/planning
  9  /default_ad_api/node/routing
  10  /default_ad_api/node/vehicle
  11  /default_ad_api/node/vehicle_info
  12  /default_ad_api/node/vehicle_door
/autoware_api/external/rtc_controller/container
  1  /autoware_api/external/rtc_controller/node
/planning/mission_planning/mission_planner_container
  1  /planning/mission_planning/container_logger_configure
  2  /planning/mission_planning/mission_planner
  3  /planning/mission_planning/route_selector
  4  /planning/mission_planning/glog_component
/system/component_state_monitor/container
  1  /system/component_state_monitor/component
/pointcloud_container
  1  /pointcloud_container/glog_component
  2  /occupancy_grid_map/pointcloud_to_laserscan_node
  3  /occupancy_grid_map/occupancy_grid_map_node
/control/control_container
  1  /control/external_cmd_converter
  2  /control/external_cmd_selector
  3  /control/trajectory_follower/controller_node_exe
  4  /control/trajectory_follower/lane_departure_checker_node
  5  /control/shift_decider
  6  /control/vehicle_cmd_gate
  7  /control/operation_mode_transition_manager
  8  /control/glog_component
/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator_container
  1  /system/mrm_emergency_stop_operator
/planning/scenario_planning/motion_velocity_smoother_container
  1  /planning/scenario_planning/container_logger_configure
  2  /planning/scenario_planning/motion_velocity_smoother
  3  /planning/scenario_planning/glog_component
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
