### PR TITLE
refactor(start_planner): improve readability of end condition

### DIFF
--- a/planning/behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_start_planner_module/README.md
@@ -91,36 +91,66 @@ The `StartPlannerModule` is designed to initiate its execution based on specific
 
 ### **End Conditions**
 
-The `StartPlannerModule` terminates if the pull out / freespace maneuver has been completed. The `canTransitSuccessState` function assesses these conditions to decide if the module should terminate its execution.
+The `StartPlannerModule` terminates when specific conditions are met, depending on the type of planner being used. The `canTransitSuccessState` function determines whether the module should transition to the success state based on the following criteria:
+
+#### When the Freespace Planner is active:
+
+- If the end point of the freespace path is reached, the module transitions to the success state.
+
+#### When any other type of planner is active:
+
+The transition to the success state is determined by the following conditions:
+
+- If a reverse path is being generated or the search for a pull out path fails:
+  - The module does not transition to the success state.
+- If the end point of the pull out path's shift section is reached:
+  - The module transitions to the success state.
+
+The flowchart below illustrates the decision-making process in the `canTransitSuccessState` function:
 
 ```plantuml
 @startuml
+@startuml
+skinparam ActivityBackgroundColor #white
+skinparam ActivityBorderColor #black
+skinparam ActivityBorderThickness 1
+skinparam ActivityArrowColor #black
+skinparam ActivityArrowThickness 1
+skinparam ActivityStartColor #black
+skinparam ActivityEndColor #black
+skinparam ActivityDiamondBackgroundColor #white
+skinparam ActivityDiamondBorderColor #black
+skinparam ActivityDiamondFontColor #black
+partition canTransitSuccessState() {
 start
-:Start hasFinishedPullOut();
-
-if (status_.driving_forward && status_.found_pull_out_path) then (yes)
-
-  if (status_.planner_type == FREESPACE) then (yes)
-    :Calculate distance\nto pull_out_path.end_pose;
-    if (distance < th_arrived_distance) then (yes)
-      :return true;\n(Terminate module);
-    else (no)
-      :return false;\n(Continue running);
-    endif
-  else (no)
-    :Calculate arclength for\ncurrent_pose and pull_out_path.end_pose;
-    if (arclength_current - arclength_pull_out_end > offset) then (yes)
-      :return true;\n(Terminate module);
-    else (no)
-      :return false;\n(Continue running);
-    endif
-  endif
-
-else (no)
-  :return false;\n(Continue running);
-endif
-
+if (planner type is FREESPACE?) then (yes)
+if (Has reached freespace end?) then (yes)
+#FF006C:true;
 stop
+else (no)
+:false;
+stop
+endif
+else (no)
+if (driving is forward?) then (yes)
+if (pull out path is found?) then (yes)
+if (Has reached pull out end?) then (yes)
+#FF006C:true;
+stop
+else (no)
+:false;
+stop
+endif
+else (no)
+:false;
+stop
+endif
+else (no)
+:false;
+stop
+endif
+endif
+}
 @enduml
 ```
 

--- a/planning/behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_start_planner_module/README.md
@@ -93,11 +93,11 @@ The `StartPlannerModule` is designed to initiate its execution based on specific
 
 The `StartPlannerModule` terminates when specific conditions are met, depending on the type of planner being used. The `canTransitSuccessState` function determines whether the module should transition to the success state based on the following criteria:
 
-#### When the Freespace Planner is active:
+#### When the Freespace Planner is active
 
 - If the end point of the freespace path is reached, the module transitions to the success state.
 
-#### When any other type of planner is active:
+#### When any other type of planner is active
 
 The transition to the success state is determined by the following conditions:
 

--- a/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_start_planner_module/include/behavior_path_start_planner_module/start_planner_module.hpp
@@ -306,7 +306,8 @@ private:
     const double velocity_threshold, const double object_check_backward_distance,
     const double object_check_forward_distance) const;
   bool needToPrepareBlinkerBeforeStartDrivingForward() const;
-  bool hasFinishedPullOut() const;
+  bool hasReachedFreespaceEnd() const;
+  bool hasReachedPullOutEnd() const;
   bool hasFinishedBackwardDriving() const;
   bool hasCollisionWithDynamicObjects() const;
   bool isStopped();

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -583,7 +583,12 @@ bool StartPlannerModule::canTransitSuccessState()
   // - Can transit to success if the goal position is reached.
   // - Cannot transit to success if the goal position is not reached.
   if (status_.planner_type == PlannerType::FREESPACE) {
-    return hasReachedFreespaceEnd();
+    if (hasReachedFreespaceEnd()) {
+      RCLCPP_DEBUG(
+        getLogger(), "Transit to success: Freespace planner reached the end point of the path.");
+      return true;
+    }
+    return false;
   }
 
   // Other Planners:
@@ -597,7 +602,12 @@ bool StartPlannerModule::canTransitSuccessState()
     return false;
   }
 
-  return hasReachedPullOutEnd();
+  if (hasReachedPullOutEnd()) {
+    RCLCPP_DEBUG(getLogger(), "Transit to success: Reached the end point of the pullout path.");
+    return true;
+  }
+
+  return false;
 }
 
 BehaviorModuleOutput StartPlannerModule::plan()

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1210,7 +1210,7 @@ PredictedObjects StartPlannerModule::filterStopObjectsInPullOutLanes(
 
 bool StartPlannerModule::hasReachedFreespaceEnd() const
 {
-  const auto current_pose = planner_data_->self_odometry->pose.pose;
+  const auto & current_pose = planner_data_->self_odometry->pose.pose;
   return tier4_autoware_utils::calcDistance2d(current_pose, status_.pull_out_path.end_pose) <
          parameters_->th_arrived_distance;
 }


### PR DESCRIPTION
## Description
- refactor the flow of `canTransitSuccessState`
- update flowchart of end condition 

---
## updated document
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/1e322106-c134-405d-9c4b-3d807bb6b94f)


<!-- Write a brief description of this PR. -->

## Tests performed

- [x] [PASS TIERIV INTERNAL LINK ](https://evaluation.tier4.jp/evaluation/reports/f23d2e5a-f618-50c3-bec4-cdc1e3707fb0?project_id=prd_jt)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
