### PR TITLE
fix(behavior_velocity_blind_spot_module): fix typo in behavior_velocity_blind_spot_module

### DIFF
--- a/planning/behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.cpp
@@ -305,7 +305,7 @@ std::optional<std::pair<size_t, size_t>> BlindSpotModule::generateStopLine(
   const InterpolatedPathInfo & interpolated_path_info,
   autoware_auto_planning_msgs::msg::PathWithLaneId * path) const
 {
-  // NOTE: this is optionallly int for later subtraction
+  // NOTE: this is optionally int for later subtraction
   const int margin_idx_dist =
     std::ceil(planner_param_.stop_line_margin / interpolated_path_info.ds);
 
@@ -326,7 +326,7 @@ std::optional<std::pair<size_t, size_t>> BlindSpotModule::generateStopLine(
       return std::nullopt;
     }
 
-    // NOTE: this is optionallly int for later subtraction
+    // NOTE: this is optionally int for later subtraction
     const auto first_conflict_idx_ip = static_cast<int>(first_conflict_idx_ip_opt.value());
 
     stop_idx_default_ip = static_cast<size_t>(std::max(first_conflict_idx_ip - margin_idx_dist, 0));

--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -143,7 +143,7 @@ private:
 
   void initializeRTCStatus();
   BlindSpotDecision modifyPathVelocityDetail(PathWithLaneId * path, StopReason * stop_reason);
-  // setDafe(), setDistance()
+  // setSafe(), setDistance()
   void setRTCStatus(
     const BlindSpotDecision & decision,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path);


### PR DESCRIPTION
## Description

Fix typo in `planning/behavior_velocity_blind_spot_module` to suppress the spell-check warnings.
I am not sure about `Dafe`. Assuming it is a typo for `Safe`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
