### PR TITLE
refactor(behavior_velocity_no_stopping_area_module): cppcheck warnings

### DIFF
--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -89,7 +89,6 @@ boost::optional<LineString2d> NoStoppingAreaModule::getStopLineGeometry2d(
         bg::intersection(area_poly, line, collision_points);
         if (!collision_points.empty()) {
           const double yaw = tier4_autoware_utils::calcAzimuthAngle(p0, p1);
-          geometry_msgs::msg::Point left_point;
           const double w = planner_data_->vehicle_info_.vehicle_width_m;
           const double l = stop_line_margin;
           stop_line.emplace_back(

--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -302,7 +302,6 @@ Polygon2d NoStoppingAreaModule::generateEgoNoStoppingAreaLanePolygon(
 
   const int num_ignore_nearest = 1;  // Do not consider nearest lane polygon
   size_t ego_area_start_idx = closest_idx + num_ignore_nearest;
-  size_t ego_area_end_idx = ego_area_start_idx;
   // return if area size is not intentional
   if (no_stopping_area_reg_elem_.noStoppingAreas().size() != 1) {
     return ego_area;
@@ -326,7 +325,7 @@ Polygon2d NoStoppingAreaModule::generateEgoNoStoppingAreaLanePolygon(
   }
   double dist_from_area_sum = 0.0;
   // decide end idx with extract distance
-  ego_area_end_idx = ego_area_start_idx;
+  size_t ego_area_end_idx = ego_area_start_idx;
   for (size_t i = ego_area_start_idx; i < pp.size() - 1; ++i) {
     dist_from_start_sum += tier4_autoware_utils::calcDistance2d(pp.at(i), pp.at(i - 1));
     const auto & p = pp.at(i).point.pose.position;

--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -87,11 +87,8 @@ boost::optional<LineString2d> NoStoppingAreaModule::getStopLineGeometry2d(
         const LineString2d line{{p0.x, p0.y}, {p1.x, p1.y}};
         std::vector<Point2d> collision_points;
         bg::intersection(area_poly, line, collision_points);
-        if (collision_points.empty()) {
-          continue;
-        }
-        const double yaw = tier4_autoware_utils::calcAzimuthAngle(p0, p1);
         if (!collision_points.empty()) {
+          const double yaw = tier4_autoware_utils::calcAzimuthAngle(p0, p1);
           geometry_msgs::msg::Point left_point;
           const double w = planner_data_->vehicle_info_.vehicle_width_m;
           const double l = stop_line_margin;


### PR DESCRIPTION
## Description

I have made several chages based on CppCheck warnings.
Some commits are irrelevant to CppCheck.

1. remove redundant if branch
https://github.com/autowarefoundation/autoware.universe/commit/e0e49be0b07240e9c2097ed726397badeb983dfd
```
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:94:13: style: Condition '!collision_points.empty()' is always true [knownConditionTrueFalse]
        if (!collision_points.empty()) {
            ^
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:90:35: note: Assuming that condition 'collision_points.empty()' is not redundant
        if (collision_points.empty()) {
                                  ^
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:94:13: note: Condition '!collision_points.empty()' is always true
        if (!collision_points.empty()) {
            ^
```

2. remove unused variable
https://github.com/autowarefoundation/autoware.universe/commit/021129ad8079f4c90443d6b2b6ee6c5ba0a208e2

3. remove redundant initialization
https://github.com/autowarefoundation/autoware.universe/commit/0eb34eb5470efc652051f3851fdea0fdf773671a
```
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:333:20: style: Redundant initialization for 'ego_area_end_idx'. The initialized value is overwritten before it is read. [redundantInitialization]
  ego_area_end_idx = ego_area_start_idx;
                   ^
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:309:27: note: ego_area_end_idx is initialized
  size_t ego_area_end_idx = ego_area_start_idx;
                          ^
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:333:20: note: ego_area_end_idx is overwritten
  ego_area_end_idx = ego_area_start_idx;
                   ^
```

4. remove unused dist_from_area_sum variable
https://github.com/autowarefoundation/autoware.universe/commit/9e76436c08597851c8143ed45cf07e53865e19c4
```
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:338:26: style: Variable 'dist_from_area_sum' is assigned a value that is never used. [unreadVariable]
      dist_from_area_sum += tier4_autoware_utils::calcDistance2d(pp.at(i), pp.at(i - 1));
                         ^
```


### Question
I have one question: there seems to be several unused functions in debug.cpp.
Is it intentional? If not, it looks it's better to delete them in terms of maintenance and readbility.
```
planning/behavior_velocity_no_stopping_area_module/src/debug.cpp:134:0: style: The function 'createDebugMarkerArray' is never used. [unusedFunction]
visualization_msgs::msg::MarkerArray NoStoppingAreaModule::createDebugMarkerArray()
^
planning/behavior_velocity_no_stopping_area_module/src/debug.cpp:165:0: style: The function 'createVirtualWalls' is never used. [unusedFunction]
motion_utils::VirtualWalls NoStoppingAreaModule::createVirtualWalls()
^
planning/behavior_velocity_no_stopping_area_module/src/manager.cpp:54:0: style: The function 'launchNewModules' is never used. [unusedFunction]
void NoStoppingAreaModuleManager::launchNewModules(
^
planning/behavior_velocity_no_stopping_area_module/src/manager.cpp:77:0: style: The function 'getModuleExpiredFunction' is never used. [unusedFunction]
NoStoppingAreaModuleManager::getModuleExpiredFunction(
^
planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp:108:0: style: The function 'modifyPathVelocity' is never used. [unusedFunction]
bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
^
```


## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
