### PR TITLE
feat(system diags): rename diag of ndt scan matcher

### DIFF
--- a/simulator/fault_injection/config/fault_injection.param.yaml
+++ b/simulator/fault_injection/config/fault_injection.param.yaml
@@ -3,7 +3,7 @@
     event_diag_list:
       vehicle_is_out_of_lane: ": lane_departure"
       trajectory_deviation_is_high: ": trajectory_deviation"
-      localization_matching_score_is_low: ": ndt_scan_matcher"
+      localization_matching_score_is_low: ": scan_matching_status"
       localization_accuracy_is_low: ": localization_error_ellipse"
       map_version_is_different: ": map_version"
       trajectory_is_invalid: ": trajectory_point_validation"

--- a/system/system_diagnostic_monitor/config/autoware-psim.yaml
+++ b/system/system_diagnostic_monitor/config/autoware-psim.yaml
@@ -3,7 +3,7 @@ files:
 
 edits:
   - { type: remove, path: /autoware/map/topic_rate_check/pointcloud_map }
-  - { type: remove, path: /autoware/localization/matching_score }
+  - { type: remove, path: /autoware/localization/scan_matching_status }
   - { type: remove, path: /autoware/localization/accuracy }
   - { type: remove, path: /autoware/localization/sensor_fusion_status }
   - { type: remove, path: /autoware/localization/topic_rate_check/pose_twist_fusion }

--- a/system/system_diagnostic_monitor/config/localization.yaml
+++ b/system/system_diagnostic_monitor/config/localization.yaml
@@ -8,7 +8,7 @@ units:
         list:
           - { type: link, link: /autoware/localization/topic_rate_check/transform }
           - { type: link, link: /autoware/localization/topic_rate_check/pose_twist_fusion }
-          - { type: link, link: /autoware/localization/matching_score }
+          - { type: link, link: /autoware/localization/scan_matching_status }
           - { type: link, link: /autoware/localization/accuracy }
           - { type: link, link: /autoware/localization/sensor_fusion_status }
 
@@ -27,10 +27,10 @@ units:
     node: topic_state_monitor_pose_twist_fusion_filter_pose
     name: localization_topic_status
 
-  - path: /autoware/localization/matching_score
+  - path: /autoware/localization/scan_matching_status
     type: diag
-    node: ""
-    name: ndt_scan_matcher
+    node: ndt_scan_matcher
+    name: scan_matching_status
 
   - path: /autoware/localization/accuracy
     type: diag

--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -18,10 +18,10 @@
           type: diagnostic_aggregator/AnalyzerGroup
           path: performance_monitoring
           analyzers:
-            matching_score:
+            scan_matching_status:
               type: diagnostic_aggregator/GenericAnalyzer
-              path: matching_score
-              contains: ["ndt_scan_matcher"]
+              path: scan_matching_status
+              contains: ["ndt_scan_matcher: scan_matching_status"]
               timeout: 1.0
 
             localization_error_ellipse:

--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -23,7 +23,7 @@
         /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false"}
 
         /autoware/localization/node_alive_monitoring: default
-        /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        /autoware/localization/performance_monitoring/scan_matching_status: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/localization/performance_monitoring/localization_error_ellipse: default
 
         /autoware/map/node_alive_monitoring: default

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -23,7 +23,7 @@
         /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false"}
 
         /autoware/localization/node_alive_monitoring: default
-        # /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        # /autoware/localization/performance_monitoring/scan_matching_status: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         # /autoware/localization/performance_monitoring/localization_error_ellipse: default
 
         /autoware/map/node_alive_monitoring: default


### PR DESCRIPTION
## Description

remaked the diag of ndt scan matcher at https://github.com/autowarefoundation/autoware.universe/pull/5076,
so I renamed accordingly.

<!-- Write a brief description of this PR. -->

## Tests performed

I confirmed that diag of localization works well.
### rqt_robot_monitor
![Screenshot from 2024-04-25 17-41-08](https://github.com/autowarefoundation/autoware.universe/assets/13819566/55734e58-5809-4157-b785-551d13823c12)

### rqt_diagnostic_graph_monitor
![Screenshot from 2024-04-25 17-40-43](https://github.com/autowarefoundation/autoware.universe/assets/13819566/cb1160ac-f505-47fc-9445-d9f16749fad2)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The conditions for becoming warn/error have changed.
For more details, please refer to [the readme of the NDT Scan Matcher](https://github.com/autowarefoundation/autoware.universe/blob/fd147ff78de55298cd827d4e57aae5e5e851b958/localization/ndt_scan_matcher/README.md).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
