### PR TITLE
fix(pointcloud preprocessor): fix ring outlier filter and concatenation to use PointXYZIRC 

### DIFF
--- a/common/autoware_point_types/include/autoware_point_types/types.hpp
+++ b/common/autoware_point_types/include/autoware_point_types/types.hpp
@@ -54,6 +54,29 @@ enum ReturnType : uint8_t {
   DUAL_ONLY,
 };
 
+struct PointXYZIRC
+{
+  float x{0.0F};
+  float y{0.0F};
+  float z{0.0F};
+  float intensity{0.0F};
+  union { // for memory alignment
+    uint16_t _data;
+    struct
+    {
+      uint8_t padding{0U};
+      uint8_t return_type{0U};
+    };
+  };
+  uint16_t channel{0U};
+  friend bool operator==(const PointXYZIRC & p1, const PointXYZIRC & p2) noexcept
+  {
+    return float_eq<float>(p1.x, p2.x) && float_eq<float>(p1.y, p2.y) &&
+           float_eq<float>(p1.z, p2.z) && float_eq<float>(p1.intensity, p2.intensity) &&
+           p1.return_type == p2.return_type && p1.channel == p2.channel;
+  }
+};
+
 struct PointXYZIRADRT
 {
   float x{0.0F};
@@ -78,9 +101,15 @@ struct PointXYZIRADRT
 enum class PointIndex { X, Y, Z, Intensity, Ring, Azimuth, Distance, ReturnType, TimeStamp };
 
 LIDAR_UTILS__DEFINE_FIELD_GENERATOR_FOR_MEMBER(azimuth);
+LIDAR_UTILS__DEFINE_FIELD_GENERATOR_FOR_MEMBER(channel);
 LIDAR_UTILS__DEFINE_FIELD_GENERATOR_FOR_MEMBER(distance);
 LIDAR_UTILS__DEFINE_FIELD_GENERATOR_FOR_MEMBER(return_type);
 LIDAR_UTILS__DEFINE_FIELD_GENERATOR_FOR_MEMBER(time_stamp);
+
+using PointXYZIRCGenerator = std::tuple<
+  point_cloud_msg_wrapper::field_x_generator, point_cloud_msg_wrapper::field_y_generator,
+  point_cloud_msg_wrapper::field_z_generator, point_cloud_msg_wrapper::field_intensity_generator,
+  field_return_type_generator, field_channel_generator>;
 
 using PointXYZIRADRTGenerator = std::tuple<
   point_cloud_msg_wrapper::field_x_generator, point_cloud_msg_wrapper::field_y_generator,
@@ -89,6 +118,12 @@ using PointXYZIRADRTGenerator = std::tuple<
   field_return_type_generator, field_time_stamp_generator>;
 
 }  // namespace autoware_point_types
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+  autoware_point_types::PointXYZIRC,
+  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(
+    std::uint8_t, padding, padding)(std::uint8_t, return_type, return_type)(
+    std::uint16_t, channel, channel))
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   autoware_point_types::PointXYZIRADRT,

--- a/common/autoware_point_types/include/autoware_point_types/types.hpp
+++ b/common/autoware_point_types/include/autoware_point_types/types.hpp
@@ -60,7 +60,7 @@ struct PointXYZIRC
   float y{0.0F};
   float z{0.0F};
   float intensity{0.0F};
-  union { // for memory alignment
+  union {  // for memory alignment
     uint16_t _data;
     struct
     {
@@ -121,9 +121,9 @@ using PointXYZIRADRTGenerator = std::tuple<
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   autoware_point_types::PointXYZIRC,
-  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(
-    std::uint8_t, padding, padding)(std::uint8_t, return_type, return_type)(
-    std::uint16_t, channel, channel))
+  (float, x,
+   x)(float, y, y)(float, z, z)(float, intensity, intensity)(std::uint8_t, padding, padding)(
+    std::uint8_t, return_type, return_type)(std::uint16_t, channel, channel))
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   autoware_point_types::PointXYZIRADRT,

--- a/common/autoware_point_types/include/autoware_point_types/types.hpp
+++ b/common/autoware_point_types/include/autoware_point_types/types.hpp
@@ -59,20 +59,13 @@ struct PointXYZIRC
   float x{0.0F};
   float y{0.0F};
   float z{0.0F};
-  float intensity{0.0F};
-  union {  // for memory alignment
-    uint16_t _data;
-    struct
-    {
-      uint8_t padding{0U};
-      uint8_t return_type{0U};
-    };
-  };
+  uint8_t intensity{0.0F};
+  uint8_t return_type{0U};
   uint16_t channel{0U};
   friend bool operator==(const PointXYZIRC & p1, const PointXYZIRC & p2) noexcept
   {
     return float_eq<float>(p1.x, p2.x) && float_eq<float>(p1.y, p2.y) &&
-           float_eq<float>(p1.z, p2.z) && float_eq<float>(p1.intensity, p2.intensity) &&
+           float_eq<float>(p1.z, p2.z) && p1.intensity == p2.intensity &&
            p1.return_type == p2.return_type && p1.channel == p2.channel;
   }
 };
@@ -121,8 +114,7 @@ using PointXYZIRADRTGenerator = std::tuple<
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   autoware_point_types::PointXYZIRC,
-  (float, x,
-   x)(float, y, y)(float, z, z)(float, intensity, intensity)(std::uint8_t, padding, padding)(
+  (float, x, x)(float, y, y)(float, z, z)(std::uint8_t, intensity, intensity)(
     std::uint8_t, return_type, return_type)(std::uint16_t, channel, channel))
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -88,6 +88,7 @@
 namespace pointcloud_preprocessor
 {
 using autoware_point_types::PointXYZI;
+using autoware_point_types::PointXYZIRC;
 using point_cloud_msg_wrapper::PointCloud2Modifier;
 
 /** \brief @b PointCloudConcatenateDataSynchronizerComponent is a special form of data

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -27,7 +27,8 @@
 
 namespace pointcloud_preprocessor
 {
-using autoware_point_types::PointXYZI;
+using autoware_point_types::PointXYZIRC;
+using autoware_point_types::PointXYZIRADRT;
 using point_cloud_msg_wrapper::PointCloud2Modifier;
 
 class RingOutlierFilterComponent : public pointcloud_preprocessor::Filter
@@ -64,8 +65,8 @@ private:
   {
     if (walk_size > num_points_threshold_) return true;
 
-    auto first_point = reinterpret_cast<const PointXYZI *>(&input->data[data_idx_both_ends.first]);
-    auto last_point = reinterpret_cast<const PointXYZI *>(&input->data[data_idx_both_ends.second]);
+    auto first_point = reinterpret_cast<const PointXYZIRADRT *>(&input->data[data_idx_both_ends.first]);
+    auto last_point = reinterpret_cast<const PointXYZIRADRT *>(&input->data[data_idx_both_ends.second]);
 
     const auto x = first_point->x - last_point->x;
     const auto y = first_point->y - last_point->y;

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -27,8 +27,8 @@
 
 namespace pointcloud_preprocessor
 {
-using autoware_point_types::PointXYZIRC;
 using autoware_point_types::PointXYZIRADRT;
+using autoware_point_types::PointXYZIRC;
 using point_cloud_msg_wrapper::PointCloud2Modifier;
 
 class RingOutlierFilterComponent : public pointcloud_preprocessor::Filter
@@ -65,8 +65,10 @@ private:
   {
     if (walk_size > num_points_threshold_) return true;
 
-    auto first_point = reinterpret_cast<const PointXYZIRADRT *>(&input->data[data_idx_both_ends.first]);
-    auto last_point = reinterpret_cast<const PointXYZIRADRT *>(&input->data[data_idx_both_ends.second]);
+    auto first_point =
+      reinterpret_cast<const PointXYZIRADRT *>(&input->data[data_idx_both_ends.first]);
+    auto last_point =
+      reinterpret_cast<const PointXYZIRADRT *>(&input->data[data_idx_both_ends.second]);
 
     const auto x = first_point->x - last_point->x;
     const auto y = first_point->y - last_point->y;

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -512,7 +512,7 @@ void PointCloudConcatenateDataSynchronizerComponent::convertToXYZICloud(
   sensor_msgs::PointCloud2Iterator<float> it_z(*input_ptr, "z");
 
   if (has_intensity) {
-    sensor_msgs::PointCloud2Iterator<float> it_i(*input_ptr, "intensity");
+    sensor_msgs::PointCloud2Iterator<uint8_t> it_i(*input_ptr, "intensity");
     for (; it_x != it_x.end(); ++it_x, ++it_y, ++it_z, ++it_i) {
       PointXYZI point;
       point.x = *it_x;
@@ -527,7 +527,7 @@ void PointCloudConcatenateDataSynchronizerComponent::convertToXYZICloud(
       point.x = *it_x;
       point.y = *it_y;
       point.z = *it_z;
-      point.intensity = 0.0f;
+      point.intensity = 0U;
       output_modifier.push_back(std::move(point));
     }
   }

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -423,7 +423,8 @@ PointCloudConcatenateDataSynchronizerComponent::combineClouds(
 
   // after concatenation, channels have no consistent meaning
   size_t channel_offset = offsetof(PointXYZIRC, channel);
-  for (size_t data_idx = 0; data_idx < concat_cloud_ptr->data.size(); data_idx += concat_cloud_ptr->point_step) {
+  for (size_t data_idx = 0; data_idx < concat_cloud_ptr->data.size();
+       data_idx += concat_cloud_ptr->point_step) {
     concat_cloud_ptr->data[data_idx + channel_offset] = 0;
   }
   concat_cloud_ptr->header.stamp = oldest_stamp;

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -239,7 +239,8 @@ void RingOutlierFilterComponent::faster_filter(
       }
     } else if (publish_outlier_pointcloud_) {
       for (int i = walk_first_idx; i < walk_last_idx; i++) {
-        auto outlier_ptr = reinterpret_cast<PointXYZIRC *>(&outlier_points.data[outlier_points_size]);
+        auto outlier_ptr =
+          reinterpret_cast<PointXYZIRC *>(&outlier_points.data[outlier_points_size]);
         auto input_ptr = reinterpret_cast<const PointXYZIRADRT *>(&input->data[indices[i]]);
         if (transform_info.need_transform) {
           Eigen::Vector4f p(input_ptr->x, input_ptr->y, input_ptr->z, 1);

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -161,7 +161,7 @@ void RingOutlierFilterComponent::faster_filter(
           }
           const float & intensity =
             *reinterpret_cast<const float *>(&input->data[indices[i] + intensity_offset]);
-          output_ptr->intensity = intensity;
+          output_ptr->intensity = static_cast<uint8_t>(intensity);
           const uint8_t & return_type =
             *reinterpret_cast<const uint8_t *>(&input->data[indices[i] + return_type_offset]);
           output_ptr->return_type = return_type;
@@ -190,7 +190,7 @@ void RingOutlierFilterComponent::faster_filter(
           }
           const float & intensity = *reinterpret_cast<const float *>(
             &input->data[indices[walk_first_idx] + intensity_offset]);
-          outlier_ptr->intensity = intensity;
+          outlier_ptr->intensity = static_cast<uint8_t>(intensity);
           const uint8_t & return_type = *reinterpret_cast<const uint8_t *>(
             &input->data[indices[walk_first_idx] + return_type_offset]);
           outlier_ptr->return_type = return_type;
@@ -227,7 +227,7 @@ void RingOutlierFilterComponent::faster_filter(
         }
         const float & intensity =
           *reinterpret_cast<const float *>(&input->data[indices[i] + intensity_offset]);
-        output_ptr->intensity = intensity;
+        output_ptr->intensity = static_cast<uint8_t>(intensity);
         const uint8_t & return_type =
           *reinterpret_cast<const uint8_t *>(&input->data[indices[i] + return_type_offset]);
         output_ptr->return_type = return_type;
@@ -255,7 +255,7 @@ void RingOutlierFilterComponent::faster_filter(
         }
         const float & intensity =
           *reinterpret_cast<const float *>(&input->data[indices[i] + intensity_offset]);
-        outlier_ptr->intensity = intensity;
+        outlier_ptr->intensity = static_cast<uint8_t>(intensity);
         const uint8_t & return_type =
           *reinterpret_cast<const uint8_t *>(&input->data[indices[i] + return_type_offset]);
         outlier_ptr->return_type = return_type;
@@ -267,10 +267,10 @@ void RingOutlierFilterComponent::faster_filter(
     }
   }
 
-  setUpPointCloudFormat(input, output, output_size, /*num_fields=*/7);
+  setUpPointCloudFormat(input, output, output_size, /*num_fields=*/6);
 
   if (publish_outlier_pointcloud_) {
-    setUpPointCloudFormat(input, outlier_points, outlier_points_size, /*num_fields=*/7);
+    setUpPointCloudFormat(input, outlier_points, outlier_points_size, /*num_fields=*/6);
     outlier_pointcloud_publisher_->publish(outlier_points);
   }
 
@@ -351,9 +351,8 @@ void RingOutlierFilterComponent::setUpPointCloudFormat(
   pcd_modifier.setPointCloud2Fields(
     num_fields, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
     sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
-    "intensity", 1, sensor_msgs::msg::PointField::FLOAT32, "padding", 1,
-    sensor_msgs::msg::PointField::UINT8, "return_type", 1, sensor_msgs::msg::PointField::UINT8,
-    "channel", 1, sensor_msgs::msg::PointField::UINT16);
+    "intensity", 1, sensor_msgs::msg::PointField::UINT8, "return_type", 1,
+    sensor_msgs::msg::PointField::UINT8, "channel", 1, sensor_msgs::msg::PointField::UINT16);
 }
 
 }  // namespace pointcloud_preprocessor


### PR DESCRIPTION
## Description

The current implementation of [RingOutlierFilter](https://github.com/autowarefoundation/autoware.universe/blob/5a6cde954790dc744b2ec10e88749437e8b57f9e/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp#L27C1-L27C27) and [PointCloudConcatenateDataSynchronizer](https://github.com/autowarefoundation/autoware.universe/blob/main/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp) does not follow the [documentation of the Autoware](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture/sensing/data-types/point-cloud/#recommended-processing-pipeline).

This PR will change the output of RingOutlierFilter and PointCloudConcatenateDataSynchronizer from `PointXYZI` to `PointXYZIRC`.
Also, after concatenation, the gathered data's channel is set to 0 (channel does not have consistent meaning).

## Related links

doc: https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture/sensing/data-types/point-cloud/#recommended-processing-pipeline

## Tests performed
Before
``` Text
...
fields:
- name: x
  offset: 0
  datatype: 7
  count: 1
- name: y
  offset: 4
  datatype: 7
  count: 1
- name: z
  offset: 8
  datatype: 7
  count: 1
- name: intensity
  offset: 12
  datatype: 7
  count: 1
is_bigendian: false
point_step: 16
...
```

After
``` text
...
fields:
- name: x
  offset: 0
  datatype: 7
  count: 1
- name: y
  offset: 4
  datatype: 7
  count: 1
- name: z
  offset: 8
  datatype: 7
  count: 1
- name: intensity
  offset: 12
  datatype: 7
  count: 1
- name: padding
  offset: 16
  datatype: 2
  count: 1
- name: return_type
  offset: 17
  datatype: 2
  count: 1
- name: channel
  offset: 18
  datatype: 4
  count: 1
is_bigendian: false
point_step: 20
...
```

## Notes for reviewers

I only checked the sensing part is working, please check the other parts if it's needed.

## Interface changes

N/A

## Effects on system behavior

N/A

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
