### PR TITLE
refactor(behavior_velocity_occlusion_spot_module): reduce cppcheck warning

### DIFF
--- a/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp
@@ -118,7 +118,7 @@ MarkerArray makeDebugInfoMarkers(T & debug_data)
 {
   // add slow down markers for occlusion spot
   MarkerArray debug_markers;
-  auto & possible_collisions = debug_data.possible_collisions;
+  const auto & possible_collisions = debug_data.possible_collisions;
   size_t id = 0;
   // draw obstacle collision
   for (const auto & pc : possible_collisions) {

--- a/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
@@ -43,23 +43,6 @@ Polygon2d pointsToPoly(const Point2d p0, const Point2d p1, const double radius)
   return line_poly;
 }
 
-std::vector<std::pair<grid_map::Position, grid_map::Position>> pointsToRays(
-  const grid_map::Position p0, const grid_map::Position p1, const double radius)
-{
-  using grid_map::Position;
-  std::vector<std::pair<Position, Position>> lines;
-  const double angle = atan2(p0.y() - p1.y(), p0.x() - p1.x());
-  const double r = radius;
-  lines.emplace_back(std::make_pair(p0, p1));
-  lines.emplace_back(std::make_pair(
-    Position(p0.x() + r * sin(angle), p0.y() - r * cos(angle)),
-    Position(p1.x() + r * sin(angle), p1.y() - r * cos(angle))));
-  lines.emplace_back(std::make_pair(
-    Position(p1.x() - r * sin(angle), p1.y() + r * cos(angle)),
-    Position(p0.x() - r * sin(angle), p0.y() + r * cos(angle))));
-  return lines;
-}
-
 void findOcclusionSpots(
   std::vector<grid_map::Position> & occlusion_spot_positions, const grid_map::GridMap & grid,
   const Polygon2d & polygon, [[maybe_unused]] double min_size)

--- a/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
@@ -86,36 +86,21 @@ bool isCollisionFree(
   const double radius)
 {
   const grid_map::Matrix & grid_data = grid["layer"];
-  bool polys = true;
   try {
-    if (polys) {
-      Point2d occlusion_p = {p1.x(), p1.y()};
-      Point2d collision_p = {p2.x(), p2.y()};
-      Polygon2d polygon = pointsToPoly(occlusion_p, collision_p, radius);
-      grid_map::Polygon grid_polygon;
-      for (const auto & point : polygon.outer()) {
-        grid_polygon.addVertex({point.x(), point.y()});
+    Point2d occlusion_p = {p1.x(), p1.y()};
+    Point2d collision_p = {p2.x(), p2.y()};
+    Polygon2d polygon = pointsToPoly(occlusion_p, collision_p, radius);
+    grid_map::Polygon grid_polygon;
+    for (const auto & point : polygon.outer()) {
+      grid_polygon.addVertex({point.x(), point.y()});
+    }
+    for (grid_map_utils::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
+         ++iterator) {
+      const grid_map::Index & index = *iterator;
+      if (grid_data(index.x(), index.y()) == grid_utils::occlusion_cost_value::OCCUPIED) {
+        return false;
       }
-      for (grid_map_utils::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
-           ++iterator) {
-        const grid_map::Index & index = *iterator;
-        if (grid_data(index.x(), index.y()) == grid_utils::occlusion_cost_value::OCCUPIED) {
-          return false;
-        }
-      }
-    } else {
-      std::vector<std::pair<grid_map::Position, grid_map::Position>> lines =
-        pointsToRays(p1, p2, radius);
-      for (const auto & p : lines) {
-        for (grid_map::LineIterator iterator(grid, p.first, p.second); !iterator.isPastEnd();
-             ++iterator) {
-          const grid_map::Index & index = *iterator;
-          if (grid_data(index.x(), index.y()) == grid_utils::occlusion_cost_value::OCCUPIED) {
-            return false;
-          }
-        }
-      }
-    }  // polys or not
+    }
   } catch (const std::invalid_argument & e) {
     std::cerr << e.what() << std::endl;
     return false;

--- a/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
@@ -309,7 +309,7 @@ void imageToOccupancyGrid(const cv::Mat & cv_image, nav_msgs::msg::OccupancyGrid
       const int idx = (height - 1 - y) + (width - 1 - x) * height;
       unsigned char intensity = cv_image.at<unsigned char>(y, x);
       if (intensity == grid_utils::occlusion_cost_value::FREE_SPACE) {
-        intensity = grid_utils::occlusion_cost_value::FREE_SPACE;
+        // do nothing
       } else if (intensity == grid_utils::occlusion_cost_value::UNKNOWN_IMAGE) {
         intensity = grid_utils::occlusion_cost_value::UNKNOWN;
       } else if (intensity == grid_utils::occlusion_cost_value::OCCUPIED_IMAGE) {

--- a/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
@@ -333,14 +333,12 @@ void toQuantizedImage(
       unsigned char intensity = occupancy_grid.data.at(idx);
       if (intensity <= param.free_space_max) {
         continue;
-      } else if (param.free_space_max < intensity && intensity < param.occupied_min) {
+      } else if (intensity < param.occupied_min) {
         intensity = grid_utils::occlusion_cost_value::UNKNOWN_IMAGE;
         occlusion_image->at<unsigned char>(y, x) = intensity;
-      } else if (param.occupied_min <= intensity) {
+      } else {
         intensity = grid_utils::occlusion_cost_value::OCCUPIED_IMAGE;
         border_image->at<unsigned char>(y, x) = intensity;
-      } else {
-        throw std::logic_error("behavior_velocity[occlusion_spot_grid]: invalid if clause");
       }
     }
   }

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -429,7 +429,7 @@ bool isBlockedByPartition(const LineString2d & direction, const BasicPolygons2d 
 std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
   const grid_map::GridMap & grid, const std::vector<grid_map::Position> & occlusion_spot_positions,
   const double offset_from_start_to_ego, const Point2d base_point,
-  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, DebugData & debug_data)
+  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, const DebugData & debug_data)
 {
   const double baselink_to_front = param.baselink_to_front;
   const double right_overhang = param.right_overhang;

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -429,7 +429,8 @@ bool isBlockedByPartition(const LineString2d & direction, const BasicPolygons2d 
 std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
   const grid_map::GridMap & grid, const std::vector<grid_map::Position> & occlusion_spot_positions,
   const double offset_from_start_to_ego, const Point2d base_point,
-  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, const DebugData & debug_data)
+  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param,
+  const DebugData & debug_data)
 {
   const double baselink_to_front = param.baselink_to_front;
   const double right_overhang = param.right_overhang;

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -117,6 +117,9 @@ void calcSlowDownPointsForPossibleCollision(
   size_t collision_index = 0;
   double dist_along_path_point = offset;
   double dist_along_next_path_point = dist_along_path_point;
+  if (path.points.size() == 0) {
+    return;
+  }
   for (size_t idx = closest_idx; idx < path.points.size() - 1; idx++) {
     auto p_prev = path.points.at(idx).point;
     auto p_next = path.points.at(idx + 1).point;

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -241,7 +241,8 @@ void calcSlowDownPointsForPossibleCollision(
 std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
   const grid_map::GridMap & grid, const std::vector<grid_map::Position> & occlusion_spot_positions,
   const double offset_from_start_to_ego, const Point2d base_point,
-  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, const DebugData & debug_data);
+  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param,
+  const DebugData & debug_data);
 //!< @brief generate possible collisions coming from occlusion spots on the side of the path
 bool generatePossibleCollisionsFromGridMap(
   std::vector<PossibleCollisionInfo> & possible_collisions, const grid_map::GridMap & grid,

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -241,7 +241,7 @@ void calcSlowDownPointsForPossibleCollision(
 std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpot(
   const grid_map::GridMap & grid, const std::vector<grid_map::Position> & occlusion_spot_positions,
   const double offset_from_start_to_ego, const Point2d base_point,
-  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, DebugData & debug_data);
+  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, const DebugData & debug_data);
 //!< @brief generate possible collisions coming from occlusion spots on the side of the path
 bool generatePossibleCollisionsFromGridMap(
   std::vector<PossibleCollisionInfo> & possible_collisions, const grid_map::GridMap & grid,


### PR DESCRIPTION
## Description

This is based on CppCheck warnings.

1. remove unnecessary if branch
https://github.com/autowarefoundation/autoware.universe/commit/30b90a3b7fc0f70a1c9851641c56682b5c48dfc3
```
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:91:9: style: Condition 'polys' is always true [knownConditionTrueFalse]
    if (polys) {
        ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:89:16: note: Assignment 'polys=true', assigned value is 1
  bool polys = true;
               ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:91:9: note: Condition 'polys' is always true
    if (polys) {
        ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:89:8: style: The scope of the variable 'polys' can be reduced. [variableScope]
  bool polys = true;
       ^
```

2. add const for const variable
https://github.com/autowarefoundation/autoware.universe/commit/b9fcb38354941e8f1a5c27262e27d927be1094d5
```
planning/behavior_velocity_occlusion_spot_module/src/debug.cpp:121:10: style: Variable 'possible_collisions' can be declared as reference to const [constVariableReference]
  auto & possible_collisions = debug_data.possible_collisions;
         ^
```

3. remove redundant assignment
https://github.com/autowarefoundation/autoware.universe/commit/06acd456a7308a2d72ff7b824b07c0e8c7fd2e47
```
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:327:19: style: Assignment 'intensity=grid_utils::occlusion_cost_value::FREE_SPACE' is redundant with condition 'intensity==grid_utils::occlusion_cost_value::FREE_SPACE'. [duplicateConditionalAssign]
        intensity = grid_utils::occlusion_cost_value::FREE_SPACE;
                  ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:326:21: note: Condition 'intensity==grid_utils::occlusion_cost_value::FREE_SPACE'
      if (intensity == grid_utils::occlusion_cost_value::FREE_SPACE) {
                    ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:327:19: note: Assignment 'intensity=grid_utils::occlusion_cost_value::FREE_SPACE' is redundant
        intensity = grid_utils::occlusion_cost_value::FREE_SPACE;
                  ^
```

4. remove redundant if branch
https://github.com/autowarefoundation/autoware.universe/commit/d740ae047d32523f8b3e786f343a8348dcc4f219
```
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:351:39: style: Condition 'param.free_space_max<intensity' is always true [knownConditionTrueFalse]
      } else if (param.free_space_max < intensity && intensity < param.occupied_min) {
                                      ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:349:21: note: Assuming that condition 'intensity<=param.free_space_max' is not redundant
      if (intensity <= param.free_space_max) {
                    ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:351:39: note: Condition 'param.free_space_max<intensity' is always true
      } else if (param.free_space_max < intensity && intensity < param.occupied_min) {
                                      ^
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:89:8: style: The scope of the variable 'polys' can be reduced. [variableScope]
  bool polys = true;
       ^
```

5. underflow check
https://github.com/autowarefoundation/autoware.universe/commit/da773258a772eda1663eabf070af5c96a512f7f0

6. use const for const parameter
https://github.com/autowarefoundation/autoware.universe/commit/eca35cd3a35b9723bccbe87ef4bd100039ba5028
```
planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp:429:87: style: Parameter 'debug_data' can be declared as reference to const [constParameterReference]
  const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param, DebugData & debug_data)
                                                                                      ^
```

### Question
If the first commit (about `polys`) is acceptable, then the function `pointsToRays` seems unnecessary anymore.
Do you think I should delete it too?
https://github.com/autowarefoundation/autoware.universe/blob/fd6306d6fc3fff852046474c71a9181ddc7aa40c/planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp#L108
```
planning/behavior_velocity_occlusion_spot_module/src/grid_utils.cpp:46:0: style: The function 'pointsToRays' is never used. [unusedFunction]
std::vector<std::pair<grid_map::Position, grid_map::Position>> pointsToRays(
^
```


## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
