### PR TITLE
fix(control_performance_analysis): fix bug of ignoredReturnValue

### DIFF
--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -401,7 +401,7 @@ std::pair<bool, Pose> ControlPerformanceAnalysisCore::calculateClosestPose()
   if (
     !interpolated_pose_ptr_ || !interpolated_velocity_ptr_ || !interpolated_acceleration_ptr_ ||
     !interpolated_steering_angle_ptr_) {
-    std::make_pair(false, interp_point.pose);
+    return std::make_pair(false, interp_point.pose);
   }
 
   return std::make_pair(true, interp_point.pose);


### PR DESCRIPTION
## Description

This is a bugfix based on the cppcheck warning `ignoredReturnValue`.
```
control/control_performance_analysis/src/control_performance_analysis_core.cpp:404:10: warning: Return value of function std::make_pair() is not used. [ignoredReturnValue]
    std::make_pair(false, interp_point.pose);
         ^
```

It means that the value of `std::make_pair(false, interp_point.pose)` was ignored.
And it seems it should be used as a return value of `calculateClosestPose`.

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
