### PR TITLE
refactor(bpp): simplify extended predicted object initialization

### DIFF
--- a/planning/behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1112,12 +1112,7 @@ ExtendedPredictedObject transform(
   [[maybe_unused]] const BehaviorPathPlannerParameters & common_parameters,
   const LaneChangeParameters & lane_change_parameters, const bool check_at_prepare_phase)
 {
-  ExtendedPredictedObject extended_object;
-  extended_object.uuid = object.object_id;
-  extended_object.initial_pose = object.kinematics.initial_pose_with_covariance;
-  extended_object.initial_twist = object.kinematics.initial_twist_with_covariance;
-  extended_object.initial_acceleration = object.kinematics.initial_acceleration_with_covariance;
-  extended_object.shape = object.shape;
+  ExtendedPredictedObject extended_object(object);
 
   const auto & time_resolution = lane_change_parameters.prediction_time_resolution;
   const auto & prepare_duration = lane_change_parameters.lane_change_prepare_duration;

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -87,6 +87,7 @@ struct ExtendedPredictedObject
     initial_pose(object.kinematics.initial_pose_with_covariance),
     initial_twist(object.kinematics.initial_twist_with_covariance),
     initial_acceleration(object.kinematics.initial_acceleration_with_covariance),
+    shape(object.shape),
     classification(object.classification)
   {
   }

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -31,6 +31,7 @@
 namespace behavior_path_planner::utils::path_safety_checker
 {
 
+using autoware_auto_perception_msgs::msg::PredictedObject;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using tier4_autoware_utils::Polygon2d;
@@ -79,6 +80,16 @@ struct ExtendedPredictedObject
   autoware_auto_perception_msgs::msg::Shape shape;
   std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> classification;
   std::vector<PredictedPathWithPolygon> predicted_paths;
+
+  ExtendedPredictedObject() = default;
+  explicit ExtendedPredictedObject(const PredictedObject & object)
+  : uuid(object.object_id),
+    initial_pose(object.kinematics.initial_pose_with_covariance),
+    initial_twist(object.kinematics.initial_twist_with_covariance),
+    initial_acceleration(object.kinematics.initial_acceleration_with_covariance),
+    classification(object.classification)
+  {
+  }
 };
 using ExtendedPredictedObjects = std::vector<ExtendedPredictedObject>;
 

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -289,13 +289,7 @@ ExtendedPredictedObject transform(
   const PredictedObject & object, const double safety_check_time_horizon,
   const double safety_check_time_resolution)
 {
-  ExtendedPredictedObject extended_object;
-  extended_object.uuid = object.object_id;
-  extended_object.initial_pose = object.kinematics.initial_pose_with_covariance;
-  extended_object.initial_twist = object.kinematics.initial_twist_with_covariance;
-  extended_object.initial_acceleration = object.kinematics.initial_acceleration_with_covariance;
-  extended_object.shape = object.shape;
-  extended_object.classification = object.classification;
+  ExtendedPredictedObject extended_object(object);
 
   const auto obj_velocity = extended_object.initial_twist.twist.linear.x;
 


### PR DESCRIPTION
## Description

Minor refactoring to simplify the initialization of Extended Predicted Object

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
