### PR TITLE
fix(avoidance): fix logger level

### DIFF
--- a/planning/behavior_path_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_avoidance_module/src/utils.cpp
@@ -2221,7 +2221,7 @@ DrivableLanes generateExpandedDrivableLanes(
           break;
         }
         if (i == max_recursive_search_num - 1) {
-          RCLCPP_ERROR(
+          RCLCPP_DEBUG(
             rclcpp::get_logger(logger_namespace), "Drivable area expansion reaches max iteration.");
         }
       }


### PR DESCRIPTION
## Description

Previously, avoidance module outputed following error even in nominal case. I fixed logger level from `ERROR` to `DEBUG`.

```
[component_container_mt-30] [ERROR 1716341804.717495512] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance.utils]: Drivable area expansion reaches max iteration.
```

![Screenshot from 2024-05-22 10-36-39](https://github.com/autowarefoundation/autoware.universe/assets/44889564/957323ad-65f1-4b1c-a1a1-09efcb4ad8cc)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
