### PR TITLE
refactor(ground_segmentation): refactor based on cppcheck 

### DIFF
--- a/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
@@ -102,7 +102,7 @@ RANSACGroundFilterComponent::RANSACGroundFilterComponent(const rclcpp::NodeOptio
     unit_vec_ = Eigen::Vector3d::UnitX();
   } else if (unit_axis_ == "y") {
     unit_vec_ = Eigen::Vector3d::UnitY();
-  } else { // including (unit_axis_ == "z")
+  } else {  // including (unit_axis_ == "z")
     unit_vec_ = Eigen::Vector3d::UnitZ();
   }
 
@@ -382,7 +382,7 @@ rcl_interfaces::msg::SetParametersResult RANSACGroundFilterComponent::paramCallb
       unit_vec_ = Eigen::Vector3d::UnitX();
     } else if (unit_axis_ == "y") {
       unit_vec_ = Eigen::Vector3d::UnitY();
-    } else { // including (unit_axis_ == "z")
+    } else {  // including (unit_axis_ == "z")
       unit_vec_ = Eigen::Vector3d::UnitZ();
     }
     RCLCPP_DEBUG(get_logger(), "Setting unit_axis to: %s.", unit_axis_.c_str());

--- a/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
@@ -102,9 +102,7 @@ RANSACGroundFilterComponent::RANSACGroundFilterComponent(const rclcpp::NodeOptio
     unit_vec_ = Eigen::Vector3d::UnitX();
   } else if (unit_axis_ == "y") {
     unit_vec_ = Eigen::Vector3d::UnitY();
-  } else if (unit_axis_ == "z") {
-    unit_vec_ = Eigen::Vector3d::UnitZ();
-  } else {
+  } else { // including (unit_axis_ == "z")
     unit_vec_ = Eigen::Vector3d::UnitZ();
   }
 
@@ -384,9 +382,7 @@ rcl_interfaces::msg::SetParametersResult RANSACGroundFilterComponent::paramCallb
       unit_vec_ = Eigen::Vector3d::UnitX();
     } else if (unit_axis_ == "y") {
       unit_vec_ = Eigen::Vector3d::UnitY();
-    } else if (unit_axis_ == "z") {
-      unit_vec_ = Eigen::Vector3d::UnitZ();
-    } else {
+    } else { // including (unit_axis_ == "z")
       unit_vec_ = Eigen::Vector3d::UnitZ();
     }
     RCLCPP_DEBUG(get_logger(), "Setting unit_axis to: %s.", unit_axis_.c_str());

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -522,7 +522,7 @@ void ScanGroundFilterComponent::classifyPointCloud(
       }
       if (calculate_slope) {
         // far from the previous point
-        local_slope = std::atan2(height_from_gnd, radius_distance_from_gnd);
+        auto local_slope = std::atan2(height_from_gnd, radius_distance_from_gnd);
         if (local_slope - prev_gnd_slope > local_slope_max_angle) {
           // the point is outside of the local slope threshold
           p->point_state = PointLabel::NON_GROUND;

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -349,13 +349,12 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
 
     // check the first point in ray
     auto * p = &in_radial_ordered_clouds[i][0];
-    auto * prev_p = &in_radial_ordered_clouds[i][0];  // for checking the distance to prev point
 
     bool initialized_first_gnd_grid = false;
     bool prev_list_init = false;
     pcl::PointXYZ p_orig_point, prev_p_orig_point;
     for (auto & point : in_radial_ordered_clouds[i]) {
-      prev_p = p;
+      auto * prev_p = p; // for checking the distance to prev point
       prev_p_orig_point = p_orig_point;
       p = &point;
       get_point_from_global_offset(in_cloud, p_orig_point, in_cloud->point_step * p->orig_index);

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -354,7 +354,7 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
     bool prev_list_init = false;
     pcl::PointXYZ p_orig_point, prev_p_orig_point;
     for (auto & point : in_radial_ordered_clouds[i]) {
-      auto * prev_p = p; // for checking the distance to prev point
+      auto * prev_p = p;  // for checking the distance to prev point
       prev_p_orig_point = p_orig_point;
       p = &point;
       get_point_from_global_offset(in_cloud, p_orig_point, in_cloud->point_step * p->orig_index);

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -469,7 +469,6 @@ void ScanGroundFilterComponent::classifyPointCloud(
     float prev_gnd_slope = 0.0f;
     float points_distance = 0.0f;
     PointsCentroid ground_cluster, non_ground_cluster;
-    float local_slope = 0.0f;
     PointLabel prev_point_label = PointLabel::INIT;
     pcl::PointXYZ prev_gnd_point(0, 0, 0), p_orig_point, prev_p_orig_point;
     // loop through each point in the radial div


### PR DESCRIPTION
## Description

These are refactoring based on cppcheck:
```
perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp:105:10: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
  } else if (unit_axis_ == "z") {
         ^
perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp:107:5: note: Found duplicate branches for 'if' and 'else'.
  } else {
    ^
perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp:105:10: note: Found duplicate branches for 'if' and 'else'.
  } else if (unit_axis_ == "z") {
         ^
perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp:387:12: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
    } else if (unit_axis_ == "z") {
           ^
perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp:389:7: note: Found duplicate branches for 'if' and 'else'.
    } else {
      ^
perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp:387:12: note: Found duplicate branches for 'if' and 'else'.
    } else if (unit_axis_ == "z") {
           ^
perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp:352:19: style: Variable 'prev_p' is assigned a value that is never used. [unreadVariable]
    auto * prev_p = &in_radial_ordered_clouds[i][0];  // for checking the distance to prev point
                  ^
perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp:472:23: style: Variable 'local_slope' is assigned a value that is never used. [unreadVariable]
    float local_slope = 0.0f;
                      ^
```

## Tests performed

Done "Rosbag Replay Simulation"
https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
