### PR TITLE
fix(behavior_velocity_run_out_module): initialize `accel_reason_`

### DIFF
--- a/planning/behavior_velocity_run_out_module/src/debug.cpp
+++ b/planning/behavior_velocity_run_out_module/src/debug.cpp
@@ -73,6 +73,8 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
 
 RunOutDebug::RunOutDebug(rclcpp::Node & node) : node_(node)
 {
+  accel_reason_ = AccelReason::UNKNOWN;
+
   pub_debug_values_ =
     node.create_publisher<Float32MultiArrayStamped>("~/debug/run_out/debug_values", 1);
   pub_accel_reason_ = node.create_publisher<Int32Stamped>("~/debug/run_out/accel_reason", 1);

--- a/planning/behavior_velocity_run_out_module/src/debug.hpp
+++ b/planning/behavior_velocity_run_out_module/src/debug.hpp
@@ -86,6 +86,7 @@ public:
     NO_OBSTACLE = 1,
     PASS = 2,
     LOW_JERK = 3,
+    UNKNOWN = 4,
   };
 
   struct TextWithPosition


### PR DESCRIPTION
## Description

This is a fix based on CppCheck warning
```
planning/behavior_velocity_run_out_module/src/debug.cpp:74:14: warning: Member variable 'RunOutDebug::accel_reason_' is not initialized in the constructor. [uninitMemberVar]
RunOutDebug::RunOutDebug(rclcpp::Node & node) : node_(node)
             ^
```

As the warning shows, the variable `accel_reason_` could be used in `publishDebugValue()` without being initialized.

I added `UNKNOWN` to `AccelReason` enum class, but if you consider somthing better, I would appreciate it.

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
