### PR TITLE
fix(ground_segmentation): fix warning of identicalConditionAfterEarlyExit

### DIFF
--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -388,16 +388,10 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
       }
 
       // initialize lists of previous gnd grids
-      if (prev_list_init == false && initialized_first_gnd_grid == true) {
+      if (!prev_list_init) {
         float h = ground_cluster.getAverageHeight();
         float r = ground_cluster.getAverageRadius();
         initializeFirstGndGrids(h, r, p->grid_id, gnd_grids);
-        prev_list_init = true;
-      }
-
-      if (prev_list_init == false && initialized_first_gnd_grid == false) {
-        // assume first gnd grid is zero
-        initializeFirstGndGrids(0.0f, p->radius, p->grid_id, gnd_grids);
         prev_list_init = true;
       }
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `identicalConditionAfterEarlyExit`.
```
perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp:398:65: warning: Identical condition '!initialized_first_gnd_grid', second condition is always false [identicalConditionAfterEarlyExit]
      if (prev_list_init == false && initialized_first_gnd_grid == false) {
                                                                ^
perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp:386:11: note: If condition '!initialized_first_gnd_grid' is true, the function will return/exit
      if (!initialized_first_gnd_grid) {
          ^
perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp:398:65: note: Testing identical condition '!initialized_first_gnd_grid'
      if (prev_list_init == false && initialized_first_gnd_grid == false) {
                                                                ^
```

It means that the program early exits if `initialized_first_gnd_grid` is false, while the proceeding if block contains related `initialized_first_gnd_grid`.
If the early exit is expected, the please accept my fix.
Otherwise, please make a proper changes.

## Tests performed

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
