### PR TITLE
fix(lane_change): transit failure if previous module path empty

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -225,6 +225,10 @@ bool LaneChangeInterface::canTransitFailureState()
   updateDebugMarker();
   log_debug_throttled(__func__);
 
+  if(getPreviousModuleOutput().path.points.empty()){
+    return true;
+  }
+
   if (module_type_->isAbortState() && !module_type_->hasFinishedAbort()) {
     log_debug_throttled("Abort process has on going.");
     return false;

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -225,7 +225,7 @@ bool LaneChangeInterface::canTransitFailureState()
   updateDebugMarker();
   log_debug_throttled(__func__);
 
-  if(getPreviousModuleOutput().path.points.empty()){
+  if (getPreviousModuleOutput().path.points.empty()) {
     return true;
   }
 

--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -226,6 +226,8 @@ bool LaneChangeInterface::canTransitFailureState()
   log_debug_throttled(__func__);
 
   if (getPreviousModuleOutput().path.points.empty()) {
+    RCLCPP_WARN(
+      getLogger(), "Previous output path is empty. Some module might accidentally reset it.");
     return true;
   }
 


### PR DESCRIPTION
## Description

When goal planner triggers the modified goals, it will clear the previous module's path at 1 iteration, which also clears lane change module's path. Lane change module is unaware of this changes and assumes that path still exist even though it is not. This causes lane change module to pass empty path to the next module (which is avoidance module).

This PR aims to fix this issue by cancelling lane change if previous module's path is empty.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
