### PR TITLE
fix(crosswalk): fix calclation distance from the null polygons

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -182,7 +182,7 @@ public:
       const rclcpp::Time & now, const geometry_msgs::msg::Point & position, const double vel,
       const bool is_ego_yielding, const std::optional<CollisionPoint> & collision_point,
       const PlannerParam & planner_param, const lanelet::BasicPolygon2d & crosswalk_polygon,
-      const bool is_object_on_ego_path)
+      const bool is_object_away_from_path)
     {
       const bool is_stopped = vel < planner_param.stop_object_velocity;
 
@@ -202,7 +202,7 @@ public:
           planner_param.timeout_set_for_no_intention_to_walk, distance_to_crosswalk);
         const bool intent_to_cross =
           (now - *time_to_start_stopped).seconds() < timeout_no_intention_to_walk;
-        if (is_ego_yielding && !intent_to_cross && !is_object_on_ego_path) {
+        if (is_ego_yielding && !intent_to_cross && is_object_away_from_path) {
           collision_state = CollisionState::IGNORE;
           return;
         }
@@ -261,16 +261,16 @@ public:
       // update current uuids
       current_uuids_.push_back(uuid);
 
-      const bool is_object_on_ego_path =
+      const bool is_object_away_from_path =
         !attention_area.outer().empty() &&
-        boost::geometry::distance(tier4_autoware_utils::fromMsg(position).to_2d(), attention_area) <
+        boost::geometry::distance(tier4_autoware_utils::fromMsg(position).to_2d(), attention_area) >
           0.5;
 
       // add new object
       if (objects.count(uuid) == 0) {
         if (
           has_traffic_light && planner_param.disable_yield_for_new_stopped_object &&
-          !is_object_on_ego_path) {
+          is_object_away_from_path) {
           objects.emplace(uuid, ObjectInfo{CollisionState::IGNORE});
         } else {
           objects.emplace(uuid, ObjectInfo{CollisionState::YIELD});
@@ -280,7 +280,7 @@ public:
       // update object state
       objects.at(uuid).transitState(
         now, position, vel, is_ego_yielding, collision_point, planner_param, crosswalk_polygon,
-        is_object_on_ego_path);
+        is_object_away_from_path);
       objects.at(uuid).collision_point = collision_point;
       objects.at(uuid).position = position;
       objects.at(uuid).classification = classification;

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -262,8 +262,9 @@ public:
       current_uuids_.push_back(uuid);
 
       const bool is_object_on_ego_path =
+        !attention_area.outer().empty() &&
         boost::geometry::distance(tier4_autoware_utils::fromMsg(position).to_2d(), attention_area) <
-        0.5;
+          0.5;
 
       // add new object
       if (objects.count(uuid) == 0) {


### PR DESCRIPTION
## Description
fix not to calculate the distance from the null polygon

## Tests performed
psim and tier4 internal tests
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
