### PR TITLE
fix(route_handler): fix std::accumlation related bug

### DIFF
--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1593,7 +1593,7 @@ double RouteHandler::getTotalLateralDistanceToPreferredLane(
   const lanelet::ConstLanelet & lanelet, const Direction direction) const
 {
   const auto intervals = getLateralIntervalsToPreferredLane(lanelet, direction);
-  return std::accumulate(intervals.begin(), intervals.end(), 0);
+  return std::accumulate(intervals.begin(), intervals.end(), 0.0);
 }
 
 std::vector<double> RouteHandler::getLateralIntervalsToPreferredLane(


### PR DESCRIPTION
## Description

This is a fix based on clang-tidy warning
```
folding type 'double' into type 'int' might result in loss of precision	1
```

The accumulation is conducted as `int`, not as `double`, in the previous implementation.

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
