### PR TITLE
fix(lane_change): return safe is object list is empty

### DIFF
--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -1939,6 +1939,11 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
 {
   PathSafetyStatus path_safety_status;
 
+  if (collision_check_objects.empty()) {
+    RCLCPP_DEBUG(logger_, "There is nothing to check.");
+    return path_safety_status;
+  }
+
   const auto & path = lane_change_path.path;
   const auto & common_parameters = planner_data_->parameters;
   const auto current_pose = getEgoPose();


### PR DESCRIPTION
## Description

For scenario simulator.

Lane change safety checks are still performed even though the collision check object list is empty.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
