### PR TITLE
fix(componet_state_monitor): remove ndt node alive monitoring

### DIFF
--- a/system/component_state_monitor/config/topics.yaml
+++ b/system/component_state_monitor/config/topics.yaml
@@ -50,19 +50,6 @@
     error_rate: 1.0
     timeout: 1.0
 
-- module: localization
-  mode: [online, logging_simulation]
-  type: autonomous
-  args:
-    node_name_suffix: pose_estimator_pose
-    topic: /localization/pose_estimator/pose_with_covariance
-    topic_type: geometry_msgs/msg/PoseWithCovarianceStamped
-    best_effort: false
-    transient_local: false
-    warn_rate: 2.0
-    error_rate: 1.0
-    timeout: 1.3
-
 - module: perception
   mode: [online, logging_simulation]
   type: launch


### PR DESCRIPTION
## Description


To monitor the health of the NDT,
it is not appropriate to monitor `/localizaiton/pose_estimator/pose_with_covariance` , and it often leads to false detections. Therefore, I will remove this monitoring.

If NDT health monitoring is still necessary, I will consider alternative methods.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

LSim works.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

N/A

## Interface changes

N/A

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
