### PR TITLE
revert: "feat(logger_level_configure): make it possible to change level of container logger (#6823)"

### DIFF
--- a/common/tier4_autoware_utils/CMakeLists.txt
+++ b/common/tier4_autoware_utils/CMakeLists.txt
@@ -18,11 +18,6 @@ ament_auto_add_library(tier4_autoware_utils SHARED
   src/system/backtrace.cpp
 )
 
-rclcpp_components_register_node(tier4_autoware_utils
-  PLUGIN "tier4_autoware_utils::LoggerLevelConfigureNode"
-  EXECUTABLE logger_level_configure_node
-)
-
 if(BUILD_TESTING)
   find_package(ament_cmake_ros REQUIRED)
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/logger_level_configure.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/logger_level_configure.hpp
@@ -64,10 +64,5 @@ private:
     const ConfigLogger::Response::SharedPtr response);
 };
 
-class LoggerLevelConfigureNode : public rclcpp::Node, public LoggerLevelConfigure
-{
-public:
-  explicit LoggerLevelConfigureNode(const rclcpp::NodeOptions & node_options);
-};
 }  // namespace tier4_autoware_utils
 #endif  // TIER4_AUTOWARE_UTILS__ROS__LOGGER_LEVEL_CONFIGURE_HPP_

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -23,7 +23,6 @@
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
-  <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tier4_debug_msgs</depend>

--- a/common/tier4_autoware_utils/src/ros/logger_level_configure.cpp
+++ b/common/tier4_autoware_utils/src/ros/logger_level_configure.cpp
@@ -58,11 +58,4 @@ void LoggerLevelConfigure::onLoggerConfigService(
   return;
 }
 
-LoggerLevelConfigureNode::LoggerLevelConfigureNode(const rclcpp::NodeOptions & node_options)
-: Node("logger_level_configure_node", node_options), LoggerLevelConfigure(this)
-{
-}
-
 }  // namespace tier4_autoware_utils
-#include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(tier4_autoware_utils::LoggerLevelConfigureNode)

--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -31,14 +31,12 @@ Planning:
   behavior_path_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: tier4_autoware_utils
 
   behavior_path_planner_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning
-      logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance.utils
 
   behavior_path_planner_goal_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
@@ -59,7 +57,7 @@ Planning:
   behavior_velocity_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
       logger_name: tier4_autoware_utils
 
   behavior_velocity_planner_intersection:
@@ -69,13 +67,13 @@ Planning:
   motion_obstacle_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
       logger_name: planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner
-    - node_name: /planning/scenario_planning/lane_driving/motion_planning/container_logger_configure
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
       logger_name: tier4_autoware_utils
 
   motion_velocity_smoother:
     - node_name: /planning/scenario_planning/motion_velocity_smoother
       logger_name: planning.scenario_planning.motion_velocity_smoother
-    - node_name: /planning/scenario_planning/lane_driving/motion_planning/container_logger_configure
+    - node_name: /planning/scenario_planning/motion_velocity_smoother
       logger_name: tier4_autoware_utils
 
 # ============================================================
@@ -85,19 +83,19 @@ Control:
   lateral_controller:
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: control.trajectory_follower.controller_node_exe.lateral_controller
-    - node_name: /control/container_logger_configure
+    - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: tier4_autoware_utils
 
   longitudinal_controller:
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: control.trajectory_follower.controller_node_exe.longitudinal_controller
-    - node_name: /control/container_logger_configure
+    - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: tier4_autoware_utils
 
   vehicle_cmd_gate:
     - node_name: /control/vehicle_cmd_gate
       logger_name: control.vehicle_cmd_gate
-    - node_name: /control/container_logger_configure
+    - node_name: /control/vehicle_cmd_gate
       logger_name: tier4_autoware_utils
 
 # ============================================================
@@ -106,9 +104,17 @@ Control:
 
 Common:
   tier4_autoware_utils:
-    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/container_logger_configure
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: tier4_autoware_utils
-    - node_name: /planning/scenario_planning/lane_driving/motion_planning/container_logger_configure
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
       logger_name: tier4_autoware_utils
-    - node_name: /control/container_logger_configure
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
+      logger_name: tier4_autoware_utils
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/path_smoother
+      logger_name: tier4_autoware_utils
+    - node_name: /planning/scenario_planning/motion_velocity_smoother
+      logger_name: tier4_autoware_utils
+    - node_name: /control/trajectory_follower/controller_node_exe
+      logger_name: tier4_autoware_utils
+    - node_name: /control/vehicle_cmd_gate
       logger_name: tier4_autoware_utils

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -381,12 +381,6 @@ def launch_setup(context, *args, **kwargs):
                 package="rclcpp_components",
                 executable=LaunchConfiguration("container_executable"),
                 composable_node_descriptions=[
-                    ComposableNode(
-                        package="tier4_autoware_utils",
-                        plugin="tier4_autoware_utils::LoggerLevelConfigureNode",
-                        name="container_logger_configure",
-                        namespace="control_validator_container",
-                    ),
                     control_validator_component,
                     ComposableNode(
                         package="glog_component",

--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -13,10 +13,8 @@
 
   <exec_depend>external_cmd_converter</exec_depend>
   <exec_depend>external_cmd_selector</exec_depend>
-  <exec_depend>glog_component</exec_depend>
   <exec_depend>lane_departure_checker</exec_depend>
   <exec_depend>shift_decider</exec_depend>
-  <exec_depend>tier4_autoware_utils</exec_depend>
   <exec_depend>trajectory_follower_node</exec_depend>
   <exec_depend>vehicle_cmd_gate</exec_depend>
 

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -182,7 +182,6 @@
   <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="both">
-    <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="container_logger_configure" namespace=""/>
     <composable_node pkg="behavior_path_planner" plugin="behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
       <!-- topic remap -->
       <remap from="~/input/route" to="$(var input_route_topic_name)"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -6,10 +6,6 @@
     <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
   </node_container>
 
-  <load_composable_node target="/planning/scenario_planning/lane_driving/motion_planning/motion_planning_container">
-    <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="config_logger" namespace=""/>
-  </load_composable_node>
-
   <!-- path smoothing -->
   <group>
     <group if="$(eval &quot;'$(var motion_path_smoother_type)' == 'elastic_band'&quot;)">

--- a/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -27,7 +27,6 @@
     <!-- motion velocity smoother -->
     <group>
       <node_container pkg="rclcpp_components" exec="component_container" name="motion_velocity_smoother_container" namespace="">
-        <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="container_logger_configure" namespace=""/>
         <composable_node pkg="motion_velocity_smoother" plugin="motion_velocity_smoother::MotionVelocitySmootherNode" name="motion_velocity_smoother" namespace="">
           <param name="algorithm_type" value="$(var motion_velocity_smoother_type)"/>
           <param from="$(var common_param_path)"/>

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -74,7 +74,6 @@
   <exec_depend>planning_validator</exec_depend>
   <exec_depend>scenario_selector</exec_depend>
   <exec_depend>surround_obstacle_checker</exec_depend>
-  <exec_depend>tier4_autoware_utils</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -5,7 +5,6 @@
   <arg name="mission_planner_param_path" default="$(find-pkg-share mission_planner)/config/mission_planner.param.yaml"/>
 
   <node_container pkg="rclcpp_components" exec="component_container_mt" name="mission_planner_container" namespace="">
-    <composable_node pkg="tier4_autoware_utils" plugin="tier4_autoware_utils::LoggerLevelConfigureNode" name="container_logger_configure" namespace=""/>
     <composable_node pkg="mission_planner" plugin="mission_planner::MissionPlanner" name="mission_planner" namespace="">
       <param from="$(var mission_planner_param_path)"/>
       <remap from="~/input/modified_goal" to="$(var modified_goal_topic_name)"/>


### PR DESCRIPTION
## Description

I found we don't have to create and load LoggerLevelConfigureNode to container. Sorry for confusion.

This reverts commit 51b5f830780eb69bd1a7dfe60e295773f394fd8e.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
