### PR TITLE
feat(start_planner): add centerline crossing check

### DIFF
--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -441,7 +441,9 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   geometry_msgs::msg::Pose ego_overhang_point_as_pose;
   const auto [gap_between_ego_and_lane_border, corresponding_lateral_gap_with_other_lane_bound] =
     get_gap_between_ego_and_lane_border(ego_overhang_point_as_pose, ego_is_merging_from_the_left);
-  if (!gap_between_ego_and_lane_border.has_value()) return false;
+  if (!gap_between_ego_and_lane_border.has_value()) {
+    return false;
+  }
   if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_other_lane_bound) {
     // middle of the lane is crossed, no need to check for collisions anymore
     return true;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -403,7 +403,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
     const auto vehicle_footprint =
       transformVector(local_vehicle_footprint, tier4_autoware_utils::pose2transform(current_pose));
     double smallest_lateral_gap_between_ego_and_border = std::numeric_limits<double>::max();
-    double corresponding_lateral_gap_with_opposite_lane;
+    double corresponding_lateral_gap_with_other_lane_bound;
     for (const auto & point : vehicle_footprint) {
       geometry_msgs::msg::Pose point_pose;
       point_pose.position.x = point.x();
@@ -414,12 +414,12 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
       lanelet::utils::query::getClosestLanelet(target_lanes, point_pose, &closest_lanelet);
       lanelet::ConstLanelet closest_lanelet_const(closest_lanelet.constData());
 
-      const lanelet::ConstLineString2d current_lane_bound = (ego_is_merging_from_the_left)
-                                                              ? closest_lanelet_const.rightBound2d()
-                                                              : closest_lanelet_const.leftBound2d();
-      const lanelet::ConstLineString2d opposite_lane_bound =
-        (ego_is_merging_from_the_left) ? closest_lanelet_const.leftBound2d()
-                                       : closest_lanelet_const.rightBound2d();
+      const auto [current_lane_bound, other_side_lane_bound] =
+        (ego_is_merging_from_the_left)
+          ? std::make_pair(
+              closest_lanelet_const.rightBound2d(), closest_lanelet_const.leftBound2d())
+          : std::make_pair(
+              closest_lanelet_const.leftBound2d(), closest_lanelet_const.rightBound2d());
       const double current_point_lateral_gap =
         calc_absolute_lateral_offset(current_lane_bound, point_pose);
       if (current_point_lateral_gap < smallest_lateral_gap_between_ego_and_border) {
@@ -427,23 +427,23 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
         ego_overhang_point_as_pose.position.x = point.x();
         ego_overhang_point_as_pose.position.y = point.y();
         ego_overhang_point_as_pose.position.z = 0.0;
-        corresponding_lateral_gap_with_opposite_lane =
-          calc_absolute_lateral_offset(opposite_lane_bound, point_pose);
+        corresponding_lateral_gap_with_other_lane_bound =
+          calc_absolute_lateral_offset(other_side_lane_bound, point_pose);
       }
     }
     if (smallest_lateral_gap_between_ego_and_border == std::numeric_limits<double>::max()) {
       return std::make_pair(std::nullopt, 0.0);
     }
     return std::make_pair(
-      smallest_lateral_gap_between_ego_and_border, corresponding_lateral_gap_with_opposite_lane);
+      smallest_lateral_gap_between_ego_and_border, corresponding_lateral_gap_with_other_lane_bound);
   };
 
   geometry_msgs::msg::Pose ego_overhang_point_as_pose;
-  const auto [gap_between_ego_and_lane_border, corresponding_lateral_gap_with_opposite_lane] =
+  const auto [gap_between_ego_and_lane_border, corresponding_lateral_gap_with_other_lane_bound] =
     get_gap_between_ego_and_lane_border(ego_overhang_point_as_pose, ego_is_merging_from_the_left);
   if (!gap_between_ego_and_lane_border) return false;
   // middle of the lane is crossed, no need to check for collisions anymore
-  if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_opposite_lane)
+  if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_other_lane_bound)
     return true;
 
   // Get the lanelets that will be queried for target objects
@@ -473,7 +473,6 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   // filtering objects based on the current position's lane
   const auto target_objects_on_lane = utils::path_safety_checker::createTargetObjectsOnLane(
     relevant_lanelets.value(), route_handler, filtered_objects, objects_filtering_params_);
-
   if (target_objects_on_lane.on_current_lane.empty()) return false;
 
   // Get the closest target obj width in the relevant lanes

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -441,11 +441,11 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   geometry_msgs::msg::Pose ego_overhang_point_as_pose;
   const auto [gap_between_ego_and_lane_border, corresponding_lateral_gap_with_other_lane_bound] =
     get_gap_between_ego_and_lane_border(ego_overhang_point_as_pose, ego_is_merging_from_the_left);
-  if (!gap_between_ego_and_lane_border) return false;
-  // middle of the lane is crossed, no need to check for collisions anymore
-  if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_other_lane_bound)
+  if (!gap_between_ego_and_lane_border.has_value()) return false;
+  if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_other_lane_bound) {
+    // middle of the lane is crossed, no need to check for collisions anymore
     return true;
-
+  }
   // Get the lanelets that will be queried for target objects
   const auto relevant_lanelets = std::invoke([&]() -> std::optional<lanelet::ConstLanelets> {
     lanelet::Lanelet closest_lanelet;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -403,7 +403,8 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
     const auto vehicle_footprint =
       transformVector(local_vehicle_footprint, tier4_autoware_utils::pose2transform(current_pose));
     double smallest_lateral_gap_between_ego_and_border = std::numeric_limits<double>::max();
-    double corresponding_lateral_gap_with_other_lane_bound;
+    double corresponding_lateral_gap_with_other_lane_bound = std::numeric_limits<double>::max();
+
     for (const auto & point : vehicle_footprint) {
       geometry_msgs::msg::Pose point_pose;
       point_pose.position.x = point.x();
@@ -448,8 +449,8 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
     return false;
   }
 
-  const auto gap_between_ego_and_lane_border = gaps_with_lane_borders_pair.value().first;
-  const auto corresponding_lateral_gap_with_other_lane_bound =
+  const auto & gap_between_ego_and_lane_border = gaps_with_lane_borders_pair.value().first;
+  const auto & corresponding_lateral_gap_with_other_lane_bound =
     gaps_with_lane_borders_pair.value().second;
 
   // middle of the lane is crossed, no need to check for collisions anymore

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -398,11 +398,12 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   auto get_gap_between_ego_and_lane_border =
     [&](
       geometry_msgs::msg::Pose & ego_overhang_point_as_pose,
-      const bool ego_is_merging_from_the_left) -> std::optional<double> {
+      const bool ego_is_merging_from_the_left) -> std::pair<std::optional<double>, double> {
     const auto local_vehicle_footprint = vehicle_info_.createFootprint();
     const auto vehicle_footprint =
       transformVector(local_vehicle_footprint, tier4_autoware_utils::pose2transform(current_pose));
     double smallest_lateral_gap_between_ego_and_border = std::numeric_limits<double>::max();
+    double corresponding_lateral_gap_with_opposite_lane;
     for (const auto & point : vehicle_footprint) {
       geometry_msgs::msg::Pose point_pose;
       point_pose.position.x = point.x();
@@ -416,6 +417,9 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
       const lanelet::ConstLineString2d current_lane_bound = (ego_is_merging_from_the_left)
                                                               ? closest_lanelet_const.rightBound2d()
                                                               : closest_lanelet_const.leftBound2d();
+      const lanelet::ConstLineString2d opposite_lane_bound =
+        (ego_is_merging_from_the_left) ? closest_lanelet_const.leftBound2d()
+                                       : closest_lanelet_const.rightBound2d();
       const double current_point_lateral_gap =
         calc_absolute_lateral_offset(current_lane_bound, point_pose);
       if (current_point_lateral_gap < smallest_lateral_gap_between_ego_and_border) {
@@ -423,18 +427,24 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
         ego_overhang_point_as_pose.position.x = point.x();
         ego_overhang_point_as_pose.position.y = point.y();
         ego_overhang_point_as_pose.position.z = 0.0;
+        corresponding_lateral_gap_with_opposite_lane =
+          calc_absolute_lateral_offset(opposite_lane_bound, point_pose);
       }
     }
     if (smallest_lateral_gap_between_ego_and_border == std::numeric_limits<double>::max()) {
-      return std::nullopt;
+      return std::make_pair(std::nullopt, 0.0);
     }
-    return smallest_lateral_gap_between_ego_and_border;
+    return std::make_pair(
+      smallest_lateral_gap_between_ego_and_border, corresponding_lateral_gap_with_opposite_lane);
   };
 
   geometry_msgs::msg::Pose ego_overhang_point_as_pose;
-  const auto gap_between_ego_and_lane_border =
+  const auto [gap_between_ego_and_lane_border, corresponding_lateral_gap_with_opposite_lane] =
     get_gap_between_ego_and_lane_border(ego_overhang_point_as_pose, ego_is_merging_from_the_left);
   if (!gap_between_ego_and_lane_border) return false;
+  // middle of the lane is crossed, no need to check for collisions anymore
+  if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_opposite_lane)
+    return true;
 
   // Get the lanelets that will be queried for target objects
   const auto relevant_lanelets = std::invoke([&]() -> std::optional<lanelet::ConstLanelets> {
@@ -463,6 +473,11 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   // filtering objects based on the current position's lane
   const auto target_objects_on_lane = utils::path_safety_checker::createTargetObjectsOnLane(
     relevant_lanelets.value(), route_handler, filtered_objects, objects_filtering_params_);
+
+  std::vector<ExtendedPredictedObject> merged_target_object;
+  merged_target_object.reserve(
+    target_objects_on_lane.on_current_lane.size() + target_objects_on_lane.on_shoulder_lane.size());
+
   if (target_objects_on_lane.on_current_lane.empty()) return false;
 
   // Get the closest target obj width in the relevant lanes

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -474,10 +474,6 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   const auto target_objects_on_lane = utils::path_safety_checker::createTargetObjectsOnLane(
     relevant_lanelets.value(), route_handler, filtered_objects, objects_filtering_params_);
 
-  std::vector<ExtendedPredictedObject> merged_target_object;
-  merged_target_object.reserve(
-    target_objects_on_lane.on_current_lane.size() + target_objects_on_lane.on_shoulder_lane.size());
-
   if (target_objects_on_lane.on_current_lane.empty()) return false;
 
   // Get the closest target obj width in the relevant lanes

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -432,11 +432,12 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
           calc_absolute_lateral_offset(other_side_lane_bound, point_pose);
       }
     }
-    if (smallest_lateral_gap_between_ego_and_border == std::numeric_limits<double>::max()) {
-      return std::make_pair(std::nullopt, std::nullopt);
-    }
-    return std::make_pair(
-      smallest_lateral_gap_between_ego_and_border, corresponding_lateral_gap_with_other_lane_bound);
+
+    return (smallest_lateral_gap_between_ego_and_border < std::numeric_limits<double>::max())
+             ? std::make_pair(
+                 std::make_optional<double>(smallest_lateral_gap_between_ego_and_border),
+                 std::make_optional<double>(corresponding_lateral_gap_with_other_lane_bound))
+             : std::make_pair(std::nullopt, std::nullopt);
   };
 
   geometry_msgs::msg::Pose ego_overhang_point_as_pose;

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -504,7 +504,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   if (!closest_object_width) return false;
   // Decide if the closest object does not fit in the gap left by the ego vehicle.
   return closest_object_width.value() + parameters_->extra_width_margin_for_rear_obstacle >
-         gap_between_ego_and_lane_border.value();
+         gap_between_ego_and_lane_border;
 }
 
 bool StartPlannerModule::isCloseToOriginalStartPose() const

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -448,8 +448,8 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
     return false;
   }
 
-  const auto & gap_between_ego_and_lane_border = gaps_with_lane_borders_pair.value().first;
-  const auto & corresponding_lateral_gap_with_other_lane_bound =
+  const auto gap_between_ego_and_lane_border = gaps_with_lane_borders_pair.value().first;
+  const auto corresponding_lateral_gap_with_other_lane_bound =
     gaps_with_lane_borders_pair.value().second;
 
   // middle of the lane is crossed, no need to check for collisions anymore

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -451,8 +451,9 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   const auto & gap_between_ego_and_lane_border = gaps_with_lane_borders_pair.value().first;
   const auto & corresponding_lateral_gap_with_other_lane_bound =
     gaps_with_lane_borders_pair.value().second;
+
+  // middle of the lane is crossed, no need to check for collisions anymore
   if (gap_between_ego_and_lane_border < corresponding_lateral_gap_with_other_lane_bound) {
-    // middle of the lane is crossed, no need to check for collisions anymore
     return true;
   }
   // Get the lanelets that will be queried for target objects

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -398,7 +398,8 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   auto get_gap_between_ego_and_lane_border =
     [&](
       geometry_msgs::msg::Pose & ego_overhang_point_as_pose,
-      const bool ego_is_merging_from_the_left) -> std::pair<std::optional<double>, double> {
+      const bool ego_is_merging_from_the_left)
+    -> std::pair<std::optional<double>, std::optional<double>> {
     const auto local_vehicle_footprint = vehicle_info_.createFootprint();
     const auto vehicle_footprint =
       transformVector(local_vehicle_footprint, tier4_autoware_utils::pose2transform(current_pose));
@@ -432,7 +433,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
       }
     }
     if (smallest_lateral_gap_between_ego_and_border == std::numeric_limits<double>::max()) {
-      return std::make_pair(std::nullopt, 0.0);
+      return std::make_pair(std::nullopt, std::nullopt);
     }
     return std::make_pair(
       smallest_lateral_gap_between_ego_and_border, corresponding_lateral_gap_with_other_lane_bound);
@@ -441,10 +442,14 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   geometry_msgs::msg::Pose ego_overhang_point_as_pose;
   const auto [gap_between_ego_and_lane_border, corresponding_lateral_gap_with_other_lane_bound] =
     get_gap_between_ego_and_lane_border(ego_overhang_point_as_pose, ego_is_merging_from_the_left);
-  if (!gap_between_ego_and_lane_border.has_value()) {
+  if (
+    !gap_between_ego_and_lane_border.has_value() ||
+    !corresponding_lateral_gap_with_other_lane_bound.has_value()) {
     return false;
   }
-  if (gap_between_ego_and_lane_border.value() < corresponding_lateral_gap_with_other_lane_bound) {
+  if (
+    gap_between_ego_and_lane_border.value() <
+    corresponding_lateral_gap_with_other_lane_bound.value()) {
     // middle of the lane is crossed, no need to check for collisions anymore
     return true;
   }


### PR DESCRIPTION
## Description

Related to this ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-6090)

on Autoware, the start planner has a check that lets it ignore rear vehicles if the gap between the ego and its merging lane is not big enough to let the rear vehicle pass through, this is done on the isPreventingRearVehicleFromPassingThrough() function. 

However, there are situations where the function isPreventingRearVehicleFromPassingThrough() does not consider objects that are not directly behind the ego vehicle but that have a predicted path that goes through the ego path. In said cases isPreventingRearVehicleFromPassingThrough() will return false because it does not detect an object behind ego (this is for safety) but then the dynamic  obstacle collision check will detect the object an issue a stop wall, even if the ego vehicle has properly merged with its target lane. 

![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/eee83692-8c33-4a02-908f-9583eaef4a32)


Ideally the function isPreventingRearVehicleFromPassingThrough() should categorize vehicles based on intention (predicted path) and not just position, but said behavior requires some though and work time. 

On the mean time I issued this PR to improve the  isPreventingRearVehicleFromPassingThrough() function by checking if any of the ego overhang points has crossed the center of the road. In that case, it does not make much sense to think about dynamic collision with obstacles from behind since the ego has already merged into its target lane. 

With this PR the start planner ignores false dynamic collision cases like in this case:


https://github.com/autowarefoundation/autoware.universe/assets/25967964/c2f79d85-a02f-4bf1-9fce-ffa78f987fb0



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Evaluator tests [TIER IV INTERNAL LINK](https://evaluation.ci.tier4.jp/evaluation/reports/02855474-ede0-557b-90fc-e35f2542ce02?project_id=prd_jt) <- there is degradation but it is not caused by this PR afaik

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
