### PR TITLE
fix(perception_online_evaluator):  add metric_value not only stat (#7100)(#7118) (revert of revert)

### DIFF
--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/metric.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/metric.hpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace perception_diagnostics
@@ -36,7 +37,11 @@ enum class Metric {
   SIZE,
 };
 
+// Each metric has a different return type. (statistic or just a one value etc).
+// To handle them all in the MetricsCalculator::calculate function, define MetricsMap as a variant
 using MetricStatMap = std::unordered_map<std::string, Stat<double>>;
+using MetricValueMap = std::unordered_map<std::string, double>;
+using MetricsMap = std::variant<MetricStatMap, MetricValueMap>;
 
 struct PredictedPathDeviationMetrics
 {

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -96,7 +96,7 @@ public:
    * @param [in] metric Metric enum value
    * @return map of string describing the requested metric and the calculated value
    */
-  std::optional<MetricStatMap> calculate(const Metric & metric) const;
+  std::optional<MetricsMap> calculate(const Metric & metric) const;
 
   /**
    * @brief set the dynamic objects used to calculate obstacle metrics
@@ -143,7 +143,7 @@ private:
   PredictedPathDeviationMetrics calcPredictedPathDeviationMetrics(
     const PredictedObjects & objects, const double time_horizon) const;
   MetricStatMap calcYawRateMetrics(const ClassObjectsMap & class_objects_map) const;
-  MetricStatMap calcObjectsCountMetrics() const;
+  MetricValueMap calcObjectsCountMetrics() const;
 
   bool hasPassedTime(const rclcpp::Time stamp) const;
   bool hasPassedTime(const std::string uuid, const rclcpp::Time stamp) const;

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
@@ -61,6 +61,8 @@ public:
 
   DiagnosticStatus generateDiagnosticStatus(
     const std::string metric, const Stat<double> & metric_stat) const;
+  DiagnosticStatus generateDiagnosticStatus(
+    const std::string metric, const double metric_value) const;
 
 private:
   // Subscribers and publishers

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
@@ -62,7 +62,7 @@ public:
   DiagnosticStatus generateDiagnosticStatus(
     const std::string metric, const Stat<double> & metric_stat) const;
   DiagnosticStatus generateDiagnosticStatus(
-    const std::string metric, const double metric_value) const;
+    const std::string & metric, const double metric_value) const;
 
 private:
   // Subscribers and publishers

--- a/evaluator/perception_online_evaluator/src/metrics_calculator.cpp
+++ b/evaluator/perception_online_evaluator/src/metrics_calculator.cpp
@@ -26,7 +26,7 @@ namespace perception_diagnostics
 using object_recognition_utils::convertLabelToString;
 using tier4_autoware_utils::inverseTransformPoint;
 
-std::optional<MetricStatMap> MetricsCalculator::calculate(const Metric & metric) const
+std::optional<MetricsMap> MetricsCalculator::calculate(const Metric & metric) const
 {
   // clang-format off
   const bool use_past_objects = metric == Metric::lateral_deviation        ||
@@ -455,15 +455,14 @@ MetricStatMap MetricsCalculator::calcYawRateMetrics(const ClassObjectsMap & clas
   return metric_stat_map;
 }
 
-MetricStatMap MetricsCalculator::calcObjectsCountMetrics() const
+MetricValueMap MetricsCalculator::calcObjectsCountMetrics() const
 {
-  MetricStatMap metric_stat_map;
+  MetricValueMap metric_stat_map;
   // calculate the average number of objects in the detection area in all past frames
   const auto overall_average_count = detection_counter_.getOverallAverageCount();
   for (const auto & [label, range_and_count] : overall_average_count) {
     for (const auto & [range, count] : range_and_count) {
-      metric_stat_map["average_objects_count_" + convertLabelToString(label) + "_" + range].add(
-        count);
+      metric_stat_map["average_objects_count_" + convertLabelToString(label) + "_" + range] = count;
     }
   }
   // calculate the average number of objects in the detection area in the past
@@ -472,8 +471,8 @@ MetricStatMap MetricsCalculator::calcObjectsCountMetrics() const
     detection_counter_.getAverageCount(parameters_->objects_count_window_seconds);
   for (const auto & [label, range_and_count] : average_count) {
     for (const auto & [range, count] : range_and_count) {
-      metric_stat_map["interval_average_objects_count_" + convertLabelToString(label) + "_" + range]
-        .add(count);
+      metric_stat_map
+        ["interval_average_objects_count_" + convertLabelToString(label) + "_" + range] = count;
     }
   }
 
@@ -481,8 +480,7 @@ MetricStatMap MetricsCalculator::calcObjectsCountMetrics() const
   const auto total_count = detection_counter_.getTotalCount();
   for (const auto & [label, range_and_count] : total_count) {
     for (const auto & [range, count] : range_and_count) {
-      metric_stat_map["total_objects_count_" + convertLabelToString(label) + "_" + range].add(
-        count);
+      metric_stat_map["total_objects_count_" + convertLabelToString(label) + "_" + range] = count;
     }
   }
 

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -80,10 +80,10 @@ void PerceptionOnlineEvaluatorNode::publishMetrics()
         for (const auto & [metric, value] : arg) {
           if constexpr (std::is_same_v<T, MetricStatMap>) {
             if (value.count() > 0) {
-              metrics_msg.status.push_back(generateDiagnosticStatus(metric, value));
+              metrics_msg.status.emplace_back(generateDiagnosticStatus(metric, value));
             }
           } else if constexpr (std::is_same_v<T, MetricValueMap>) {
-            metrics_msg.status.push_back(generateDiagnosticStatus(metric, value));
+            metrics_msg.status.emplace_back(generateDiagnosticStatus(metric, value));
           }
         }
       },

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -121,7 +121,7 @@ DiagnosticStatus PerceptionOnlineEvaluatorNode::generateDiagnosticStatus(
 }
 
 DiagnosticStatus PerceptionOnlineEvaluatorNode::generateDiagnosticStatus(
-  const std::string metric, const double value) const
+  const std::string & metric, const double value) const
 {
   DiagnosticStatus status;
 

--- a/evaluator/perception_online_evaluator/test/test_perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/test/test_perception_online_evaluator_node.cpp
@@ -141,7 +141,19 @@ protected:
       [=](const DiagnosticArray::ConstSharedPtr msg) {
         const auto it = std::find_if(msg->status.begin(), msg->status.end(), is_target_metric);
         if (it != msg->status.end()) {
-          metric_value_ = boost::lexical_cast<double>(it->values[2].value);
+          const auto mean_it = std::find_if(
+            it->values.begin(), it->values.end(),
+            [](const auto & key_value) { return key_value.key == "mean"; });
+          if (mean_it != it->values.end()) {
+            metric_value_ = boost::lexical_cast<double>(mean_it->value);
+          } else {
+            const auto metric_value_it = std::find_if(
+              it->values.begin(), it->values.end(),
+              [](const auto & key_value) { return key_value.key == "metric_value"; });
+            if (metric_value_it != it->values.end()) {
+              metric_value_ = boost::lexical_cast<double>(metric_value_it->value);
+            }
+          }
           metric_updated_ = true;
         }
       });


### PR DESCRIPTION
this PR need to wait for driving log replayer

Reverts autowarefoundation/autoware.universe#7118

https://github.com/autowarefoundation/autoware.universe/pull/7100

## Description

<!-- Write a brief description of this PR. -->

Previously, only stat with `max`, `mean`, and `min` as keys could be handled in diagnostics, but this PR allows `metric_value` with a single value.
This is to allow only one value to be included in metrics such as object counts, since all stat values are the same, which is redundant.

- stat type
```
- level: "\0"
  name: predicted_path_deviation_variance_CAR_5.00
  message: ''
  hardware_id: ''
  values:
  - key: min
    value: '0.039821'
  - key: max
    value: '0.039821'
  - key: mean
    value: '0.039821'
```

- metric_value type
```
- level: "\0"
  name: interval_average_objects_count_UNKNOWN_r100.00_h10.00
  message: ''
  hardware_id: ''
  values:
  - key: metric_value
    value: '4.000000'
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/c702c46d-ef43-4cc2-aafb-5a9e5051f59d)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

no interface changes for autoware.

but the diagnostic key used for tools (driving_log_replayer etc) is chaged

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
