### PR TITLE
refactor(motion_utils): supress log message with rclcpp logging

### DIFF
--- a/common/motion_utils/include/motion_utils/resample/resample_utils.hpp
+++ b/common/motion_utils/include/motion_utils/resample/resample_utils.hpp
@@ -21,13 +21,18 @@
 #include <motion_utils/trajectory/trajectory.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 
+#include <string>
 #include <vector>
 
 namespace resample_utils
 {
 constexpr double close_s_threshold = 1e-6;
 
-#define log_error(message) std::cerr << "\033[31m " << message << " \033[0m" << std::endl;
+static inline rclcpp::Logger get_logger()
+{
+  constexpr const char * logger{"motion_utils.resample_utils"};
+  return rclcpp::get_logger(logger);
+}
 
 template <class T>
 bool validate_size(const T & points)
@@ -62,27 +67,27 @@ bool validate_arguments(const T & input_points, const std::vector<double> & resa
 {
   // Check size of the arguments
   if (!validate_size(input_points)) {
-    log_error("[resample_utils] invalid argument: The number of input points is less than 2");
+    RCLCPP_DEBUG(get_logger(), "invalid argument: The number of input points is less than 2");
     tier4_autoware_utils::print_backtrace();
     return false;
   }
   if (!validate_size(resampling_intervals)) {
-    log_error(
-      "[resample_utils] invalid argument: The number of resampling intervals is less than 2");
+    RCLCPP_DEBUG(
+      get_logger(), "invalid argument: The number of resampling intervals is less than 2");
     tier4_autoware_utils::print_backtrace();
     return false;
   }
 
   // Check resampling range
   if (!validate_resampling_range(input_points, resampling_intervals)) {
-    log_error("[resample_utils] invalid argument: resampling interval is longer than input points");
+    RCLCPP_DEBUG(get_logger(), "invalid argument: resampling interval is longer than input points");
     tier4_autoware_utils::print_backtrace();
     return false;
   }
 
   // Check duplication
   if (!validate_points_duplication(input_points)) {
-    log_error("[resample_utils] invalid argument: input points has some duplicated points");
+    RCLCPP_DEBUG(get_logger(), "invalid argument: input points has some duplicated points");
     tier4_autoware_utils::print_backtrace();
     return false;
   }
@@ -95,23 +100,23 @@ bool validate_arguments(const T & input_points, const double resampling_interval
 {
   // Check size of the arguments
   if (!validate_size(input_points)) {
-    log_error("[resample_utils] invalid argument: The number of input points is less than 2");
+    RCLCPP_DEBUG(get_logger(), "invalid argument: The number of input points is less than 2");
     tier4_autoware_utils::print_backtrace();
     return false;
   }
 
   // check resampling interval
   if (resampling_interval < motion_utils::overlap_threshold) {
-    log_error(
-      "[resample_utils] invalid argument: resampling interval is less than " +
-      std::to_string(motion_utils::overlap_threshold));
+    RCLCPP_DEBUG(
+      get_logger(), "invalid argument: resampling interval is less than %f",
+      motion_utils::overlap_threshold);
     tier4_autoware_utils::print_backtrace();
     return false;
   }
 
   // Check duplication
   if (!validate_points_duplication(input_points)) {
-    log_error("[resample_utils] invalid argument: input points has some duplicated points");
+    RCLCPP_DEBUG(get_logger(), "invalid argument: input points has some duplicated points");
     tier4_autoware_utils::print_backtrace();
     return false;
   }

--- a/common/motion_utils/include/motion_utils/resample/resample_utils.hpp
+++ b/common/motion_utils/include/motion_utils/resample/resample_utils.hpp
@@ -21,7 +21,6 @@
 #include <motion_utils/trajectory/trajectory.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 
-#include <string>
 #include <vector>
 
 namespace resample_utils

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -21,6 +21,7 @@
 #include "tier4_autoware_utils/system/backtrace.hpp"
 
 #include <Eigen/Geometry>
+#include <rclcpp/logging.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_point.hpp>
 #include <autoware_auto_planning_msgs/msg/path_point_with_lane_id.hpp>
@@ -33,9 +34,14 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 namespace motion_utils
 {
-#define log_error(message) std::cerr << "\033[31m " << message << " \033[0m" << std::endl;
+static inline rclcpp::Logger get_logger()
+{
+  constexpr const char * logger{"motion_utils.trajectory"};
+  return rclcpp::get_logger(logger);
+}
 
 /**
  * @brief validate if points container is empty or not
@@ -216,7 +222,7 @@ std::optional<size_t> searchZeroVelocityIndex(
   try {
     validateNonEmpty(points_with_twist);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -248,7 +254,7 @@ std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const
   try {
     validateNonEmpty(points_with_twist);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -338,7 +344,7 @@ std::optional<size_t> findNearestIndex(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -411,9 +417,10 @@ double calcLongitudinalOffsetToSegment(
     if (throw_exception) {
       throw std::out_of_range(error_message);
     }
-    log_error(
-      error_message +
-      " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+    RCLCPP_DEBUG(
+      get_logger(),
+      "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+      error_message.c_str());
     return std::nan("");
   }
 
@@ -425,7 +432,7 @@ double calcLongitudinalOffsetToSegment(
     try {
       validateNonEmpty(overlap_removed_points);
     } catch (const std::exception & e) {
-      log_error(e.what());
+      RCLCPP_DEBUG(get_logger(), "%s", e.what());
       return std::nan("");
     }
   }
@@ -438,9 +445,10 @@ double calcLongitudinalOffsetToSegment(
     if (throw_exception) {
       throw std::runtime_error(error_message);
     }
-    log_error(
-      error_message +
-      " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+    RCLCPP_DEBUG(
+      get_logger(),
+      "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+      error_message.c_str());
     return std::nan("");
   }
 
@@ -586,9 +594,10 @@ double calcLateralOffset(
     try {
       validateNonEmpty(overlap_removed_points);
     } catch (const std::exception & e) {
-      log_error(
-        std::string(e.what()) +
-        " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+      RCLCPP_DEBUG(
+        get_logger(),
+        "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+        e.what());
       return std::nan("");
     }
   }
@@ -601,9 +610,10 @@ double calcLateralOffset(
     if (throw_exception) {
       throw std::runtime_error(error_message);
     }
-    log_error(
-      error_message +
-      " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+    RCLCPP_DEBUG(
+      get_logger(),
+      "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+      error_message.c_str());
     return std::nan("");
   }
 
@@ -658,9 +668,10 @@ double calcLateralOffset(
     try {
       validateNonEmpty(overlap_removed_points);
     } catch (const std::exception & e) {
-      log_error(
-        std::string(e.what()) +
-        " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+      RCLCPP_DEBUG(
+        get_logger(),
+        "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+        e.what());
       return std::nan("");
     }
   }
@@ -673,9 +684,10 @@ double calcLateralOffset(
     if (throw_exception) {
       throw std::runtime_error(error_message);
     }
-    log_error(
-      error_message +
-      " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+    RCLCPP_DEBUG(
+      get_logger(),
+      "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+      error_message.c_str());
     return std::nan("");
   }
 
@@ -711,7 +723,7 @@ double calcSignedArcLength(const T & points, const size_t src_idx, const size_t 
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return 0.0;
   }
 
@@ -754,7 +766,7 @@ std::vector<double> calcSignedArcLengthPartialSum(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -806,7 +818,7 @@ double calcSignedArcLength(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return 0.0;
   }
 
@@ -849,7 +861,7 @@ double calcSignedArcLength(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return 0.0;
   }
 
@@ -888,7 +900,7 @@ double calcSignedArcLength(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return 0.0;
   }
 
@@ -928,7 +940,7 @@ double calcArcLength(const T & points)
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return 0.0;
   }
 
@@ -1037,7 +1049,7 @@ std::optional<double> calcDistanceToForwardStopPoint(
   try {
     validateNonEmpty(points_with_twist);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -1071,7 +1083,7 @@ std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -1084,9 +1096,10 @@ std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
     if (throw_exception) {
       throw std::out_of_range(error_message);
     }
-    log_error(
-      error_message +
-      " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+    RCLCPP_DEBUG(
+      get_logger(),
+      "%s Return NaN since no_throw option is enabled. The maintainer must check the code.",
+      error_message.c_str());
     return {};
   }
 
@@ -1153,7 +1166,7 @@ std::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error("Failed to calculate longitudinal offset: " + std::string(e.what()));
+    RCLCPP_DEBUG(get_logger(), "Failed to calculate longitudinal offset: %s", e.what());
     return {};
   }
 
@@ -1201,7 +1214,7 @@ std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error("Failed to calculate longitudinal offset: " + std::string(e.what()));
+    RCLCPP_DEBUG(get_logger(), "Failed to calculate longitudinal offset: %s", e.what());
     return {};
   }
 
@@ -1214,12 +1227,12 @@ std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
     if (throw_exception) {
       throw std::out_of_range(error_message);
     }
-    log_error(error_message);
+    RCLCPP_DEBUG(get_logger(), "%s", error_message.c_str());
     return {};
   }
 
   if (points.size() == 1) {
-    log_error("Failed to calculate longitudinal offset: points size is one.");
+    RCLCPP_DEBUG(get_logger(), "Failed to calculate longitudinal offset: points size is one.");
     return {};
   }
 
@@ -1304,7 +1317,7 @@ std::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -1350,7 +1363,7 @@ std::optional<size_t> insertTargetPoint(
   try {
     validateNonEmpty(points);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -1365,7 +1378,7 @@ std::optional<size_t> insertTargetPoint(
   try {
     validateNonSharpAngle(p_front, p_target, p_back);
   } catch (const std::exception & e) {
-    log_error(e.what());
+    RCLCPP_DEBUG(get_logger(), "%s", e.what());
     return {};
   }
 
@@ -2231,7 +2244,7 @@ std::optional<double> calcDistanceToForwardStopPoint(
   try {
     validateNonEmpty(points_with_twist);
   } catch (const std::exception & e) {
-    log_error("Failed to calculate stop distance" + std::string(e.what()));
+    RCLCPP_DEBUG(get_logger(), "Failed to calculate stop distance %s", e.what());
     return {};
   }
 
@@ -2370,7 +2383,7 @@ T cropPoints(
     cropped_forward_points, target_pos, modified_target_seg_idx, backward_length);
 
   if (cropped_points.size() < 2) {
-    log_error("Return original points since cropped_points size is less than 2.");
+    RCLCPP_DEBUG(get_logger(), "Return original points since cropped_points size is less than 2.");
     return points;
   }
 
@@ -2415,7 +2428,7 @@ double calcYawDeviation(
     try {
       validateNonEmpty(overlap_removed_points);
     } catch (const std::exception & e) {
-      log_error(e.what());
+      RCLCPP_DEBUG(get_logger(), "%s", e.what());
       return 0.0;
     }
   }
@@ -2428,9 +2441,10 @@ double calcYawDeviation(
     if (throw_exception) {
       throw std::runtime_error(error_message);
     }
-    log_error(
-      error_message +
-      " Return 0 since no_throw option is enabled. The maintainer must check the code.");
+    RCLCPP_DEBUG(
+      get_logger(),
+      "%s Return 0 since no_throw option is enabled. The maintainer must check the code.",
+      error_message.c_str());
     return 0.0;
   }
 

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -1876,40 +1876,34 @@ TEST(trajectory, insertTargetPoint)
 
   // Invalid target point(In front of begin point)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(-1.0, 0.0, 0.0);
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle"), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Behind of end point)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(10.0, 0.0, 0.0);
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle"), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Huge lateral offset)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(4.0, 10.0, 0.0);
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle"), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 
@@ -2304,13 +2298,11 @@ TEST(trajectory, insertTargetPoint_Length)
 
   // Invalid target point(Huge lateral offset)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(4.0, 10.0, 0.0);
     const auto insert_idx = insertTargetPoint(4.0, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle."), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 
@@ -4310,40 +4302,34 @@ TEST(trajectory, insertStopPoint_with_pose_and_segment_index)
 
   // Invalid target point(In front of begin point)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(-1.0, 0.0, 0.0);
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle."), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Behind of end point)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(10.0, 0.0, 0.0);
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle."), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 
   // Invalid target point(Huge lateral offset)
   {
-    testing::internal::CaptureStderr();
     auto traj_out = traj;
 
     const auto p_target = createPoint(4.0, 10.0, 0.0);
     const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
     const auto insert_idx = insertStopPoint(base_idx, p_target, traj_out.points);
 
-    EXPECT_NE(testing::internal::GetCapturedStderr().find("sharp angle."), std::string::npos);
     EXPECT_EQ(insert_idx, std::nullopt);
   }
 

--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -35,6 +35,8 @@ Planning:
       logger_name: tier4_autoware_utils
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: behavior_path_planner.path_shifter
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
+      logger_name: motion_utils
 
   behavior_path_planner_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
@@ -67,6 +69,8 @@ Planning:
       logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
       logger_name: tier4_autoware_utils
+    - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
+      logger_name: motion_utils
 
   behavior_velocity_planner_intersection:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner
@@ -77,12 +81,16 @@ Planning:
       logger_name: planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner
     - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
       logger_name: tier4_autoware_utils
+    - node_name: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner
+      logger_name: motion_utils
 
   motion_velocity_smoother:
     - node_name: /planning/scenario_planning/motion_velocity_smoother
       logger_name: planning.scenario_planning.motion_velocity_smoother
     - node_name: /planning/scenario_planning/motion_velocity_smoother
       logger_name: tier4_autoware_utils
+    - node_name: /planning/scenario_planning/motion_velocity_smoother
+      logger_name: motion_utils
 
   route_handler:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
@@ -97,12 +105,16 @@ Control:
       logger_name: control.trajectory_follower.controller_node_exe.lateral_controller
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: tier4_autoware_utils
+    - node_name: /control/trajectory_follower/controller_node_exe
+      logger_name: motion_utils
 
   longitudinal_controller:
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: control.trajectory_follower.controller_node_exe.longitudinal_controller
     - node_name: /control/trajectory_follower/controller_node_exe
       logger_name: tier4_autoware_utils
+    - node_name: /control/trajectory_follower/controller_node_exe
+      logger_name: motion_utils
 
   vehicle_cmd_gate:
     - node_name: /control/vehicle_cmd_gate


### PR DESCRIPTION
## Description

Use rclcpp logging instead so that we can control the log with logging level configure plugin.

Directly use RCLCPP::DEBUG instead of common function, because it allows us to see which line in the the code is actually printing the messages.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
