### PR TITLE
feat(object_lanelet_filter): add velocity direction based object lanelet filter

### DIFF
--- a/perception/detected_object_validation/config/object_lanelet_filter.param.yaml
+++ b/perception/detected_object_validation/config/object_lanelet_filter.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     filter_target_label:
       UNKNOWN : true
-      CAR : true
+      CAR : false
       TRUCK : false
       BUS : false
       TRAILER : false
@@ -16,6 +16,6 @@
        enabled: true
       # velocity direction based filter
       lanelet_direction_filter:
-        enabled: true
+        enabled: false
         velocity_yaw_threshold: 0.785398 # [rad] (45 deg)
         object_speed_threshold: 3.0 # [m/s]

--- a/perception/detected_object_validation/config/object_lanelet_filter.param.yaml
+++ b/perception/detected_object_validation/config/object_lanelet_filter.param.yaml
@@ -2,10 +2,20 @@
   ros__parameters:
     filter_target_label:
       UNKNOWN : true
-      CAR : false
+      CAR : true
       TRUCK : false
       BUS : false
       TRAILER : false
       MOTORCYCLE : false
       BICYCLE : false
       PEDESTRIAN : false
+
+    filter_settings:
+      # polygon overlap based filter
+      polygon_overlap_filter:
+       enabled: true
+      # velocity direction based filter
+      lanelet_direction_filter:
+        enabled: true
+        velocity_yaw_threshold: 0.785398 # [rad] (45 deg)
+        object_speed_threshold: 3.0 # [m/s]

--- a/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
@@ -63,6 +63,12 @@ private:
 
   utils::FilterTargetLabel filter_target_;
 
+  bool filterObject(
+    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object,
+    const autoware_auto_perception_msgs::msg::DetectedObject & input_object,
+    const lanelet::ConstLanelets & intersected_road_lanelets,
+    const lanelet::ConstLanelets & intersected_shoulder_lanelets,
+    autoware_auto_perception_msgs::msg::DetectedObjects & output_object_msg);
   LinearRing2d getConvexHull(const autoware_auto_perception_msgs::msg::DetectedObjects &);
   lanelet::ConstLanelets getIntersectedLanelets(
     const LinearRing2d &, const lanelet::ConstLanelets &);

--- a/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
@@ -17,6 +17,7 @@
 
 #include "detected_object_validation/utils/utils.hpp"
 
+#include <lanelet2_extension/utility/utilities.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
@@ -62,6 +63,13 @@ private:
   tf2_ros::TransformListener tf_listener_;
 
   utils::FilterTargetLabel filter_target_;
+  struct FilterSettings
+  {
+    bool polygon_overlap_filter;
+    bool lanelet_direction_filter;
+    double lanelet_direction_filter_velocity_yaw_threshold;
+    double lanelet_direction_filter_object_speed_threshold;
+  } filter_settings_;
 
   bool filterObject(
     const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object,
@@ -73,6 +81,9 @@ private:
   lanelet::ConstLanelets getIntersectedLanelets(
     const LinearRing2d &, const lanelet::ConstLanelets &);
   bool isPolygonOverlapLanelets(const Polygon2d &, const lanelet::ConstLanelets &);
+  bool isSameDirectionWithLanelets(
+    const lanelet::ConstLanelets & lanelets,
+    const autoware_auto_perception_msgs::msg::DetectedObject & object);
   geometry_msgs::msg::Polygon setFootprint(
     const autoware_auto_perception_msgs::msg::DetectedObject &);
 

--- a/perception/detected_object_validation/src/object_lanelet_filter.cpp
+++ b/perception/detected_object_validation/src/object_lanelet_filter.cpp
@@ -154,7 +154,10 @@ bool ObjectLaneletFilterNode::filterObject(
     }
 
     // 2. check if objects velocity is the same with the lanelet direction
-    if (filter_settings_.lanelet_direction_filter) {
+    const bool orientation_not_available =
+      transformed_object.kinematics.orientation_availability ==
+      autoware_auto_perception_msgs::msg::ObjectFeature::UNAVAILABLE;
+    if (filter_settings_.lanelet_direction_filter && !orientation_not_available) {
       const bool is_same_direction =
         isSameDirectionWithLanelets(intersected_road_lanelets, transformed_object) ||
         isSameDirectionWithLanelets(intersected_shoulder_lanelets, transformed_object);

--- a/perception/detected_object_validation/src/object_lanelet_filter.cpp
+++ b/perception/detected_object_validation/src/object_lanelet_filter.cpp
@@ -156,7 +156,7 @@ bool ObjectLaneletFilterNode::filterObject(
     // 2. check if objects velocity is the same with the lanelet direction
     const bool orientation_not_available =
       transformed_object.kinematics.orientation_availability ==
-      autoware_auto_perception_msgs::msg::ObjectFeature::UNAVAILABLE;
+      autoware_auto_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
     if (filter_settings_.lanelet_direction_filter && !orientation_not_available) {
       const bool is_same_direction =
         isSameDirectionWithLanelets(intersected_road_lanelets, transformed_object) ||


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR updates lanelet filter so that it can filter objects with opposite velocity toward belonging lanelet.
New filter will check if:
- object has valid velocity larger than threshold (defalt: 3.0 m/s)
- object velocity direction does not differ with its lanelet (default 45 deg)

merge [launcher PR](https://github.com/autowarefoundation/autoware_launch/pull/998) first.

Here shows the example that filter opposite directed car.

|before| after filtered|
|--|--|
|![Screenshot from 2024-05-24 02-08-53](https://github.com/autowarefoundation/autoware.universe/assets/20086766/f3860426-5290-40bd-8267-60749dd4bf32) |![Screenshot from 2024-05-24 02-08-58](https://github.com/autowarefoundation/autoware.universe/assets/20086766/151da453-5053-4ad3-b7a4-03b2aa7e8adc) |


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://tier4.atlassian.net/browse/RT0-31022

## Tests performed

<!-- Describe how you have tested this PR. -->

Tested with Lsim.
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
