### PR TITLE
feat: add low_intensity_cluster_filter

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -8,7 +8,7 @@
   <!-- Lidar + Camera detector parameters -->
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="use_roi_based_cluster" default="false"/>
-  <arg name="use_low_intensity_cluster_filter" default="true"/>
+  <arg name="use_low_intensity_cluster_filter" default="false"/>
 
   <!-- Camera parameters -->
   <arg name="image_raw0" default="/image_raw" description="image raw topic name"/>
@@ -209,19 +209,19 @@
         </include>
       </group>
 
-      <!-- add intensity validator -->
+      <!-- low_intensity_cluster_filter -->
       <group>
-        <include file="$(find-pkg-share detected_object_validation)/launch/low_intensity_cluster_filter.launch.xml" if="$(var use_low_intensity_cluster_filter)">
+        <include file="$(find-pkg-share raindrop_cluster_filter)/launch/low_intensity_cluster_filter.launch.xml" if="$(var use_low_intensity_cluster_filter)">
           <arg name="input/objects" value="clusters"/>
           <arg name="output/objects" value="filtered/clusters"/>
         </include>
       </group>
 
       <group>
-        <let name="input/clusters" value="filtered/clusters" if="$(var use_low_intensity_cluster_filter)"/>
-        <let name="input/clusters" value="clusters" unless="$(var use_low_intensity_cluster_filter)"/>
+        <let name="shape_estimation/input" value="filtered/clusters" if="$(var use_low_intensity_cluster_filter)"/>
+        <let name="shape_estimation/input" value="clusters" unless="$(var use_low_intensity_cluster_filter)"/>
         <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
-          <arg name="input/objects" value="$(var input/clusters)"/>
+          <arg name="input/objects" value="$(var shape_estimation/input)"/>
           <arg name="output/objects" value="objects_with_feature"/>
         </include>
       </group>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -8,6 +8,7 @@
   <!-- Lidar + Camera detector parameters -->
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="use_roi_based_cluster" default="false"/>
+  <arg name="use_low_intensity_cluster_filter" default="true"/>
 
   <!-- Camera parameters -->
   <arg name="image_raw0" default="/image_raw" description="image raw topic name"/>
@@ -208,9 +209,19 @@
         </include>
       </group>
 
+      <!-- add intensity validator -->
       <group>
-        <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+        <include file="$(find-pkg-share detected_object_validation)/launch/low_intensity_cluster_filter.launch.xml" if="$(var use_low_intensity_cluster_filter)">
           <arg name="input/objects" value="clusters"/>
+          <arg name="output/objects" value="filtered/clusters"/>
+        </include>
+      </group>
+
+      <group>
+        <let name="input/clusters" value="filtered/clusters" if="$(var use_low_intensity_cluster_filter)"/>
+        <let name="input/clusters" value="clusters" unless="$(var use_low_intensity_cluster_filter)"/>
+        <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+          <arg name="input/objects" value="$(var input/clusters)"/>
           <arg name="output/objects" value="objects_with_feature"/>
         </include>
       </group>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -77,6 +77,7 @@
   <arg name="use_low_height_cropbox" default="true" description="use low height crop filter in clustering"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_roi_based_cluster" default="true" description="use roi_based_cluster in clustering"/>
+  <arg name="use_low_intensity_cluster_filter" default="false" description="use low_intensity_cluster_filter in clustering"/>
   <arg
     name="use_empty_dynamic_object_publisher"
     default="false"

--- a/perception/raindrop_cluster_filter/CMakeLists.txt
+++ b/perception/raindrop_cluster_filter/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+project(raindrop_cluster_filter)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+# find dependencies
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+# Targets
+ament_auto_add_library(low_intensity_cluster_filter SHARED
+  src/low_intensity_cluster_filter.cpp
+)
+
+rclcpp_components_register_node(low_intensity_cluster_filter
+  PLUGIN "low_intensity_cluster_filter::LowIntensityClusterFilter"
+  EXECUTABLE low_intensity_cluster_filter_node)
+
+
+if(BUILD_TESTING)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/perception/raindrop_cluster_filter/config/low_intensity_cluster_filter.param.yaml
+++ b/perception/raindrop_cluster_filter/config/low_intensity_cluster_filter.param.yaml
@@ -1,0 +1,17 @@
+/**:
+  ros__parameters:
+    intensity_threshold: 1.0
+    existence_probability_threshold: 0.2
+    max_x: 60.0
+    min_x: -20.0
+    max_y: 20.0
+    min_y: -20.0
+    filter_target_label:
+      UNKNOWN: true
+      CAR: false
+      TRUCK: false
+      BUS: false
+      TRAILER: false
+      MOTORCYCLE: false
+      BICYCLE: false
+      PEDESTRIAN: false

--- a/perception/raindrop_cluster_filter/include/raindrop_cluster_filter/low_intensity_cluster_filter/low_intensity_cluster_filter.hpp
+++ b/perception/raindrop_cluster_filter/include/raindrop_cluster_filter/low_intensity_cluster_filter/low_intensity_cluster_filter.hpp
@@ -28,6 +28,7 @@
 // #include <tf2_eigen/tf2_eigen.hpp>
 #include <Eigen/Eigen>
 
+#include <memory>
 #include <string>
 
 namespace low_intensity_cluster_filter

--- a/perception/raindrop_cluster_filter/include/raindrop_cluster_filter/low_intensity_cluster_filter/low_intensity_cluster_filter.hpp
+++ b/perception/raindrop_cluster_filter/include/raindrop_cluster_filter/low_intensity_cluster_filter/low_intensity_cluster_filter.hpp
@@ -1,0 +1,77 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RAINDROP_CLUSTER_FILTER__LOW_INTENSITY_CLUSTER_FILTER__LOW_INTENSITY_CLUSTER_FILTER_HPP_
+#define RAINDROP_CLUSTER_FILTER__LOW_INTENSITY_CLUSTER_FILTER__LOW_INTENSITY_CLUSTER_FILTER_HPP_
+
+#include "detected_object_validation/utils/utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/debug_publisher.hpp>
+#include <tier4_autoware_utils/system/stop_watch.hpp>
+
+#include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+// #include <tf2_eigen/tf2_eigen.hpp>
+#include <Eigen/Eigen>
+
+#include <string>
+
+namespace low_intensity_cluster_filter
+{
+
+class LowIntensityClusterFilter : public rclcpp::Node
+{
+public:
+  explicit LowIntensityClusterFilter(const rclcpp::NodeOptions & node_options);
+
+private:
+  void objectCallback(
+    const tier4_perception_msgs::msg::DetectedObjectsWithFeature::ConstSharedPtr input_msg);
+  bool isValidatedCluster(const sensor_msgs::msg::PointCloud2 & cluster);
+
+  rclcpp::Publisher<tier4_perception_msgs::msg::DetectedObjectsWithFeature>::SharedPtr object_pub_;
+  rclcpp::Subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>::SharedPtr
+    object_sub_;
+
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  double intensity_threshold_;
+  double existence_probability_threshold_;
+  double max_x_;
+  double min_x_;
+  double max_y_;
+  double min_y_;
+
+  double max_x_transformed_;
+  double min_x_transformed_;
+  double max_y_transformed_;
+  double min_y_transformed_;
+  // Eigen::Vector4f min_boundary_transformed_;
+  // Eigen::Vector4f max_boundary_transformed_;
+  bool is_validation_range_transformed_ = false;
+  const std::string base_link_frame_id_ = "base_link";
+  utils::FilterTargetLabel filter_target_;
+
+  // debugger
+  std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
+    nullptr};
+  std::unique_ptr<tier4_autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
+};
+
+}  // namespace low_intensity_cluster_filter
+
+#endif  // RAINDROP_CLUSTER_FILTER__LOW_INTENSITY_CLUSTER_FILTER__LOW_INTENSITY_CLUSTER_FILTER_HPP_

--- a/perception/raindrop_cluster_filter/launch/low_intensity_cluster_filter.launch.xml
+++ b/perception/raindrop_cluster_filter/launch/low_intensity_cluster_filter.launch.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="input/objects" default="/perception/object_recognition/detection/clustering/objects_with_feature"/>
+  <arg name="output/objects" default="/perception/object_recognition/detection/clustering/validated_objects_with_feature"/>
+
+  <arg name="low_intensity_cluster_filter_param_path" default="$(find-pkg-share raindrop_cluster_filter)/config/low_intensity_cluster_filter.param.yaml"/>
+
+  <node pkg="raindrop_cluster_filter" exec="low_intensity_cluster_filter_node" name="low_intensity_cluster_filter_node" output="screen">
+    <remap from="input/objects" to="$(var input/objects)"/>
+    <remap from="output/objects" to="$(var output/objects)"/>
+    <param name="input_obstacle_pointcloud" value="false"/>
+    <param from="$(var low_intensity_cluster_filter_param_path)"/>
+  </node>
+</launch>

--- a/perception/raindrop_cluster_filter/package.xml
+++ b/perception/raindrop_cluster_filter/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>raindrop_cluster_filter</name>
+  <version>0.1.0</version>
+  <description>The ROS 2 filter cluster package</description>
+  <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
+  <maintainer email="dai.nguyen@tier4.jp">Dai Nguyen</maintainer>
+  <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="dai.nguyen@tier4.jp">Dai Nguyen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>detected_object_validation</depend>
+  <depend>lanelet2_extension</depend>
+  <depend>message_filters</depend>
+  <depend>nav_msgs</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_autoware_utils</depend>
+  <depend>tier4_perception_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/perception/raindrop_cluster_filter/package.xml
+++ b/perception/raindrop_cluster_filter/package.xml
@@ -11,6 +11,7 @@
   <author email="dai.nguyen@tier4.jp">Dai Nguyen</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>detected_object_validation</depend>
   <depend>lanelet2_extension</depend>
   <depend>message_filters</depend>

--- a/perception/raindrop_cluster_filter/raindrop_cluster_filter.md
+++ b/perception/raindrop_cluster_filter/raindrop_cluster_filter.md
@@ -1,0 +1,54 @@
+# low_intensity_cluster_filter
+
+## Purpose
+
+The `low_intensity_cluster_filter` is a node that filters clusters based on the intensity of their pointcloud.
+
+Mainly this focuses on filtering out unknown objects with very low intensity pointcloud, such as fail detection of unknown objects caused by raindrop or water splash from ego or other fast moving vehicles.
+
+## Inner-workings / Algorithms
+
+## Inputs / Outputs
+
+### Input
+
+| Name           | Type                                                     | Description            |
+| -------------- | -------------------------------------------------------- | ---------------------- |
+| `input/object` | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | input detected objects |
+
+### Output
+
+| Name            | Type                                                     | Description               |
+| --------------- | -------------------------------------------------------- | ------------------------- |
+| `output/object` | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | filtered detected objects |
+
+## Parameters
+
+### Core Parameters
+
+| Name                              | Type  | Default Value                                           | Description                                   |
+| --------------------------------- | ----- | ------------------------------------------------------- | --------------------------------------------- |
+| `filter_target_label.UNKNOWN`     | bool  | false                                                   | If true, unknown objects are filtered.        |
+| `filter_target_label.CAR`         | bool  | false                                                   | If true, car objects are filtered.            |
+| `filter_target_label.TRUCK`       | bool  | false                                                   | If true, truck objects are filtered.          |
+| `filter_target_label.BUS`         | bool  | false                                                   | If true, bus objects are filtered.            |
+| `filter_target_label.TRAILER`     | bool  | false                                                   | If true, trailer objects are filtered.        |
+| `filter_target_label.MOTORCYCLE`  | bool  | false                                                   | If true, motorcycle objects are filtered.     |
+| `filter_target_label.BICYCLE`     | bool  | false                                                   | If true, bicycle objects are filtered.        |
+| `filter_target_label.PEDESTRIAN`  | bool  | false                                                   | If true, pedestrian objects are filtered.     |
+| `max_x`                           | float | 60.00                                                   | Maximum of x of the filter effective range    |
+| `min_x`                           | float | -20.00                                                  | Minimum of x of the filter effective range    |
+| `max_y`                           | float | 20.00                                                   | Maximum of y of the filter effective range    |
+| `min_y`                           | float | -20.00                                                  | Minium of y of the filter effective range     |
+| `intensity_threshold`             | float | 1.0                                                     | The threshold of average intensity for filter |
+| `existence_probability_threshold` | float | The existence probability threshold to apply the filter |
+
+## Assumptions / Known limits
+
+## (Optional) Error detection and handling
+
+## (Optional) Performance characterization
+
+## (Optional) References/External links
+
+## (Optional) Future extensions / Unimplemented parts

--- a/perception/raindrop_cluster_filter/src/low_intensity_cluster_filter.cpp
+++ b/perception/raindrop_cluster_filter/src/low_intensity_cluster_filter.cpp
@@ -1,0 +1,141 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "raindrop_cluster_filter/low_intensity_cluster_filter/low_intensity_cluster_filter.hpp"
+
+#include <pcl_ros/transforms.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <pcl_conversions/pcl_conversions.h>
+namespace low_intensity_cluster_filter
+{
+LowIntensityClusterFilter::LowIntensityClusterFilter(const rclcpp::NodeOptions & node_options)
+: Node("low_intensity_cluster_filter_node", node_options),
+  tf_buffer_(this->get_clock()),
+  tf_listener_(tf_buffer_)
+{
+  intensity_threshold_ = declare_parameter<double>("intensity_threshold");
+  existence_probability_threshold_ = declare_parameter<double>("existence_probability_threshold");
+  max_x_ = declare_parameter<double>("max_x");
+  min_x_ = declare_parameter<double>("min_x");
+  max_y_ = declare_parameter<double>("max_y");
+  min_y_ = declare_parameter<double>("min_y");
+
+  filter_target_.UNKNOWN = declare_parameter<bool>("filter_target_label.UNKNOWN");
+  filter_target_.CAR = declare_parameter<bool>("filter_target_label.CAR");
+  filter_target_.TRUCK = declare_parameter<bool>("filter_target_label.TRUCK");
+  filter_target_.BUS = declare_parameter<bool>("filter_target_label.BUS");
+  filter_target_.TRAILER = declare_parameter<bool>("filter_target_label.TRAILER");
+  filter_target_.MOTORCYCLE = declare_parameter<bool>("filter_target_label.MOTORCYCLE");
+  filter_target_.BICYCLE = declare_parameter<bool>("filter_target_label.BICYCLE");
+  filter_target_.PEDESTRIAN = declare_parameter<bool>("filter_target_label.PEDESTRIAN");
+
+  using std::placeholders::_1;
+  // Set publisher/subscriber
+  object_sub_ = this->create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+    "input/objects", rclcpp::QoS{1},
+    std::bind(&LowIntensityClusterFilter::objectCallback, this, _1));
+  object_pub_ = this->create_publisher<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+    "output/objects", rclcpp::QoS{1});
+  // initialize debug tool
+  {
+    using tier4_autoware_utils::DebugPublisher;
+    using tier4_autoware_utils::StopWatch;
+    stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
+    debug_publisher_ptr_ =
+      std::make_unique<DebugPublisher>(this, "low_intensity_cluster_filter_node");
+    stop_watch_ptr_->tic("cyclic_time");
+    stop_watch_ptr_->tic("processing_time");
+  }
+}
+
+void LowIntensityClusterFilter::objectCallback(
+  const tier4_perception_msgs::msg::DetectedObjectsWithFeature::ConstSharedPtr input_msg)
+{
+  // Guard
+  stop_watch_ptr_->toc("processing_time", true);
+  if (object_pub_->get_subscription_count() < 1) return;
+
+  tier4_perception_msgs::msg::DetectedObjectsWithFeature output_object_msg;
+  output_object_msg.header = input_msg->header;
+  geometry_msgs::msg::TransformStamped transform_stamp;
+  try {
+    transform_stamp = tf_buffer_.lookupTransform(
+      input_msg->header.frame_id, base_link_frame_id_, tf2_ros::fromMsg(input_msg->header.stamp));
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR(get_logger(), "Failed to lookup transform: %s", ex.what());
+    return;
+  }
+  geometry_msgs::msg::Pose min_range;
+  min_range.position.x = min_x_;
+  min_range.position.y = min_y_;
+  geometry_msgs::msg::Pose max_pose;
+  max_pose.position.x = max_x_;
+  max_pose.position.y = max_y_;
+  auto min_ranged_transformed = tier4_autoware_utils::transformPose(min_range, transform_stamp);
+  auto max_range_transformed = tier4_autoware_utils::transformPose(max_pose, transform_stamp);
+  for (const auto & feature_object : input_msg->feature_objects) {
+    const auto & object = feature_object.object;
+    const auto & label = object.classification.front().label;
+    const auto & feature = feature_object.feature;
+    const auto & cluster = feature.cluster;
+    const auto existence_probability = object.existence_probability;
+    const auto & position = object.kinematics.pose_with_covariance.pose.position;
+    bool is_inside_validation_range = min_ranged_transformed.position.x < position.x &&
+                                      position.x < max_range_transformed.position.x &&
+                                      min_ranged_transformed.position.y < position.x &&
+                                      position.y < max_range_transformed.position.y;
+    int intensity_index = pcl::getFieldIndex(cluster, "intensity");
+    if (
+      intensity_index != -1 && filter_target_.isTarget(label) && is_inside_validation_range &&
+      !isValidatedCluster(cluster) && existence_probability < existence_probability_threshold_) {
+      continue;
+    }
+    output_object_msg.feature_objects.emplace_back(feature_object);
+  }
+  object_pub_->publish(output_object_msg);
+  if (debug_publisher_ptr_ && stop_watch_ptr_) {
+    const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
+    const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
+    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/cyclic_time_ms", cyclic_time_ms);
+    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/processing_time_ms", processing_time_ms);
+  }
+}
+bool LowIntensityClusterFilter::isValidatedCluster(const sensor_msgs::msg::PointCloud2 & cluster)
+{
+  double mean_intensity = 0.0;
+  if (cluster.point_step < 16) {
+    RCLCPP_WARN(get_logger(), "Invalid point cloud data. point_step is less than 16.");
+    return true;
+  }
+  for (sensor_msgs::PointCloud2ConstIterator<float> iter(cluster, "intensity"); iter != iter.end();
+       ++iter) {
+    mean_intensity += *iter;
+  }
+  const size_t num_points = cluster.width * cluster.height;
+  mean_intensity /= static_cast<double>(num_points);
+  if (mean_intensity > intensity_threshold_) {
+    return true;
+  }
+  return false;
+}
+
+}  // namespace low_intensity_cluster_filter
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(low_intensity_cluster_filter::LowIntensityClusterFilter)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- This PR to add a new node called `low_intensity_cluster_filter` which mainly focus on filtering known objects with very low intensity pointcloud such as raindrop or water splash to solve issue: https://github.com/autowarefoundation/autoware.universe/issues/6785 

## Related links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-6030)

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

- I have tested on [internal rosbag](https://console.data-search.tier4.jp/projects/prd_jt/environments/559b0634-c871-40e6-876e-0c57b20f7fe1/rosbags/c8a0b111-8b67-4a51-a27b-2773b6f19954) and confirmed by `logging_simulator` and `perception_online_evaluator` tool that the unknown objects number in `/perception/object_recognition/objects` has been decreased. 

| Before | After | 
| -- | -- |
![before](https://github.com/autowarefoundation/autoware.universe/assets/94814556/1cba40eb-6c02-4d47-82a2-b6759b3f4273)| ![after](https://github.com/autowarefoundation/autoware.universe/assets/94814556/2104640e-7d59-48e5-8901-fb1cb57a97ea) | 

Red Unknown Polygon: Before change
White Unknown Polygon: After change
[Screencast from 2024年05月08日 21時51分48秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/94814556/27cbdb16-62ae-47bc-9935-033135605632)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
