### PR TITLE
refactor(bpp): path shifter clang tidy and logging level configuration

### DIFF
--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -33,6 +33,8 @@ Planning:
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: tier4_autoware_utils
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+      logger_name: behavior_path_planner.path_shifter
 
   behavior_path_planner_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
@@ -94,9 +94,9 @@ public:
   void setLongitudinalAcceleration(const double longitudinal_acc);
 
   /**
-   * @brief  Add shift point. You don't have to care about the start/end_idx.
+   * @brief  Add shift line. You don't have to care about the start/end_idx.
    */
-  void addShiftLine(const ShiftLine & point);
+  void addShiftLine(const ShiftLine & line);
 
   /**
    * @brief  Set new shift point. You don't have to care about the start/end_idx.
@@ -143,7 +143,7 @@ public:
   ////////////////////////////////////////
 
   static double calcFeasibleVelocityFromJerk(
-    const double lateral, const double jerk, const double distance);
+    const double lateral, const double jerk, const double longitudinal_distance);
 
   static double calcLateralDistFromJerk(
     const double longitudinal, const double jerk, const double velocity);
@@ -196,12 +196,12 @@ private:
   std::pair<std::vector<double>, std::vector<double>> calcBaseLengths(
     const double arclength, const double shift_length, const bool offset_back) const;
 
-  std::pair<std::vector<double>, std::vector<double>> getBaseLengthsWithoutAccelLimit(
-    const double arclength, const double shift_length, const bool offset_back) const;
+  static std::pair<std::vector<double>, std::vector<double>> getBaseLengthsWithoutAccelLimit(
+    const double arclength, const double shift_length, const bool offset_back);
 
-  std::pair<std::vector<double>, std::vector<double>> getBaseLengthsWithoutAccelLimit(
+  static std::pair<std::vector<double>, std::vector<double>> getBaseLengthsWithoutAccelLimit(
     const double arclength, const double shift_length, const double velocity,
-    const double longitudinal_acc, const double total_time, const bool offset_back) const;
+    const double longitudinal_acc, const double total_time, const bool offset_back);
 
   /**
    * @brief Calculate path index for shift_lines and set is_index_aligned_ to true.
@@ -235,9 +235,9 @@ private:
    */
   bool checkShiftLinesAlignment(const ShiftLineArray & shift_lines) const;
 
-  void addLateralOffsetOnIndexPoint(ShiftedPath * path, double offset, size_t index) const;
+  static void addLateralOffsetOnIndexPoint(ShiftedPath * path, double offset, size_t index);
 
-  void shiftBaseLength(ShiftedPath * path, double offset) const;
+  static void shiftBaseLength(ShiftedPath * path, double offset);
 
   void setBaseOffset(const double val)
   {


### PR DESCRIPTION
## Description

Clean up clang-tidy a little bit.

- added path shifter into logging level configuration.
- I didn't change function names to snake case.
- There are some variables that i think are better if we leave as is.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
