### PR TITLE
fix(perception_online_evaluator): fix bug of constStatement

### DIFF
--- a/evaluator/perception_online_evaluator/src/metrics/detection_count.cpp
+++ b/evaluator/perception_online_evaluator/src/metrics/detection_count.cpp
@@ -68,7 +68,7 @@ void DetectionCounter::addObjects(
   }
 
   const auto timestamp = objects.header.stamp;
-  unique_timestamps_.insert(timestamp).second;
+  unique_timestamps_.insert(timestamp);
 
   for (const auto & object : objects.objects) {
     const auto uuid = toHexString(object.object_id);
@@ -119,7 +119,7 @@ void DetectionCounter::updateDetectionMap(
   const std::string uuid, const std::uint8_t classification, const std::string & range,
   const rclcpp::Time & timestamp)
 {
-  seen_uuids_[classification][range].insert(uuid).second;
+  seen_uuids_[classification][range].insert(uuid);
 
   // Record the detection time for averaging
   time_series_counts_[classification][range].push_back(timestamp);


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `constStatement`.
```
evaluator/perception_online_evaluator/src/metrics/detection_count.cpp:71:39: warning: Redundant code: Found unused member access. [constStatement]
  unique_timestamps_.insert(timestamp).second;
                                      ^
evaluator/perception_online_evaluator/src/metrics/detection_count.cpp:122:50: warning: Redundant code: Found unused member access. [constStatement]
  seen_uuids_[classification][range].insert(uuid).second;
                                                 ^
```

It means that the return values are not used even though `.second` returns `bool`.
And it seems they should be deleted.

## Tests performed

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
