### PR TITLE
chore(component_state_monitor): relax pose_estimator_pose timeout

### DIFF
--- a/system/component_state_monitor/config/topics.yaml
+++ b/system/component_state_monitor/config/topics.yaml
@@ -61,7 +61,7 @@
     transient_local: false
     warn_rate: 2.0
     error_rate: 1.0
-    timeout: 1.0
+    timeout: 1.3
 
 - module: perception
   mode: [online, logging_simulation]


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Similar to https://github.com/autowarefoundation/autoware.universe/pull/6563, this PR relaxes the timeout of  pose_estimator_pose. 

Related PR: https://github.com/autowarefoundation/autoware_launch/pull/979

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Suppressed too much diag warning

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
