### PR TITLE
chore(simple_planning_simulator): publish control mode before the self-position is given

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -358,6 +358,7 @@ double SimplePlanningSimulator::calculate_ego_pitch() const
 void SimplePlanningSimulator::on_timer()
 {
   if (!is_initialized_) {
+    publish_control_mode_report();
     RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 5000, "waiting initialization...");
     return;
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, when using the Planning_simulator, /vehicle/status/control_mode [is not published until the vehicle's position is provided](https://github.com/autowarefoundation/autoware.universe/blob/a5fdb8d85b2f27f632e48f1fa5682d6b055b696c/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp#L360-L419). However, in actual vehicle usage, /vehicle/status/control_mode is published immediately after the vehicle_interface and the vehicle start up (ex. [pacmod_interface](https://github.com/tier4/pacmod_interface/blob/b779f8496f7f5c92ddf2dcf321897fe8602f0414/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp#L323)) . To align the Planning_simulator with this actual behavior, I have modified it to publish /vehicle/status/control_mode immediately after the node starts.

([TIER IV Internal Slack Link](https://star4.slack.com/archives/CTEJP8L4T/p1715244107785749) )

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed that the /vehicle/status/control_mode becomes to be published before the vehicle's position is provided

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
No effects on the actual vehicle behavior.

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
