### PR TITLE
fix(behavior_path_planner_common): fix warning of containerOutOfBounds

### DIFF
--- a/planning/behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_utils.cpp
@@ -447,6 +447,8 @@ std::vector<double> splineTwoPoints(
   std::vector<double> base_s, std::vector<double> base_x, const double begin_diff,
   const double end_diff, std::vector<double> new_s)
 {
+  assert(base_s.size() == 2 && base_x.size() == 2);
+
   const double h = base_s.at(1) - base_s.at(0);
 
   const double c = begin_diff;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `containerOutOfBounds`.
```
planning/behavior_path_planner_common/src/utils/path_utils.cpp:450:29: error: Out of bounds access in expression 'base_s.at(1)' because 'base_s' is empty. [containerOutOfBounds]
  const double h = base_s.at(1) - base_s.at(0);
                            ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:483:5: note: Calling function 'splineTwoPoints', 1st argument 'base_s' value is size=0
    base_s, base_x, std::cos(tf2::getYaw(start_pose.orientation)),
    ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:450:29: note: Access out of bounds
  const double h = base_s.at(1) - base_s.at(0);
                            ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:450:44: error: Out of bounds access in expression 'base_s.at(0)' because 'base_s' is empty. [containerOutOfBounds]
  const double h = base_s.at(1) - base_s.at(0);
                                           ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:483:5: note: Calling function 'splineTwoPoints', 1st argument 'base_s' value is size=0
    base_s, base_x, std::cos(tf2::getYaw(start_pose.orientation)),
    ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:450:44: note: Access out of bounds
  const double h = base_s.at(1) - base_s.at(0);
                                           ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:459:36: error: Out of bounds access in expression 'base_s.at(0)' because 'base_s' is empty. [containerOutOfBounds]
    const double ds = s - base_s.at(0);
                                   ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:483:5: note: Calling function 'splineTwoPoints', 1st argument 'base_s' value is size=0
    base_s, base_x, std::cos(tf2::getYaw(start_pose.orientation)),
    ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:458:25: note: Assuming container is not empty
  for (const auto & s : new_s) {
                        ^
planning/behavior_path_planner_common/src/utils/path_utils.cpp:459:36: note: Access out of bounds
    const double ds = s - base_s.at(0);
                                   ^
```

Though the current implementation only uses `splineTwoPoints` correctly with two arguments and will not fail in runtime, these kind of assumptions between functions should be asserted by callee functions.

## Tests performed

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
