### PR TITLE
feat(probabilistic_occupancy_grid_map): enable to create partial occupancy grid map without filter obstacle pointcloud

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_fixed.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_fixed.cpp
@@ -71,7 +71,7 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
   utils::transformPointcloud(map_raw_pointcloud, scan2map_pose, scan_raw_pointcloud);
   utils::transformPointcloud(map_obstacle_pointcloud, scan2map_pose, scan_obstacle_pointcloud);
 
-  // Create angle bins
+  // Create angle bins and sort by distance
   struct BinInfo
   {
     BinInfo() = default;
@@ -96,45 +96,43 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
     raw_pointcloud_angle_bins.at(angle_bin_index)
       .push_back(BinInfo(std::hypot(*iter_y, *iter_x), *iter_wx, *iter_wy));
   }
-  for (PointCloud2ConstIterator<float> iter_x(scan_obstacle_pointcloud, "x"),
-       iter_y(scan_obstacle_pointcloud, "y"), iter_wx(map_obstacle_pointcloud, "x"),
-       iter_wy(map_obstacle_pointcloud, "y");
-       iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_wx, ++iter_wy) {
-    const double angle = atan2(*iter_y, *iter_x);
-    int angle_bin_index = (angle - min_angle) / angle_increment;
-    obstacle_pointcloud_angle_bins.at(angle_bin_index)
-      .push_back(BinInfo(std::hypot(*iter_y, *iter_x), *iter_wx, *iter_wy));
-  }
-
-  // Sort by distance
-  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
-    std::sort(
-      obstacle_pointcloud_angle_bin.begin(), obstacle_pointcloud_angle_bin.end(),
-      [](auto a, auto b) { return a.range < b.range; });
-  }
   for (auto & raw_pointcloud_angle_bin : raw_pointcloud_angle_bins) {
     std::sort(raw_pointcloud_angle_bin.begin(), raw_pointcloud_angle_bin.end(), [](auto a, auto b) {
       return a.range < b.range;
     });
   }
+  // create and sort bin for obstacle pointcloud
+  for (PointCloud2ConstIterator<float> iter_x(scan_obstacle_pointcloud, "x"),
+       iter_y(scan_obstacle_pointcloud, "y"), iter_wx(map_obstacle_pointcloud, "x"),
+       iter_wy(map_obstacle_pointcloud, "y");
+       iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_wx, ++iter_wy) {
+    const double angle = atan2(*iter_y, *iter_x);
+    const int angle_bin_index = (angle - min_angle) / angle_increment;
+    const double range = std::hypot(*iter_y, *iter_x);
+    // process only for valid angle bin and range
+    if (raw_pointcloud_angle_bins.at(angle_bin_index).empty()) {
+      continue;  // ignore obstacle point out of raw points
+    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
+      continue;  // ignore obstacle point that is further than raw points
+    }
+    obstacle_pointcloud_angle_bins.at(angle_bin_index)
+      .push_back(BinInfo(range, *iter_wx, *iter_wy));
+  }
+  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
+    std::sort(
+      obstacle_pointcloud_angle_bin.begin(), obstacle_pointcloud_angle_bin.end(),
+      [](auto a, auto b) { return a.range < b.range; });
+  }
 
   // First step: Initialize cells to the final point with freespace
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
-    auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
     auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
 
     BinInfo end_distance;
-    if (raw_pointcloud_angle_bin.empty() && obstacle_pointcloud_angle_bin.empty()) {
+    if (raw_pointcloud_angle_bin.empty()) {
       continue;
-    } else if (raw_pointcloud_angle_bin.empty()) {
-      end_distance = obstacle_pointcloud_angle_bin.back();
-    } else if (obstacle_pointcloud_angle_bin.empty()) {
-      end_distance = raw_pointcloud_angle_bin.back();
     } else {
-      end_distance = obstacle_pointcloud_angle_bin.back().range + distance_margin_ <
-                         raw_pointcloud_angle_bin.back().range
-                       ? raw_pointcloud_angle_bin.back()
-                       : obstacle_pointcloud_angle_bin.back();
+      end_distance = raw_pointcloud_angle_bin.back();
     }
     raytrace(
       scan_origin.position.x, scan_origin.position.y, end_distance.wx, end_distance.wy,

--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_fixed.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_fixed.cpp
@@ -109,11 +109,11 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
     const double angle = atan2(*iter_y, *iter_x);
     const int angle_bin_index = (angle - min_angle) / angle_increment;
     const double range = std::hypot(*iter_y, *iter_x);
-    // process only for valid angle bin and range
+    // Ignore obstacle points exceed the range of the raw points
     if (raw_pointcloud_angle_bins.at(angle_bin_index).empty()) {
-      continue;  // ignore obstacle point out of raw points
+      continue;  // No raw point in this angle bin
     } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
-      continue;  // ignore obstacle point that is further than raw points
+      continue;  // Obstacle point exceeds the range of the raw points
     }
     obstacle_pointcloud_angle_bins.at(angle_bin_index)
       .push_back(BinInfo(range, *iter_wx, *iter_wy));


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR is mainly for the multi_lidar occupancy grid map creation feature.
Previously, we need to filter obstacle pointcloud by raw one to get correct sensor fov. This filtering process yields accurate correspondence between raw and obstacle pointcloud and unignorable computation cost.

With this PR, we can roughly get similar result without that process and it means sensor fov imitation works even when `filter_obstacle_pointcloud_by_raw_pointcloud` is `false`.


Here show the sample result with front_left lidar. 
- color point: raw pc
- white point: obstacle pc

| previous | with this PR |
|--|--|
|![Screenshot from 2024-04-21 02-34-35](https://github.com/autowarefoundation/autoware.universe/assets/20086766/4ed5d558-6f55-49f1-bcfe-4cd1b7f09f8e)| ![Screenshot from 2024-04-21 02-25-39](https://github.com/autowarefoundation/autoware.universe/assets/20086766/dc68a2aa-7b6f-4757-bbde-f233c29e0883)|



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
