### PR TITLE
feat(autonomous_emergency_braking): filter and crop aeb pointcloud

### DIFF
--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -3,6 +3,8 @@
     publish_debug_pointcloud: false
     use_predicted_trajectory: true
     use_imu_path: true
+    crop_pointcloud_with_path_footprint: true
+    path_footprint_extra_margin: 1.0
     detection_range_min_height: 0.0
     detection_range_max_height_margin: 0.0
     voxel_grid_x: 0.05

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -3,7 +3,6 @@
     publish_debug_pointcloud: false
     use_predicted_trajectory: true
     use_imu_path: true
-    crop_pointcloud_with_path_footprint: true
     path_footprint_extra_margin: 1.0
     detection_range_min_height: 0.0
     detection_range_max_height_margin: 0.0

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -15,6 +15,9 @@
     t_response: 1.0
     a_ego_min: -3.0
     a_obj_min: -1.0
+    cluster_tolerance: 0.1 #[m]
+    minimum_cluster_size: 10
+    maximum_cluster_size: 10000
     imu_prediction_time_horizon: 1.5
     imu_prediction_time_interval: 0.1
     mpc_prediction_time_horizon: 1.5

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -148,6 +148,8 @@ public:
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
 
+  void cropPointCloudWithEgoPath(const std::vector<Polygon2d> & ego_polys);
+
   void createClusteredPointCloudObjectData(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
@@ -161,6 +163,8 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
+  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
+
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};
   Trajectory::ConstSharedPtr predicted_traj_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -185,7 +185,6 @@ public:
   bool publish_debug_pointcloud_;
   bool use_predicted_trajectory_;
   bool use_imu_path_;
-  bool crop_pointcloud_with_path_footprint_;
   double path_footprint_extra_margin_;
   double detection_range_min_height_;
   double detection_range_max_height_margin_;

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -148,6 +148,10 @@ public:
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
 
+  void createClusteredPointCloudObjectData(
+    const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
+    std::vector<ObjectData> & objects);
+
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,
     const std::vector<ObjectData> & objects, const double color_r, const double color_g,

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -219,6 +219,9 @@ public:
   double t_response_;
   double a_ego_min_;
   double a_obj_min_;
+  double cluster_tolerance_;
+  int minimum_cluster_size_;
+  int maximum_cluster_size_;
   double imu_prediction_time_horizon_;
   double imu_prediction_time_interval_;
   double mpc_prediction_time_horizon_;

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -67,7 +67,8 @@ using visualization_msgs::msg::MarkerArray;
 using Path = std::vector<geometry_msgs::msg::Pose>;
 using Vector3 = geometry_msgs::msg::Vector3;
 
-class TimeIT
+// For debugging
+class DebugTimer
 {
 private:
   std::chrono::time_point<std::chrono::steady_clock> t_start;
@@ -75,13 +76,14 @@ private:
   double duration_warning_threshold_;
 
 public:
-  explicit TimeIT(std::string instance, const double duration_warning_threshold = 0.03)  // 40 ms
+  explicit DebugTimer(
+    std::string instance, const double duration_warning_threshold = 0.03)  // 40 ms
   : instance_(instance), duration_warning_threshold_(duration_warning_threshold)
   {
     t_start = std::chrono::steady_clock::now();
   }
 
-  ~TimeIT()
+  ~DebugTimer()
   {
     std::chrono::time_point<std::chrono::steady_clock> t_end = std::chrono::steady_clock::now();
     std::chrono::duration<double> duration = t_end - t_start;

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -142,16 +142,18 @@ public:
   bool hasCollision(
     const double current_v, const Path & ego_path, const std::vector<ObjectData> & objects);
 
-  Path generateEgoPath(const double curr_v, const double curr_w, std::vector<Polygon2d> & polygons);
-  std::optional<Path> generateEgoPath(
-    const Trajectory & predicted_traj, std::vector<Polygon2d> & polygons);
+  Path generateEgoPath(const double curr_v, const double curr_w);
+  std::optional<Path> generateEgoPath(const Trajectory & predicted_traj);
+
+  std::vector<Polygon2d> generatePathFootprint(const Path & path, const double extra_width_margin);
+
   void createObjectData(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
 
-  void cropPointCloudWithEgoPath(const std::vector<Polygon2d> & ego_polys);
+  void cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_polys);
 
-  void createClusteredPointCloudObjectData(
+  void createObjectDataUsingPointCloudClusters(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
 
@@ -184,6 +186,8 @@ public:
   bool publish_debug_pointcloud_;
   bool use_predicted_trajectory_;
   bool use_imu_path_;
+  bool crop_pointcloud_with_path_footprint_;
+  double path_footprint_extra_margin_;
   double detection_range_min_height_;
   double detection_range_max_height_margin_;
   double voxel_grid_x_;

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -40,7 +40,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -166,27 +166,15 @@ public:
   void onCheckCollision(DiagnosticStatusWrapper & stat);
   bool checkCollision(MarkerArray & debug_markers);
   bool hasCollision(const double current_v, const ObjectData & closest_object);
-  bool hasCollision(
-    const double current_v, const Path & ego_path, const std::vector<ObjectData> & objects);
 
   Path generateEgoPath(const double curr_v, const double curr_w);
   std::optional<Path> generateEgoPath(const Trajectory & predicted_traj);
-
   std::vector<Polygon2d> generatePathFootprint(const Path & path, const double extra_width_margin);
-
-  void createObjectData(
-    const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
-    std::vector<ObjectData> & objects);
 
   void createObjectDataUsingPointCloudClusters(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
-
   void cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_polys);
-
-  ObjectData getClosestObject(
-    std::vector<ObjectData> & objects, const Path & ego_path,
-    const geometry_msgs::msg::Pose & ego_pose);
 
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -18,6 +18,7 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -166,7 +166,6 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
-  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
 
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -166,6 +166,7 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
+  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
 
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -358,7 +358,12 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
     if (objects_from_point_clusters.empty()) {
       return false;
     }
-    return hasCollision(current_v, path, objects_from_point_clusters);
+    const auto closest_object_point = std::min_element(
+      objects_from_point_clusters.begin(), objects_from_point_clusters.end(),
+      [](const auto & o1, const auto & o2) {
+        return o1.distance_to_object < o2.distance_to_object;
+      });
+    return hasCollision(current_v, *closest_object_point);
   };
 
   // step3. create ego path based on sensor data

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -151,6 +151,11 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   t_response_ = declare_parameter<double>("t_response");
   a_ego_min_ = declare_parameter<double>("a_ego_min");
   a_obj_min_ = declare_parameter<double>("a_obj_min");
+
+  cluster_tolerance_ = declare_parameter<double>("cluster_tolerance");
+  minimum_cluster_size_ = declare_parameter<double>("minimum_cluster_size");
+  maximum_cluster_size_ = declare_parameter<double>("maximum_cluster_size");
+
   imu_prediction_time_horizon_ = declare_parameter<double>("imu_prediction_time_horizon");
   imu_prediction_time_interval_ = declare_parameter<double>("imu_prediction_time_interval");
   mpc_prediction_time_horizon_ = declare_parameter<double>("mpc_prediction_time_horizon");
@@ -527,9 +532,9 @@ void AEB::createObjectDataUsingPointCloudClusters(
     pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
     tree->setInputCloud(obstacle_points_ptr);
     pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
-    ec.setClusterTolerance(0.1);
-    ec.setMinClusterSize(10);
-    ec.setMaxClusterSize(10000);
+    ec.setClusterTolerance(cluster_tolerance_);
+    ec.setMinClusterSize(minimum_cluster_size_);
+    ec.setMaxClusterSize(maximum_cluster_size_);
     ec.setSearchMethod(tree);
     ec.setInputCloud(obstacle_points_ptr);
     ec.extract(cluster_idx);

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -153,9 +153,7 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   const double aeb_hz = declare_parameter<double>("aeb_hz");
   const auto period_ns = rclcpp::Rate(aeb_hz).period();
   std::cerr << "period " << period_ns.count() << "\n";
-  cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  timer_ = rclcpp::create_timer(
-    this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this), cb_group_);
+  timer_ = rclcpp::create_timer(this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
 }
 
 void AEB::onTimer()

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -148,8 +148,6 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   publish_debug_pointcloud_ = declare_parameter<bool>("publish_debug_pointcloud");
   use_predicted_trajectory_ = declare_parameter<bool>("use_predicted_trajectory");
   use_imu_path_ = declare_parameter<bool>("use_imu_path");
-  crop_pointcloud_with_path_footprint_ =
-    declare_parameter<bool>("crop_pointcloud_with_path_footprint");
   path_footprint_extra_margin_ = declare_parameter<double>("path_footprint_extra_margin");
   detection_range_min_height_ = declare_parameter<double>("detection_range_min_height");
   detection_range_max_height_margin_ =
@@ -355,11 +353,9 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
     const auto ego_path = generateEgoPath(current_v, current_w);
 
     // Crop out Pointcloud using an extra wide ego path
-    if (crop_pointcloud_with_path_footprint_) {
-      const auto expanded_ego_polys =
-        generatePathFootprint(ego_path, expand_width_ + path_footprint_extra_margin_);
-      cropPointCloudWithEgoFootprintPath(expanded_ego_polys);
-    }
+    const auto expanded_ego_polys =
+      generatePathFootprint(ego_path, expand_width_ + path_footprint_extra_margin_);
+    cropPointCloudWithEgoFootprintPath(expanded_ego_polys);
 
     std::vector<ObjectData> objects_from_point_clusters;
     const auto ego_polys = generatePathFootprint(ego_path, expand_width_);
@@ -387,11 +383,9 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
       const auto & predicted_path = predicted_path_opt.value();
 
       // Crop out Pointcloud using an extra wide ego path
-      if (crop_pointcloud_with_path_footprint_) {
-        const auto expanded_ego_polys =
-          generatePathFootprint(predicted_path, expand_width_ + path_footprint_extra_margin_);
-        cropPointCloudWithEgoFootprintPath(expanded_ego_polys);
-      }
+      const auto expanded_ego_polys =
+        generatePathFootprint(predicted_path, expand_width_ + path_footprint_extra_margin_);
+      cropPointCloudWithEgoFootprintPath(expanded_ego_polys);
 
       std::vector<ObjectData> objects_from_point_clusters;
       const auto predicted_polys = generatePathFootprint(predicted_path, expand_width_);

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -153,8 +153,8 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   a_obj_min_ = declare_parameter<double>("a_obj_min");
 
   cluster_tolerance_ = declare_parameter<double>("cluster_tolerance");
-  minimum_cluster_size_ = declare_parameter<double>("minimum_cluster_size");
-  maximum_cluster_size_ = declare_parameter<double>("maximum_cluster_size");
+  minimum_cluster_size_ = declare_parameter<int>("minimum_cluster_size");
+  maximum_cluster_size_ = declare_parameter<int>("maximum_cluster_size");
 
   imu_prediction_time_horizon_ = declare_parameter<double>("imu_prediction_time_horizon");
   imu_prediction_time_interval_ = declare_parameter<double>("imu_prediction_time_interval");

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -547,7 +547,7 @@ void AEB::createObjectDataUsingPointCloudClusters(
     for (const auto & index : indices.indices) {
       cluster->push_back((*obstacle_points_ptr)[index]);
     }
-    // Make a surface hull of the objects
+    // Make a 2d convex hull for the objects
     pcl::ConvexHull<pcl::PointXYZ> hull;
     hull.setDimension(2);
     hull.setInputCloud(cluster);

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -153,7 +153,9 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   const double aeb_hz = declare_parameter<double>("aeb_hz");
   const auto period_ns = rclcpp::Rate(aeb_hz).period();
   std::cerr << "period " << period_ns.count() << "\n";
-  timer_ = rclcpp::create_timer(this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
+  cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  timer_ = rclcpp::create_timer(
+    this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this), cb_group_);
 }
 
 void AEB::onTimer()

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -290,7 +290,6 @@ bool AEB::isDataReady()
 
 void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 {
-  TimeIT t(__func__);
   MarkerArray debug_markers;
   checkCollision(debug_markers);
 
@@ -315,7 +314,6 @@ void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 bool AEB::checkCollision(MarkerArray & debug_markers)
 {
   using colorTuple = std::tuple<double, double, double, double>;
-  TimeIT t(__func__);
 
   // step1. check data
   if (!isDataReady()) {
@@ -336,8 +334,6 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   auto check_collision = [&](
                            const auto & path, const colorTuple & debug_colors,
                            const std::string & debug_ns, const rclcpp::Time & current_time) {
-    TimeIT t("check_collision lambda");
-
     // Crop out Pointcloud using an extra wide ego path
     const auto expanded_ego_polys =
       generatePathFootprint(path, expand_width_ + path_footprint_extra_margin_);
@@ -516,7 +512,6 @@ void AEB::createObjectDataUsingPointCloudClusters(
   const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
   std::vector<ObjectData> & objects)
 {
-  TimeIT t(__func__);
   // check if the predicted path has valid number of points
   if (ego_path.size() < 2 || ego_polys.empty() || cropped_ros_pointcloud_ptr_->data.empty()) {
     return;

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -262,6 +262,7 @@ void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
   filter.filter(*no_height_filtered_pointcloud_ptr);
 
   obstacle_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
+  cropped_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
 
   pcl::toROSMsg(*no_height_filtered_pointcloud_ptr, *obstacle_ros_pointcloud_ptr_);
   obstacle_ros_pointcloud_ptr_->header = input_msg->header;
@@ -401,8 +402,8 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
     }
   }
 
-  if (obstacle_ros_pointcloud_ptr_) {
-    pub_obstacle_pointcloud_->publish(*obstacle_ros_pointcloud_ptr_);
+  if (cropped_ros_pointcloud_ptr_) {
+    pub_obstacle_pointcloud_->publish(*cropped_ros_pointcloud_ptr_);
   }
 
   return has_collision_ego || has_collision_predicted;
@@ -587,7 +588,7 @@ void AEB::cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_
   path_polygon_hull_filter.filter(*objects);
   // Store the results
   if (!objects->empty()) {
-    pcl::toROSMsg(*objects, *obstacle_ros_pointcloud_ptr_);
+    pcl::toROSMsg(*objects, *cropped_ros_pointcloud_ptr_);
   }
 }
 
@@ -596,11 +597,11 @@ void AEB::createObjectDataUsingPointCloudClusters(
   std::vector<ObjectData> & objects)
 {
   // check if the predicted path has valid number of points
-  if (ego_path.size() < 2 || ego_polys.empty() || obstacle_ros_pointcloud_ptr_->data.empty()) {
+  if (ego_path.size() < 2 || ego_polys.empty() || cropped_ros_pointcloud_ptr_->data.empty()) {
     return;
   }
   PointCloud::Ptr obstacle_points_ptr(new PointCloud);
-  pcl::fromROSMsg(*obstacle_ros_pointcloud_ptr_, *obstacle_points_ptr);
+  pcl::fromROSMsg(*cropped_ros_pointcloud_ptr_, *obstacle_points_ptr);
   if (obstacle_points_ptr->empty()) return;
   std::vector<pcl::PointIndices> cluster_indices;
   pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -264,7 +264,6 @@ void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
   filter.filter(*no_height_filtered_pointcloud_ptr);
 
   obstacle_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
-  cropped_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
 
   pcl::toROSMsg(*no_height_filtered_pointcloud_ptr, *obstacle_ros_pointcloud_ptr_);
   obstacle_ros_pointcloud_ptr_->header = input_msg->header;
@@ -408,8 +407,8 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
     }
   }
 
-  if (cropped_ros_pointcloud_ptr_) {
-    pub_obstacle_pointcloud_->publish(*cropped_ros_pointcloud_ptr_);
+  if (obstacle_ros_pointcloud_ptr_) {
+    pub_obstacle_pointcloud_->publish(*obstacle_ros_pointcloud_ptr_);
   }
 
   return has_collision_ego || has_collision_predicted;
@@ -594,7 +593,7 @@ void AEB::cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_
   path_polygon_hull_filter.filter(*objects);
   // Store the results
   if (!objects->empty()) {
-    pcl::toROSMsg(*objects, *cropped_ros_pointcloud_ptr_);
+    pcl::toROSMsg(*objects, *obstacle_ros_pointcloud_ptr_);
   }
 }
 
@@ -603,11 +602,11 @@ void AEB::createObjectDataUsingPointCloudClusters(
   std::vector<ObjectData> & objects)
 {
   // check if the predicted path has valid number of points
-  if (ego_path.size() < 2 || ego_polys.empty() || cropped_ros_pointcloud_ptr_->data.empty()) {
+  if (ego_path.size() < 2 || ego_polys.empty() || obstacle_ros_pointcloud_ptr_->data.empty()) {
     return;
   }
   PointCloud::Ptr obstacle_points_ptr(new PointCloud);
-  pcl::fromROSMsg(*cropped_ros_pointcloud_ptr_, *obstacle_points_ptr);
+  pcl::fromROSMsg(*obstacle_ros_pointcloud_ptr_, *obstacle_points_ptr);
   if (obstacle_points_ptr->empty()) return;
   std::vector<pcl::PointIndices> cluster_indices;
   pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -316,7 +316,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   }
 
   // step2. create velocity data check if the vehicle stops or not
-  const double current_v = current_velocity_ptr_->longitudinal_velocity + 2.25;
+  const double current_v = current_velocity_ptr_->longitudinal_velocity;
   if (current_v < 0.1) {
     return false;
   }


### PR DESCRIPTION
## Description

This PR introduces an overhaul to the autonomous_emergency_braking (AEB) module. 

1. Added Euclidean clustering to consider only groups of point clouds that are bigger than a certain size (given by cluster tolerance and min amount of point parameters).
2. The Point Cloud from sensing is cropped to only include points close to, or inside the ego predicted path.
3. A Convex hull is created around each cluster of objects. The Vertices of the hull are the points used to calculate if a collision happens or not (the vertices of the hull correspond to the most “external points”, so it really only makes sense to consider said points.
4. Only the closest Object/Vertex is evaluated for collision, (if ego evaluates that the closest point is safe, the other points will be safe too since they have, by definition, larger distances to the ego).

The goal of these changes is to avoid false positive triggering of the AEB by noisy points, reduce computation time by cropping out unrelated points off of the AEB point cloud, and simplify collision detection by checking the closest point

Example of AEB ignoring objects far from path (AEB points show as red points, normal are grey):

https://github.com/autowarefoundation/autoware.universe/assets/25967964/94b2ff62-adae-4e44-86ce-e0c34a56190f



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

PSIM tests

LSIM
Replayed these rosbags where AEB was wrongly activated, and there was no longer an activation
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-5364)
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-5666)


## Notes for reviewers

Requires changes to Launch: https://github.com/autowarefoundation/autoware_launch/pull/966

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Reduced false positive detection for AEB

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
