### PR TITLE
feat(autonomous_emergency_braking): add obstacle velocity estimation for AEB

### DIFF
--- a/control/autonomous_emergency_braking/README.md
+++ b/control/autonomous_emergency_braking/README.md
@@ -108,6 +108,33 @@ After Noise filtering, it performs a geometric collision check to determine whet
 
 Finally, the vertex that is closest to the ego vehicle is chosen as the candidate for collision checking: Since rss distance is used to judge if a collision will happen or not, if the closest vertex to the ego is deemed to be safe, the rest of the vertices (and the points in the clusters) will also be safe.
 
+#### Obstacle velocity estimation
+
+Once the position of the closest obstacle/point is determined, the AEB modules uses the history of previously detected objects to estimate the closest object speed using the following equations:
+
+$$
+d_{t} = o_{time stamp} - prev_{time stamp}
+$$
+
+$$
+d_{pos} = norm(o_{pos} - prev_{pos})
+$$
+
+$$
+v_{norm} = d_{pos} / d_{t}
+$$
+
+Where $o_{time stamp}$ and $prev_{time stamp}$ are the timestamps of the point clouds used to detect the current closest object and the closest object of the previous point cloud frame, and $o_{pos}$ and $prev_{pos}$ are the positions of those objects, respectively.
+
+Finally, the velocity vector is compared against the ego's predicted path to get the longitudinal velocity $v_{obj}$:
+
+$$
+v_{obj} = v_{norm} * Cos(yaw_{diff}) + v_{ego}
+$$
+
+where $yaw_{diff}$ is the difference in yaw between the ego path and the displacement vector $$v_{pos} = o_{pos} - prev_{pos} $$ and $v_{ego}$ is the ego's speed, which accounts for the movement of points caused by the ego moving and not the object.
+All these equations are performed disregarding the z axis (in 2D).
+
 ### 4. Collision check with target obstacles
 
 In the fourth step, it checks the collision with filtered obstacles using RSS distance. RSS is formulated as:

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -10,7 +10,7 @@
     mpc_prediction_time_interval: 0.1
 
     # Debug
-    publish_debug_pointcloud: true
+    publish_debug_pointcloud: false
 
     # Point cloud partitioning
     detection_range_min_height: 0.0
@@ -33,12 +33,6 @@
     t_response: 1.0
     a_ego_min: -3.0
     a_obj_min: -1.0
-    minimum_cluster_size: 10
-    maximum_cluster_size: 10000
-    imu_prediction_time_horizon: 1.5
-    imu_prediction_time_interval: 0.1
-    mpc_prediction_time_horizon: 1.5
-    mpc_prediction_time_interval: 0.1
     collision_keeping_sec: 2.0
     previous_obstacle_keep_time: 1.0
     aeb_hz: 10.0

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -33,7 +33,6 @@
     t_response: 1.0
     a_ego_min: -3.0
     a_obj_min: -1.0
-    cluster_tolerance: 0.1 #[m]
     minimum_cluster_size: 10
     maximum_cluster_size: 10000
     imu_prediction_time_horizon: 1.5

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -1,26 +1,39 @@
 /**:
   ros__parameters:
-    publish_debug_pointcloud: false
+    # Ego path calculation
     use_predicted_trajectory: true
-    use_imu_path: true
-    path_footprint_extra_margin: 1.0
+    use_imu_path: false
+    min_generated_path_length: 0.5
+    imu_prediction_time_horizon: 1.5
+    imu_prediction_time_interval: 0.1
+    mpc_prediction_time_horizon: 1.5
+    mpc_prediction_time_interval: 0.1
+
+    # Debug
+    publish_debug_pointcloud: true
+
+    # Point cloud voxelization
     detection_range_min_height: 0.0
     detection_range_max_height_margin: 0.0
     voxel_grid_x: 0.05
     voxel_grid_y: 0.05
     voxel_grid_z: 100000.0
-    min_generated_path_length: 0.5
+
+    # Point cloud cropping
     expand_width: 0.1
+    path_footprint_extra_margin: 4.0
+
+    # Point cloud clustering
+    cluster_tolerance: 0.1 #[m]
+    minimum_cluster_size: 10
+    maximum_cluster_size: 10000
+
+    # RSS distance collision check
     longitudinal_offset: 2.0
     t_response: 1.0
     a_ego_min: -3.0
     a_obj_min: -1.0
-    cluster_tolerance: 0.1 #[m]
-    minimum_cluster_size: 10
-    maximum_cluster_size: 10000
-    imu_prediction_time_horizon: 1.5
-    imu_prediction_time_interval: 0.1
-    mpc_prediction_time_horizon: 1.5
-    mpc_prediction_time_interval: 0.1
-    collision_keeping_sec: 0.0
+    collision_keeping_sec: 2.0
+
+    # Meta params
     aeb_hz: 10.0

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -12,7 +12,7 @@
     # Debug
     publish_debug_pointcloud: true
 
-    # Point cloud voxelization
+    # Point cloud partitioning
     detection_range_min_height: 0.0
     detection_range_max_height_margin: 0.0
     voxel_grid_x: 0.05

--- a/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -33,7 +33,13 @@
     t_response: 1.0
     a_ego_min: -3.0
     a_obj_min: -1.0
+    cluster_tolerance: 0.1 #[m]
+    minimum_cluster_size: 10
+    maximum_cluster_size: 10000
+    imu_prediction_time_horizon: 1.5
+    imu_prediction_time_interval: 0.1
+    mpc_prediction_time_horizon: 1.5
+    mpc_prediction_time_interval: 0.1
     collision_keeping_sec: 2.0
-
-    # Meta params
+    previous_obstacle_keep_time: 1.0
     aeb_hz: 10.0

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -156,12 +156,7 @@ public:
   void createObjectDataUsingPointCloudClusters(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
-
   void cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_polys);
-
-  ObjectData getClosestObject(
-    std::vector<ObjectData> & objects, const Path & ego_path,
-    const geometry_msgs::msg::Pose & ego_pose);
 
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -40,7 +40,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -152,9 +152,9 @@ public:
   void cropPointCloudWithEgoFootprintPath(
     const std::vector<Polygon2d> & ego_polys, pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects);
 
-  void cropPointCloudWithEgoPath(const std::vector<Polygon2d> & ego_polys);
+  void cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_polys);
 
-  void createClusteredPointCloudObjectData(
+  void createObjectDataUsingPointCloudClusters(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
 

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -44,7 +44,6 @@
 #include <deque>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 #include <utility>
@@ -322,7 +321,6 @@ public:
   double mpc_prediction_time_horizon_;
   double mpc_prediction_time_interval_;
   CollisionDataKeeper collision_data_keeper_;
-  std::mutex data_mutex_;
 };
 }  // namespace autoware::motion::control::autonomous_emergency_braking
 

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -273,9 +273,9 @@ public:
 
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,
-    const std::vector<ObjectData> & objects, const double color_r, const double color_g,
-    const double color_b, const double color_a, const std::string & ns,
-    MarkerArray & debug_markers);
+    const std::vector<ObjectData> & objects, const std::optional<ObjectData> & closest_object,
+    const double color_r, const double color_g, const double color_b, const double color_a,
+    const std::string & ns, MarkerArray & debug_markers);
 
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -40,6 +40,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -152,11 +153,15 @@ public:
   void cropPointCloudWithEgoFootprintPath(
     const std::vector<Polygon2d> & ego_polys, pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects);
 
-  void cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_polys);
-
   void createObjectDataUsingPointCloudClusters(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
+
+  void cropPointCloudWithEgoFootprintPath(const std::vector<Polygon2d> & ego_polys);
+
+  ObjectData getClosestObject(
+    std::vector<ObjectData> & objects, const Path & ego_path,
+    const geometry_msgs::msg::Pose & ego_pose);
 
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -152,6 +152,8 @@ public:
   void cropPointCloudWithEgoFootprintPath(
     const std::vector<Polygon2d> & ego_polys, pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects);
 
+  void cropPointCloudWithEgoPath(const std::vector<Polygon2d> & ego_polys);
+
   void createClusteredPointCloudObjectData(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects);
@@ -165,6 +167,8 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
+  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
+
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};
   Trajectory::ConstSharedPtr predicted_traj_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -152,6 +152,10 @@ public:
   void cropPointCloudWithEgoFootprintPath(
     const std::vector<Polygon2d> & ego_polys, pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects);
 
+  void createClusteredPointCloudObjectData(
+    const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
+    std::vector<ObjectData> & objects);
+
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,
     const std::vector<ObjectData> & objects, const double color_r, const double color_g,

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -167,8 +167,6 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
-  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
-
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};
   Trajectory::ConstSharedPtr predicted_traj_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -167,7 +167,6 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
-  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
 
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -216,7 +216,6 @@ public:
     }
 
     const auto & estimated_velocity = estimated_velocity_opt.value();
-
     this->setPreviousObjectData(closest_object);
     this->updateVelocityHistory(estimated_velocity, closest_object.stamp);
     return this->getMedianObstacleVelocity();

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -167,6 +167,7 @@ public:
   void addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
+  PointCloud2::SharedPtr cropped_ros_pointcloud_ptr_{nullptr};
 
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -326,7 +326,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   }
 
   // step2. create velocity data check if the vehicle stops or not
-  const double current_v = current_velocity_ptr_->longitudinal_velocity + 2.25;
+  const double current_v = current_velocity_ptr_->longitudinal_velocity;
   if (current_v < 0.1) {
     return false;
   }

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -107,17 +107,17 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
 {
   // Subscribers
   sub_point_cloud_ = this->create_subscription<PointCloud2>(
-    "/perception/obstacle_segmentation/pointcloud", rclcpp::SensorDataQoS(),
+    "~/input/pointcloud", rclcpp::SensorDataQoS(),
     std::bind(&AEB::onPointCloud, this, std::placeholders::_1));
 
   sub_velocity_ = this->create_subscription<VelocityReport>(
-    "/input/velocity", rclcpp::QoS{1}, std::bind(&AEB::onVelocity, this, std::placeholders::_1));
+    "~/input/velocity", rclcpp::QoS{1}, std::bind(&AEB::onVelocity, this, std::placeholders::_1));
 
   sub_imu_ = this->create_subscription<Imu>(
-    "/input/imu", rclcpp::QoS{1}, std::bind(&AEB::onImu, this, std::placeholders::_1));
+    "~/input/imu", rclcpp::QoS{1}, std::bind(&AEB::onImu, this, std::placeholders::_1));
 
   sub_predicted_traj_ = this->create_subscription<Trajectory>(
-    "/input/predicted_trajectory", rclcpp::QoS{1},
+    "~/input/predicted_trajectory", rclcpp::QoS{1},
     std::bind(&AEB::onPredictedTrajectory, this, std::placeholders::_1));
 
   sub_autoware_state_ = this->create_subscription<AutowareState>(

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -295,6 +295,7 @@ bool AEB::isDataReady()
 
 void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 {
+  TimeIT t(__func__);
   MarkerArray debug_markers;
   checkCollision(debug_markers);
 
@@ -319,6 +320,7 @@ void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 bool AEB::checkCollision(MarkerArray & debug_markers)
 {
   using colorTuple = std::tuple<double, double, double, double>;
+  TimeIT t(__func__);
 
   // step1. check data
   if (!isDataReady()) {

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -257,7 +257,6 @@ void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
   filter.filter(*no_height_filtered_pointcloud_ptr);
 
   obstacle_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
-  cropped_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
 
   pcl::toROSMsg(*no_height_filtered_pointcloud_ptr, *obstacle_ros_pointcloud_ptr_);
   obstacle_ros_pointcloud_ptr_->header = input_msg->header;

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -693,9 +693,9 @@ void AEB::addMarker(
     closest_object_velocity_marker_array.pose.position = obj.position;
     const auto ego_velocity = current_velocity_ptr_->longitudinal_velocity;
     closest_object_velocity_marker_array.text =
-      "Object velocity: " + std::to_string(obj.velocity) + "\n";
+      "Object velocity: " + std::to_string(obj.velocity) + " [m/s]\n";
     closest_object_velocity_marker_array.text +=
-      "Object relative velocity to ego: " + std::to_string(obj.velocity - ego_velocity);
+      "Object relative velocity to ego: " + std::to_string(obj.velocity - ego_velocity) + " [m/s]";
     debug_markers.markers.push_back(closest_object_velocity_marker_array);
   }
 }

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -169,7 +169,10 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   timer_ = rclcpp::create_timer(this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
 }
 
-void AEB::onTimer() { updater_.force_update(); }
+void AEB::onTimer()
+{
+  updater_.force_update();
+}
 
 void AEB::onVelocity(const VelocityReport::ConstSharedPtr input_msg)
 {

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -184,14 +184,12 @@ void AEB::onTimer()
 
 void AEB::onVelocity(const VelocityReport::ConstSharedPtr input_msg)
 {
-  std::lock_guard<std::mutex> lock(data_mutex_);
   current_velocity_ptr_ = input_msg;
 }
 
 void AEB::onImu(const Imu::ConstSharedPtr input_msg)
 {
   // transform imu
-  std::lock_guard<std::mutex> lock(data_mutex_);
   geometry_msgs::msg::TransformStamped transform_stamped{};
   try {
     transform_stamped = tf_buffer_.lookupTransform(
@@ -211,19 +209,16 @@ void AEB::onImu(const Imu::ConstSharedPtr input_msg)
 void AEB::onPredictedTrajectory(
   const autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr input_msg)
 {
-  std::lock_guard<std::mutex> lock(data_mutex_);
   predicted_traj_ptr_ = input_msg;
 }
 
 void AEB::onAutowareState(const AutowareState::ConstSharedPtr input_msg)
 {
-  std::lock_guard<std::mutex> lock(data_mutex_);
   autoware_state_ = input_msg;
 }
 
 void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
 {
-  std::lock_guard<std::mutex> lock(data_mutex_);
   PointCloud::Ptr pointcloud_ptr(new PointCloud);
   pcl::fromROSMsg(*input_msg, *pointcloud_ptr);
 
@@ -333,7 +328,6 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   using colorTuple = std::tuple<double, double, double, double>;
 
   // step1. check data
-  std::lock_guard<std::mutex> lock(data_mutex_);
   if (!isDataReady()) {
     return false;
   }

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -168,13 +168,7 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
     const auto previous_obstacle_keep_time =
       declare_parameter<double>("previous_obstacle_keep_time");
     const auto collision_keeping_sec = declare_parameter<double>("collision_keeping_sec");
-    const auto min_closest_point_velocity_threshold =
-      declare_parameter<double>("min_closest_point_velocity_threshold");
-    const auto max_closest_point_velocity_threshold =
-      declare_parameter<double>("max_closest_point_velocity_threshold");
     collision_data_keeper_.setTimeout(collision_keeping_sec, previous_obstacle_keep_time);
-    collision_data_keeper_.setObjectSpeedLimits(
-      min_closest_point_velocity_threshold, max_closest_point_velocity_threshold);
   }
 
   // start time
@@ -322,6 +316,7 @@ void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
     const auto & data = collision_data_keeper_.get();
     stat.addf("RSS", "%.2f", data.rss);
     stat.addf("Distance", "%.2f", data.distance_to_object);
+    stat.addf("Object Speed", "%.2f", data.velocity);
     addCollisionMarker(data, debug_markers);
   } else {
     const std::string error_msg = "[AEB]: No Collision";

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -108,17 +108,17 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
 {
   // Subscribers
   sub_point_cloud_ = this->create_subscription<PointCloud2>(
-    "~/input/pointcloud", rclcpp::SensorDataQoS(),
+    "/perception/obstacle_segmentation/pointcloud", rclcpp::SensorDataQoS(),
     std::bind(&AEB::onPointCloud, this, std::placeholders::_1));
 
   sub_velocity_ = this->create_subscription<VelocityReport>(
-    "~/input/velocity", rclcpp::QoS{1}, std::bind(&AEB::onVelocity, this, std::placeholders::_1));
+    "/input/velocity", rclcpp::QoS{1}, std::bind(&AEB::onVelocity, this, std::placeholders::_1));
 
   sub_imu_ = this->create_subscription<Imu>(
-    "~/input/imu", rclcpp::QoS{1}, std::bind(&AEB::onImu, this, std::placeholders::_1));
+    "/input/imu", rclcpp::QoS{1}, std::bind(&AEB::onImu, this, std::placeholders::_1));
 
   sub_predicted_traj_ = this->create_subscription<Trajectory>(
-    "~/input/predicted_trajectory", rclcpp::QoS{1},
+    "/input/predicted_trajectory", rclcpp::QoS{1},
     std::bind(&AEB::onPredictedTrajectory, this, std::placeholders::_1));
 
   sub_autoware_state_ = this->create_subscription<AutowareState>(
@@ -172,6 +172,7 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
 
 void AEB::onTimer()
 {
+  std::cerr << "On TIMER!\n";
   updater_.force_update();
 }
 
@@ -295,6 +296,7 @@ bool AEB::isDataReady()
 void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 {
   MarkerArray debug_markers;
+  std::cerr << " onCheckCollision \n";
   checkCollision(debug_markers);
 
   if (!collision_data_keeper_.checkExpired()) {
@@ -321,17 +323,20 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
   // step1. check data
   if (!isDataReady()) {
+    std::cerr << __func__ << " !isDataReady() \n";
     return false;
   }
 
   // if not driving, disable aeb
   if (autoware_state_->state != AutowareState::DRIVING) {
+    std::cerr << __func__ << " Driving \n";
     return false;
   }
 
   // step2. create velocity data check if the vehicle stops or not
   const double current_v = current_velocity_ptr_->longitudinal_velocity;
   if (current_v < 0.1) {
+    std::cerr << __func__ << " Current vel \n";
     return false;
   }
 

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -35,6 +35,7 @@
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/surface/convex_hull.h>
 #include <tf2/utils.h>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -35,7 +35,6 @@
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/surface/convex_hull.h>
 #include <tf2/utils.h>
-
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -296,7 +295,6 @@ bool AEB::isDataReady()
 void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 {
   MarkerArray debug_markers;
-  std::cerr << " onCheckCollision \n";
   checkCollision(debug_markers);
 
   if (!collision_data_keeper_.checkExpired()) {
@@ -334,7 +332,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   }
 
   // step2. create velocity data check if the vehicle stops or not
-  const double current_v = current_velocity_ptr_->longitudinal_velocity;
+  const double current_v = current_velocity_ptr_->longitudinal_velocity + 2.25;
   if (current_v < 0.1) {
     std::cerr << __func__ << " Current vel \n";
     return false;

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -256,6 +256,7 @@ void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
   filter.filter(*no_height_filtered_pointcloud_ptr);
 
   obstacle_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
+  cropped_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
 
   pcl::toROSMsg(*no_height_filtered_pointcloud_ptr, *obstacle_ros_pointcloud_ptr_);
   obstacle_ros_pointcloud_ptr_->header = input_msg->header;

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -326,7 +326,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   }
 
   // step2. create velocity data check if the vehicle stops or not
-  const double current_v = current_velocity_ptr_->longitudinal_velocity;
+  const double current_v = current_velocity_ptr_->longitudinal_velocity + 2.25;
   if (current_v < 0.1) {
     return false;
   }

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -295,7 +295,6 @@ bool AEB::isDataReady()
 
 void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 {
-  TimeIT t(__func__);
   MarkerArray debug_markers;
   checkCollision(debug_markers);
 
@@ -320,7 +319,6 @@ void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 bool AEB::checkCollision(MarkerArray & debug_markers)
 {
   using colorTuple = std::tuple<double, double, double, double>;
-  TimeIT t(__func__);
 
   // step1. check data
   if (!isDataReady()) {

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -169,11 +169,7 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   timer_ = rclcpp::create_timer(this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
 }
 
-void AEB::onTimer()
-{
-  std::cerr << "On TIMER!\n";
-  updater_.force_update();
-}
+void AEB::onTimer() { updater_.force_update(); }
 
 void AEB::onVelocity(const VelocityReport::ConstSharedPtr input_msg)
 {
@@ -321,20 +317,17 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
   // step1. check data
   if (!isDataReady()) {
-    std::cerr << __func__ << " !isDataReady() \n";
     return false;
   }
 
   // if not driving, disable aeb
   if (autoware_state_->state != AutowareState::DRIVING) {
-    std::cerr << __func__ << " Driving \n";
     return false;
   }
 
   // step2. create velocity data check if the vehicle stops or not
-  const double current_v = current_velocity_ptr_->longitudinal_velocity + 2.25;
+  const double current_v = current_velocity_ptr_->longitudinal_velocity;
   if (current_v < 0.1) {
-    std::cerr << __func__ << " Current vel \n";
     return false;
   }
 


### PR DESCRIPTION
## Description

This PR introduces obstacle velocity estimation to the AEB module. 
Currently, the AEB module uses RSS distance to determine if a collision between ego and the obstacle will collide or not, but the object speed is set to 0 by default. This sometimes causes the ego vehicle to issue a stop when it gets close to an object in front that is moving forward.

This PR uses detected object history and the change of object position between point cloud frames to calculate the object's velocity along the ego path's longitudinal axis. Furthermore the velocity is added to a queue of "object velocities" and the median value is chosen as the current object speed (That is done to account for possible jumps of velocity due to false detection).

This calculation is necessary to correctly compute the RSS distance that AEB uses to determine if a collision will happen, currently AEB just assigns 0 as the object speed. This PR fixes that

Additionally this PR adds debug markers to show the closest object velocity and velocity relative to ego.

## Related links

Launch required changes: https://github.com/autowarefoundation/autoware_launch/pull/978

## Tests performed

PSim

Comparison: 

Before: AEB sends an error (emergency stop) when we suddenly place a car running at 10 m/s in front of ego even though the NPC vehicle is moving faster than the ego and the risk of not being able to slow down on time is not there. You can see the error being sent on the rqt_robot_monitor screen

https://github.com/autowarefoundation/autoware.universe/assets/25967964/74acf839-9a41-4adc-9de0-40408409217b


With this PR: same situation, but the AEB module correctly judges the situation to be safe because it calculates the object speed to be around 10 m/s on the longitudinal axis of the ego path and there is no emergency stop issued:


https://github.com/autowarefoundation/autoware.universe/assets/25967964/3432bcda-2498-4026-aae7-16484cfb034c



## Notes for reviewers

Requires changes to Launch: https://github.com/autowarefoundation/autoware_launch/pull/978

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

By estimating object speed, false positive stops will happen less often.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
