### PR TITLE
perf(yabloc): fix performance warning of iterateByValue

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp
@@ -50,9 +50,9 @@ cv::Mat ProjectorModule::project_image(const cv::Mat & mask_image)
     cv::findContours(masks[i], contours, cv::RETR_LIST, cv::CHAIN_APPROX_NONE);
 
     std::vector<std::vector<cv::Point> > projected_contours;
-    for (auto contour : contours) {
+    for (const auto & contour : contours) {
       std::vector<cv::Point> projected;
-      for (auto c : contour) {
+      for (const auto & c : contour) {
         auto opt = project_func_(c);
         if (!opt.has_value()) continue;
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `iterateByValue`.
```
localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:53:15: performance: Range variable 'contour' should be declared as const reference. [iterateByValue]
    for (auto contour : contours) {
              ^
```

If you have any problem with const references, please close this PR without merging.

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
