### PR TITLE
chore(autoware_auto_perception_rviz_plugin): improve distant object visibility 

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -87,7 +87,7 @@ get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
   const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
-  const bool & is_orientation_available = true);
+  const bool & is_orientation_available = true, const int fill_type = 0);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_2d_shape_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -57,6 +57,9 @@ struct ObjectPropertyValues
   float alpha{0.999F};
 };
 
+// Control object marker visualization
+enum class ObjectFillType { Skeleton, Fill };
+
 // Map defining colors according to value of label field in ObjectClassification msg
 const std::map<
   autoware_auto_perception_msgs::msg::ObjectClassification::_label_type, ObjectPropertyValues>
@@ -87,7 +90,8 @@ get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
   const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
-  const bool & is_orientation_available = true, const int fill_type = 0);
+  const bool & is_orientation_available = true,
+  const ObjectFillType fill_type = ObjectFillType::Skeleton);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_2d_shape_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -113,8 +113,8 @@ public:
     m_confidence_interval_property->addOption("99%", 3);
 
     m_object_fill_type_property = new rviz_common::properties::EnumProperty(
-      "Object Fill Type", "Skelton", "Change object fill type in visualization", this);
-    m_object_fill_type_property->addOption("Skelton", 0);
+      "Object Fill Type", "skeleton", "Change object fill type in visualization", this);
+    m_object_fill_type_property->addOption("skeleton", 0);
     m_object_fill_type_property->addOption("Fill", 1);
 
     // iterate over default values to create and initialize the properties.

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -114,8 +114,9 @@ public:
 
     m_object_fill_type_property = new rviz_common::properties::EnumProperty(
       "Object Fill Type", "skeleton", "Change object fill type in visualization", this);
-    m_object_fill_type_property->addOption("skeleton", 0);
-    m_object_fill_type_property->addOption("Fill", 1);
+    m_object_fill_type_property->addOption(
+      "skeleton", static_cast<int>(detail::ObjectFillType::Skeleton));
+    m_object_fill_type_property->addOption("Fill", static_cast<int>(detail::ObjectFillType::Fill));
 
     // iterate over default values to create and initialize the properties.
     for (const auto & map_property_it : detail::kDefaultObjectPropertyValues) {
@@ -194,7 +195,8 @@ protected:
     const bool & is_orientation_available) const
   {
     const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
-    const auto fill_type = m_object_fill_type_property->getOptionInt();
+    const auto fill_type =
+      static_cast<detail::ObjectFillType>(m_object_fill_type_property->getOptionInt());
 
     if (m_display_type_property->getOptionInt() == 0) {
       return detail::get_shape_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -112,6 +112,11 @@ public:
     m_confidence_interval_property->addOption("95%", 2);
     m_confidence_interval_property->addOption("99%", 3);
 
+    m_object_fill_type_property = new rviz_common::properties::EnumProperty(
+      "Object Fill Type", "Skelton", "Change object fill type in visualization", this);
+    m_object_fill_type_property->addOption("Skelton", 0);
+    m_object_fill_type_property->addOption("Fill", 1);
+
     // iterate over default values to create and initialize the properties.
     for (const auto & map_property_it : detail::kDefaultObjectPropertyValues) {
       const auto & class_property_values = map_property_it.second;
@@ -189,9 +194,12 @@ protected:
     const bool & is_orientation_available) const
   {
     const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
+    const auto fill_type = m_object_fill_type_property->getOptionInt();
+
     if (m_display_type_property->getOptionInt() == 0) {
       return detail::get_shape_marker_ptr(
-        shape_msg, centroid, orientation, color_rgba, line_width, is_orientation_available);
+        shape_msg, centroid, orientation, color_rgba, line_width, is_orientation_available,
+        fill_type);
     } else if (m_display_type_property->getOptionInt() == 1) {
       return detail::get_2d_shape_marker_ptr(
         shape_msg, centroid, orientation, color_rgba, line_width, is_orientation_available);
@@ -526,6 +534,8 @@ private:
   rviz_common::properties::EnumProperty * m_simple_visualize_mode_property;
   // Property to set confidence interval of state estimations
   rviz_common::properties::EnumProperty * m_confidence_interval_property;
+  // Property to set visualization type
+  rviz_common::properties::EnumProperty * m_object_fill_type_property;
   // Property to enable/disable label visualization
   rviz_common::properties::BoolProperty m_display_label_property;
   // Property to enable/disable uuid visualization

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -495,23 +495,37 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
   const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
-  const bool & is_orientation_available)
+  const bool & is_orientation_available, const int fill_type)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->ns = std::string("shape");
+  marker_ptr->color = color_rgba;
+  marker_ptr->scale.x = line_width;
 
   using autoware_auto_perception_msgs::msg::Shape;
   if (shape_msg.type == Shape::BOUNDING_BOX) {
-    marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
-    calc_bounding_box_line_list(shape_msg, marker_ptr->points);
+    if (fill_type == 0) {
+      marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
+      calc_bounding_box_line_list(shape_msg, marker_ptr->points);
+    } else if (fill_type == 1) {
+      marker_ptr->type = visualization_msgs::msg::Marker::CUBE;
+      marker_ptr->scale = shape_msg.dimensions;
+      marker_ptr->color.a = 0.75f;
+    }
     if (is_orientation_available) {
       calc_bounding_box_direction_line_list(shape_msg, marker_ptr->points);
     } else {
       calc_bounding_box_orientation_line_list(shape_msg, marker_ptr->points);
     }
   } else if (shape_msg.type == Shape::CYLINDER) {
-    marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
-    calc_cylinder_line_list(shape_msg, marker_ptr->points);
+    if (fill_type == 0) {
+      marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
+      calc_cylinder_line_list(shape_msg, marker_ptr->points);
+    } else if (fill_type == 1) {
+      marker_ptr->type = visualization_msgs::msg::Marker::CYLINDER;
+      marker_ptr->scale = shape_msg.dimensions;
+      marker_ptr->color.a = 0.75f;
+    }
   } else if (shape_msg.type == Shape::POLYGON) {
     marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
     calc_polygon_line_list(shape_msg, marker_ptr->points);
@@ -523,8 +537,6 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = to_pose(centroid, orientation);
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.15);
-  marker_ptr->scale.x = line_width;
-  marker_ptr->color = color_rgba;
 
   return marker_ptr;
 }

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -495,7 +495,7 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
   const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width,
-  const bool & is_orientation_available, const int fill_type)
+  const bool & is_orientation_available, const ObjectFillType fill_type)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->ns = std::string("shape");
@@ -504,10 +504,10 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
 
   using autoware_auto_perception_msgs::msg::Shape;
   if (shape_msg.type == Shape::BOUNDING_BOX) {
-    if (fill_type == 0) {
+    if (fill_type == ObjectFillType::Skeleton) {
       marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
       calc_bounding_box_line_list(shape_msg, marker_ptr->points);
-    } else if (fill_type == 1) {
+    } else if (fill_type == ObjectFillType::Fill) {
       marker_ptr->type = visualization_msgs::msg::Marker::CUBE;
       marker_ptr->scale = shape_msg.dimensions;
       marker_ptr->color.a = 0.75f;
@@ -518,10 +518,10 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
       calc_bounding_box_orientation_line_list(shape_msg, marker_ptr->points);
     }
   } else if (shape_msg.type == Shape::CYLINDER) {
-    if (fill_type == 0) {
+    if (fill_type == ObjectFillType::Skeleton) {
       marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
       calc_cylinder_line_list(shape_msg, marker_ptr->points);
-    } else if (fill_type == 1) {
+    } else if (fill_type == ObjectFillType::Fill) {
       marker_ptr->type = visualization_msgs::msg::Marker::CYLINDER;
       marker_ptr->scale = shape_msg.dimensions;
       marker_ptr->color.a = 0.75f;


### PR DESCRIPTION
## Description

The detected objects are now displayed as skeletons. It is now difficult to determine if distant objects are being detected, e.g. in crowded intersections. 
I have added a visualization option to fill in the objects. In Rviz, you can toggle a flag to change the visualization.



**Set Object Fill Type to `Skeleton` (Default):**

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/419a812d-6710-4f12-971a-df6dda5f35cf)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/a9026940-e5c8-41b9-9c00-6517b896f34c)



**Set Object Fill Type to `Fill`:**
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/e7b20dc2-76d5-4ce0-a228-b3bae8d90758)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/7d9b5d79-cdc0-4b47-b536-63f9b28827bc)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

- Run psim/lsim
- Change the `Object Fill Type` to `Skeleton(Default)/FIll` and check if the visualization is changed.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

Object marker will have a new option in Rviz

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
