### PR TITLE
fix(system_monitor): fix warning of containerOutOfBounds

### DIFF
--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -258,7 +258,7 @@ void NetMonitor::monitor_traffic(diagnostic_updater::DiagnosticStatusWrapper & s
         if (line.empty()) continue;
 
         boost::split(list, line, boost::is_any_of("\t"), boost::token_compress_on);
-        if (list.size() >= 3) {
+        if (list.size() > 3) {
           status.add(fmt::format("nethogs {}: program", index), list[3].c_str());
           status.add(fmt::format("nethogs {}: sent (KB/s)", index), list[1].c_str());
           status.add(fmt::format("nethogs {}: received (KB/sec)", index), list[2].c_str());


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `containerOutOfBounds`.
```
system/system_monitor/src/net_monitor/net_monitor.cpp:262:69: warning: Either the condition 'list.size()>=3' is redundant or size of 'list' can be 3. Expression 'list[3]' causes access out of bounds. [containerOutOfBounds]
          status.add(fmt::format("nethogs {}: program", index), list[3].c_str());
                                                                    ^
system/system_monitor/src/net_monitor/net_monitor.cpp:261:25: note: Assuming that condition 'list.size()>=3' is not redundant
        if (list.size() >= 3) {
                        ^
system/system_monitor/src/net_monitor/net_monitor.cpp:262:69: note: Access out of bounds
          status.add(fmt::format("nethogs {}: program", index), list[3].c_str());
                                                                    ^
```

## Tests performed

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
