### PR TITLE
fix(bpp): keep publishing rtc cooperate status

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -290,8 +290,6 @@ private:
 
     module_ptr->updateCurrentState();
 
-    module_ptr->publishRTCStatus();
-
     module_ptr->publishSteeringFactor();
 
     module_ptr->publishObjectsOfInterestMarker();
@@ -323,7 +321,6 @@ private:
   void deleteExpiredModules(SceneModulePtr & module_ptr) const
   {
     module_ptr->onExit();
-    module_ptr->publishRTCStatus();
     module_ptr->publishObjectsOfInterestMarker();
     module_ptr.reset();
   }

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -191,8 +191,10 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
     return BehaviorModuleOutput{};  // something wrong.
   }();
 
-  std::for_each(
-    manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->updateObserver(); });
+  std::for_each(manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) {
+    m->updateObserver();
+    m->publishRTCStatus();
+  });
 
   generateCombinedDrivableArea(result_output, data);
 

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -186,7 +186,6 @@ public:
 
     clearWaitingApproval();
     removeRTCStatus();
-    publishRTCStatus();
     unlockNewModuleLaunch();
     unlockOutputPath();
     steering_factor_interface_ptr_->clearSteeringFactors();
@@ -194,18 +193,6 @@ public:
     stop_reason_ = StopReason();
 
     processOnExit();
-  }
-
-  /**
-   * @brief Publish status if the module is requested to run
-   */
-  void publishRTCStatus()
-  {
-    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
-      if (ptr) {
-        ptr->publishCooperateStatus(clock_->now());
-      }
-    }
   }
 
   void publishObjectsOfInterestMarker()

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
@@ -99,6 +99,15 @@ public:
     observers_.erase(itr, observers_.end());
   }
 
+  void publishRTCStatus()
+  {
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      if (ptr) {
+        ptr->publishCooperateStatus(rclcpp::Clock(RCL_ROS_TIME).now());
+      }
+    }
+  }
+
   void publishVirtualWall() const
   {
     using tier4_autoware_utils::appendMarkerArray;
@@ -235,7 +244,6 @@ public:
     std::for_each(observers_.begin(), observers_.end(), [](const auto & observer) {
       if (!observer.expired()) {
         observer.lock()->onExit();
-        observer.lock()->publishRTCStatus();
       }
     });
 
@@ -243,7 +251,6 @@ public:
 
     if (idle_module_ptr_ != nullptr) {
       idle_module_ptr_->onExit();
-      idle_module_ptr_->publishRTCStatus();
       idle_module_ptr_.reset();
     }
 


### PR DESCRIPTION
## Description

Before: Since the publisher was in scene module interface, it stopped publishing rtc cooperate status when scene module was killed by planner manager.

**After: It keeps publishing rtc cooperate status even after scene module is killed. In this case, it publishes empty cooperate status. (See following movie.)**

https://github.com/autowarefoundation/autoware.universe/assets/44889564/8a5762c5-560c-466e-b6ee-b48922c95e44

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/af6a66a1-7104-53fe-9862-c40cedffc912?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Keep publishing rtc cooperate status.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
