### PR TITLE
fix(bpp, bvp): keep rtc cooperate status even after manager stops module execution

### DIFF
--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -187,7 +187,6 @@ public:
     RCLCPP_DEBUG(getLogger(), "%s %s", name_.c_str(), __func__);
 
     clearWaitingApproval();
-    removeRTCStatus();
     unlockNewModuleLaunch();
     unlockOutputPath();
     steering_factor_interface_ptr_->clearSteeringFactors();

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
@@ -103,6 +103,7 @@ public:
   {
     for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
       if (ptr) {
+        ptr->removeExpiredCooperateStatus();
         ptr->publishCooperateStatus(rclcpp::Clock(RCL_ROS_TIME).now());
       }
     }

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -247,7 +247,11 @@ protected:
 
   void removeRTCStatus(const UUID & uuid) { rtc_interface_.removeCooperateStatus(uuid); }
 
-  void publishRTCStatus(const Time & stamp) { rtc_interface_.publishCooperateStatus(stamp); }
+  void publishRTCStatus(const Time & stamp)
+  {
+    rtc_interface_.removeExpiredCooperateStatus();
+    rtc_interface_.publishCooperateStatus(stamp);
+  }
 
   UUID getUUID(const int64_t & module_id) const;
 

--- a/planning/behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -272,7 +272,10 @@ void SceneModuleManagerInterfaceWithRTC::deleteExpiredModules(
 
   for (const auto & scene_module : copied_scene_modules) {
     if (isModuleExpired(scene_module)) {
-      removeRTCStatus(getUUID(scene_module->getModuleId()));
+      const UUID uuid = getUUID(scene_module->getModuleId());
+      updateRTCStatus(
+        uuid, scene_module->isSafe(), State::SUCCEEDED, std::numeric_limits<double>::lowest(),
+        clock_->now());
       removeUUID(scene_module->getModuleId());
       unregisterModule(scene_module);
     }

--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -56,6 +56,7 @@ public:
     const UUID & uuid, const bool safe, const uint8_t state, const double start_distance,
     const double finish_distance, const rclcpp::Time & stamp);
   void removeCooperateStatus(const UUID & uuid);
+  void removeExpiredCooperateStatus();
   void clearCooperateStatus();
   bool isActivated(const UUID & uuid) const;
   bool isRegistered(const UUID & uuid) const;

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -265,6 +265,18 @@ void RTCInterface::removeStoredCommand(const UUID & uuid)
   }
 }
 
+void RTCInterface::removeExpiredCooperateStatus()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto itr = std::remove_if(
+    registered_status_.statuses.begin(), registered_status_.statuses.end(),
+    [](const auto & status) {
+      return (rclcpp::Clock{RCL_ROS_TIME}.now() - status.stamp).seconds() > 10.0;
+    });
+
+  registered_status_.statuses.erase(itr, registered_status_.statuses.end());
+}
+
 void RTCInterface::clearCooperateStatus()
 {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
## Description

Don't remove rtc cooperate status even after manager stops module execution immediately. The manager checks timestamp in cooperate status and removes old cooperate status by using following function.

```c++
void RTCInterface::removeExpiredCooperateStatus()
{
  std::lock_guard<std::mutex> lock(mutex_);
  const auto itr = std::remove_if(
    registered_status_.statuses.begin(), registered_status_.statuses.end(),
    [](const auto & status) {
      return (rclcpp::Clock{RCL_ROS_TIME}.now() - status.stamp).seconds() > 10.0;
    });

  registered_status_.statuses.erase(itr, registered_status_.statuses.end());
}
```

https://github.com/autowarefoundation/autoware.universe/assets/44889564/14fdbb9f-6ec2-47a9-8cd0-384c5d536ddb

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/9757ea40-17a6-5875-96d3-215d0dc0219a?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
