### PR TITLE
feat(tier4_screen_capture_panel): add new service to capture screen shot

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/README.md
+++ b/common/tier4_screen_capture_rviz_plugin/README.md
@@ -4,6 +4,13 @@
 
 This plugin captures the screen of rviz.
 
+## Interface
+
+| Name                         | Type                     | Description                        |
+| ---------------------------- | ------------------------ | ---------------------------------- |
+| `/debug/capture/video`       | `std_srvs::srv::Trigger` | Trigger to start screen capturing. |
+| `/debug/capture/screen_shot` | `std_srvs::srv::Trigger` | Trigger to capture screen shot.    |
+
 ## Assumptions / Known limits
 
 This is only for debug or analyze.

--- a/common/tier4_screen_capture_rviz_plugin/package.xml
+++ b/common/tier4_screen_capture_rviz_plugin/package.xml
@@ -5,6 +5,8 @@
   <version>0.0.0</version>
   <description>The screen capture package</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki, Tanaka</maintainer>
+  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
+  <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -81,7 +81,7 @@ AutowareScreenCapturePanel::AutowareScreenCapturePanel(QWidget * parent)
   state_ = State::WAITING_FOR_CAPTURE;
 }
 
-void AutowareScreenCapturePanel::onCaptureTrigger(
+void AutowareScreenCapturePanel::onCaptureVideoTrigger(
   [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr req,
   const std_srvs::srv::Trigger::Response::SharedPtr res)
 {
@@ -90,12 +90,24 @@ void AutowareScreenCapturePanel::onCaptureTrigger(
   res->message = stateToString(state_);
 }
 
+void AutowareScreenCapturePanel::onCaptureScreenShotTrigger(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr req,
+  const std_srvs::srv::Trigger::Response::SharedPtr res)
+{
+  onClickScreenCapture();
+  res->success = true;
+  res->message = stateToString(state_);
+}
+
 void AutowareScreenCapturePanel::onInitialize()
 {
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
-  capture_service_ = raw_node_->create_service<std_srvs::srv::Trigger>(
-    "/debug/service/capture_screen",
-    std::bind(&AutowareScreenCapturePanel::onCaptureTrigger, this, _1, _2));
+  capture_video_srv_ = raw_node_->create_service<std_srvs::srv::Trigger>(
+    "/debug/capture/video",
+    std::bind(&AutowareScreenCapturePanel::onCaptureVideoTrigger, this, _1, _2));
+  capture_screen_shot_srv_ = raw_node_->create_service<std_srvs::srv::Trigger>(
+    "/debug/capture/screen_shot",
+    std::bind(&AutowareScreenCapturePanel::onCaptureScreenShotTrigger, this, _1, _2));
 }
 
 void onPrefixChanged()

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -60,7 +60,10 @@ public:
   void onTimer();
   void save(rviz_common::Config config) const override;
   void load(const rviz_common::Config & config) override;
-  void onCaptureTrigger(
+  void onCaptureVideoTrigger(
+    const std_srvs::srv::Trigger::Request::SharedPtr req,
+    const std_srvs::srv::Trigger::Response::SharedPtr res);
+  void onCaptureScreenShotTrigger(
     const std_srvs::srv::Trigger::Request::SharedPtr req,
     const std_srvs::srv::Trigger::Response::SharedPtr res);
 
@@ -98,7 +101,8 @@ private:
   }
 
 protected:
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr capture_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr capture_video_srv_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr capture_screen_shot_srv_;
   rclcpp::Node::SharedPtr raw_node_;
 };
 


### PR DESCRIPTION
## Description

Add new service to capture screen shot by external trigger.

## Example usage

I think this feature is very useful when we use it with RandomSim or AWSIM. I added client to RandomSim scenario file in order to output capture trigger so that it can record the situation as a screen shot as follow.

Ego vehicle is stuck due to the node death.
![cap- 2024-04-23-09-23-39](https://github.com/autowarefoundation/autoware.universe/assets/44889564/95a328b2-5fbc-4429-a81f-c2e9ba6c9aa5)

<!-- Write a brief description of this PR. -->

## Interface

```c++
  capture_video_srv_ = raw_node_->create_service<std_srvs::srv::Trigger>(
    "/debug/capture/video",
    std::bind(&AutowareScreenCapturePanel::onCaptureVideoTrigger, this, _1, _2));
  capture_screen_shot_srv_ = raw_node_->create_service<std_srvs::srv::Trigger>(
    "/debug/capture/screen_shot",
    std::bind(&AutowareScreenCapturePanel::onCaptureScreenShotTrigger, this, _1, _2));
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
