### PR TITLE
fix(localization_error_monitor): fixed header stamp

### DIFF
--- a/localization/localization_error_monitor/src/localization_error_monitor.cpp
+++ b/localization/localization_error_monitor/src/localization_error_monitor.cpp
@@ -129,7 +129,7 @@ void LocalizationErrorMonitor::onOdom(nav_msgs::msg::Odometry::ConstSharedPtr in
   diag_merged_status.hardware_id = this->get_name();
 
   diagnostic_msgs::msg::DiagnosticArray diag_msg;
-  diag_msg.header.stamp = this->now();
+  diag_msg.header.stamp = input_msg->header.stamp;
   diag_msg.status.push_back(diag_merged_status);
   diag_pub_->publish(diag_msg);
 }


### PR DESCRIPTION
## Description

Currently, `localization_error_monitor` outputs a timestamp in the diagnostic message header with the node's `this->now()` set. However, we are interested in the time when the message monitored by the `localization_error_monitor` node was published. So I changed the timestamp to be set, from `this->now()` to `input_msg->header.stamp`.

## Tests performed

I ran logging_simulator and parsed the `/diagnostics` topic from the saved rosbag.
I have confirmed that all timestamps in `localization: localization_error_monitor` have a match in `localization: ekf_localizer`.  

## Effects on system behavior

There are no effects on system behavior.

## Interface changes

There are no interface changes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
