### PR TITLE
fix(start_planner): issue when ego does not straddle lane bounds and starts from 0 speed

### DIFF
--- a/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -731,10 +731,13 @@ std::pair<TurnSignalInfo, bool> TurnSignalDecider::getBehaviorTurnSignalInfo(
     return std::make_pair(TurnSignalInfo{}, true);
   }
 
-  if (!straddleRoadBound(path, shift_line, current_lanelets, p.vehicle_info)) {
+  // Check if the ego will cross lane bounds.
+  // Note that pull out requires blinkers, even if the ego does not cross lane bounds
+  if (!is_pull_out && !straddleRoadBound(path, shift_line, current_lanelets, p.vehicle_info)) {
     return std::make_pair(TurnSignalInfo{}, true);
   }
 
+  // If the ego has stopped and its close to completing its shift, turn off the blinkers
   constexpr double STOPPED_THRESHOLD = 0.1;  // [m/s]
   if (ego_speed < STOPPED_THRESHOLD && !override_ego_stopped_check) {
     if (isNearEndOfShift(

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -74,6 +74,8 @@ struct PullOutStatus
   //! record the first time when ego started forward-driving (maybe after backward driving
   //! completion) in AUTONOMOUS operation mode
   std::optional<rclcpp::Time> first_engaged_and_driving_forward_time{std::nullopt};
+  // record if the ego has departed from the start point
+  bool has_departed{false};
 
   PullOutStatus() {}
 };


### PR DESCRIPTION
## Description

When the ego vehicle is starting from a road and not the shoulder lane, it is possible that the blinkers are not properly activated. 
This is caused by 2 things:

1.  The check for lane bound straddling (crossing a lane bound) is failed. This check is not necessary when doing a pull out because we should turn on the blinkers anyways.
2. The shift is small and the ego is stopped. This happens because the ego is starting from complete stop so its speed is close to 0 and if the shift pull out lane is small/has a small shift, the blinkers are ignored, which is not desired in this case. 

To solve the issue I added an override for the first check if the ego is doing a pullout, and for the second issue I slightly modified the variable  `status_.first_engaged_and_driving_forward_time` to only be initialized when the ego vehicle has surpassed a minimum threshold velocity.

## Related links
Ticket: [TIER IV COMPANY INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-31321)

## Tests performed
PSim


https://github.com/autowarefoundation/autoware.universe/assets/25967964/169ba8c2-ca75-4b93-b614-b5f1f4576d5f




## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
