### PR TITLE
fix(autonomous_emergency_braking): add missing erase to velocity history

### DIFF
--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -137,13 +137,14 @@ public:
   {
     // remove old msg from deque
     const auto now = clock_->now();
-    std::remove_if(
-      obstacle_velocity_history_.begin(), obstacle_velocity_history_.end(),
-      [&](const auto & velocity_time_pair) {
-        const auto & vel_time = velocity_time_pair.second;
-        return ((now - vel_time).nanoseconds() * 1e-9 > previous_obstacle_keep_time_);
-      });
-
+    obstacle_velocity_history_.erase(
+      std::remove_if(
+        obstacle_velocity_history_.begin(), obstacle_velocity_history_.end(),
+        [&](const auto & velocity_time_pair) {
+          const auto & vel_time = velocity_time_pair.second;
+          return ((now - vel_time).nanoseconds() * 1e-9 > previous_obstacle_keep_time_);
+        }),
+      obstacle_velocity_history_.end());
     obstacle_velocity_history_.emplace_back(
       std::make_pair(current_object_velocity, current_object_velocity_time_stamp));
   }
@@ -199,8 +200,6 @@ public:
     });
 
     if (!estimated_velocity_opt.has_value()) {
-      this->setPreviousObjectData(closest_object);
-      this->resetVelocityHistory();
       return std::nullopt;
     }
 


### PR DESCRIPTION
## Description

std::remove_if does not directly remove the objects from the container, so old velocities might still remain after the timeout has passed, it is necessary to call erase too as parth of the [erase-remove idiom](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom). Also, it is not necessary to delete history if a speed cannot be calculated. This PR fixes those issues.

## Tests performed
PSim
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
