### PR TITLE
feat(mrm_emergency_stop_operator): add support for real time param reconfigure for mrm_emergency_stop

### DIFF
--- a/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
+++ b/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
@@ -27,6 +27,7 @@
 // ROS 2 core
 #include <rclcpp/rclcpp.hpp>
 
+#include <vector>
 namespace mrm_emergency_stop_operator
 {
 using autoware_auto_control_msgs::msg::AckermannControlCommand;
@@ -48,6 +49,10 @@ public:
 private:
   // Parameters
   Parameters params_;
+  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+
+  rcl_interfaces::msg::SetParametersResult onParameter(
+    const std::vector<rclcpp::Parameter> & parameters);
 
   // Subscriber
   rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_control_cmd_;

--- a/system/mrm_emergency_stop_operator/package.xml
+++ b/system/mrm_emergency_stop_operator/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tier4_autoware_utils</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
+++ b/system/mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
@@ -14,6 +14,8 @@
 
 #include "mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp"
 
+#include <tier4_autoware_utils/ros/update_param.hpp>
+
 namespace mrm_emergency_stop_operator
 {
 
@@ -49,6 +51,23 @@ MrmEmergencyStopOperator::MrmEmergencyStopOperator(const rclcpp::NodeOptions & n
   // Initialize
   status_.state = MrmBehaviorStatus::AVAILABLE;
   is_prev_control_cmd_subscribed_ = false;
+
+  // Parameter Callback
+  set_param_res_ = add_on_set_parameters_callback(
+    std::bind(&MrmEmergencyStopOperator::onParameter, this, std::placeholders::_1));
+}
+
+rcl_interfaces::msg::SetParametersResult MrmEmergencyStopOperator::onParameter(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  using tier4_autoware_utils::updateParam;
+  updateParam<double>(parameters, "target_acceleration", params_.target_acceleration);
+  updateParam<double>(parameters, "target_jerk", params_.target_jerk);
+
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+  return result;
 }
 
 void MrmEmergencyStopOperator::onControlCommand(AckermannControlCommand::ConstSharedPtr msg)


### PR DESCRIPTION
## Description

Add support for updating mrm emergency stop with rqt_reconfigure. Also added the vector include requested by pre-commit.

## Tests performed

PSim

Using the AEB module to test the changes, I lowered the min jerk and acceleration and the ego cannot stop reasonably fast (as expected), see video:

https://github.com/autowarefoundation/autoware.universe/assets/25967964/42eebb30-b953-41ff-84d6-91156f744b41



Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
