### PR TITLE
fix(tvm_utility): fix warning of negativeContainerIndex

### DIFF
--- a/common/tvm_utility/example/yolo_v2_tiny/main.cpp
+++ b/common/tvm_utility/example/yolo_v2_tiny/main.cpp
@@ -200,6 +200,8 @@ public:
             }
           }
 
+          if (max_ind == -1) continue;
+
           // Decode and copy class probabilities
           std::vector<float> class_probabilities{};
           float p_total = 0;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `negativeContainerIndex`.
```
common/tvm_utility/example/yolo_v2_tiny/main.cpp:213:28: warning: Array index -1 is out of bounds. [negativeContainerIndex]
          auto max_score = class_probabilities[max_ind] * p_0 / p_total;
                           ^
common/tvm_utility/example/yolo_v2_tiny/main.cpp:194:26: note: Assignment 'max_ind=-1', assigned value is -1
          int max_ind = -1;
                         ^
common/tvm_utility/example/yolo_v2_tiny/main.cpp:195:44: note: Assuming condition is false
          for (size_t i_class = 0; i_class < n_classes; i_class++) {
                                           ^
common/tvm_utility/example/yolo_v2_tiny/main.cpp:213:28: note: Negative array index
          auto max_score = class_probabilities[max_ind] * p_0 / p_total;
                           ^
```

It means that `class_probabilities[max_ind]` will cause out of bounds array access, if `max_ind` is not updated from -1.
It could happen in cases where all the `class_p` values are negative or the `n_classes` is equal to 0.

## Tests performed

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
