### PR TITLE
feat(tier4_autoware_utils): faster sin and cos

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/math/trigonometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/math/trigonometry.hpp
@@ -15,12 +15,16 @@
 #ifndef TIER4_AUTOWARE_UTILS__MATH__TRIGONOMETRY_HPP_
 #define TIER4_AUTOWARE_UTILS__MATH__TRIGONOMETRY_HPP_
 
+#include<utility>
+
 namespace tier4_autoware_utils
 {
 
 float sin(float radian);
 
 float cos(float radian);
+
+std::pair<float, float> sin_and_cos(float radian);
 
 }  // namespace tier4_autoware_utils
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/math/trigonometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/math/trigonometry.hpp
@@ -15,7 +15,7 @@
 #ifndef TIER4_AUTOWARE_UTILS__MATH__TRIGONOMETRY_HPP_
 #define TIER4_AUTOWARE_UTILS__MATH__TRIGONOMETRY_HPP_
 
-#include<utility>
+#include <utility>
 
 namespace tier4_autoware_utils
 {

--- a/common/tier4_autoware_utils/src/math/trigonometry.cpp
+++ b/common/tier4_autoware_utils/src/math/trigonometry.cpp
@@ -62,13 +62,13 @@ std::pair<float, float> sin_and_cos(float radian)
     return {g_sin_table[idx], g_sin_table[discrete_arcs_num_90 - idx]};
   } else if (discrete_arcs_num_90 <= idx && idx < 2 * discrete_arcs_num_90) {
     idx = 2 * discrete_arcs_num_90 - idx;
-    return {g_sin_table[idx], - g_sin_table[discrete_arcs_num_90 - idx]};
+    return {g_sin_table[idx], -g_sin_table[discrete_arcs_num_90 - idx]};
   } else if (2 * discrete_arcs_num_90 <= idx && idx < 3 * discrete_arcs_num_90) {
     idx = idx - 2 * discrete_arcs_num_90;
-    return {- g_sin_table[idx], - g_sin_table[discrete_arcs_num_90 - idx]};
-  } else { // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
+    return {-g_sin_table[idx], -g_sin_table[discrete_arcs_num_90 - idx]};
+  } else {  // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
     idx = 4 * discrete_arcs_num_90 - idx;
-    return {- g_sin_table[idx], g_sin_table[discrete_arcs_num_90 - idx]};
+    return {-g_sin_table[idx], g_sin_table[discrete_arcs_num_90 - idx]};
   }
 }
 

--- a/common/tier4_autoware_utils/src/math/trigonometry.cpp
+++ b/common/tier4_autoware_utils/src/math/trigonometry.cpp
@@ -58,25 +58,18 @@ std::pair<float, float> sin_and_cos(float radian)
     (static_cast<int>(std::round(degree)) % discrete_arcs_num_360 + discrete_arcs_num_360) %
     discrete_arcs_num_360;
 
-  float sin, cos;
   if (idx < discrete_arcs_num_90) {
-    sin = g_sin_table[idx];
-    cos = g_sin_table[discrete_arcs_num_90 - idx];
+    return {g_sin_table[idx], g_sin_table[discrete_arcs_num_90 - idx]};
   } else if (discrete_arcs_num_90 <= idx && idx < 2 * discrete_arcs_num_90) {
     idx = 2 * discrete_arcs_num_90 - idx;
-    sin = g_sin_table[idx];
-    cos = -1.f * g_sin_table[discrete_arcs_num_90 - idx];
+    return {g_sin_table[idx], - g_sin_table[discrete_arcs_num_90 - idx]};
   } else if (2 * discrete_arcs_num_90 <= idx && idx < 3 * discrete_arcs_num_90) {
     idx = idx - 2 * discrete_arcs_num_90;
-    sin = -1.f * g_sin_table[idx];
-    cos = -1.f * g_sin_table[discrete_arcs_num_90 - idx];
-  } else {  // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
+    return {- g_sin_table[idx], - g_sin_table[discrete_arcs_num_90 - idx]};
+  } else { // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
     idx = 4 * discrete_arcs_num_90 - idx;
-    sin = -1.f * g_sin_table[idx];
-    cos = g_sin_table[discrete_arcs_num_90 - idx];
+    return {- g_sin_table[idx], g_sin_table[discrete_arcs_num_90 - idx]};
   }
-
-  return std::make_pair(sin, cos);
 }
 
 }  // namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/src/math/trigonometry.cpp
+++ b/common/tier4_autoware_utils/src/math/trigonometry.cpp
@@ -49,8 +49,10 @@ float cos(float radian)
   return sin(radian + static_cast<float>(tier4_autoware_utils::pi) / 2.f);
 }
 
-std::pair<float, float> sin_and_cos(float radian) {
-  constexpr float tmp = (180.f / static_cast<float>(tier4_autoware_utils::pi)) * (discrete_arcs_num_360 / 360.f);
+std::pair<float, float> sin_and_cos(float radian)
+{
+  constexpr float tmp =
+    (180.f / static_cast<float>(tier4_autoware_utils::pi)) * (discrete_arcs_num_360 / 360.f);
   const float degree = radian * tmp;
   size_t idx =
     (static_cast<int>(std::round(degree)) % discrete_arcs_num_360 + discrete_arcs_num_360) %
@@ -68,7 +70,7 @@ std::pair<float, float> sin_and_cos(float radian) {
     idx = idx - 2 * discrete_arcs_num_90;
     sin = -1.f * g_sin_table[idx];
     cos = -1.f * g_sin_table[discrete_arcs_num_90 - idx];
-  } else { // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
+  } else {  // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
     idx = 4 * discrete_arcs_num_90 - idx;
     sin = -1.f * g_sin_table[idx];
     cos = g_sin_table[discrete_arcs_num_90 - idx];

--- a/common/tier4_autoware_utils/src/math/trigonometry.cpp
+++ b/common/tier4_autoware_utils/src/math/trigonometry.cpp
@@ -49,4 +49,32 @@ float cos(float radian)
   return sin(radian + static_cast<float>(tier4_autoware_utils::pi) / 2.f);
 }
 
+std::pair<float, float> sin_and_cos(float radian) {
+  constexpr float tmp = (180.f / static_cast<float>(tier4_autoware_utils::pi)) * (discrete_arcs_num_360 / 360.f);
+  const float degree = radian * tmp;
+  size_t idx =
+    (static_cast<int>(std::round(degree)) % discrete_arcs_num_360 + discrete_arcs_num_360) %
+    discrete_arcs_num_360;
+
+  float sin, cos;
+  if (idx < discrete_arcs_num_90) {
+    sin = g_sin_table[idx];
+    cos = g_sin_table[discrete_arcs_num_90 - idx];
+  } else if (discrete_arcs_num_90 <= idx && idx < 2 * discrete_arcs_num_90) {
+    idx = 2 * discrete_arcs_num_90 - idx;
+    sin = g_sin_table[idx];
+    cos = -1.f * g_sin_table[discrete_arcs_num_90 - idx];
+  } else if (2 * discrete_arcs_num_90 <= idx && idx < 3 * discrete_arcs_num_90) {
+    idx = idx - 2 * discrete_arcs_num_90;
+    sin = -1.f * g_sin_table[idx];
+    cos = -1.f * g_sin_table[discrete_arcs_num_90 - idx];
+  } else { // 3 * discrete_arcs_num_90 <= idx && idx < 4 * discrete_arcs_num_90
+    idx = 4 * discrete_arcs_num_90 - idx;
+    sin = -1.f * g_sin_table[idx];
+    cos = g_sin_table[discrete_arcs_num_90 - idx];
+  }
+
+  return std::make_pair(sin, cos);
+}
+
 }  // namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/test/src/math/test_trigonometry.cpp
+++ b/common/tier4_autoware_utils/test/src/math/test_trigonometry.cpp
@@ -40,3 +40,16 @@ TEST(trigonometry, cos)
         tier4_autoware_utils::cos(x * static_cast<float>(i))) < 10e-5);
   }
 }
+
+TEST(trigonometry, sin_and_cos)
+{
+  float x = 4.f * tier4_autoware_utils::pi / 128.f;
+  for (int i = 0; i < 128; i++) {
+    const auto sin_and_cos = tier4_autoware_utils::sin_and_cos(x * static_cast<float>(i));
+    EXPECT_TRUE(
+      std::abs(std::sin(x * static_cast<float>(i)) - sin_and_cos.first) < 10e-7);
+    EXPECT_TRUE(
+      std::abs(std::cos(x * static_cast<float>(i)) - sin_and_cos.second) < 10e-7);
+  }
+}
+

--- a/common/tier4_autoware_utils/test/src/math/test_trigonometry.cpp
+++ b/common/tier4_autoware_utils/test/src/math/test_trigonometry.cpp
@@ -46,10 +46,7 @@ TEST(trigonometry, sin_and_cos)
   float x = 4.f * tier4_autoware_utils::pi / 128.f;
   for (int i = 0; i < 128; i++) {
     const auto sin_and_cos = tier4_autoware_utils::sin_and_cos(x * static_cast<float>(i));
-    EXPECT_TRUE(
-      std::abs(std::sin(x * static_cast<float>(i)) - sin_and_cos.first) < 10e-7);
-    EXPECT_TRUE(
-      std::abs(std::cos(x * static_cast<float>(i)) - sin_and_cos.second) < 10e-7);
+    EXPECT_TRUE(std::abs(std::sin(x * static_cast<float>(i)) - sin_and_cos.first) < 10e-7);
+    EXPECT_TRUE(std::abs(std::cos(x * static_cast<float>(i)) - sin_and_cos.second) < 10e-7);
   }
 }
-


### PR DESCRIPTION
## Description

I have implemented a faster sin ans cos calculation.
Calling `sin_and_cos` is faster than calling `sin` and `cos` separately.

It is useful, for example, for `DistortionCorrector`.
I found that around 35% of CPU time in DistortionCorrector is occupied by `sin` and `cos`,
and I have confirmed 10~20% latency improvement with faster `sin_and_cos`. cc @vividf 

## Tests performed

I have written a test code and the test has passed.

## Effects on system behavior

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
