### PR TITLE
fix(accel_brake_map_calibrator): fix accel_brake_map_calibrator not to output invalid maps

### DIFF
--- a/vehicle/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -703,17 +703,19 @@ void AccelBrakeMapCalibrator::takeConsistencyOfAccelMap()
 {
   const double bit = std::pow(1e-01, precision_);
   for (std::size_t ped_idx = 0; ped_idx < update_accel_map_value_.size() - 1; ped_idx++) {
-    for (std::size_t vel_idx = 0; vel_idx < update_accel_map_value_.at(0).size() - 1; vel_idx++) {
+    for (std::size_t vel_idx = update_accel_map_value_.at(0).size() - 1;; vel_idx--) {
+      if (vel_idx == 0) break;
+
       const double current_acc = update_accel_map_value_.at(ped_idx).at(vel_idx);
       const double next_ped_acc = update_accel_map_value_.at(ped_idx + 1).at(vel_idx);
-      const double next_vel_acc = update_accel_map_value_.at(ped_idx).at(vel_idx + 1);
+      const double prev_vel_acc = update_accel_map_value_.at(ped_idx).at(vel_idx - 1);
 
-      if (current_acc <= next_vel_acc) {
+      if (current_acc + bit >= prev_vel_acc) {
         // the higher the velocity, the lower the acceleration
-        update_accel_map_value_.at(ped_idx).at(vel_idx + 1) = current_acc - bit;
+        update_accel_map_value_.at(ped_idx).at(vel_idx - 1) = current_acc + bit;
       }
 
-      if (current_acc >= next_ped_acc) {
+      if (current_acc + bit >= next_ped_acc) {
         // the higher the accel pedal, the higher the acceleration
         update_accel_map_value_.at(ped_idx + 1).at(vel_idx) = current_acc + bit;
       }


### PR DESCRIPTION
## Description
I have fixed accel_brake_map_calibrator not to output invalid maps.
( 
In particular, in previous implementations, there were cases where an invalid map would be outputted when the values of adjacent elements in the map were very close. I have fixed this issue. )


<!-- Write a brief description of this PR. -->

## Related links
(TIERIV Internal Link) https://tier4.atlassian.net/browse/RT0-31507

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Before:

An accel_brake_map_calibrator output invalid accel_map.csv

Output:
> default,0,0.1,0.572158,1.04432,1.51647,1.98863,2.46079,2.93295,3.40511,3.87726,4.34942,4.82158,5.29374,5.76589,6.23805,6.71021,7.18237,7.65453,8.12668,8.59884,9.071
0,-0.13,-0.129,-0.163,-0.163,-0.165,-0.201,-0.227,-0.283,-0.333,-0.411,-0.465,-0.498,-0.499,-0.5,-0.553,-0.58,-0.581,-0.582,-0.583,-0.584,-0.585
0.001,-0.129,-0.128,-0.162,-0.162,-0.164,-0.2,-0.226,-0.282,-0.332,-0.41,-0.464,-0.497,-0.498,-0.499,-0.552,-0.579,-0.58,-0.581,-0.582,-0.583,-0.584
0.032,0.231,0.232,0.137,-0.026,-0.027,-0.051,-0.052,-0.053,-0.054,-0.055,-0.056,-0.057,-0.058,-0.059,-0.06,-0.061,-0.062,-0.063,-0.064,-0.065,-0.067
0.063,0.311,0.312,0.153,0.04,0.039,0.017,-0.035,-0.052,-0.053,-0.054,-0.055,-0.056,-0.057,-0.058,-0.059,-0.06,-0.061,-0.062,-0.063,-0.064,-0.066
0.093,0.312,**0.314**,0.167,0.095,0.094,0.083,0.063,0.04,0.039,0.038,0.037,0.036,0.035,0.034,0.033,0.032,0.031,0.03,0.029,0.028,0.027
0.124,0.313,**0.314**,0.222,0.096,0.095,0.086,0.064,0.041,0.04,0.039,0.038,0.037,0.036,0.035,0.034,0.033,0.032,0.031,0.03,0.029,0.028
0.155,**0.4,0.401**,0.337,0.097,0.096,0.087,0.075,0.074,0.073,0.072,0.071,0.07,0.069,0.068,0.067,0.066,0.065,0.064,0.063,0.062,0.061



After:

Even if an invalid accel_map is provided as input, the output of accel_brake_map_calibrator will be a valid file.


Input:
> 0,0.3,0.3,0.3,0.3001,-0.4,-0.41,-0.42,-0.44,-0.46,-0.48,-0.5
0.1,**0.3,0.3,0.3002**,0.18,0.12,0.05,-0.08,-0.16,-0.2,-0.24,-0.28
0.2,**0.3,0.3,0.3**,0.6,0.48,0.34,0.26,0.2,0.1,0.05,-0.03
0.3,1.75,1.6,1.42,1.3,1.14,1,0.9,0.8,0.72,0.64,0.58
0.4,2.65,2.48,2.3,2.13,1.95,1.75,1.58,1.45,1.32,1.2,1.1
0.5,3.3,3.25,3.12,2.92,2.68,2.35,2.17,1.98,1.88,1.73,1.61

Output:
> default,0,1.39,2.78,4.17,5.56,6.94,8.33,9.72,11.11,12.5,13.89
0,0.303,0.302,0.301,0.300,-0.400,-0.410,-0.420,-0.440,-0.460,-0.480,-0.500
0.100,0.305,0.303,0.302,0.301,0.120,0.050,-0.080,-0.160,-0.200,-0.240,-0.280


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes
none
<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes
none
<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior
accel_brake_map_calibrator becomes not to output invalid maps.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
