### PR TITLE
feat(crosswalk): restricts to enter the IGNORE status

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1075,7 +1075,7 @@ void CrosswalkModule::updateObjectState(
     object_info_manager_.update(
       obj_uuid, obj_pos, std::hypot(obj_vel.x, obj_vel.y), clock_->now(), is_ego_yielding,
       has_traffic_light, collision_point, object.classification.front().label, planner_param_,
-      crosswalk_.polygon2d().basicPolygon());
+      crosswalk_.polygon2d().basicPolygon(), attention_area);
 
     const auto collision_state = object_info_manager_.getCollisionState(obj_uuid);
     if (collision_point) {

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -180,7 +180,8 @@ public:
     void transitState(
       const rclcpp::Time & now, const geometry_msgs::msg::Point & position, const double vel,
       const bool is_ego_yielding, const std::optional<CollisionPoint> & collision_point,
-      const PlannerParam & planner_param, const lanelet::BasicPolygon2d & crosswalk_polygon)
+      const PlannerParam & planner_param, const lanelet::BasicPolygon2d & crosswalk_polygon,
+      const bool is_object_on_ego_path)
     {
       const bool is_stopped = vel < planner_param.stop_object_velocity;
 
@@ -200,7 +201,7 @@ public:
           planner_param.timeout_set_for_no_intention_to_walk, distance_to_crosswalk);
         const bool intent_to_cross =
           (now - *time_to_start_stopped).seconds() < timeout_no_intention_to_walk;
-        if (is_ego_yielding && !intent_to_cross) {
+        if (is_ego_yielding && !intent_to_cross && !is_object_on_ego_path) {
           collision_state = CollisionState::IGNORE;
           return;
         }
@@ -253,14 +254,20 @@ public:
       const std::string & uuid, const geometry_msgs::msg::Point & position, const double vel,
       const rclcpp::Time & now, const bool is_ego_yielding, const bool has_traffic_light,
       const std::optional<CollisionPoint> & collision_point, const uint8_t classification,
-      const PlannerParam & planner_param, const lanelet::BasicPolygon2d & crosswalk_polygon)
+      const PlannerParam & planner_param, const lanelet::BasicPolygon2d & crosswalk_polygon,
+      const Polygon2d & attention_area)
     {
       // update current uuids
       current_uuids_.push_back(uuid);
 
+      const bool is_object_on_ego_path =
+        boost::geometry::within(tier4_autoware_utils::fromMsg(position).to_2d(), attention_area);
+
       // add new object
       if (objects.count(uuid) == 0) {
-        if (has_traffic_light && planner_param.disable_yield_for_new_stopped_object) {
+        if (
+          has_traffic_light && planner_param.disable_yield_for_new_stopped_object &&
+          !is_object_on_ego_path) {
           objects.emplace(uuid, ObjectInfo{CollisionState::IGNORE});
         } else {
           objects.emplace(uuid, ObjectInfo{CollisionState::YIELD});
@@ -269,7 +276,8 @@ public:
 
       // update object state
       objects.at(uuid).transitState(
-        now, position, vel, is_ego_yielding, collision_point, planner_param, crosswalk_polygon);
+        now, position, vel, is_ego_yielding, collision_point, planner_param, crosswalk_polygon,
+        is_object_on_ego_path);
       objects.at(uuid).collision_point = collision_point;
       objects.at(uuid).position = position;
       objects.at(uuid).classification = classification;

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -261,7 +261,8 @@ public:
       current_uuids_.push_back(uuid);
 
       const bool is_object_on_ego_path =
-        boost::geometry::within(tier4_autoware_utils::fromMsg(position).to_2d(), attention_area);
+        boost::geometry::distance(tier4_autoware_utils::fromMsg(position).to_2d(), attention_area) <
+        0.5;
 
       // add new object
       if (objects.count(uuid) == 0) {


### PR DESCRIPTION
## Description
restricts to enter the IGNORE status for the objects is on the ego's path
[Screencast from 04-17-2024 08:06:50 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/141538661/0b8886c8-9418-4ee3-95c4-8107e88da200)


## Tests performed
psim and tier4 internal tests were performed

## Effects on system behavior


Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
