### PR TITLE
fix(diagnostic_graph_aggregator): fix a bug where unit links were incorrectly updated

### DIFF
--- a/system/diagnostic_graph_aggregator/src/common/graph/config.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.cpp
@@ -232,8 +232,8 @@ void apply_edits(FileConfig & config)
       if (remove_links.count(link) == 0) {
         filtered_list.push_back(link);
       }
-      unit->list = filtered_list;
     }
+    unit->list = filtered_list;
   }
 
   // Remove units and links.


### PR DESCRIPTION
## Description

Close #6928
Fixed a bug where unit links were incorrectly updated. https://github.com/autowarefoundation/autoware.universe/issues/6928

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable (the iterator is invalidated by assignment, but it works in my environment, so I didn't add any code to detect it.).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
