### PR TITLE
feat(obstacle cruise): reduce computation cost

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -47,8 +47,7 @@ std::vector<PointWithStamp> getCollisionPoints(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,
   const rclcpp::Time & current_time, const bool is_driving_forward,
-  std::vector<size_t> & collision_index, const vehicle_info_util::VehicleInfo & vehicle_info,
-  const double max_lat_dist = std::numeric_limits<double>::max(),
+  std::vector<size_t> & collision_index, const double max_dist = std::numeric_limits<double>::max(),
   const double max_prediction_time_for_collision_check = std::numeric_limits<double>::max());
 
 }  // namespace polygon_utils

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -47,7 +47,7 @@ std::vector<PointWithStamp> getCollisionPoints(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,
   const rclcpp::Time & current_time, const bool is_driving_forward,
-  std::vector<size_t> & collision_index,
+  std::vector<size_t> & collision_index, const vehicle_info_util::VehicleInfo & vehicle_info,
   const double max_lat_dist = std::numeric_limits<double>::max(),
   const double max_prediction_time_for_collision_check = std::numeric_limits<double>::max());
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -821,6 +821,8 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   RCLCPP_INFO_EXPRESSION(
     rclcpp::get_logger("ObstacleCruisePlanner"), enable_calculation_time_info_, "  %s := %f [ms]",
     __func__, calculation_time);
+  // RCLCPP_INFO(
+  //   rclcpp::get_logger("ObstacleCruisePlanner"), "  %s := %f [ms]", __func__, calculation_time);
 
   return {stop_obstacles, cruise_obstacles, slow_down_obstacles};
 }
@@ -1074,7 +1076,7 @@ ObstacleCruisePlannerNode::createCollisionPointsForInsideCruiseObstacle(
   std::vector<size_t> collision_index;
   const auto collision_points = polygon_utils::getCollisionPoints(
     traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
-    is_driving_forward_, collision_index);
+    is_driving_forward_, collision_index, vehicle_info_);
   return collision_points;
 }
 
@@ -1113,7 +1115,7 @@ ObstacleCruisePlannerNode::createCollisionPointsForOutsideCruiseObstacle(
   std::vector<size_t> collision_index;
   const auto collision_points = polygon_utils::getCollisionPoints(
     traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
-    is_driving_forward_, collision_index,
+    is_driving_forward_, collision_index, vehicle_info_,
     vehicle_info_.vehicle_width_m + p.max_lat_margin_for_cruise,
     p.max_prediction_time_for_collision_check);
   if (collision_points.empty()) {
@@ -1190,7 +1192,7 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
     std::vector<size_t> collision_index;
     const auto collision_points = polygon_utils::getCollisionPoints(
       traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
-      is_driving_forward_, collision_index);
+      is_driving_forward_, collision_index, vehicle_info_);
     if (collision_points.empty()) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), enable_debug_info_,

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -821,8 +821,8 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   RCLCPP_INFO_EXPRESSION(
     rclcpp::get_logger("ObstacleCruisePlanner"), enable_calculation_time_info_, "  %s := %f [ms]",
     __func__, calculation_time);
-  // RCLCPP_INFO(
-  //   rclcpp::get_logger("ObstacleCruisePlanner"), "  %s := %f [ms]", __func__, calculation_time);
+  RCLCPP_INFO(
+    rclcpp::get_logger("ObstacleCruisePlanner"), "  %s := %f [ms]", __func__, calculation_time);
 
   return {stop_obstacles, cruise_obstacles, slow_down_obstacles};
 }
@@ -1076,7 +1076,12 @@ ObstacleCruisePlannerNode::createCollisionPointsForInsideCruiseObstacle(
   std::vector<size_t> collision_index;
   const auto collision_points = polygon_utils::getCollisionPoints(
     traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
-    is_driving_forward_, collision_index, vehicle_info_);
+    is_driving_forward_, collision_index,
+    std::hypot(obstacle.shape.dimensions.x * 0.5, obstacle.shape.dimensions.y * 0.5) +
+      std::hypot(
+        vehicle_info_.vehicle_length_m,
+        vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_cruise) +
+      p.decimate_trajectory_step_length);
   return collision_points;
 }
 
@@ -1115,8 +1120,12 @@ ObstacleCruisePlannerNode::createCollisionPointsForOutsideCruiseObstacle(
   std::vector<size_t> collision_index;
   const auto collision_points = polygon_utils::getCollisionPoints(
     traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
-    is_driving_forward_, collision_index, vehicle_info_,
-    vehicle_info_.vehicle_width_m + p.max_lat_margin_for_cruise,
+    is_driving_forward_, collision_index,
+    std::hypot(obstacle.shape.dimensions.x * 0.5, obstacle.shape.dimensions.y * 0.5) +
+      std::hypot(
+        vehicle_info_.vehicle_length_m,
+        vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_cruise) +
+      p.decimate_trajectory_step_length,
     p.max_prediction_time_for_collision_check);
   if (collision_points.empty()) {
     // Ignore vehicle obstacles outside the trajectory without collision
@@ -1192,7 +1201,12 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
     std::vector<size_t> collision_index;
     const auto collision_points = polygon_utils::getCollisionPoints(
       traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
-      is_driving_forward_, collision_index, vehicle_info_);
+      is_driving_forward_, collision_index,
+      std::hypot(obstacle.shape.dimensions.x * 0.5, obstacle.shape.dimensions.y * 0.5) +
+        std::hypot(
+          vehicle_info_.vehicle_length_m,
+          vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_stop) +
+        p.decimate_trajectory_step_length);
     if (collision_points.empty()) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), enable_debug_info_,

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -821,8 +821,6 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   RCLCPP_INFO_EXPRESSION(
     rclcpp::get_logger("ObstacleCruisePlanner"), enable_calculation_time_info_, "  %s := %f [ms]",
     __func__, calculation_time);
-  RCLCPP_INFO(
-    rclcpp::get_logger("ObstacleCruisePlanner"), "  %s := %f [ms]", __func__, calculation_time);
 
   return {stop_obstacles, cruise_obstacles, slow_down_obstacles};
 }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1075,11 +1075,10 @@ ObstacleCruisePlannerNode::createCollisionPointsForInsideCruiseObstacle(
   const auto collision_points = polygon_utils::getCollisionPoints(
     traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
     is_driving_forward_, collision_index,
-    std::hypot(obstacle.shape.dimensions.x * 0.5, obstacle.shape.dimensions.y * 0.5) +
+    calcObstacleMaxLength(obstacle.shape) + p.decimate_trajectory_step_length +
       std::hypot(
         vehicle_info_.vehicle_length_m,
-        vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_cruise) +
-      p.decimate_trajectory_step_length);
+        vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_cruise));
   return collision_points;
 }
 
@@ -1119,11 +1118,10 @@ ObstacleCruisePlannerNode::createCollisionPointsForOutsideCruiseObstacle(
   const auto collision_points = polygon_utils::getCollisionPoints(
     traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
     is_driving_forward_, collision_index,
-    std::hypot(obstacle.shape.dimensions.x * 0.5, obstacle.shape.dimensions.y * 0.5) +
+    calcObstacleMaxLength(obstacle.shape) + p.decimate_trajectory_step_length +
       std::hypot(
         vehicle_info_.vehicle_length_m,
-        vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_cruise) +
-      p.decimate_trajectory_step_length,
+        vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_cruise),
     p.max_prediction_time_for_collision_check);
   if (collision_points.empty()) {
     // Ignore vehicle obstacles outside the trajectory without collision
@@ -1200,11 +1198,10 @@ std::optional<StopObstacle> ObstacleCruisePlannerNode::createStopObstacle(
     const auto collision_points = polygon_utils::getCollisionPoints(
       traj_points, traj_polys, obstacle.stamp, resampled_predicted_path, obstacle.shape, now(),
       is_driving_forward_, collision_index,
-      std::hypot(obstacle.shape.dimensions.x * 0.5, obstacle.shape.dimensions.y * 0.5) +
+      calcObstacleMaxLength(obstacle.shape) + p.decimate_trajectory_step_length +
         std::hypot(
           vehicle_info_.vehicle_length_m,
-          vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_stop) +
-        p.decimate_trajectory_step_length);
+          vehicle_info_.vehicle_width_m * 0.5 + p.max_lat_margin_for_stop));
     if (collision_points.empty()) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), enable_debug_info_,

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -17,7 +17,6 @@
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
-// #include "tier4_autoware_utils/system/stop_watch.hpp"
 
 namespace
 {
@@ -45,34 +44,18 @@ PointWithStamp calcNearestCollisionPoint(
   return collision_points.at(min_idx);
 }
 
-// NOTE: max_lat_dist is used for efficient calculation to suppress boost::geometry's polygon
+// NOTE: max_dist is used for efficient calculation to suppress boost::geometry's polygon
 // calculation.
 std::optional<std::pair<size_t, std::vector<PointWithStamp>>> getCollisionIndex(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const geometry_msgs::msg::Pose & object_pose, const rclcpp::Time & object_time,
-  const Shape & object_shape, const vehicle_info_util::VehicleInfo & vehicle_info,
-  const double max_lat_dist = std::numeric_limits<double>::max())
+  const Shape & object_shape, const double max_dist = std::numeric_limits<double>::max())
 {
-  // tier4_autoware_utils::StopWatch<
-  //   std::chrono::microseconds, std::chrono::nanoseconds, std::chrono::steady_clock>
-  //   stop_watch;
-  // stop_watch.tic(__func__);
-
   const auto obj_polygon = tier4_autoware_utils::toPolygon2d(object_pose, object_shape);
   for (size_t i = 0; i < traj_polygons.size(); ++i) {
-    const double center_dist =
+    const double approximated_dist =
       tier4_autoware_utils::calcDistance2d(traj_points.at(i).pose, object_pose);
-    if (center_dist > max_lat_dist) {
-      continue;
-    }
-
-    if (
-      (object_shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX ||
-       object_shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) &&
-      center_dist >
-        std::hypot(object_shape.dimensions.x * 0.5, object_shape.dimensions.y * 0.5) +
-          std::hypot(vehicle_info.vehicle_length_m, vehicle_info.vehicle_width_m * 0.5)) {
-      // std::cerr << "skip" << std::endl;
+    if (approximated_dist > max_dist) {
       continue;
     }
 
@@ -99,14 +82,9 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> getCollisionIndex(
     if (has_collision) {
       const auto collision_info =
         std::pair<size_t, std::vector<PointWithStamp>>{i, collision_geom_points};
-      // std::cerr << "getCollisionIndex(), until: " << i << ", time: " << stop_watch.toc(__func__)
-      //           << " [us]" << std::endl;
       return collision_info;
     }
   }
-
-  // std::cerr << "getCollisionIndex(), until: all, time: " << stop_watch.toc(__func__) << " [us]"
-  //           << std::endl;
 
   return std::nullopt;
 }
@@ -119,8 +97,8 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const Obstacle & obstacle, const bool is_driving_forward,
   const vehicle_info_util::VehicleInfo & vehicle_info)
 {
-  const auto collision_info = getCollisionIndex(
-    traj_points, traj_polygons, obstacle.pose, obstacle.stamp, obstacle.shape, vehicle_info);
+  const auto collision_info =
+    getCollisionIndex(traj_points, traj_polygons, obstacle.pose, obstacle.stamp, obstacle.shape);
   if (!collision_info) {
     return std::nullopt;
   }
@@ -152,17 +130,11 @@ std::vector<PointWithStamp> getCollisionPoints(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,
   const rclcpp::Time & current_time, const bool is_driving_forward,
-  std::vector<size_t> & collision_index, const vehicle_info_util::VehicleInfo & vehicle_info,
-  const double max_lat_dist, const double max_prediction_time_for_collision_check)
+  std::vector<size_t> & collision_index, const double max_lat_dist,
+  const double max_prediction_time_for_collision_check)
 {
-  // tier4_autoware_utils::StopWatch<
-  //   std::chrono::microseconds, std::chrono::nanoseconds, std::chrono::steady_clock>
-  //   stop_watch;
-  // stop_watch.tic(__func__);
-
   std::vector<PointWithStamp> collision_points;
   for (size_t i = 0; i < predicted_path.path.size(); ++i) {
-    // stop_watch.tic(std::to_string(i));
     if (
       max_prediction_time_for_collision_check <
       rclcpp::Duration(predicted_path.time_step).seconds() * static_cast<double>(i)) {
@@ -177,19 +149,14 @@ std::vector<PointWithStamp> getCollisionPoints(
     }
 
     const auto collision_info = getCollisionIndex(
-      traj_points, traj_polygons, predicted_path.path.at(i), object_time, shape, vehicle_info,
-      max_lat_dist);
+      traj_points, traj_polygons, predicted_path.path.at(i), object_time, shape, max_lat_dist);
     if (collision_info) {
       const auto nearest_collision_point = calcNearestCollisionPoint(
         collision_info->first, collision_info->second, traj_points, is_driving_forward);
       collision_points.push_back(nearest_collision_point);
       collision_index.push_back(collision_info->first);
     }
-    // std::cerr << "getCollisionPoints(), " << i << ": " << stop_watch.toc(std::to_string(i))
-    //           << " [us]" << std::endl;
   }
-  // std::cerr << "getCollisionPoints(), total: " << stop_watch.toc(__func__) << " [us]" <<
-  // std::endl;
 
   return collision_points;
 }

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -87,8 +87,8 @@ PoseWithStamp getCurrentObjectPose(
     getCurrentObjectPoseFromPredictedPaths(predicted_paths, obj_base_time, current_time);
 
   if (!interpolated_pose) {
-    // RCLCPP_WARN(
-    //   rclcpp::get_logger("ObstacleCruisePlanner"), "Failed to find the interpolated obstacle pose");
+    RCLCPP_WARN(
+      rclcpp::get_logger("ObstacleCruisePlanner"), "Failed to find the interpolated obstacle pose");
     return PoseWithStamp{obj_base_time, pose};
   }
 

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -87,8 +87,8 @@ PoseWithStamp getCurrentObjectPose(
     getCurrentObjectPoseFromPredictedPaths(predicted_paths, obj_base_time, current_time);
 
   if (!interpolated_pose) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("ObstacleCruisePlanner"), "Failed to find the interpolated obstacle pose");
+    // RCLCPP_WARN(
+    //   rclcpp::get_logger("ObstacleCruisePlanner"), "Failed to find the interpolated obstacle pose");
     return PoseWithStamp{obj_base_time, pose};
   }
 


### PR DESCRIPTION
## Description
reduce computation cost in polygon collision check by setting adopting inclusive circle distance

Before
![Screenshot from 2024-05-16 14-14-27](https://github.com/autowarefoundation/autoware.universe/assets/141538661/9fa87d75-b6c4-41c1-a0e4-e171e41075e7)

After
![Screenshot from 2024-05-16 19-08-58](https://github.com/autowarefoundation/autoware.universe/assets/141538661/7fccdf0b-95b0-4cfa-8ec4-763f0ee21ecf)

## Tests performed
psim and tier4 internal test

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
