### PR TITLE
fix(tier4_perception_launch): change traffic light recognition pipeline

### DIFF
--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -12,8 +12,8 @@
   <arg name="car_traffic_light_classifier_model_name" default="traffic_light_classifier_mobilenetv2_batch_6.onnx" description="classifier onnx model filename"/>
   <arg name="pedestrian_traffic_light_classifier_model_name" default="ped_traffic_light_classifier_mobilenetv2_batch_6.onnx" description="classifier onnx model filename"/>
   <arg name="input/cloud" default="/sensing/lidar/top/pointcloud_raw" description="point cloud for occlusion prediction"/>
+  <arg name="judged/traffic_signals" default="/perception/traffic_light_recognition/judged/traffic_signals"/>
   <arg name="internal/traffic_signals" default="/perception/traffic_light_recognition/internal/traffic_signals"/>
-  <arg name="fusion/traffic_signals" default="/perception/traffic_light_recognition/fusion/traffic_signals"/>
   <arg name="external/traffic_signals" default="/perception/traffic_light_recognition/external/traffic_signals"/>
   <arg name="output/traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
   <arg name="use_crosswalk_traffic_light_estimator" default="true" description="output pedestrian's traffic light signals"/>
@@ -144,25 +144,7 @@
       <param name="camera_namespaces" value="$(var all_camera_namespaces)"/>
       <param name="perform_group_fusion" value="true"/>
       <remap from="~/input/vector_map" to="/map/vector_map"/>
-      <remap from="~/output/traffic_signals" to="$(var fusion/traffic_signals)"/>
-    </node>
-  </group>
-
-  <group if="$(var use_crosswalk_traffic_light_estimator)">
-    <node pkg="crosswalk_traffic_light_estimator" exec="crosswalk_traffic_light_estimator_node" name="crosswalk_traffic_light_estimator" output="screen">
-      <remap from="~/input/vector_map" to="/map/vector_map"/>
-      <remap from="~/input/route" to="/planning/mission_planning/route"/>
-      <remap from="~/input/classified/traffic_signals" to="$(var fusion/traffic_signals)"/>
       <remap from="~/output/traffic_signals" to="$(var internal/traffic_signals)"/>
-      <param from="$(var crosswalk_traffic_light_estimator_param_file)"/>
-    </node>
-  </group>
-
-  <group unless="$(var use_crosswalk_traffic_light_estimator)">
-    <node pkg="topic_tools" exec="relay" name="fusion_signals_relay" output="screen">
-      <param name="input_topic" value="$(var fusion/traffic_signals)"/>
-      <param name="output_topic" value="$(var internal/traffic_signals)"/>
-      <param name="type" value="autoware_auto_perception_msgs/msg/TrafficSignalArray"/>
     </node>
   </group>
 
@@ -171,9 +153,28 @@
     <include file="$(find-pkg-share traffic_light_arbiter)/launch/traffic_light_arbiter.launch.xml">
       <arg name="perception_traffic_signals" value="$(var internal/traffic_signals)"/>
       <arg name="external_traffic_signals" value="$(var external/traffic_signals)"/>
-      <arg name="output_traffic_signals" value="$(var output/traffic_signals)"/>
+      <arg name="output_traffic_signals" value="$(var judged/traffic_signals)"/>
     </include>
   </group>
+
+  <group if="$(var use_crosswalk_traffic_light_estimator)">
+    <node pkg="crosswalk_traffic_light_estimator" exec="crosswalk_traffic_light_estimator_node" name="crosswalk_traffic_light_estimator" output="screen">
+      <remap from="~/input/vector_map" to="/map/vector_map"/>
+      <remap from="~/input/route" to="/planning/mission_planning/route"/>
+      <remap from="~/input/classified/traffic_signals" to="$(var judged/traffic_signals)"/>
+      <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
+      <param from="$(var crosswalk_traffic_light_estimator_param_file)"/>
+    </node>
+  </group>
+
+  <group unless="$(var use_crosswalk_traffic_light_estimator)">
+    <node pkg="topic_tools" exec="relay" name="fusion_signals_relay" output="screen">
+      <param name="input_topic" value="$(var judged/traffic_signals)"/>
+      <param name="output_topic" value="$(var output/traffic_signals)"/>
+      <param name="type" value="autoware_auto_perception_msgs/msg/TrafficSignalArray"/>
+    </node>
+  </group>
+
   <!-- visualizer -->
   <group>
     <include file="$(find-pkg-share traffic_light_visualization)/launch/traffic_light_map_visualizer.launch.xml"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR changes the traffic light recognition pipeline. 

Currently, `crosswalk_traffic_light_estimator` is launched before `traffic_light_arbiter`. This causes crosswalk traffic light estimation to work only for internal traffic signals, not for external V2X signals.

Switching their places on the launch file is proposed, so that `crosswalk_traffic_light_estimator` will be the last node on the pipeline and will work for all traffic signals including V2X.

![pipeline](https://github.com/autowarefoundation/autoware.universe/assets/13589149/d3384b16-6e95-4be7-9f4d-14563b5b3d52)

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

Fixes: https://github.com/autowarefoundation/autoware.universe/issues/6878

## Tests performed

<!-- Describe how you have tested this PR. -->

Tested on logging simulator with a bag file.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

`traffic_light_arbiter` used to output the traffic signals at the end of the pipeline as `/perception/traffic_light_recognition/traffic_signals` topic. Now, `crosswalk_traffic_light_estimator` is at the end and it outputs that topic.

`traffic_light_arbiter` now produces `/perception/traffic_light_recognition/judged/traffic_signals` topic and it goes to `crosswalk_traffic_light_estimator`

It is possible to do a naming refactor for `judged`.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

`traffic_light_arbiter` and `crosswalk_traffic_light_estimator` will be switched in the launch file.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
