### PR TITLE
fix(mpc_lateral_controller): align the initial steering angle in MPC with the actual steering angle

### DIFF
--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -295,7 +295,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
     for (auto & value : m_mpc->m_input_buffer) {
       value = m_ctrl_cmd_prev.steering_tire_angle;
     }
-    // Use previous command value as previous raw steer command
+    // Use previous current steering angle as previous raw steer command (offset) to set the constraints
     m_mpc->m_raw_steer_cmd_prev = m_current_steering.steering_tire_angle;
     return createLateralOutput(m_ctrl_cmd_prev, false);
   }

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -296,7 +296,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
       value = m_ctrl_cmd_prev.steering_tire_angle;
     }
     // Use previous command value as previous raw steer command
-    m_mpc->m_raw_steer_cmd_prev = m_current_steering;
+    m_mpc->m_raw_steer_cmd_prev = m_current_steering.steering_tire_angle;
     return createLateralOutput(m_ctrl_cmd_prev, false);
   }
 

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -293,7 +293,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   if (isStoppedState()) {
     // Reset input buffer
     for (auto & value : m_mpc->m_input_buffer) {
-      value = m_ctrl_cmd_prev.steering_tire_angle;
+      value = m_current_steering.steering_tire_angle;
     }
     // Use previous current steering angle as previous raw steer command (offset) to set the constraints
     m_mpc->m_raw_steer_cmd_prev = m_current_steering.steering_tire_angle;

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -296,7 +296,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
       value = m_ctrl_cmd_prev.steering_tire_angle;
     }
     // Use previous command value as previous raw steer command
-    m_mpc->m_raw_steer_cmd_prev = m_ctrl_cmd_prev.steering_tire_angle;
+    m_mpc->m_raw_steer_cmd_prev = m_current_steering;
     return createLateralOutput(m_ctrl_cmd_prev, false);
   }
 


### PR DESCRIPTION
## Description

Some cases can diverge the actual steering angle and the desired steering angle from MPC.
    e.g., changing from manual to auto will introduce a transient where the aforementioned steering angles are not identical.

The effect of this difference is displayed below:


https://github.com/autowarefoundation/autoware.universe/assets/80969277/1ac70af6-d514-49c7-93c2-e6513b16f456



![image](https://github.com/autowarefoundation/autoware.universe/assets/80969277/f741bd74-8190-4622-afc8-9d926bc68d88)
**Blue**: _MPC result._  **Green:** _actual steering angle._

This PR solves this problem by correcting the assignments when `isStoppedState()` is activated:

**1. correct the offset of the constraints.**
`m_raw_steer_cmd_prev` serves as the offset for the constraints. https://github.com/autowarefoundation/autoware.universe/blob/main/control/mpc_lateral_controller/src/mpc.cpp#L583-L584

This offset should be aligned with the current actual steering angle, rather than the previous MPC results.

**2. correct the buffer.**

`m_input_buffer` is programmed to predict the state of the vehicle.
https://github.com/autowarefoundation/autoware.universe/blob/main/control/mpc_lateral_controller/src/mpc.cpp#L362-L381

When `isStoppedState()` is activated, `m_input_buffer` could be assigned to the actual steering angle, rather than the previous MPC results, to make a prediction of higher precision.

## Related links

https://tier4.atlassian.net/browse/RT0-31121

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
