### PR TITLE
refactor(ci): rename docker image from `autoware-openadk` to `autoware`

### DIFF
--- a/.github/workflows/build-and-test-arm64.yaml
+++ b/.github/workflows/build-and-test-arm64.yaml
@@ -19,7 +19,7 @@ jobs:
           - -cuda
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt
+            container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -29,7 +29,7 @@ jobs:
           - -cuda
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt
+            container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -28,7 +28,7 @@ jobs:
           - -cuda
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt
+            container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
@@ -77,7 +77,7 @@ jobs:
 
   clang-tidy-differential:
     runs-on: ubuntu-latest
-    container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt-cuda
+    container: ghcr.io/autowarefoundation/autoware:latest-prebuilt-cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,7 +21,7 @@ jobs:
           - -cuda
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware-openadk:latest-prebuilt
+            container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Description

This PR changes the docker image name from `autoware-openadk` to `autoware` according to https://github.com/autowarefoundation/autoware/pull/4785.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
