### PR TITLE
feat(behavior_velocity_traffic_light): do not overwrite unknown with past known color

### DIFF
--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -352,6 +352,7 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
       planner_data_.traffic_light_id_map_last_observed_[signal.traffic_signal_id].stamp =
         msg->stamp;
     } else {
+      // if (1)the observation is not UNKNOWN or (2)the very first observation is UNKNOWN
       planner_data_.traffic_light_id_map_last_observed_[signal.traffic_signal_id] = traffic_signal;
     }
   }

--- a/planning/behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_traffic_light_module/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/planning/behavior_velocity_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.hpp
@@ -58,7 +58,7 @@ private:
   // Debug
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficSignal>::SharedPtr pub_tl_state_;
 
-  std::optional<int> first_ref_stop_path_point_index_;
+  std::optional<int> nearest_ref_stop_path_point_index_;
 };
 
 class TrafficLightModulePlugin : public PluginWrapper<TrafficLightModuleManager>

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -162,11 +162,10 @@ bool calcStopPointAndInsertIndex(
 }  // namespace
 
 TrafficLightModule::TrafficLightModule(
-  const int64_t module_id, const int64_t lane_id,
-  const lanelet::TrafficLight & traffic_light_reg_elem, lanelet::ConstLanelet lane,
-  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const int64_t lane_id, const lanelet::TrafficLight & traffic_light_reg_elem,
+  lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
+: SceneModuleInterface(lane_id, logger, clock),
   lane_id_(lane_id),
   traffic_light_reg_elem_(traffic_light_reg_elem),
   lane_(lane),
@@ -365,7 +364,7 @@ bool TrafficLightModule::findValidTrafficSignal(TrafficSignalStamped & valid_tra
 {
   // get traffic signal associated with the regulatory element id
   const auto traffic_signal_stamped_opt = planner_data_->getTrafficSignal(
-    traffic_light_reg_elem_.id(), true /* traffic light module keeps last observation */);
+    traffic_light_reg_elem_.id(), false /* traffic light module does not keep last observation */);
   if (!traffic_signal_stamped_opt) {
     RCLCPP_WARN_STREAM_ONCE(
       logger_, "the traffic signal data associated with regulatory element id "

--- a/planning/behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.hpp
@@ -66,9 +66,8 @@ public:
 
 public:
   TrafficLightModule(
-    const int64_t module_id, const int64_t lane_id,
-    const lanelet::TrafficLight & traffic_light_reg_elem, lanelet::ConstLanelet lane,
-    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const int64_t lane_id, const lanelet::TrafficLight & traffic_light_reg_elem,
+    lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;


### PR DESCRIPTION
## Description

do not use the option to overwrite unknown with past known information

## Tests performed

### Before this PR

On change to from GREEN to UNKNOWN, ego does not stop

https://github.com/autowarefoundation/autoware.universe/assets/28677420/c0b9aaf9-7795-469e-bde8-9b2b21b23956


### After this PR

On change to from GREEN to UNKNOWN, ego stops

https://github.com/autowarefoundation/autoware.universe/assets/28677420/6b6556a8-29cd-42e0-86ba-5cd187c014a6


## Effects on system behavior

Not applicable.

## Interface changes

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
