### PR TITLE
feat(autonomous_emergency_braking): add info about IMU vs Steering info for AEB doc

### DIFF
--- a/control/autonomous_emergency_braking/README.md
+++ b/control/autonomous_emergency_braking/README.md
@@ -16,6 +16,24 @@ This module has following assumptions.
 
 ![aeb_range](./image/range.drawio.svg)
 
+### IMU path generation: steering vs IMU' angular velocity
+
+Currently, the IMU-based path is generated using the angular velocity obtained by the IMU itself. It has been suggested that the steering rate could be used instead onf the angular velocity.
+
+The pros and cons of both approaches are:
+
+IMU angular velocity:
+
+- (+) Usually, it has high accuracy
+- (-)Vehicle vibration might introduce noise.
+
+Steering rate:
+
+- (+) Not so noisy
+- (-) May have a steering offset or a wrong gear ratio, and the steering angle of Autoware and the real steering may not be the same.
+
+For the moment, there are no plans to implement the steering rate on the path creation process of the AEB module.
+
 ### Limitations
 
 - AEB might not be able to react with obstacles that are close to the ground. It depends on the performance of the pre-processing methods applied to the point cloud.

--- a/control/autonomous_emergency_braking/README.md
+++ b/control/autonomous_emergency_braking/README.md
@@ -16,9 +16,9 @@ This module has following assumptions.
 
 ![aeb_range](./image/range.drawio.svg)
 
-### IMU path generation: steering vs IMU' angular velocity
+### IMU path generation: steering angle vs IMU's angular velocity
 
-Currently, the IMU-based path is generated using the angular velocity obtained by the IMU itself. It has been suggested that the steering rate could be used instead onf the angular velocity.
+Currently, the IMU-based path is generated using the angular velocity obtained by the IMU itself. It has been suggested that the steering angle could be used instead onf the angular velocity.
 
 The pros and cons of both approaches are:
 
@@ -27,12 +27,12 @@ IMU angular velocity:
 - (+) Usually, it has high accuracy
 - (-)Vehicle vibration might introduce noise.
 
-Steering rate:
+Steering angle:
 
 - (+) Not so noisy
 - (-) May have a steering offset or a wrong gear ratio, and the steering angle of Autoware and the real steering may not be the same.
 
-For the moment, there are no plans to implement the steering rate on the path creation process of the AEB module.
+For the moment, there are no plans to implement the steering angle on the path creation process of the AEB module.
 
 ### Limitations
 


### PR DESCRIPTION
## Description

Add a brief section explaining pros and cons of using steering and IMU.
Related link: [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QW0GU6P7/p1713420391372759?thread_ts=1713419406.383599&cid=C03QW0GU6P7)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
