### PR TITLE
perf(behavior_path_dynamic_avoidance_module): use const reference

### DIFF
--- a/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
@@ -1800,8 +1800,8 @@ DynamicAvoidanceModule::EgoPathReservePoly DynamicAvoidanceModule::calcEgoPathRe
   }
 
   auto calcReservePoly = [&ego_path_lines](
-                           strategy::distance_asymmetric<double> path_expand_strategy,
-                           strategy::distance_asymmetric<double> steer_expand_strategy,
+                           const strategy::distance_asymmetric<double> path_expand_strategy,
+                           const strategy::distance_asymmetric<double> steer_expand_strategy,
                            const std::vector<geometry_msgs::msg::Point> & outer_body_path)
     -> tier4_autoware_utils::Polygon2d {
     // reserve area based on the reference path

--- a/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
@@ -1803,7 +1803,7 @@ DynamicAvoidanceModule::EgoPathReservePoly DynamicAvoidanceModule::calcEgoPathRe
     [&ego_path_lines](
       strategy::distance_asymmetric<double> path_expand_strategy,
       strategy::distance_asymmetric<double> steer_expand_strategy,
-      std::vector<geometry_msgs::msg::Point> outer_body_path) -> tier4_autoware_utils::Polygon2d {
+      const std::vector<geometry_msgs::msg::Point> & outer_body_path) -> tier4_autoware_utils::Polygon2d {
     // reserve area based on the reference path
     tier4_autoware_utils::MultiPolygon2d path_poly;
     boost::geometry::buffer(

--- a/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_dynamic_avoidance_module/src/scene.cpp
@@ -1799,11 +1799,11 @@ DynamicAvoidanceModule::EgoPathReservePoly DynamicAvoidanceModule::calcEgoPathRe
     ego_path_lines.push_back(tier4_autoware_utils::fromMsg(path_point.point.pose.position).to_2d());
   }
 
-  auto calcReservePoly =
-    [&ego_path_lines](
-      strategy::distance_asymmetric<double> path_expand_strategy,
-      strategy::distance_asymmetric<double> steer_expand_strategy,
-      const std::vector<geometry_msgs::msg::Point> & outer_body_path) -> tier4_autoware_utils::Polygon2d {
+  auto calcReservePoly = [&ego_path_lines](
+                           strategy::distance_asymmetric<double> path_expand_strategy,
+                           strategy::distance_asymmetric<double> steer_expand_strategy,
+                           const std::vector<geometry_msgs::msg::Point> & outer_body_path)
+    -> tier4_autoware_utils::Polygon2d {
     // reserve area based on the reference path
     tier4_autoware_utils::MultiPolygon2d path_poly;
     boost::geometry::buffer(


### PR DESCRIPTION
## Description

This is a fix based on CppCheck warning
```
planning/behavior_path_dynamic_avoidance_module/src/scene.cpp:1806:46: performance: Function parameter 'outer_body_path' should be passed by const reference. [passedByValue]
      std::vector<geometry_msgs::msg::Point> outer_body_path) -> tier4_autoware_utils::Polygon2d {
                                             ^
```

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
