### PR TITLE
fix(voxel_grid_downsample_filter): add intensity field

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -85,7 +85,7 @@ class PointcloudMapFilterPipeline:
         components.append(
             ComposableNode(
                 package="pointcloud_preprocessor",
-                plugin="pointcloud_preprocessor::ApproximateDownsampleFilterComponent",
+                plugin="pointcloud_preprocessor::VoxelGridDownsampleFilterComponent",
                 name="voxel_grid_downsample_filter",
                 remappings=[
                     ("input", LaunchConfiguration("input_topic")),

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/faster_voxel_grid_downsample_filter.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/faster_voxel_grid_downsample_filter.hpp
@@ -45,16 +45,22 @@ private:
     float x;
     float y;
     float z;
+    float intensity;
     uint32_t point_count_;
 
-    Centroid() : x(0), y(0), z(0) {}
-    Centroid(float _x, float _y, float _z) : x(_x), y(_y), z(_z) { this->point_count_ = 1; }
+    Centroid() : x(0), y(0), z(0), intensity(-1.0) {}
+    Centroid(float _x, float _y, float _z, float _intensity)
+    : x(_x), y(_y), z(_z), intensity(_intensity)
+    {
+      this->point_count_ = 1;
+    }
 
-    void add_point(float _x, float _y, float _z)
+    void add_point(float _x, float _y, float _z, float _intensity)
     {
       this->x += _x;
       this->y += _y;
       this->z += _z;
+      this->intensity += _intensity;
       this->point_count_++;
     }
 
@@ -62,20 +68,20 @@ private:
     {
       Eigen::Vector4f centroid(
         (this->x / this->point_count_), (this->y / this->point_count_),
-        (this->z / this->point_count_), 1.0f);
+        (this->z / this->point_count_), (this->intensity / this->point_count_));
       return centroid;
     }
   };
 
   Eigen::Vector3f inverse_voxel_size_;
-  std::vector<pcl::PCLPointField> xyz_fields_;
   int x_offset_;
   int y_offset_;
   int z_offset_;
+  int intensity_index_;
   int intensity_offset_;
   bool offset_initialized_;
 
-  Eigen::Vector3f get_point_from_global_offset(
+  Eigen::Vector4f get_point_from_global_offset(
     const PointCloud2ConstPtr & input, size_t global_offset);
 
   bool get_min_max_voxel(


### PR DESCRIPTION
## Description

- To process and output the intensity field for `voxel_grid_downsample_filter` to solve the issue https://github.com/autowarefoundation/autoware.universe/issues/6785
- As internal discuss, this PR will assign intensity for centroid pointcloud by using the average intensity of the points inside the voxel.

## Related Link 
- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-6007)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
- Confirmed by logging_simulator that `pointcloud_map_filtered/downsampled/pointcloud` node is able to output pointcloud with intensity within 16bytes
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/fbd9759d-6c78-4d72-8d20-7005335c1a47)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
