### PR TITLE
perf(pointcloud_preprocessor): prevent excessive log and speed up a bit

### DIFF
--- a/sensing/pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
+++ b/sensing/pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
@@ -246,43 +246,38 @@ bool DistortionCorrectorComponent::undistortPointCloud(
   bool twist_time_stamp_is_too_late = false;
   bool imu_time_stamp_is_too_late = false;
 
+  while (twist_it != std::end(twist_queue_) - 1 && first_point_time_stamp_sec > twist_stamp) {
+    ++twist_it;
+    twist_stamp = rclcpp::Time(twist_it->header.stamp).seconds();
+  }
+
+  float v{static_cast<float>(twist_it->twist.linear.x)};
+  float w{static_cast<float>(twist_it->twist.angular.z)};
+
+  if (std::abs(first_point_time_stamp_sec - twist_stamp) > 0.2) {
+    twist_time_stamp_is_too_late = true;
+    v = 0.0f;
+    w = 0.0f;
+  }
+
+  if (use_imu_ && !angular_velocity_queue_.empty()) {
+    // For performance, do not instantiate `rclcpp::Time` inside of the for-loop
+    double imu_stamp = rclcpp::Time(imu_it->header.stamp).seconds();
+
+    while (imu_it != std::end(angular_velocity_queue_) - 1 &&
+           first_point_time_stamp_sec > imu_stamp) {
+      ++imu_it;
+      imu_stamp = rclcpp::Time(imu_it->header.stamp).seconds();
+    }
+
+    if (std::abs(first_point_time_stamp_sec - imu_stamp) > 0.2) {
+      imu_time_stamp_is_too_late = true;
+    } else {
+      w = static_cast<float>(imu_it->vector.z);
+    }
+  }
+
   for (; it_x != it_x.end(); ++it_x, ++it_y, ++it_z, ++it_time_stamp) {
-    while (twist_it != std::end(twist_queue_) - 1 && *it_time_stamp > twist_stamp) {
-      ++twist_it;
-      twist_stamp = rclcpp::Time(twist_it->header.stamp).seconds();
-    }
-
-    float v{static_cast<float>(twist_it->twist.linear.x)};
-    float w{static_cast<float>(twist_it->twist.angular.z)};
-
-    if (std::abs(*it_time_stamp - twist_stamp) > 0.1) {
-      twist_time_stamp_is_too_late = true;
-      v = 0.0f;
-      w = 0.0f;
-    }
-
-    if (use_imu_ && !angular_velocity_queue_.empty()) {
-      // For performance, do not instantiate `rclcpp::Time` inside of the for-loop
-      double imu_stamp = rclcpp::Time(imu_it->header.stamp).seconds();
-
-      for (;
-           (imu_it != std::end(angular_velocity_queue_) - 1 &&
-            *it_time_stamp > rclcpp::Time(imu_it->header.stamp).seconds());
-           ++imu_it) {
-      }
-
-      while (imu_it != std::end(angular_velocity_queue_) - 1 && *it_time_stamp > imu_stamp) {
-        ++imu_it;
-        imu_stamp = rclcpp::Time(imu_it->header.stamp).seconds();
-      }
-
-      if (std::abs(*it_time_stamp - imu_stamp) > 0.1) {
-        imu_time_stamp_is_too_late = true;
-      } else {
-        w = static_cast<float>(imu_it->vector.z);
-      }
-    }
-
     const auto time_offset = static_cast<float>(*it_time_stamp - prev_time_stamp_sec);
 
     point.setValue(*it_x, *it_y, *it_z);


### PR DESCRIPTION
## Description

This PR contains two changes:

1. Avoiding calling `RCLCPP_WARN_STREAM_THROTTLE` for a number of points
2. Removing unnecessary `for` loops and `rclcpp::Time` class instantiations

**`RCLCPP_WARN_STREAM_THROTTLE` takes some processing time even if it does not actually output logs**, so calling it for a number of points would take a very long time. :sob:   In practice, printing once per point cloud is sufficient, so I made that change.

The second change provides a slight speedup. In my environment (with about 300,000 points), it resulted in a maximum speedup of about **10 ms**.

---

Also, if the distortion_corrector is delayed for some reason, the following scenario occurs, which is fatal:

1. Processing is significantly delayed for some reason.
2. Twist and IMU are stored in the queue at the correct time, so regardless of which data is paired with the point cloud, the stamp difference is large.
3. When the stamp difference is large, `RCLCPP_WARN_STREAM_THROTTLE` is called for each point cloud (~300,000 times).
4. Even if `RCLCPP_WARN_STREAM_THROTTLE` does not output logs, calling it many times takes a lot of time.
5. If step 4 takes too long, the stamp difference for matching between the vehicle speed and IMU in subsequent iterations also becomes large.
6. Return to step 2 and repeat indefinitely.

When it actually happens, it looks like the image below. This PR resolves this issue.

<img src=https://github.com/autowarefoundation/autoware.universe/assets/24854875/b893eef7-686b-4f77-94c6-2dced2310c5d width="400"> 


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I ran the logging_simulator on the sample data and measured the processing time. Unfortunately, there was minimal improvement in processing speed with the sample data.
The following graph shows the processing time for two runs before and after the changes. The vertical axis represents processing_time_ms. While there was little effect in the beginning, an improvement can be observed around 80-85 seconds

![compare_distortion_corrector](https://github.com/autowarefoundation/autoware.universe/assets/24854875/65fb6ef4-2d7e-4a89-9808-1e2c6adaa544)

Also, in my environment (with about 300,000 points), it resulted in a maximum speedup of about 10 ms.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The system behavior does not change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
