### PR TITLE
perf(side_shift): fix unupdated prev path that caused heavy interpolation

### DIFF
--- a/planning/behavior_path_side_shift_module/include/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_side_shift_module/include/behavior_path_side_shift_module/scene.hpp
@@ -92,7 +92,6 @@ private:
   // member
   PathWithLaneId refined_path_{};
   PathWithLaneId reference_path_{};
-  PathWithLaneId prev_reference_{};
   lanelet::ConstLanelets current_lanelets_;
   std::shared_ptr<SideShiftParameters> parameters_;
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix https://github.com/autowarefoundation/autoware.universe/issues/6554

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim
Evaluator (TIER IV INTERNAL LINK): https://evaluation.tier4.jp/evaluation/reports/2df90fa5-bb82-5846-bbbe-735a6a541c0e?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
