### PR TITLE
perf(map_height_fitter): more efficient query to find closest lanelet

### DIFF
--- a/map/map_height_fitter/src/map_height_fitter.cpp
+++ b/map/map_height_fitter/src/map_height_fitter.cpp
@@ -200,20 +200,12 @@ double MapHeightFitter::Impl::get_ground_height(const Point & point) const
       }
     }
   } else if (fit_target_ == "vector_map") {
-    lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(vector_map_);
-
-    geometry_msgs::msg::Pose pose;
-    pose.position.x = x;
-    pose.position.y = y;
-    pose.position.z = 0.0;
-    lanelet::ConstLanelet closest_lanelet;
-    const bool result =
-      lanelet::utils::query::getClosestLanelet(all_lanelets, pose, &closest_lanelet);
-    if (!result) {
+    const auto closest_lanelets = vector_map_->laneletLayer.nearest(lanelet::BasicPoint2d{x, y}, 1);
+    if (closest_lanelets.empty()) {
       RCLCPP_WARN_STREAM(logger, "failed to get closest lanelet");
       return point.z;
     }
-    height = closest_lanelet.centerline().back().z();
+    height = closest_lanelets.front().centerline().back().z();
   }
 
   return std::isfinite(height) ? height : point.z;

--- a/map/map_height_fitter/src/map_height_fitter.cpp
+++ b/map/map_height_fitter/src/map_height_fitter.cpp
@@ -200,12 +200,12 @@ double MapHeightFitter::Impl::get_ground_height(const Point & point) const
       }
     }
   } else if (fit_target_ == "vector_map") {
-    const auto closest_lanelets = vector_map_->laneletLayer.nearest(lanelet::BasicPoint2d{x, y}, 1);
-    if (closest_lanelets.empty()) {
+    const auto closest_points = vector_map_->pointLayer.nearest(lanelet::BasicPoint2d{x, y}, 1);
+    if (closest_points.empty()) {
       RCLCPP_WARN_STREAM(logger, "failed to get closest lanelet");
       return point.z;
     }
-    height = closest_lanelets.front().centerline().back().z();
+    height = closest_points.front().z();
   }
 
   return std::isfinite(height) ? height : point.z;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Improve performance of the `map_height_fitter` when getting the ground height.
Currently, it checks ALL lanelets to find the closest one. With this PR, the query is more efficient (thanks to the R-tree used in the lanelet layer). 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
