### PR TITLE
fix(avoidance): unexpected road shoulder distance calculation result

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -932,7 +932,8 @@ double getRoadShoulderDistance(
       }
 
       const auto envelope_polygon_width =
-        boost::geometry::area(object.envelope_poly) / object.length;
+        boost::geometry::area(object.envelope_poly) /
+        std::max(object.length, 1e-3);  // prevent division by zero
 
       {
         const auto p2 =

--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -931,8 +931,13 @@ double getRoadShoulderDistance(
         }
       }
 
+      const auto envelope_polygon_width =
+        boost::geometry::area(object.envelope_poly) / object.length;
+
       {
-        const auto p2 = calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -1.0 : 1.0), 0.0).position;
+        const auto p2 =
+          calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -0.5 : 0.5) * envelope_polygon_width, 0.0)
+            .position;
         const auto opt_intersect =
           tier4_autoware_utils::intersect(p1.second, p2, bound.at(i - 1), bound.at(i));
 


### PR DESCRIPTION
## Description

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-6050)

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/6781

The module searches most overhanging point by following steps:

1. pick a point from envelope polygon contour (P1).
2. create new point from P1 by using `calcOffsetPose` (P2).
3. search intersection point between P1-P2 and drivable bound.
4. calculate distance between intersection point and P1.
5. _apply step1~4 for all polygon points._
6. sort point by distance calculated in step4.
7. pick the point whose distance is smallest from sorted points as most overhanging point.

```c++
const auto p2 = calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -1.0 : 1.0), 0.0).position;
```

Previously, the point (P2) is calculated with constant offset value. **However, I found sometimes it couldn't find intersection point for some polygon points when the distance between P1 and drivable bound was larger than 1.0m.**

In following case, it couldn't find intersection point for bottom left/right points on white polygon. As a result, it got wrong point as the most overhanging point and created infeasible path.

![Screenshot from 2024-05-01 13-28-31](https://github.com/autowarefoundation/autoware.universe/assets/44889564/e6928fc6-1a45-4df8-bac2-f35ab75c681b)

In this PR, I fixed the logic for step2 to decide offset value based on polygon width so that it always can find intersection point for all polygon points.

```c++
const auto envelope_polygon_width =
        boost::geometry::area(object.envelope_poly) / object.length;

      {
        const auto p2 =
          calcOffsetPose(p_tmp, 0.0, (isOnRight(object) ? -0.5 : 0.5) * envelope_polygon_width, 0.0)
            .position;
...
```
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Overhang distance is calculated expectedly. And it doesn't create infeasible path.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/61b5b391-4032-41bc-8f79-2bb83e527787)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
