### PR TITLE
feat(mission_planner): publish initial and goal poses to logs

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -247,6 +247,24 @@ void MissionPlanner::on_set_lanelet_route(
   change_route(route);
   change_state(RouteState::SET);
   res->status.success = true;
+
+  {
+    const auto & p = odometry_->pose.pose.position;
+    RCLCPP_INFO(this->get_logger(), "Initial pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
+    const auto & quaternion = odometry_->pose.pose.orientation;
+    RCLCPP_INFO(
+      this->get_logger(), "Initial orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
+      quaternion.y, quaternion.z, quaternion.w);
+  }
+
+  {
+    const auto & p = req->goal_pose.position;
+    RCLCPP_INFO(this->get_logger(), "Goal pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
+    const auto & quaternion = req->goal_pose.orientation;
+    RCLCPP_INFO(
+      this->get_logger(), "Goal orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
+      quaternion.y, quaternion.z, quaternion.w);
+  }
 }
 
 void MissionPlanner::on_set_waypoint_route(
@@ -292,6 +310,24 @@ void MissionPlanner::on_set_waypoint_route(
   change_route(route);
   change_state(RouteState::SET);
   res->status.success = true;
+
+  {
+    const auto & p = odometry_->pose.pose.position;
+    RCLCPP_INFO(this->get_logger(), "Initial pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
+    const auto & quaternion = odometry_->pose.pose.orientation;
+    RCLCPP_INFO(
+      this->get_logger(), "Initial orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
+      quaternion.y, quaternion.z, quaternion.w);
+  }
+
+  {
+    const auto & p = req->goal_pose.position;
+    RCLCPP_INFO(this->get_logger(), "Goal pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
+    const auto & quaternion = req->goal_pose.orientation;
+    RCLCPP_INFO(
+      this->get_logger(), "Goal orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
+      quaternion.y, quaternion.z, quaternion.w);
+  }
 }
 
 void MissionPlanner::change_route()

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -87,6 +87,17 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   logger_configure_ = std::make_unique<tier4_autoware_utils::LoggerLevelConfigure>(this);
 }
 
+void MissionPlanner::publish_pose_log(const Pose & pose, const std::string & pose_type)
+{
+  const auto & p = pose.position;
+  RCLCPP_INFO(
+    this->get_logger(), "%s pose - x: %f, y: %f, z: %f", pose_type.c_str(), p.x, p.y, p.z);
+  const auto & quaternion = pose.orientation;
+  RCLCPP_INFO(
+    this->get_logger(), "%s orientation - qx: %f, qy: %f, qz: %f, qw: %f", pose_type.c_str(),
+    quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+}
+
 void MissionPlanner::check_initialization()
 {
   auto logger = get_logger();
@@ -248,23 +259,8 @@ void MissionPlanner::on_set_lanelet_route(
   change_state(RouteState::SET);
   res->status.success = true;
 
-  {
-    const auto & p = odometry_->pose.pose.position;
-    RCLCPP_INFO(this->get_logger(), "Initial pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
-    const auto & quaternion = odometry_->pose.pose.orientation;
-    RCLCPP_INFO(
-      this->get_logger(), "Initial orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
-      quaternion.y, quaternion.z, quaternion.w);
-  }
-
-  {
-    const auto & p = req->goal_pose.position;
-    RCLCPP_INFO(this->get_logger(), "Goal pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
-    const auto & quaternion = req->goal_pose.orientation;
-    RCLCPP_INFO(
-      this->get_logger(), "Goal orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
-      quaternion.y, quaternion.z, quaternion.w);
-  }
+  publish_pose_log(odometry_->pose.pose, "initial");
+  publish_pose_log(req->goal_pose, "goal");
 }
 
 void MissionPlanner::on_set_waypoint_route(
@@ -311,23 +307,8 @@ void MissionPlanner::on_set_waypoint_route(
   change_state(RouteState::SET);
   res->status.success = true;
 
-  {
-    const auto & p = odometry_->pose.pose.position;
-    RCLCPP_INFO(this->get_logger(), "Initial pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
-    const auto & quaternion = odometry_->pose.pose.orientation;
-    RCLCPP_INFO(
-      this->get_logger(), "Initial orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
-      quaternion.y, quaternion.z, quaternion.w);
-  }
-
-  {
-    const auto & p = req->goal_pose.position;
-    RCLCPP_INFO(this->get_logger(), "Goal pose - x: %f, y: %f, z: %f", p.x, p.y, p.z);
-    const auto & quaternion = req->goal_pose.orientation;
-    RCLCPP_INFO(
-      this->get_logger(), "Goal orientation - qx: %f, qy: %f, qz: %f, qw: %f", quaternion.x,
-      quaternion.y, quaternion.z, quaternion.w);
-  }
+  publish_pose_log(odometry_->pose.pose, "initial");
+  publish_pose_log(req->goal_pose, "goal");
 }
 
 void MissionPlanner::change_route()

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -122,6 +122,8 @@ private:
     const Header & header, const std::vector<Pose> & waypoints, const Pose & goal_pose,
     const UUID & uuid, const bool allow_goal_modification);
 
+  void publish_pose_log(const Pose & pose, const std::string & pose_type);
+
   rclcpp::TimerBase::SharedPtr data_check_timer_;
   void check_initialization();
 


### PR DESCRIPTION
## Description

Sometimes, while investigating the planning module, we might find a bug that we want to report on GitHub issues. 

However, if we didn't echo the initial and goal poses before the simulation, we might miss this information, which could cause difficulties for the ticket's assignee in reproducing the issues. 

Since log information is stored in the .ros folder, if we printed the above information, then we could just search back through the log and add the information to the ticket accurately. 

Additionally, I personally think that initial and goal poses are essential pieces of information, and it is acceptable to publish them in the terminal. 

I believe a lot of man-hours can be saved if we have this information in the terminal log.

#### After PR

The following information are published.

```
[component_container_mt-25] [INFO 1714642765.582309670] [planning.mission_planning.mission_planner] publish_pose_log(): initial pose - x: 89154.851562, y: 42421.679688, z: 7.037300:(L93)
[component_container_mt-25] [INFO 1714642765.582357231] [planning.mission_planning.mission_planner] publish_pose_log(): initial orientation - qx: 0.000580, qy: 0.000231, qz: -0.929063, qw: 0.369921:(L96)
[component_container_mt-25] [INFO 1714642765.582366538] [planning.mission_planning.mission_planner] publish_pose_log(): goal pose - x: 89428.851562, y: 43234.484375, z: 5.915613:(L93)
[component_container_mt-25] [INFO 1714642765.582373472] [planning.mission_planning.mission_planner] publish_pose_log(): goal orientation - qx: 0.000000, qy: 0.000000, qz: -0.487659, qw: 0.873034:(L96)
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
