### PR TITLE
fix(image_projection_based_fusion): add intensity field for roi_pointcloud_fusion

### DIFF
--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/utils.hpp
@@ -54,6 +54,12 @@ namespace image_projection_based_fusion
 {
 
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+using PointCloud2 = sensor_msgs::msg::PointCloud2;
+struct PointData
+{
+  float distance;
+  size_t orig_index;
+};
 std::optional<geometry_msgs::msg::TransformStamped> getTransformStamped(
   const tf2_ros::Buffer & tf_buffer, const std::string & target_frame_id,
   const std::string & source_frame_id, const rclcpp::Time & time);
@@ -63,15 +69,16 @@ Eigen::Affine3d transformToEigen(const geometry_msgs::msg::Transform & t);
 void convertCluster2FeatureObject(
   const std_msgs::msg::Header & header, const PointCloud & cluster,
   DetectedObjectWithFeature & feature_obj);
-PointCloud closest_cluster(
-  PointCloud & cluster, const double cluster_2d_tolerance, const int min_cluster_size,
-  const pcl::PointXYZ & center);
+void closest_cluster(
+  const PointCloud2 & cluster, const double cluster_2d_tolerance, const int min_cluster_size,
+  const pcl::PointXYZ & center, PointCloud2 & out_cluster);
 
 void updateOutputFusedObjects(
-  std::vector<DetectedObjectWithFeature> & output_objs, const std::vector<PointCloud> & clusters,
-  const std_msgs::msg::Header & in_cloud_header, const std_msgs::msg::Header & in_roi_header,
-  const tf2_ros::Buffer & tf_buffer, const int min_cluster_size, const int max_cluster_size,
-  const float cluster_2d_tolerance, std::vector<DetectedObjectWithFeature> & output_fused_objects);
+  std::vector<DetectedObjectWithFeature> & output_objs, std::vector<PointCloud2> & clusters,
+  const std::vector<size_t> clusters_data_size, const PointCloud2 & in_cloud,
+  const std_msgs::msg::Header & in_roi_header, const tf2_ros::Buffer & tf_buffer,
+  const int min_cluster_size, const int max_cluster_size, const float cluster_2d_tolerance,
+  std::vector<DetectedObjectWithFeature> & output_fused_objects);
 
 geometry_msgs::msg::Point getCentroid(const sensor_msgs::msg::PointCloud2 & pointcloud);
 

--- a/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -36,6 +36,7 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
   fuse_unknown_only_ = declare_parameter<bool>("fuse_unknown_only");
   min_cluster_size_ = declare_parameter<int>("min_cluster_size");
   max_cluster_size_ = declare_parameter<int>("max_cluster_size");
+  max_cluster_size_ = declare_parameter<int>("max_cluster_size");
   cluster_2d_tolerance_ = declare_parameter<double>("cluster_2d_tolerance");
   pub_objects_ptr_ =
     this->create_publisher<DetectedObjectsWithFeature>("output_clusters", rclcpp::QoS{1});
@@ -115,26 +116,37 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
     }
     transform_stamped = transform_stamped_optional.value();
   }
+  int point_step = input_pointcloud_msg.point_step;
+  int x_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "x")].offset;
+  int y_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "y")].offset;
+  int z_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "z")].offset;
 
   sensor_msgs::msg::PointCloud2 transformed_cloud;
   tf2::doTransform(input_pointcloud_msg, transformed_cloud, transform_stamped);
 
-  std::vector<PointCloud> clusters;
+  std::vector<sensor_msgs::msg::PointCloud2> clusters;
+  std::vector<size_t> clusters_data_size;
   clusters.resize(output_objs.size());
-
-  for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(transformed_cloud, "x"),
-       iter_y(transformed_cloud, "y"), iter_z(transformed_cloud, "z"),
-       iter_orig_x(input_pointcloud_msg, "x"), iter_orig_y(input_pointcloud_msg, "y"),
-       iter_orig_z(input_pointcloud_msg, "z");
-       iter_x != iter_x.end();
-       ++iter_x, ++iter_y, ++iter_z, ++iter_orig_x, ++iter_orig_y, ++iter_orig_z) {
-    if (*iter_z <= 0.0) {
+  for (auto & cluster : clusters) {
+    cluster.point_step = input_pointcloud_msg.point_step;
+    cluster.height = input_pointcloud_msg.height;
+    cluster.data.resize(max_cluster_size_ * input_pointcloud_msg.point_step);
+    clusters_data_size.push_back(0);
+  }
+  for (size_t offset = 0; offset < input_pointcloud_msg.data.size(); offset += point_step) {
+    const float transformed_x =
+      *reinterpret_cast<const float *>(&transformed_cloud.data[offset + x_offset]);
+    const float transformed_y =
+      *reinterpret_cast<const float *>(&transformed_cloud.data[offset + y_offset]);
+    const float transformed_z =
+      *reinterpret_cast<const float *>(&transformed_cloud.data[offset + z_offset]);
+    if (transformed_z <= 0.0) {
       continue;
     }
-    Eigen::Vector4d projected_point = projection * Eigen::Vector4d(*iter_x, *iter_y, *iter_z, 1.0);
+    Eigen::Vector4d projected_point =
+      projection * Eigen::Vector4d(transformed_x, transformed_y, transformed_z, 1.0);
     Eigen::Vector2d normalized_projected_point = Eigen::Vector2d(
       projected_point.x() / projected_point.z(), projected_point.y() / projected_point.z());
-
     for (std::size_t i = 0; i < output_objs.size(); ++i) {
       auto & feature_obj = output_objs.at(i);
       const auto & check_roi = feature_obj.feature.roi;
@@ -146,16 +158,37 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
         check_roi.x_offset <= normalized_projected_point.x() &&
         check_roi.y_offset <= normalized_projected_point.y() &&
         check_roi.x_offset + check_roi.width >= normalized_projected_point.x() &&
-        check_roi.y_offset + check_roi.height >= normalized_projected_point.y()) {
-        cluster.push_back(pcl::PointXYZ(*iter_orig_x, *iter_orig_y, *iter_orig_z));
+        check_roi.y_offset + check_roi.height >= normalized_projected_point.y() &&
+        clusters_data_size.at(i) < static_cast<size_t>(max_cluster_size_ * point_step)) {
+        std::memcpy(
+          &cluster.data[clusters_data_size.at(i)], &input_pointcloud_msg.data[offset], point_step);
+        clusters_data_size.at(i) += point_step;
       }
     }
   }
 
-  // refine and update output_fused_objects_
-  updateOutputFusedObjects(
-    output_objs, clusters, input_pointcloud_msg.header, input_roi_msg.header, tf_buffer_,
-    min_cluster_size_, max_cluster_size_, cluster_2d_tolerance_, output_fused_objects_);
+  for (size_t i = 0; i < output_objs.size(); ++i) {
+    auto & feature_obj = output_objs.at(i);
+    auto & cluster = clusters.at(i);
+    if (
+      clusters_data_size.at(i) < static_cast<size_t>(min_cluster_size_ * point_step) ||
+      clusters_data_size.at(i) >= static_cast<size_t>(max_cluster_size_ * point_step)) {
+      continue;
+    }
+    cluster.data.resize(clusters_data_size.at(i));
+    cluster.width = clusters_data_size.at(i) / point_step / input_pointcloud_msg.height;
+    cluster.row_step = clusters_data_size.at(i) / input_pointcloud_msg.height;
+    cluster.is_bigendian = input_pointcloud_msg.is_bigendian;
+    cluster.is_dense = input_pointcloud_msg.is_dense;
+    cluster.header = input_pointcloud_msg.header;
+    cluster.fields = input_pointcloud_msg.fields;
+
+    feature_obj.feature.cluster = cluster;
+    feature_obj.object.kinematics.pose_with_covariance.pose.position = getCentroid(cluster);
+    feature_obj.object.existence_probability = 1.0f;
+
+    output_fused_objects_.push_back(feature_obj);
+  }
 }
 
 bool RoiPointCloudFusionNode::out_of_scope(__attribute__((unused))

--- a/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -36,7 +36,6 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
   fuse_unknown_only_ = declare_parameter<bool>("fuse_unknown_only");
   min_cluster_size_ = declare_parameter<int>("min_cluster_size");
   max_cluster_size_ = declare_parameter<int>("max_cluster_size");
-  max_cluster_size_ = declare_parameter<int>("max_cluster_size");
   cluster_2d_tolerance_ = declare_parameter<double>("cluster_2d_tolerance");
   pub_objects_ptr_ =
     this->create_publisher<DetectedObjectsWithFeature>("output_clusters", rclcpp::QoS{1});


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- To process and output the clusters' pointcloud field as input topic including `intensity` field for `roi_pointcloud_fusion` node to solve the issue https://github.com/autowarefoundation/autoware.universe/issues/6785

## Releated Linkk 
- [TIER IV INTERNAL JIRA LINK](https://tier4.atlassian.net/browse/RT1-6035)

## Tests performed
- Confirmed by logging_simulator that the node output cluster with intensity 
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/dad76e9c-2b67-46d9-99ed-1230d9163429)
- Compare the performance on traffic cones detection by roi_pointcloud_fusion node  

|    Before    |    After    |
|  --- | ---  |
|[c94c9405-edde-4fd9-8316-91091575d839_2024-04-16-09-58-15_p0900_0_n3_roi_pointcloud_original.webm](https://github.com/autowarefoundation/autoware.universe/assets/94814556/c47f68e8-ab06-48c2-994a-5a6fd6b12785) | [c94c9405-edde-4fd9-8316-91091575d839_2024-04-16-09-58-15_p0900_0_n3_roi_pointcloud_updated.webm](https://github.com/autowarefoundation/autoware.universe/assets/94814556/04d11cee-5555-42e8-a2cd-f5c407dd49e6) |
|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/a5e53d79-7e9b-421d-a266-99782b83a49b) | ![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/d208042a-65c6-4553-8dbb-0884a2cab2fd)| 


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
