### PR TITLE
fix(mpc_lateral_controller): align the MPC steering angle when the car is controlled manually.

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -443,7 +443,7 @@ public:
   bool calculateMPC(
     const SteeringReport & current_steer, const Odometry & current_kinematics, Lateral & ctrl_cmd,
     Trajectory & predicted_trajectory, Float32MultiArrayStamped & diagnostic);
-  
+
   /**
    * @brief Set the reference trajectory to be followed.
    * @param trajectory_msg The reference trajectory message.

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -443,7 +443,6 @@ public:
   bool calculateMPC(
     const SteeringReport & current_steer, const Odometry & current_kinematics, Lateral & ctrl_cmd,
     Trajectory & predicted_trajectory, Float32MultiArrayStamped & diagnostic);
-
   /**
    * @brief Set the reference trajectory to be followed.
    * @param trajectory_msg The reference trajectory message.

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -443,6 +443,7 @@ public:
   bool calculateMPC(
     const SteeringReport & current_steer, const Odometry & current_kinematics, Lateral & ctrl_cmd,
     Trajectory & predicted_trajectory, Float32MultiArrayStamped & diagnostic);
+  
   /**
    * @brief Set the reference trajectory to be followed.
    * @param trajectory_msg The reference trajectory message.

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -244,7 +244,7 @@ void MPC::setReferenceTrajectory(
 
 void MPC::resetPrevResult(const SteeringReport & current_steer)
 {
-  // Consider limit. The prev value larger than limitation brakes the optimization constraint and
+  // Consider limit. The prev value larger than limitation breaks the optimization constraint and
   // results in optimization failure.
   const float steer_lim_f = static_cast<float>(m_steer_lim);
   m_raw_steer_cmd_prev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -102,10 +102,6 @@ bool MPC::calculateMPC(
   // save previous input for the mpc rate limit
   m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
   m_raw_steer_cmd_prev = Uex(0);
-  if (is_driving_manually) { // align the MPC steering angle to the actual steering angle when the vehicle is manually controlled
-    m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
-    m_raw_steer_cmd_prev = mpc_data.steer;
-  }
 
   /* calculate predicted trajectory */
   predicted_trajectory =

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -102,6 +102,10 @@ bool MPC::calculateMPC(
   // save previous input for the mpc rate limit
   m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
   m_raw_steer_cmd_prev = Uex(0);
+  if (!is_under_control) {
+    m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
+    m_raw_steer_cmd_prev = mpc_data.steer;
+  }
 
   /* calculate predicted trajectory */
   predicted_trajectory =

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -102,7 +102,7 @@ bool MPC::calculateMPC(
   // save previous input for the mpc rate limit
   m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
   m_raw_steer_cmd_prev = Uex(0);
-  if (is_driving_manually) {
+  if (is_driving_manually) { // align the MPC steering angle to the actual steering angle when the vehicle is manually controlled
     m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
     m_raw_steer_cmd_prev = mpc_data.steer;
   }

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -102,7 +102,7 @@ bool MPC::calculateMPC(
   // save previous input for the mpc rate limit
   m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
   m_raw_steer_cmd_prev = Uex(0);
-  if (!is_under_control) {
+  if (is_driving_manually) {
     m_raw_steer_cmd_pprev = m_raw_steer_cmd_prev;
     m_raw_steer_cmd_prev = mpc_data.steer;
   }

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -252,10 +252,6 @@ trajectory_follower::LateralOutput MpcLateralController::run(
     m_is_ctrl_cmd_prev_initialized = true;
   }
 
-  const bool is_driving_manually = input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL ||
-                                   input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE ||
-                                   input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::STOP;
-
   const bool is_mpc_solved = m_mpc->calculateMPC(
     m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values);
 
@@ -264,7 +260,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   // the vehicle will return to the path by re-planning the trajectory or external operation.
   // After the recovery, the previous value of the optimization may deviate greatly from
   // the actual steer angle, and it may make the optimization result unstable.
-  if (!is_mpc_solved||is_driving_manually) {
+  if (!is_mpc_solved||!input_data.current_operation_mode.is_autoware_control_enabled) {
     m_mpc->resetPrevResult(m_current_steering);
   } else {
     setSteeringToHistory(ctrl_cmd);

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -260,7 +260,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   // the vehicle will return to the path by re-planning the trajectory or external operation.
   // After the recovery, the previous value of the optimization may deviate greatly from
   // the actual steer angle, and it may make the optimization result unstable.
-  if (!is_mpc_solved||!is_under_control) {
+  if (!is_mpc_solved || !is_under_control) {
     m_mpc->resetPrevResult(m_current_steering);
   } else {
     setSteeringToHistory(ctrl_cmd);

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -260,7 +260,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   // the vehicle will return to the path by re-planning the trajectory or external operation.
   // After the recovery, the previous value of the optimization may deviate greatly from
   // the actual steer angle, and it may make the optimization result unstable.
-  if (!is_mpc_solved||!input_data.current_operation_mode.is_autoware_control_enabled) {
+  if (!is_mpc_solved||!is_under_control) {
     m_mpc->resetPrevResult(m_current_steering);
   } else {
     setSteeringToHistory(ctrl_cmd);

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -257,14 +257,14 @@ trajectory_follower::LateralOutput MpcLateralController::run(
                                    input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::STOP;
 
   const bool is_mpc_solved = m_mpc->calculateMPC(
-    m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values, is_driving_manually);
+    m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values);
 
   // reset previous MPC result
   // Note: When a large deviation from the trajectory occurs, the optimization stops and
   // the vehicle will return to the path by re-planning the trajectory or external operation.
   // After the recovery, the previous value of the optimization may deviate greatly from
   // the actual steer angle, and it may make the optimization result unstable.
-  if (!is_mpc_solved) {
+  if (!is_mpc_solved||is_driving_manually) {
     m_mpc->resetPrevResult(m_current_steering);
   } else {
     setSteeringToHistory(ctrl_cmd);

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -252,8 +252,11 @@ trajectory_follower::LateralOutput MpcLateralController::run(
     m_is_ctrl_cmd_prev_initialized = true;
   }
 
+  const bool is_driving_manually = input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL ||
+                                   input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE;
+
   const bool is_mpc_solved = m_mpc->calculateMPC(
-    m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values, is_under_control);
+    m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values, is_driving_manually);
 
   // reset previous MPC result
   // Note: When a large deviation from the trajectory occurs, the optimization stops and

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -253,7 +253,8 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   }
 
   const bool is_driving_manually = input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL ||
-                                   input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE;
+                                   input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE ||
+                                   input_data.current_operation_mode.mode == autoware_adapi_v1_msgs::msg::OperationModeState::STOP;
 
   const bool is_mpc_solved = m_mpc->calculateMPC(
     m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values, is_driving_manually);

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -253,7 +253,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   }
 
   const bool is_mpc_solved = m_mpc->calculateMPC(
-    m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values);
+    m_current_steering, m_current_kinematic_state, ctrl_cmd, predicted_traj, debug_values, is_under_control);
 
   // reset previous MPC result
   // Note: When a large deviation from the trajectory occurs, the optimization stops and


### PR DESCRIPTION
## Description

The MPC steering angle stops tracking the actual one while the car is driving manually.

This causes the so-called "improper initial steering angle" after switching from manual to auto as below:

_case 1_
[Screencast from 06-14-2024 01:39:49 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/80969277/6fea01bd-8df3-4dbd-915e-749d7fb49b1b)

_case 2_
[Screencast from 06-14-2024 02:10:00 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/80969277/e7c29978-28c2-404e-9aa9-65d7e099a633)

_case 3_
[Screencast from 06-14-2024 02:31:54 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/80969277/08ce5885-81b9-4d93-ae9f-64cea905dfb4)



This PR aligns the MPC steering angle when the car is controlled manually.

The resulting response of the updated algorithm is given below:

_case 1 (after modification)_
[Screencast from 06-14-2024 01:27:01 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/80969277/48d980e6-f244-4637-956c-3d70ae0b87f6)

_case 2  (after modification)_
[Screencast from 06-14-2024 02:04:21 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/80969277/1c384fa9-7b58-4c89-89be-2d2ba1ec04af)

_case 3  (after modification)_
[Screencast from 06-14-2024 02:28:51 PM.webm](https://github.com/autowarefoundation/autoware.universe/assets/80969277/041fde9a-7607-44a1-92dc-e33a4612ef8f)


The flag used is const `bool is_under_control` = input_data.current_operation_mode.is_autoware_control_enabled &&
                                input_data.current_operation_mode.mode ==
                                  autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS;



## Related links
_case 1_
https://tier4.atlassian.net/jira/software/c/projects/RT1/boards/438?selectedIssue=RT0-31121

_case 2_
https://tier4.atlassian.net/jira/software/c/projects/RT1/boards/438?selectedIssue=RT0-30739

_case 3_
Case 3 was raised by Dr. M. @maxime-clem 

## Tests performed

https://evaluation.tier4.jp/evaluation/reports/b49b340f-dcb8-5bf0-8feb-7dfbdfd24179?page=1&project_id=prd_jt

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
