### PR TITLE
refactor(ndt_scan_matcher): remove unread variable

### DIFF
--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -464,17 +464,14 @@ bool NDTScanMatcher::callback_sensor_points_main(
   diagnostics_scan_points_->addKeyValue("transform_probability", ndt_result.transform_probability);
   diagnostics_scan_points_->addKeyValue(
     "nearest_voxel_transformation_likelihood", ndt_result.nearest_voxel_transformation_likelihood);
-  std::string score_name = "";
   double score = 0.0;
   double score_threshold = 0.0;
   if (param_.score_estimation.converged_param_type == ConvergedParamType::TRANSFORM_PROBABILITY) {
-    score_name = "Transform Probability";
     score = ndt_result.transform_probability;
     score_threshold = param_.score_estimation.converged_param_transform_probability;
   } else if (
     param_.score_estimation.converged_param_type ==
     ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD) {
-    score_name = "Nearest Voxel Transformation Likelihood";
     score = ndt_result.nearest_voxel_transformation_likelihood;
     score_threshold =
       param_.score_estimation.converged_param_nearest_voxel_transformation_likelihood;


### PR DESCRIPTION
## Description

Removed unread variable `score_name`

This is from cppcheck
```
localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:467:26: style: Variable 'score_name' is assigned a value that is never used. [unreadVariable]
  std::string score_name = "";
                         ^
localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:471:16: style: Variable 'score_name' is assigned a value that is never used. [unreadVariable]
    score_name = "Transform Probability";
               ^
localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:477:16: style: Variable 'score_name' is assigned a value that is never used. [unreadVariable]
    score_name = "Nearest Voxel Transformation Likelihood";
               ^
```

## Tests performed

No

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
