### PR TITLE
feat(bpp-interface): add empty path validation

### DIFF
--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -141,7 +141,13 @@ public:
   virtual BehaviorModuleOutput run()
   {
     updateData();
-    return isWaitingApproval() ? planWaitingApproval() : plan();
+    const auto output = isWaitingApproval() ? planWaitingApproval() : plan();
+    try {
+      motion_utils::validateNonEmpty(output.path.points);
+    } catch (const std::exception & ex) {
+      throw std::invalid_argument("[" + name_ + "]" + ex.what());
+    }
+    return output;
   }
 
   /**


### PR DESCRIPTION
## Description

Add validation to detect empty path.

```
[component_container_mt-30]   what():  [avoidance][motion_utils] validateNonEmpty(): Points is empty.  
```

```c++
  virtual BehaviorModuleOutput run()
  {
    updateData();
    const auto output = isWaitingApproval() ? planWaitingApproval() : plan();
    try {
      motion_utils::validateNonEmpty(output.path.points);
    } catch (const std::exception & ex) {
      throw std::invalid_argument("[" + name_ + "]" + ex.what());
    }
    return output;
  }
```
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim.

```
[component_container_mt-30] terminate called after throwing an instance of 'std::invalid_argument'                                                                                                                                                                                                                                                                                                                              
[component_container_mt-30]   what():  [avoidance][motion_utils] validateNonEmpty(): Points is empty.                                                                                                                                                                                                                                                                                                                           
[component_container_mt-30] *** Aborted at 1713838696 (unix time) try "date -d @1713838696" if you are using GNU date ***                                                                                                                                                                                                                                                                                                       
[component_container_mt-30] PC: @                0x0 (unknown)                                                                                                                                                                                                                                                                                                                                                                  
[component_container_mt-30] *** SIGABRT (@0x3e8000b891f) received by PID 755999 (TID 0x7f8ce5ffb640) from PID 755999; stack trace: ***                                                                                                                                                                                                                                                                                          
[component_container_mt-30]     @     0x7f8c2792c046 (unknown)                                                                                                                                                                                                                                                                                                                                                                  
[component_container_mt-30]     @     0x7f8cf1d38520 (unknown)                                                                                                                                                                                                                                                                                                                                                                  
[component_container_mt-30]     @     0x7f8cf1d8c9fc pthread_kill                                                                                                                                                                                                                                                                                                                                                               
[component_container_mt-30]     @     0x7f8cf1d38476 raise                                                                                                                                                                                                                                                                                                                                                                      
[component_container_mt-30]     @     0x7f8cf1d1e7f3 abort                                                                                                                                                                                                                                                                                                                                                                      
[component_container_mt-30]     @     0x7f8cf1fe3b9e (unknown)                                                                                                                                                                                                                                                                                                                                                                  
[component_container_mt-30]     @     0x7f8cf1fef20c (unknown)                                                                                                                                                                                                                                                                                                                                                                  
[component_container_mt-30]     @     0x7f8cf1fef277 std::terminate()                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-30]     @     0x7f8cf1fef4d8 __cxa_throw                                                                                                                                                                                                                                                                                                                                                                
[component_container_mt-30]     @     0x7f8ce18b9e9c behavior_path_planner::SceneModuleInterface::run()                                                                                                                                                                                                                                                                                                                         
[component_container_mt-30]     @     0x7f8cec50b77d behavior_path_planner::PlannerManager::run()                                                                                                                                                                                                                                                                                                                               
[component_container_mt-30]     @     0x7f8cec4ccbe2 behavior_path_planner::PlannerManager::runRequestModules()                                                                                                                                                                                                                                                                                                                 
[component_container_mt-30]     @     0x7f8cec4d0fd4 _ZZN21behavior_path_planner14PlannerManager3runERKSt10shared_ptrINS_11PlannerDataEEENKUlvE0_clEv                                                                                                                                                                                                                                                                           
[component_container_mt-30]     @     0x7f8cec4d1bff behavior_path_planner::PlannerManager::run()                                                                                                                                                                                                                                                                                                                               
[component_container_mt-30]     @     0x7f8cec523319 behavior_path_planner::BehaviorPathPlannerNode::run()                                                                                                                                                                                                                                                                                                                      
[component_container_mt-30]     @     0x7f8cec528585 rclcpp::GenericTimer<>::execute_callback()                                                                                                                                                                                                                                                                                                                                 
[component_container_mt-30]     @     0x7f8cf2294651 rclcpp::Executor::execute_any_executable()                                                                                                                                                                                                                                                                                                                                 
[component_container_mt-30]     @     0x7f8cf229b90a rclcpp::executors::MultiThreadedExecutor::run()                                                                                                                                                                                                                                                                                                                            
[component_container_mt-30]     @     0x7f8cf201d253 (unknown)                                                                                                                                                                                                                                                                                                                                                                  
[component_container_mt-30]     @     0x7f8cf1d8aac3 (unknown)                                                                                                                                                  
[component_container_mt-30]     @     0x7f8cf1e1c850 (unknown)                                                                                                                                                  
[component_container_mt-30]     @                0x0 (unknown)
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
