### PR TITLE
perf(lanelet2_map_preprocessor): use set.find instead of std::find

### DIFF
--- a/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
@@ -48,11 +48,6 @@ bool loadLaneletMap(
   return true;
 }
 
-bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
-{
-  return std::find(set.begin(), set.end(), element) != set.end();
-}
-
 lanelet::Lanelets convertToVector(lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::Lanelets lanelets;

--- a/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp
@@ -91,11 +91,6 @@ double getMinHeightAroundPoint(
   return min_height;
 }
 
-bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
-{
-  return std::find(set.begin(), set.end(), element) != set.end();
-}
-
 void adjustHeight(
   const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr, lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
@@ -108,7 +103,7 @@ void adjustHeight(
 
   for (lanelet::Lanelet & llt : lanelet_map_ptr->laneletLayer) {
     for (lanelet::Point3d & pt : llt.leftBound()) {
-      if (exists(done, pt.id())) {
+      if (done.find(pt.id()) != done.end()) {
         continue;
       }
       pcl::PointXYZ pcl_pt;
@@ -122,7 +117,7 @@ void adjustHeight(
       done.insert(pt.id());
     }
     for (lanelet::Point3d & pt : llt.rightBound()) {
-      if (exists(done, pt.id())) {
+      if (done.find(pt.id()) != done.end()) {
         continue;
       }
       pcl::PointXYZ pcl_pt;

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
@@ -49,7 +49,7 @@ bool loadLaneletMap(
 
 bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
 {
-  return std::find(set.begin(), set.end(), element) != set.end();
+  return set.find(element) != set.end();
 }
 
 lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp
@@ -45,7 +45,7 @@ bool loadLaneletMap(
 
 bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
 {
-  return std::find(set.begin(), set.end(), element) != set.end();
+  return set.find(element) != set.end();
 }
 
 lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)

--- a/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp
@@ -43,11 +43,6 @@ bool loadLaneletMap(
   return true;
 }
 
-bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
-{
-  return std::find(set.begin(), set.end(), element) != set.end();
-}
-
 lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::Points3d points;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
use set.find instead of std::find for better performance.
Also remove the unused `exists` functions.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
