### PR TITLE
fix(bvp): don't use numeric limits for start/finish distance

### DIFF
--- a/planning/behavior_velocity_blind_spot_module/src/manager.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/manager.cpp
@@ -72,8 +72,6 @@ void BlindSpotModuleManager::launchNewModules(
       module_id, lane_id, planner_data_, planner_param_, logger_.get_child("blind_spot_module"),
       clock_));
     generateUUID(module_id);
-    updateRTCStatus(
-      getUUID(module_id), true, std::numeric_limits<double>::lowest(), path.header.stamp);
   }
 }
 

--- a/planning/behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.cpp
@@ -189,9 +189,6 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
       node_, road_lanelet_id, crosswalk_lanelet_id, reg_elem_id, lanelet_map_ptr, p, logger,
       clock_));
     generateUUID(crosswalk_lanelet_id);
-    updateRTCStatus(
-      getUUID(crosswalk_lanelet_id), true, std::numeric_limits<double>::lowest(),
-      path.header.stamp);
   };
 
   const auto crosswalk_reg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(

--- a/planning/behavior_velocity_detection_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_detection_area_module/src/manager.cpp
@@ -65,8 +65,6 @@ void DetectionAreaModuleManager::launchNewModules(
         module_id, lane_id, *detection_area_with_lane_id.first, planner_param_,
         logger_.get_child("detection_area_module"), clock_));
       generateUUID(module_id);
-      updateRTCStatus(
-        getUUID(module_id), true, std::numeric_limits<double>::lowest(), path.header.stamp);
     }
   }
 }

--- a/planning/behavior_velocity_no_stopping_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/manager.cpp
@@ -67,8 +67,6 @@ void NoStoppingAreaModuleManager::launchNewModules(
         module_id, lane_id, *m.first, planner_param_, logger_.get_child("no_stopping_area_module"),
         clock_));
       generateUUID(module_id);
-      updateRTCStatus(
-        getUUID(module_id), true, std::numeric_limits<double>::lowest(), path.header.stamp);
     }
   }
 }

--- a/planning/behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -31,7 +31,7 @@ SceneModuleInterface::SceneModuleInterface(
 : module_id_(module_id),
   activated_(false),
   safe_(false),
-  distance_(std::numeric_limits<double>::lowest()),
+  distance_(-10000.0),
   logger_(logger),
   clock_(clock)
 {

--- a/planning/behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.cpp
@@ -132,8 +132,6 @@ void TrafficLightModuleManager::launchNewModules(
         module_id, lane_id, *(traffic_light_reg_elem.first), traffic_light_reg_elem.second,
         planner_param_, logger_.get_child("traffic_light_module"), clock_));
       generateUUID(module_id);
-      updateRTCStatus(
-        getUUID(module_id), true, std::numeric_limits<double>::lowest(), path.header.stamp);
     }
   }
 }


### PR DESCRIPTION
## Description

- Remove redundant process calling `updateRTCStatus`.
- Don't use `std::numeric_limits<double>::lowest()` for start/finish distance in order to avoid ros2 command crashing. https://github.com/ros2/rclpy/issues/848

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/e8201714-b1df-5d2c-85e8-17695c9eb301?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
