### PR TITLE
fix(automatic_pose_initializer): fix plugin name

### DIFF
--- a/system/default_ad_api_helpers/automatic_pose_initializer/CMakeLists.txt
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/CMakeLists.txt
@@ -9,7 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "ServiceLogChecker"
+  PLUGIN "automatic_pose_initializer::AutomaticPoseInitializer"
   EXECUTABLE ${PROJECT_NAME}_node
   EXECUTOR MultiThreadedExecutor
 )


### PR DESCRIPTION
## Description
`automatic_pose_initializer` is changed as a plugin in the pull request below, but it is not launched because the name is incorrect, causing an issue where autoware cannot start automatic initial pose estimation.

* https://github.com/autowarefoundation/autoware.universe/pull/7021

## Tests performed

logging_simulator works well.

## Effects on system behavior

Initial pose estimation starts successfully.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
