### PR TITLE
fix(planning_test_utils): fix build error `-werror=sign-compare`

### DIFF
--- a/planning/planning_test_utils/test/test_mock_data_parser.cpp
+++ b/planning/planning_test_utils/test/test_mock_data_parser.cpp
@@ -80,11 +80,12 @@ TEST(ParseFunctions, CompleteYAMLTest)
 
   // Test parsing of segments
   std::vector<LaneletSegment> segments = parse_segments(config["segments"]);
-  ASSERT_EQ(segments.size(), 1);  // Assuming only one segment in the provided YAML for this test
+  ASSERT_EQ(
+    segments.size(), uint64_t(1));  // Assuming only one segment in the provided YAML for this test
 
   const auto & segment0 = segments[0];
   EXPECT_EQ(segment0.preferred_primitive.id, 11);
-  EXPECT_EQ(segment0.primitives.size(), 2);
+  EXPECT_EQ(segment0.primitives.size(), uint64_t(2));
   EXPECT_EQ(segment0.primitives[0].id, 22);
   EXPECT_EQ(segment0.primitives[0].primitive_type, "lane");
   EXPECT_EQ(segment0.primitives[1].id, 33);
@@ -118,10 +119,10 @@ TEST(ParseFunction, CompleteFromFilename)
 
   ASSERT_EQ(
     lanelet_route.segments.size(),
-    2);  // Assuming only one segment in the provided YAML for this test
+    uint64_t(2));  // Assuming only one segment in the provided YAML for this test
   const auto & segment1 = lanelet_route.segments[1];
   EXPECT_EQ(segment1.preferred_primitive.id, 44);
-  EXPECT_EQ(segment1.primitives.size(), 4);
+  EXPECT_EQ(segment1.primitives.size(), uint64_t(4));
   EXPECT_EQ(segment1.primitives[0].id, 55);
   EXPECT_EQ(segment1.primitives[0].primitive_type, "lane");
   EXPECT_EQ(segment1.primitives[1].id, 66);


### PR DESCRIPTION
## Description

```
--- stderr: planning_test_utils                                                                                     
In file included from /home/satoshi/pilot-auto/src/autoware/universe/planning/planning_test_utils/test/test_mock_data_parser.cpp:15:
/opt/ros/humble/src/gtest_vendor/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
/opt/ros/humble/src/gtest_vendor/include/gtest/gtest.h:1554:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; typename std::enable_if<((! std::is_integral<_Tp>::value) || (! std::is_pointer<_Dp>::value))>::type* <anonymous> = 0]’
/home/satoshi/pilot-auto/src/autoware/universe/planning/planning_test_utils/test/test_mock_data_parser.cpp:83:3:   required from here
/opt/ros/humble/src/gtest_vendor/include/gtest/gtest.h:1527:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
 1527 |   if (lhs == rhs) {
      |       ~~~~^~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/test_mock_data_parser.dir/build.make:76: CMakeFiles/test_mock_data_parser.dir/test/test_mock_data_parser.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:185: CMakeFiles/test_mock_data_parser.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Nothing.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
