### PR TITLE
feat(detected_object_validation): filter unknown objects with its footprint

### DIFF
--- a/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
@@ -80,6 +80,9 @@ private:
   LinearRing2d getConvexHull(const autoware_auto_perception_msgs::msg::DetectedObjects &);
   lanelet::ConstLanelets getIntersectedLanelets(
     const LinearRing2d &, const lanelet::ConstLanelets &);
+  bool isObjectOverlapLanelets(
+    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const lanelet::ConstLanelets & intersected_lanelets);
   bool isPolygonOverlapLanelets(const Polygon2d &, const lanelet::ConstLanelets &);
   bool isSameDirectionWithLanelets(
     const lanelet::ConstLanelets & lanelets,

--- a/perception/detected_object_validation/include/detected_object_validation/utils/utils.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/utils/utils.hpp
@@ -15,8 +15,9 @@
 #ifndef DETECTED_OBJECT_VALIDATION__UTILS__UTILS_HPP_
 #define DETECTED_OBJECT_VALIDATION__UTILS__UTILS_HPP_
 
-#include <cstdint>
+#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
 
+#include <cstdint>
 namespace utils
 {
 struct FilterTargetLabel
@@ -31,6 +32,21 @@ struct FilterTargetLabel
   bool PEDESTRIAN;
   bool isTarget(const uint8_t label) const;
 };  // struct FilterTargetLabel
+
+inline bool hasBoundingBox(const autoware_auto_perception_msgs::msg::DetectedObject & object)
+{
+  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    return true;
+  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+    return true;
+  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+    return false;
+  } else {
+    // unknown shape type.
+    return false;
+  }
+}
+
 }  // namespace utils
 
 #endif  // DETECTED_OBJECT_VALIDATION__UTILS__UTILS_HPP_


### PR DESCRIPTION
## Description

This PR tries to use an object footprint pointcloud to judge the object is inside any lanelet. 
<!-- Write a brief description of this PR. -->
Currently, objects are filtered by calculating polygon overlap with lanelet.
This PR fixes the issue that unknown objects sometimes assumed to be inside the lanelet even if its pointcloud do not exist in the lanelet.

![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/7b9fe29d-01d6-4eaa-a0db-533b5c4d0938)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
Tested with actual driving data

- Before this change: 
  - pink is clustering result, white is detection output 
![Screenshot from 2024-06-01 04-15-58](https://github.com/autowarefoundation/autoware.universe/assets/20086766/0a9b3b40-5ebe-4743-808b-abf7d52e44f0)

- After
  - unknown object is properly filtered with this PR
![Screenshot from 2024-06-01 04-32-00](https://github.com/autowarefoundation/autoware.universe/assets/20086766/e36e8be1-dc69-4560-8ceb-bd5466d42e02)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
