### PR TITLE
refactor(mission_planner): remove redundant `is_reroute` check

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -250,7 +250,7 @@ void MissionPlanner::on_set_lanelet_route(
 
   if (is_reroute && !check_reroute_safety(*current_route_, route)) {
     cancel_route();
-    change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
+    change_state(RouteState::SET);
     throw service_utils::ServiceException(
       ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
   }
@@ -298,7 +298,7 @@ void MissionPlanner::on_set_waypoint_route(
 
   if (is_reroute && !check_reroute_safety(*current_route_, route)) {
     cancel_route();
-    change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
+    change_state(RouteState::SET);
     throw service_utils::ServiceException(
       ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
   }


### PR DESCRIPTION
## Description

This is a fix based on CppCheck warning
```
planning/mission_planner/src/mission_planner/mission_planner.cpp:253:18: style: Condition 'is_reroute' is always true [knownConditionTrueFalse]
    change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
                 ^
planning/mission_planner/src/mission_planner/mission_planner.cpp:251:7: note: Assuming that condition 'is_reroute' is not redundant
  if (is_reroute && !check_reroute_safety(*current_route_, route)) {
      ^
planning/mission_planner/src/mission_planner/mission_planner.cpp:253:18: note: Condition 'is_reroute' is always true
    change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
                 ^
planning/mission_planner/src/mission_planner/mission_planner.cpp:301:18: style: Condition 'is_reroute' is always true [knownConditionTrueFalse]
    change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
                 ^
planning/mission_planner/src/mission_planner/mission_planner.cpp:299:7: note: Assuming that condition 'is_reroute' is not redundant
  if (is_reroute && !check_reroute_safety(*current_route_, route)) {
      ^
planning/mission_planner/src/mission_planner/mission_planner.cpp:301:18: note: Condition 'is_reroute' is always true
    change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
                 ^
```

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
