### PR TITLE
refactor(behavior_velocity_occlusion_spot_module): remove unnecessary declaration

### DIFF
--- a/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp
@@ -33,7 +33,6 @@ using BasicPolygons = std::vector<lanelet::BasicPolygon2d>;
 using occlusion_spot_utils::PossibleCollisionInfo;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
-using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerOrientation;
 using tier4_autoware_utils::createMarkerPosition;

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -295,8 +295,7 @@ PossibleCollisionInfo calculateCollisionPathPointFromOcclusionSpot(
 {
   auto calcPosition =
     [](const lanelet::ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
-      BasicPoint2d bp = lanelet::geometry::fromArcCoordinates;
-      (ll, arc);
+      BasicPoint2d bp = lanelet::geometry::fromArcCoordinates(ll, arc);
       Point position;
       position.x = bp[0];
       position.y = bp[1];

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -242,7 +242,8 @@ void categorizeVehicles(
   return;
 }
 
-lanelet::ArcCoordinates getOcclusionPoint(const PredictedObject & obj, const ConstLineString2d & ll_string)
+lanelet::ArcCoordinates getOcclusionPoint(
+  const PredictedObject & obj, const ConstLineString2d & ll_string)
 {
   const auto poly = tier4_autoware_utils::toPolygon2d(obj);
   std::deque<lanelet::ArcCoordinates> arcs;
@@ -257,16 +258,18 @@ lanelet::ArcCoordinates getOcclusionPoint(const PredictedObject & obj, const Con
    * Ego===============> path
    **/
   // sort by arc length
-  std::sort(arcs.begin(), arcs.end(), [](lanelet::ArcCoordinates arc1, lanelet::ArcCoordinates arc2) {
-    return arc1.length < arc2.length;
-  });
+  std::sort(
+    arcs.begin(), arcs.end(), [](lanelet::ArcCoordinates arc1, lanelet::ArcCoordinates arc2) {
+      return arc1.length < arc2.length;
+    });
   // remove closest 2 polygon point
   arcs.pop_front();
   arcs.pop_front();
   // sort by arc distance
-  std::sort(arcs.begin(), arcs.end(), [](lanelet::ArcCoordinates arc1, lanelet::ArcCoordinates arc2) {
-    return std::abs(arc1.distance) < std::abs(arc2.distance);
-  });
+  std::sort(
+    arcs.begin(), arcs.end(), [](lanelet::ArcCoordinates arc1, lanelet::ArcCoordinates arc2) {
+      return std::abs(arc1.distance) < std::abs(arc2.distance);
+    });
   // return closest to path point which is choosen by farthest 2 points.
   return arcs.at(0);
 }

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -243,7 +243,7 @@ void categorizeVehicles(
 }
 
 lanelet::ArcCoordinates getOcclusionPoint(
-  const PredictedObject & obj, const ConstLineString2d & ll_string)
+  const PredictedObject & obj, const lanelet::ConstLineString2d & ll_string)
 {
   const auto poly = tier4_autoware_utils::toPolygon2d(obj);
   std::deque<lanelet::ArcCoordinates> arcs;
@@ -293,7 +293,7 @@ PossibleCollisionInfo calculateCollisionPathPointFromOcclusionSpot(
   const lanelet::ArcCoordinates & arc_coord_occlusion_with_offset,
   const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param)
 {
-  auto calcPosition = [](const ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
+  auto calcPosition = [](const lanelet::ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
     BasicPoint2d bp = lanelet::geometry::fromArcCoordinates;(ll, arc);
     Point position;
     position.x = bp[0];

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -293,14 +293,16 @@ PossibleCollisionInfo calculateCollisionPathPointFromOcclusionSpot(
   const lanelet::ArcCoordinates & arc_coord_occlusion_with_offset,
   const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param)
 {
-  auto calcPosition = [](const lanelet::ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
-    BasicPoint2d bp = lanelet::geometry::fromArcCoordinates;(ll, arc);
-    Point position;
-    position.x = bp[0];
-    position.y = bp[1];
-    position.z = 0.0;
-    return position;
-  };
+  auto calcPosition =
+    [](const lanelet::ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
+      BasicPoint2d bp = lanelet::geometry::fromArcCoordinates;
+      (ll, arc);
+      Point position;
+      position.x = bp[0];
+      position.y = bp[1];
+      position.z = 0.0;
+      return position;
+    };
   /**
    * @brief calculate obstacle collision intersection from arc coordinate info.
    *                                      ^

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -291,7 +291,7 @@ PossibleCollisionInfo calculateCollisionPathPointFromOcclusionSpot(
   const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param)
 {
   auto calcPosition = [](const ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
-    BasicPoint2d bp = fromArcCoordinates(ll, arc);
+    BasicPoint2d bp = lanelet::geometry::fromArcCoordinates;(ll, arc);
     Point position;
     position.x = bp[0];
     position.y = bp[1];

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -242,7 +242,7 @@ void categorizeVehicles(
   return;
 }
 
-ArcCoordinates getOcclusionPoint(const PredictedObject & obj, const ConstLineString2d & ll_string)
+lanelet::ArcCoordinates getOcclusionPoint(const PredictedObject & obj, const ConstLineString2d & ll_string)
 {
   const auto poly = tier4_autoware_utils::toPolygon2d(obj);
   std::deque<lanelet::ArcCoordinates> arcs;
@@ -257,14 +257,14 @@ ArcCoordinates getOcclusionPoint(const PredictedObject & obj, const ConstLineStr
    * Ego===============> path
    **/
   // sort by arc length
-  std::sort(arcs.begin(), arcs.end(), [](ArcCoordinates arc1, ArcCoordinates arc2) {
+  std::sort(arcs.begin(), arcs.end(), [](lanelet::ArcCoordinates arc1, lanelet::ArcCoordinates arc2) {
     return arc1.length < arc2.length;
   });
   // remove closest 2 polygon point
   arcs.pop_front();
   arcs.pop_front();
   // sort by arc distance
-  std::sort(arcs.begin(), arcs.end(), [](ArcCoordinates arc1, ArcCoordinates arc2) {
+  std::sort(arcs.begin(), arcs.end(), [](lanelet::ArcCoordinates arc1, lanelet::ArcCoordinates arc2) {
     return std::abs(arc1.distance) < std::abs(arc2.distance);
   });
   // return closest to path point which is choosen by farthest 2 points.
@@ -286,11 +286,11 @@ double calcSignedLateralDistanceWithOffset(
 }
 
 PossibleCollisionInfo calculateCollisionPathPointFromOcclusionSpot(
-  const ArcCoordinates & arc_coord_occlusion,
-  const ArcCoordinates & arc_coord_occlusion_with_offset,
+  const lanelet::ArcCoordinates & arc_coord_occlusion,
+  const lanelet::ArcCoordinates & arc_coord_occlusion_with_offset,
   const lanelet::ConstLanelet & path_lanelet, const PlannerParam & param)
 {
-  auto calcPosition = [](const ConstLineString2d & ll, const ArcCoordinates & arc) {
+  auto calcPosition = [](const ConstLineString2d & ll, const lanelet::ArcCoordinates & arc) {
     BasicPoint2d bp = fromArcCoordinates(ll, arc);
     Point position;
     position.x = bp[0];
@@ -338,8 +338,8 @@ bool generatePossibleCollisionsFromObjects(
   lanelet::ConstLanelet path_lanelet = toPathLanelet(path);
   auto ll = path_lanelet.centerline2d();
   for (const auto & dyn : dyn_objects) {
-    ArcCoordinates arc_coord_occlusion = getOcclusionPoint(dyn, ll);
-    ArcCoordinates arc_coord_occlusion_with_offset = {
+    lanelet::ArcCoordinates arc_coord_occlusion = getOcclusionPoint(dyn, ll);
+    lanelet::ArcCoordinates arc_coord_occlusion_with_offset = {
       arc_coord_occlusion.length - param.baselink_to_front,
       calcSignedLateralDistanceWithOffset(
         arc_coord_occlusion.distance, param.right_overhang, param.left_overhang,
@@ -451,7 +451,7 @@ std::optional<PossibleCollisionInfo> generateOneNotableCollisionFromOcclusionSpo
     if (length_to_col < offset_from_start_to_ego) {
       continue;
     }
-    ArcCoordinates arc_coord_collision_point = {
+    lanelet::ArcCoordinates arc_coord_collision_point = {
       length_to_col,
       calcSignedLateralDistanceWithOffset(
         arc_coord_occlusion_point.distance, right_overhang, left_overhang, wheel_tread)};

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -60,7 +60,6 @@ using geometry_msgs::msg::Pose;
 using lanelet::BasicLineString2d;
 using lanelet::BasicPoint2d;
 using lanelet::BasicPolygon2d;
-using lanelet::ConstLineString2d;
 using lanelet::LaneletMapPtr;
 using DetectionAreaIdx = std::optional<std::pair<double, double>>;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -62,7 +62,6 @@ using lanelet::BasicPoint2d;
 using lanelet::BasicPolygon2d;
 using lanelet::ConstLineString2d;
 using lanelet::LaneletMapPtr;
-using lanelet::geometry::fromArcCoordinates;
 using DetectionAreaIdx = std::optional<std::pair<double, double>>;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
 

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -57,7 +57,6 @@ using autoware_auto_planning_msgs::msg::PathPointWithLaneId;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
-using lanelet::ArcCoordinates;
 using lanelet::BasicLineString2d;
 using lanelet::BasicPoint2d;
 using lanelet::BasicPolygon2d;

--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -64,7 +64,6 @@ using lanelet::BasicPolygon2d;
 using lanelet::ConstLineString2d;
 using lanelet::LaneletMapPtr;
 using lanelet::geometry::fromArcCoordinates;
-using lanelet::geometry::toArcCoordinates;
 using DetectionAreaIdx = std::optional<std::pair<double, double>>;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
 


### PR DESCRIPTION
## Description

This fixes `build-and-test-differential / clang-tidy-differential` errors in https://github.com/autowarefoundation/autoware.universe/pull/6987:
```
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp:36:29: error: using decl 'createDefaultMarker' is unused [misc-unused-using-decls,-warnings-as-errors]
using tier4_autoware_utils::createDefaultMarker;
                            ^
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp:36:29: note: remove the using
using tier4_autoware_utils::createDefaultMarker;
~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~

/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:60:16: error: using decl 'ArcCoordinates' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::ArcCoordinates;
               ^
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:60:16: note: remove the using
using lanelet::ArcCoordinates;
~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:64:16: error: using decl 'ConstLineString2d' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::ConstLineString2d;
               ^
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:64:16: note: remove the using
using lanelet::ConstLineString2d;
~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:66:26: error: using decl 'fromArcCoordinates' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::geometry::fromArcCoordinates;
                         ^
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:66:26: note: remove the using
using lanelet::geometry::fromArcCoordinates;
~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:67:26: error: using decl 'toArcCoordinates' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::geometry::toArcCoordinates;
                         ^
/__w/autoware.universe/autoware.universe/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp:67:26: note: remove the using
using lanelet::geometry::toArcCoordinates;
~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
