### PR TITLE
chore(roi_pointcloud_fusion): add maximum cluster size param

### DIFF
--- a/perception/image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
+++ b/perception/image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
@@ -2,4 +2,5 @@
   ros__parameters:
     fuse_unknown_only: true
     min_cluster_size: 2
+    max_cluster_size: 20
     cluster_2d_tolerance: 0.5

--- a/perception/image_projection_based_fusion/docs/roi-pointcloud-fusion.md
+++ b/perception/image_projection_based_fusion/docs/roi-pointcloud-fusion.md
@@ -37,6 +37,7 @@ The node `roi_pointcloud_fusion` is to cluster the pointcloud based on Region Of
 | Name                   | Type   | Description                                                                                  |
 | ---------------------- | ------ | -------------------------------------------------------------------------------------------- |
 | `min_cluster_size`     | int    | the minimum number of points that a cluster needs to contain in order to be considered valid |
+| `max_cluster_size`     | int    | the maximum number of points that a cluster needs to contain in order to be considered valid |
 | `cluster_2d_tolerance` | double | cluster tolerance measured in radial direction                                               |
 | `rois_number`          | int    | the number of input rois                                                                     |
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
@@ -26,6 +26,7 @@ class RoiPointCloudFusionNode
 {
 private:
   int min_cluster_size_{1};
+  int max_cluster_size_{20};
   bool fuse_unknown_only_{true};
   double cluster_2d_tolerance_;
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/utils.hpp
@@ -70,8 +70,8 @@ PointCloud closest_cluster(
 void updateOutputFusedObjects(
   std::vector<DetectedObjectWithFeature> & output_objs, const std::vector<PointCloud> & clusters,
   const std_msgs::msg::Header & in_cloud_header, const std_msgs::msg::Header & in_roi_header,
-  const tf2_ros::Buffer & tf_buffer, const int min_cluster_size, const float cluster_2d_tolerance,
-  std::vector<DetectedObjectWithFeature> & output_fused_objects);
+  const tf2_ros::Buffer & tf_buffer, const int min_cluster_size, const int max_cluster_size,
+  const float cluster_2d_tolerance, std::vector<DetectedObjectWithFeature> & output_fused_objects);
 
 geometry_msgs::msg::Point getCentroid(const sensor_msgs::msg::PointCloud2 & pointcloud);
 

--- a/perception/image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
+++ b/perception/image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
@@ -16,6 +16,11 @@
           "description": "The minimum number of points that a cluster must contain to be considered as valid.",
           "default": 2
         },
+        "max_cluster_size": {
+          "type": "integer",
+          "description": "The maximum number of points that a cluster must contain to be considered as valid.",
+          "default": 20
+        },
         "cluster_2d_tolerance": {
           "type": "number",
           "description": "A cluster tolerance measured in radial direction [m]",

--- a/perception/image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/image_projection_based_fusion/src/utils/utils.cpp
@@ -83,8 +83,8 @@ PointCloud closest_cluster(
 void updateOutputFusedObjects(
   std::vector<DetectedObjectWithFeature> & output_objs, const std::vector<PointCloud> & clusters,
   const std_msgs::msg::Header & in_cloud_header, const std_msgs::msg::Header & in_roi_header,
-  const tf2_ros::Buffer & tf_buffer, const int min_cluster_size, const float cluster_2d_tolerance,
-  std::vector<DetectedObjectWithFeature> & output_fused_objects)
+  const tf2_ros::Buffer & tf_buffer, const int min_cluster_size, const int max_cluster_size,
+  const float cluster_2d_tolerance, std::vector<DetectedObjectWithFeature> & output_fused_objects)
 {
   if (output_objs.size() != clusters.size()) {
     return;
@@ -107,7 +107,9 @@ void updateOutputFusedObjects(
   for (std::size_t i = 0; i < output_objs.size(); ++i) {
     PointCloud cluster = clusters.at(i);
     auto & feature_obj = output_objs.at(i);
-    if (cluster.points.size() < std::size_t(min_cluster_size)) {
+    if (
+      cluster.points.size() < std::size_t(min_cluster_size) ||
+      cluster.points.size() >= std::size_t(max_cluster_size)) {
       continue;
     }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- This PR to add `max_cluster_size` to limit the range of objects that roi_pointcloud fusion node processes, since this node mainly focuses on small and less points unknown (traffic cones) objects which missed by Euclidean Clusters.

- Need to merge after https://github.com/autowarefoundation/autoware_launch/pull/956 is merged.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
