### PR TITLE
feat(goal_planner): align z-height of road_shoulder

### DIFF
--- a/planning/behavior_path_goal_planner_module/src/shift_pull_over.cpp
+++ b/planning/behavior_path_goal_planner_module/src/shift_pull_over.cpp
@@ -220,11 +220,6 @@ std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     shifted_path.path.points.push_back(p);
   }
 
-  // set the same z as the goal
-  for (auto & p : shifted_path.path.points) {
-    p.point.pose.position.z = goal_pose.position.z;
-  }
-
   // set lane_id and velocity to shifted_path
   for (size_t i = path_shifter.getShiftLines().front().start_idx;
        i < shifted_path.path.points.size() - 1; ++i) {


### PR DESCRIPTION
## Description

currently the z height of shifted path is ignored

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/9447d3aa-0208-4085-b0cd-5dbf98ca4295)

## Related links

this scenario 
https://evaluation.tier4.jp/evaluation/reports/7176a79c-e86f-5c51-a4f9-c540f26bc201/tests/118f7554-b829-5b59-a447-2c4cc3df9bdf/d353d3e8-f86e-52b3-8cab-6b0cc855e832/1dc1b0e9-fd19-5cde-a7f1-79053bb2e8d6?project_id=prd_jt&state=failed

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
