### PR TITLE
fix(avoidance): add missing parameter declaration

### DIFF
--- a/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_avoidance_module/include/behavior_path_avoidance_module/parameter_helper.hpp
@@ -132,6 +132,11 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
   }
 
   {
+    const std::string ns = "avoidance.target_filtering.merging_vehicle.";
+    p.th_overhang_distance = getOrDeclareParameter<double>(*node, ns + "th_overhang_distance");
+  }
+
+  {
     const std::string ns = "avoidance.target_filtering.avoidance_for_ambiguous_vehicle.";
     p.enable_avoidance_for_ambiguous_vehicle = getOrDeclareParameter<bool>(*node, ns + "enable");
     p.closest_distance_to_wait_and_see_for_ambiguous_vehicle =

--- a/planning/behavior_path_avoidance_module/schema/avoidance.schema.json
+++ b/planning/behavior_path_avoidance_module/schema/avoidance.schema.json
@@ -686,7 +686,7 @@
               "properties": {
                 "th_overhang_distance": {
                   "type": "number",
-                  "description": "Distance threshold between overhang point and ego lane's centerline. If the nearest overhang point of merging/deviating vehicle is less than this param, the module never avoid it. (Basically, the ego stops behind of it.)",
+                  "description": "Distance threshold to ignore merging/deviating vehicle to/from ego drivng lane. The distance represents how the object polygon overlaps ego lane, and it's calculated from polygon overhang point and lane centerline. If the distance is more than this param, the module never avoid the object. (Basically, the ego stops behind of it.)",
                   "default": 0.5
                 }
               },

--- a/planning/behavior_path_avoidance_module/schema/avoidance.schema.json
+++ b/planning/behavior_path_avoidance_module/schema/avoidance.schema.json
@@ -686,7 +686,7 @@
               "properties": {
                 "th_overhang_distance": {
                   "type": "number",
-                  "description": "Distance threshold to ignore merging/deviating vehicle to/from ego drivng lane. The distance represents how the object polygon overlaps ego lane, and it's calculated from polygon overhang point and lane centerline. If the distance is more than this param, the module never avoid the object. (Basically, the ego stops behind of it.)",
+                  "description": "Distance threshold to ignore merging/deviating vehicle to/from ego driving lane. The distance represents how the object polygon overlaps ego lane, and it's calculated from polygon overhang point and lane centerline. If the distance is more than this param, the module never avoid the object. (Basically, the ego stops behind of it.)",
                   "default": 0.5
                 }
               },

--- a/planning/behavior_path_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_avoidance_module/src/manager.cpp
@@ -125,6 +125,11 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
   }
 
   {
+    const std::string ns = "avoidance.target_filtering.merging_vehicle.";
+    updateParam<double>(parameters, ns + "th_overhang_distance", p->th_overhang_distance);
+  }
+
+  {
     const std::string ns = "avoidance.avoidance.lateral.avoidance_for_ambiguous_vehicle.";
     updateParam<bool>(parameters, ns + "enable", p->enable_avoidance_for_ambiguous_vehicle);
     updateParam<double>(


### PR DESCRIPTION
## Description

Add missing parameter declaration.

```c++
  {
    const std::string ns = "avoidance.target_filtering.merging_vehicle.";
    p.th_overhang_distance = getOrDeclareParameter<double>(*node, ns + "th_overhang_distance");
  }
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
