### PR TITLE
refactor(tracking_object_merger): remove unread variables

### DIFF
--- a/perception/tracking_object_merger/src/data_association/data_association.cpp
+++ b/perception/tracking_object_merger/src/data_association/data_association.cpp
@@ -180,13 +180,6 @@ double DataAssociation::calcScoreBetweenObjects(
   const std::uint8_t object0_label =
     object_recognition_utils::getHighestProbLabel(object0.classification);
 
-  std::vector<double> tracker_pose = {
-    object1.kinematics.pose_with_covariance.pose.position.x,
-    object1.kinematics.pose_with_covariance.pose.position.y};
-  std::vector<double> measurement_pose = {
-    object0.kinematics.pose_with_covariance.pose.position.x,
-    object0.kinematics.pose_with_covariance.pose.position.y};
-
   double score = 0.0;
   if (can_assign_matrix_(object1_label, object0_label)) {
     const double max_dist = max_dist_matrix_(object1_label, object0_label);


### PR DESCRIPTION
## Description

Removed unused `tracker_pose` and `measurement_pose` variables.

There is a warning from cppcheck:
```
perception/tracking_object_merger/src/data_association/data_association.cpp:183:36: style: Variable 'tracker_pose' is assigned a value that is never used. [unreadVariable]
  std::vector<double> tracker_pose = {
                                   ^
perception/tracking_object_merger/src/data_association/data_association.cpp:186:40: style: Variable 'measurement_pose' is assigned a value that is never used. [unreadVariable]
  std::vector<double> measurement_pose = {
                                       ^
```

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
