### PR TITLE
fix(traffic_light_classifier): fix warning of uninitvar

### DIFF
--- a/perception/traffic_light_classifier/src/cnn_classifier.cpp
+++ b/perception/traffic_light_classifier/src/cnn_classifier.cpp
@@ -108,7 +108,7 @@ bool CNNClassifier::getTrafficSignals(
 void CNNClassifier::outputDebugImage(
   cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal)
 {
-  float probability;
+  float probability = 0.0f;
   std::string label;
   for (std::size_t i = 0; i < traffic_signal.elements.size(); i++) {
     auto light = traffic_signal.elements.at(i);


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `uninitvar`.
```
perception/traffic_light_classifier/src/cnn_classifier.cpp:130:51: warning: Uninitialized variable: probability [uninitvar]
  std::string text = label + " " + std::to_string(probability);
                                                  ^
perception/traffic_light_classifier/src/cnn_classifier.cpp:113:29: note: Assuming condition is false
  for (std::size_t i = 0; i < traffic_signal.elements.size(); i++) {
                            ^
perception/traffic_light_classifier/src/cnn_classifier.cpp:130:51: note: Uninitialized variable: probability
  std::string text = label + " " + std::to_string(probability);
                                                  ^
```

When the argument `traffic_signal` is empty, the `probability` will not be initialized.

## Tests performed

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
