### PR TITLE
fix(multi_object_tracker): prevent too large object tracking

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
@@ -299,12 +299,6 @@ inline void convertConvexHullToBoundingBox(
   const autoware_auto_perception_msgs::msg::DetectedObject & input_object,
   autoware_auto_perception_msgs::msg::DetectedObject & output_object)
 {
-  const Eigen::Vector2d center{
-    input_object.kinematics.pose_with_covariance.pose.position.x,
-    input_object.kinematics.pose_with_covariance.pose.position.y};
-  const auto yaw = tf2::getYaw(input_object.kinematics.pose_with_covariance.pose.orientation);
-  const Eigen::Matrix2d R_inv = Eigen::Rotation2Dd(-yaw).toRotationMatrix();
-
   double max_x = 0;
   double max_y = 0;
   double min_x = 0;
@@ -313,22 +307,27 @@ inline void convertConvexHullToBoundingBox(
 
   // look for bounding box boundary
   for (size_t i = 0; i < input_object.shape.footprint.points.size(); ++i) {
-    Eigen::Vector2d vertex{
-      input_object.shape.footprint.points.at(i).x, input_object.shape.footprint.points.at(i).y};
-
-    const Eigen::Vector2d local_vertex = R_inv * (vertex - center);
-    max_x = std::max(max_x, local_vertex.x());
-    max_y = std::max(max_y, local_vertex.y());
-    min_x = std::min(min_x, local_vertex.x());
-    min_y = std::min(min_y, local_vertex.y());
-
-    max_z = std::max(max_z, static_cast<double>(input_object.shape.footprint.points.at(i).z));
+    const double foot_x = input_object.shape.footprint.points.at(i).x;
+    const double foot_y = input_object.shape.footprint.points.at(i).y;
+    const double foot_z = input_object.shape.footprint.points.at(i).z;
+    max_x = std::max(max_x, foot_x);
+    max_y = std::max(max_y, foot_y);
+    min_x = std::min(min_x, foot_x);
+    min_y = std::min(min_y, foot_y);
+    max_z = std::max(max_z, foot_z);
   }
 
   // calc bounding box state
   const double length = max_x - min_x;
   const double width = max_y - min_y;
   const double height = max_z;
+
+  // calc new center
+  const Eigen::Vector2d center{
+    input_object.kinematics.pose_with_covariance.pose.position.x,
+    input_object.kinematics.pose_with_covariance.pose.position.y};
+  const auto yaw = tf2::getYaw(input_object.kinematics.pose_with_covariance.pose.orientation);
+  const Eigen::Matrix2d R_inv = Eigen::Rotation2Dd(-yaw).toRotationMatrix();
   const Eigen::Vector2d new_local_center{(max_x + min_x) / 2.0, (max_y + min_y) / 2.0};
   const Eigen::Vector2d new_center = center + R_inv.transpose() * new_local_center;
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
@@ -35,6 +35,7 @@
 #include <cmath>
 #include <tuple>
 #include <vector>
+#include <iostream>
 
 namespace utils
 {
@@ -295,17 +296,21 @@ inline void calcAnchorPointOffset(
  * @param input_object: input convex hull objects
  * @param output_object: output bounding box objects
  */
-inline void convertConvexHullToBoundingBox(
+inline bool convertConvexHullToBoundingBox(
   const autoware_auto_perception_msgs::msg::DetectedObject & input_object,
   autoware_auto_perception_msgs::msg::DetectedObject & output_object)
 {
+  // check footprint size
+  if (input_object.shape.footprint.points.size() < 3) {
+    return false;
+  }
+
+  // look for bounding box boundary
   double max_x = 0;
   double max_y = 0;
   double min_x = 0;
   double min_y = 0;
   double max_z = 0;
-
-  // look for bounding box boundary
   for (size_t i = 0; i < input_object.shape.footprint.points.size(); ++i) {
     const double foot_x = input_object.shape.footprint.points.at(i).x;
     const double foot_y = input_object.shape.footprint.points.at(i).y;
@@ -340,6 +345,10 @@ inline void convertConvexHullToBoundingBox(
   output_object.shape.dimensions.x = length;
   output_object.shape.dimensions.y = width;
   output_object.shape.dimensions.z = height;
+
+  // print debug info, object size
+  std::cout << "convertConvexHullToBoundingBox: length: " << length << ", width: " << width << ", height: " << height << std::endl;
+  return true;
 }
 
 inline bool getMeasurementYaw(

--- a/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
@@ -33,7 +33,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <tuple>
 #include <vector>
 
@@ -346,9 +345,6 @@ inline bool convertConvexHullToBoundingBox(
   output_object.shape.dimensions.y = width;
   output_object.shape.dimensions.z = height;
 
-  // print debug info, object size
-  std::cout << "convertConvexHullToBoundingBox: length: " << length << ", width: " << width
-            << ", height: " << height << std::endl;
   return true;
 }
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
@@ -33,9 +33,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <tuple>
 #include <vector>
-#include <iostream>
 
 namespace utils
 {
@@ -347,7 +347,8 @@ inline bool convertConvexHullToBoundingBox(
   output_object.shape.dimensions.z = height;
 
   // print debug info, object size
-  std::cout << "convertConvexHullToBoundingBox: length: " << length << ", width: " << width << ", height: " << height << std::endl;
+  std::cout << "convertConvexHullToBoundingBox: length: " << length << ", width: " << width
+            << ", height: " << height << std::endl;
   return true;
 }
 

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -71,10 +71,12 @@ BicycleTracker::BicycleTracker(
   } else {
     bounding_box_ = {1.0, 0.5, 1.7};
   }
-  // set minimum size
-  bounding_box_.length = std::max(bounding_box_.length, 0.3);
-  bounding_box_.width = std::max(bounding_box_.width, 0.3);
-  bounding_box_.height = std::max(bounding_box_.height, 0.3);
+  // set maximum and minimum size
+  constexpr double max_size = 5.0;
+  constexpr double min_size = 0.3;
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
 
   // Set motion model parameters
   {
@@ -167,16 +169,7 @@ autoware_auto_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingOb
   const autoware_auto_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject updating_object;
-
-  // // OBJECT SHAPE MODEL
-  // // convert to bounding box if input is convex shape
-  // if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-  //   utils::convertConvexHullToBoundingBox(object, updating_object);
-  // } else {
-  //   updating_object = object;
-  // }
-  updating_object = object;
+  autoware_auto_perception_msgs::msg::DetectedObject updating_object = object;
 
   // UNCERTAINTY MODEL
   if (!object.kinematics.has_position_covariance) {

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -169,7 +169,17 @@ autoware_auto_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingOb
   const autoware_auto_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject updating_object = object;
+  autoware_auto_perception_msgs::msg::DetectedObject updating_object;
+
+  // OBJECT SHAPE MODEL
+  // convert to bounding box if input is convex shape
+  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    if(!utils::convertConvexHullToBoundingBox(object, updating_object)){
+      updating_object = object;
+    }
+  } else {
+    updating_object = object;
+  }
 
   // UNCERTAINTY MODEL
   if (!object.kinematics.has_position_covariance) {

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -257,14 +257,11 @@ bool BicycleTracker::measureWithShape(
   bounding_box_.height = gain_inv * bounding_box_.height + gain * bbox_object.shape.dimensions.z;
 
   // set maximum and minimum size
-  constexpr double max_size = 10.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
+  constexpr double max_size = 5.0;
   constexpr double min_size = 0.3;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
 
   // update motion model
   motion_model_.updateExtendedState(bounding_box_.length);

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -255,9 +255,9 @@ bool BicycleTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 10.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 0.3;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -169,13 +169,14 @@ autoware_auto_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingOb
 {
   autoware_auto_perception_msgs::msg::DetectedObject updating_object;
 
-  // OBJECT SHAPE MODEL
-  // convert to bounding box if input is convex shape
-  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    utils::convertConvexHullToBoundingBox(object, updating_object);
-  } else {
-    updating_object = object;
-  }
+  // // OBJECT SHAPE MODEL
+  // // convert to bounding box if input is convex shape
+  // if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  //   utils::convertConvexHullToBoundingBox(object, updating_object);
+  // } else {
+  //   updating_object = object;
+  // }
+  updating_object = object;
 
   // UNCERTAINTY MODEL
   if (!object.kinematics.has_position_covariance) {

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -174,7 +174,7 @@ autoware_auto_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingOb
   // OBJECT SHAPE MODEL
   // convert to bounding box if input is convex shape
   if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    if(!utils::convertConvexHullToBoundingBox(object, updating_object)){
+    if (!utils::convertConvexHullToBoundingBox(object, updating_object)) {
       updating_object = object;
     }
   } else {

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -79,10 +79,12 @@ BigVehicleTracker::BigVehicleTracker(
     last_input_bounding_box_ = bounding_box_;
   } else {
     autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)){
-      RCLCPP_WARN(logger_, "BigVehicleTracker::BigVehicleTracker: Failed to convert convex hull to bounding box.");
-      bounding_box_ = {6.0, 2.0, 2.0}; // default value
-    }else{
+    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)) {
+      RCLCPP_WARN(
+        logger_,
+        "BigVehicleTracker::BigVehicleTracker: Failed to convert convex hull to bounding box.");
+      bounding_box_ = {6.0, 2.0, 2.0};  // default value
+    } else {
       bounding_box_ = {
         bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y,
         bbox_object.shape.dimensions.z};

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -93,13 +93,10 @@ BigVehicleTracker::BigVehicleTracker(
   }
   // set maximum and minimum size
   constexpr double max_size = 30.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
 
   // Set motion model parameters
   {
@@ -348,13 +345,10 @@ bool BigVehicleTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 30.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
 
   // update motion model
   motion_model_.updateExtendedState(bounding_box_.length);

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -205,12 +205,16 @@ autoware_auto_perception_msgs::msg::DetectedObject BigVehicleTracker::getUpdatin
   // OBJECT SHAPE MODEL
   // convert to bounding box if input is convex shape
   autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-  // if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-  //   if(!utils::convertConvexHullToBoundingBox(object, bbox_object))
-  // } else {
-  //   bbox_object = object;
-  // }
-  bbox_object = object;
+  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)) {
+      RCLCPP_WARN(
+        logger_,
+        "BigVehicleTracker::getUpdatingObject: Failed to convert convex hull to bounding box.");
+      bbox_object = object;
+    }
+  } else {
+    bbox_object = object;
+  }
 
   // get offset measurement
   int nearest_corner_index = utils::getNearestCornerOrSurface(

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -79,16 +79,25 @@ BigVehicleTracker::BigVehicleTracker(
     last_input_bounding_box_ = bounding_box_;
   } else {
     autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-    utils::convertConvexHullToBoundingBox(object, bbox_object);
-    bounding_box_ = {
-      bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y,
-      bbox_object.shape.dimensions.z};
+    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)){
+      RCLCPP_WARN(logger_, "BigVehicleTracker::BigVehicleTracker: Failed to convert convex hull to bounding box.");
+      bounding_box_ = {6.0, 2.0, 2.0}; // default value
+    }else{
+      bounding_box_ = {
+        bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y,
+        bbox_object.shape.dimensions.z};
+    }
     last_input_bounding_box_ = bounding_box_;
   }
-  // set minimum size
-  bounding_box_.length = std::max(bounding_box_.length, 0.3);
-  bounding_box_.width = std::max(bounding_box_.width, 0.3);
-  bounding_box_.height = std::max(bounding_box_.height, 0.3);
+  // set maximum and minimum size
+  constexpr double max_size = 30.0;
+  bounding_box_.length = std::max(bounding_box_.length, max_size);
+  bounding_box_.width = std::max(bounding_box_.width, max_size);
+  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  constexpr double min_size = 1.0;
+  bounding_box_.length = std::max(bounding_box_.length, min_size);
+  bounding_box_.width = std::max(bounding_box_.width, min_size);
+  bounding_box_.height = std::max(bounding_box_.height, min_size);
 
   // Set motion model parameters
   {
@@ -194,11 +203,12 @@ autoware_auto_perception_msgs::msg::DetectedObject BigVehicleTracker::getUpdatin
   // OBJECT SHAPE MODEL
   // convert to bounding box if input is convex shape
   autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    utils::convertConvexHullToBoundingBox(object, bbox_object);
-  } else {
-    bbox_object = object;
-  }
+  // if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  //   if(!utils::convertConvexHullToBoundingBox(object, bbox_object))
+  // } else {
+  //   bbox_object = object;
+  // }
+  bbox_object = object;
 
   // get offset measurement
   int nearest_corner_index = utils::getNearestCornerOrSurface(
@@ -329,10 +339,16 @@ bool BigVehicleTracker::measureWithShape(
   bounding_box_.height = gain_inv * bounding_box_.height + gain * object.shape.dimensions.z;
   last_input_bounding_box_ = {
     object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
-  // set minimum size
-  bounding_box_.length = std::max(bounding_box_.length, 0.3);
-  bounding_box_.width = std::max(bounding_box_.width, 0.3);
-  bounding_box_.height = std::max(bounding_box_.height, 0.3);
+
+  // set maximum and minimum size
+  constexpr double max_size = 30.0;
+  bounding_box_.length = std::max(bounding_box_.length, max_size);
+  bounding_box_.width = std::max(bounding_box_.width, max_size);
+  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  constexpr double min_size = 1.0;
+  bounding_box_.length = std::max(bounding_box_.length, min_size);
+  bounding_box_.width = std::max(bounding_box_.width, min_size);
+  bounding_box_.height = std::max(bounding_box_.height, min_size);
 
   // update motion model
   motion_model_.updateExtendedState(bounding_box_.length);

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -306,6 +306,20 @@ bool BigVehicleTracker::measureWithPose(
 bool BigVehicleTracker::measureWithShape(
   const autoware_auto_perception_msgs::msg::DetectedObject & object)
 {
+  if (!object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    // do not update shape if the input is not a bounding box
+    return false;
+  }
+
+  // check object size abnormality
+  constexpr double size_max = 40.0;  // [m]
+  constexpr double size_min = 1.0;   // [m]
+  if (object.shape.dimensions.x > size_max || object.shape.dimensions.y > size_max) {
+    return false;
+  } else if (object.shape.dimensions.x < size_min || object.shape.dimensions.y < size_min) {
+    return false;
+  }
+
   constexpr double gain = 0.1;
   constexpr double gain_inv = 1.0 - gain;
 

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -91,9 +91,9 @@ BigVehicleTracker::BigVehicleTracker(
   }
   // set maximum and minimum size
   constexpr double max_size = 30.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);
@@ -342,9 +342,9 @@ bool BigVehicleTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 30.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -82,7 +82,8 @@ NormalVehicleTracker::NormalVehicleTracker(
     if (!utils::convertConvexHullToBoundingBox(object, bbox_object)) {
       RCLCPP_WARN(
         logger_,
-        "BigVehicleTracker::BigVehicleTracker: Failed to convert convex hull to bounding box.");
+        "NormalVehicleTracker::NormalVehicleTracker: Failed to convert convex hull to bounding "
+        "box.");
       bounding_box_ = {3.0, 2.0, 1.8};  // default value
     } else {
       bounding_box_ = {
@@ -205,12 +206,17 @@ autoware_auto_perception_msgs::msg::DetectedObject NormalVehicleTracker::getUpda
   // OBJECT SHAPE MODEL
   // convert to bounding box if input is convex shape
   autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-  // if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-  //   utils::convertConvexHullToBoundingBox(object, bbox_object);
-  // } else {
-  //   bbox_object = object;
-  // }
-  bbox_object = object;
+  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)) {
+      RCLCPP_WARN(
+        logger_,
+        "NormalVehicleTracker::getUpdatingObject: Failed to convert convex hull to bounding box.");
+      bbox_object = object;
+    }
+
+  } else {
+    bbox_object = object;
+  }
 
   // get offset measurement
   int nearest_corner_index = utils::getNearestCornerOrSurface(

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -79,10 +79,12 @@ NormalVehicleTracker::NormalVehicleTracker(
     last_input_bounding_box_ = bounding_box_;
   } else {
     autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)){
-      RCLCPP_WARN(logger_, "BigVehicleTracker::BigVehicleTracker: Failed to convert convex hull to bounding box.");
-      bounding_box_ = {3.0, 2.0, 1.8}; // default value
-    }else{
+    if (!utils::convertConvexHullToBoundingBox(object, bbox_object)) {
+      RCLCPP_WARN(
+        logger_,
+        "BigVehicleTracker::BigVehicleTracker: Failed to convert convex hull to bounding box.");
+      bounding_box_ = {3.0, 2.0, 1.8};  // default value
+    } else {
       bounding_box_ = {
         bbox_object.shape.dimensions.x, bbox_object.shape.dimensions.y,
         bbox_object.shape.dimensions.z};
@@ -349,7 +351,6 @@ bool NormalVehicleTracker::measureWithShape(
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);
   bounding_box_.height = std::max(bounding_box_.height, min_size);
-
 
   // update motion model
   motion_model_.updateExtendedState(bounding_box_.length);

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -91,9 +91,9 @@ NormalVehicleTracker::NormalVehicleTracker(
   }
   // set maximum and minimum size
   constexpr double max_size = 20.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);
@@ -342,9 +342,9 @@ bool NormalVehicleTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 20.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -306,6 +306,20 @@ bool NormalVehicleTracker::measureWithPose(
 bool NormalVehicleTracker::measureWithShape(
   const autoware_auto_perception_msgs::msg::DetectedObject & object)
 {
+  if (!object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    // do not update shape if the input is not a bounding box
+    return false;
+  }
+
+  // check object size abnormality
+  constexpr double size_max = 30.0;  // [m]
+  constexpr double size_min = 1.0;   // [m]
+  if (object.shape.dimensions.x > size_max || object.shape.dimensions.y > size_max) {
+    return false;
+  } else if (object.shape.dimensions.x < size_min || object.shape.dimensions.y < size_min) {
+    return false;
+  }
+
   constexpr double gain = 0.1;
   constexpr double gain_inv = 1.0 - gain;
 

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -94,13 +94,10 @@ NormalVehicleTracker::NormalVehicleTracker(
   }
   // set maximum and minimum size
   constexpr double max_size = 20.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
 
   // Set motion model parameters
   {
@@ -350,13 +347,10 @@ bool NormalVehicleTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 20.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
   constexpr double min_size = 1.0;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
 
   // update motion model
   motion_model_.updateExtendedState(bounding_box_.length);

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -77,17 +77,12 @@ PedestrianTracker::PedestrianTracker(
   }
   // set maximum and minimum size
   constexpr double max_size = 5.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
-  cylinder_.width = std::min(cylinder_.width, max_size);
-  cylinder_.height = std::min(cylinder_.height, max_size);
   constexpr double min_size = 0.3;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
-  cylinder_.width = std::max(cylinder_.width, min_size);
-  cylinder_.height = std::max(cylinder_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
+  cylinder_.width = std::min(std::max(cylinder_.width, min_size), max_size);
+  cylinder_.height = std::min(std::max(cylinder_.height, min_size), max_size);
 
   // Set motion model parameters
   {
@@ -252,17 +247,12 @@ bool PedestrianTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 5.0;
-  bounding_box_.length = std::min(bounding_box_.length, max_size);
-  bounding_box_.width = std::min(bounding_box_.width, max_size);
-  bounding_box_.height = std::min(bounding_box_.height, max_size);
-  cylinder_.width = std::min(cylinder_.width, max_size);
-  cylinder_.height = std::min(cylinder_.height, max_size);
   constexpr double min_size = 0.3;
-  bounding_box_.length = std::max(bounding_box_.length, min_size);
-  bounding_box_.width = std::max(bounding_box_.width, min_size);
-  bounding_box_.height = std::max(bounding_box_.height, min_size);
-  cylinder_.width = std::max(cylinder_.width, min_size);
-  cylinder_.height = std::max(cylinder_.height, min_size);
+  bounding_box_.length = std::min(std::max(bounding_box_.length, min_size), max_size);
+  bounding_box_.width = std::min(std::max(bounding_box_.width, min_size), max_size);
+  bounding_box_.height = std::min(std::max(bounding_box_.height, min_size), max_size);
+  cylinder_.width = std::min(std::max(cylinder_.width, min_size), max_size);
+  cylinder_.height = std::min(std::max(cylinder_.height, min_size), max_size);
 
   return true;
 }

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -209,22 +209,51 @@ bool PedestrianTracker::measureWithShape(
   constexpr double gain_inv = 1.0 - gain;
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    // check bound box size abnormality
+    constexpr double size_max = 30.0;  // [m]
+    constexpr double size_min = 0.1;   // [m]
+    if (
+      object.shape.dimensions.x > size_max || object.shape.dimensions.y > size_max ||
+      object.shape.dimensions.z > size_max) {
+      return false;
+    } else if (
+      object.shape.dimensions.x < size_min || object.shape.dimensions.y < size_min ||
+      object.shape.dimensions.z < size_min) {
+      return false;
+    }
+    // update bounding box size
     bounding_box_.length = gain_inv * bounding_box_.length + gain * object.shape.dimensions.x;
     bounding_box_.width = gain_inv * bounding_box_.width + gain * object.shape.dimensions.y;
     bounding_box_.height = gain_inv * bounding_box_.height + gain * object.shape.dimensions.z;
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+    // check cylinder size abnormality
+    constexpr double size_max = 30.0;  // [m]
+    constexpr double size_min = 0.1;   // [m]
+    if (object.shape.dimensions.x > size_max || object.shape.dimensions.z > size_max) {
+      return false;
+    } else if (object.shape.dimensions.x < size_min || object.shape.dimensions.z < size_min) {
+      return false;
+    }
     cylinder_.width = gain_inv * cylinder_.width + gain * object.shape.dimensions.x;
     cylinder_.height = gain_inv * cylinder_.height + gain * object.shape.dimensions.z;
   } else {
+    // do not update polygon shape
     return false;
   }
 
-  // set minimum size
-  bounding_box_.length = std::max(bounding_box_.length, 0.3);
-  bounding_box_.width = std::max(bounding_box_.width, 0.3);
-  bounding_box_.height = std::max(bounding_box_.height, 0.3);
-  cylinder_.width = std::max(cylinder_.width, 0.3);
-  cylinder_.height = std::max(cylinder_.height, 0.3);
+  // set maximum and minimum size
+  constexpr double max_size = 5.0;
+  bounding_box_.length = std::max(bounding_box_.length, max_size);
+  bounding_box_.width = std::max(bounding_box_.width, max_size);
+  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  cylinder_.width = std::max(cylinder_.width, max_size);
+  cylinder_.height = std::max(cylinder_.height, max_size);
+  constexpr double min_size = 0.3;
+  bounding_box_.length = std::max(bounding_box_.length, min_size);
+  bounding_box_.width = std::max(bounding_box_.width, min_size);
+  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  cylinder_.width = std::max(cylinder_.width, min_size);
+  cylinder_.height = std::max(cylinder_.height, min_size);
 
   return true;
 }

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -77,11 +77,11 @@ PedestrianTracker::PedestrianTracker(
   }
   // set maximum and minimum size
   constexpr double max_size = 5.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
-  cylinder_.width = std::max(cylinder_.width, max_size);
-  cylinder_.height = std::max(cylinder_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
+  cylinder_.width = std::min(cylinder_.width, max_size);
+  cylinder_.height = std::min(cylinder_.height, max_size);
   constexpr double min_size = 0.3;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);
@@ -252,11 +252,11 @@ bool PedestrianTracker::measureWithShape(
 
   // set maximum and minimum size
   constexpr double max_size = 5.0;
-  bounding_box_.length = std::max(bounding_box_.length, max_size);
-  bounding_box_.width = std::max(bounding_box_.width, max_size);
-  bounding_box_.height = std::max(bounding_box_.height, max_size);
-  cylinder_.width = std::max(cylinder_.width, max_size);
-  cylinder_.height = std::max(cylinder_.height, max_size);
+  bounding_box_.length = std::min(bounding_box_.length, max_size);
+  bounding_box_.width = std::min(bounding_box_.width, max_size);
+  bounding_box_.height = std::min(bounding_box_.height, max_size);
+  cylinder_.width = std::min(cylinder_.width, max_size);
+  cylinder_.height = std::min(cylinder_.height, max_size);
   constexpr double min_size = 0.3;
   bounding_box_.length = std::max(bounding_box_.length, min_size);
   bounding_box_.width = std::max(bounding_box_.width, min_size);

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -73,7 +73,7 @@ PedestrianTracker::PedestrianTracker(
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_ = {object.shape.dimensions.x, object.shape.dimensions.z};
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
-    // do not update polygon shape, use default value
+    // do not update polygon shape
   }
   // set maximum and minimum size
   constexpr double max_size = 5.0;

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -66,19 +66,28 @@ PedestrianTracker::PedestrianTracker(
 
   // OBJECT SHAPE MODEL
   bounding_box_ = {0.5, 0.5, 1.7};
-  cylinder_ = {0.3, 1.7};
+  cylinder_ = {0.5, 1.7};
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
       object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_ = {object.shape.dimensions.x, object.shape.dimensions.z};
+  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+    // do not update polygon shape, use default value
   }
-  // set minimum size
-  bounding_box_.length = std::max(bounding_box_.length, 0.3);
-  bounding_box_.width = std::max(bounding_box_.width, 0.3);
-  bounding_box_.height = std::max(bounding_box_.height, 0.3);
-  cylinder_.width = std::max(cylinder_.width, 0.3);
-  cylinder_.height = std::max(cylinder_.height, 0.3);
+  // set maximum and minimum size
+  constexpr double max_size = 5.0;
+  bounding_box_.length = std::max(bounding_box_.length, max_size);
+  bounding_box_.width = std::max(bounding_box_.width, max_size);
+  bounding_box_.height = std::max(bounding_box_.height, max_size);
+  cylinder_.width = std::max(cylinder_.width, max_size);
+  cylinder_.height = std::max(cylinder_.height, max_size);
+  constexpr double min_size = 0.3;
+  bounding_box_.length = std::max(bounding_box_.length, min_size);
+  bounding_box_.width = std::max(bounding_box_.width, min_size);
+  bounding_box_.height = std::max(bounding_box_.height, min_size);
+  cylinder_.width = std::max(cylinder_.width, min_size);
+  cylinder_.height = std::max(cylinder_.height, min_size);
 
   // Set motion model parameters
   {


### PR DESCRIPTION
## Description
A bug was reported that a huge (length of 6km) object is appeared from the object tracking.

It is happening when a unknown object (shape of `autoware_auto_perception_msgs::msg::Shape::POLYGON`) is assigned to a bicycle tracker.
It was caused by `utils::convertConvexHullToBoundingBox(object, bbox_object)` which treats the footprint points as global (map coordinate) position, while the input is local (the object coordinate).

1. Fix bug on `utils::convertConvexHullToBoundingBox(object, bbox_object)`
2. Add a detected object size checker. Update the object size only if the size is proper

## Tests performed
1. Configure `data_association_matrix.param.yaml` to enable the unknown object can be assigned to bicycle tracker
```yaml
/**:
  ros__parameters:
    can_assign_matrix:
      #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN <-Measurement
      [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN <-Tracker
       0,       1,   1,     1,    1,       0,         0,      0,         #CAR
       0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
       0,       1,   1,     1,    1,       0,         0,      0,         #BUS
       0,       1,   1,     1,    1,       0,         0,      0,         #TRAILER
       1,       0,   0,     0,    0,       1,         1,      1,         #MOTORBIKE
       1,       0,   0,     0,    0,       1,         1,      1,         #BICYCLE
       1,       0,   0,     0,    0,       1,         1,      1]         #PEDESTRIAN
```
Replay a file that contains to associate an object that have poligon shape to a tracker. 

https://github.com/autowarefoundation/autoware.universe/assets/42434141/89a3ab5a-1c1f-40fb-bceb-b9d885507fae

Red box: previous tracking object
Green box: fixed tracking object

2. Perception Regular Test
test result: [TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/5f5ca3c5-8d96-558f-948b-c13b4850e91f?project_id=prd_jt)
261/264 PASS
! This test shows that the reference mode can be used as before, not testing the problem is resolved (since this scene is not in the test)

## Effects on system behavior
Not applicable.

## Interface changes
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
