### PR TITLE
feat(map_height_fitter): componentize MapHeightFitter

### DIFF
--- a/map/map_height_fitter/CMakeLists.txt
+++ b/map/map_height_fitter/CMakeLists.txt
@@ -5,8 +5,9 @@ find_package(autoware_cmake REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 autoware_package()
 
-ament_auto_add_library(map_height_fitter SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_height_fitter.cpp
+  src/map_height_fitter_node.cpp
 )
 target_link_libraries(map_height_fitter ${PCL_LIBRARIES})
 
@@ -14,11 +15,14 @@ target_link_libraries(map_height_fitter ${PCL_LIBRARIES})
 # These are treated as errors in compile, so pedantic warnings are disabled for this package.
 target_compile_options(map_height_fitter PRIVATE -Wno-pedantic)
 
-ament_auto_add_executable(node
-  src/node.cpp
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "MapHeightFitterNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+  EXECUTOR MultiThreadedExecutor
 )
 
 ament_auto_package(
   INSTALL_TO_SHARE
   launch
-  config)
+  config
+)

--- a/map/map_height_fitter/launch/map_height_fitter.launch.xml
+++ b/map/map_height_fitter/launch/map_height_fitter.launch.xml
@@ -3,7 +3,7 @@
 
   <group>
     <push-ros-namespace namespace="map"/>
-    <node pkg="map_height_fitter" exec="node" name="map_height_fitter">
+    <node pkg="map_height_fitter" exec="map_height_fitter_node" output="both">
       <param from="$(var param_path)"/>
       <remap from="~/pointcloud_map" to="/map/pointcloud_map"/>
       <remap from="~/partial_map_load" to="/map/get_partial_pointcloud_map"/>

--- a/map/map_height_fitter/package.xml
+++ b/map/map_height_fitter/package.xml
@@ -25,6 +25,7 @@
   <depend>libpcl-common</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/map/map_height_fitter/src/map_height_fitter_node.cpp
+++ b/map/map_height_fitter/src/map_height_fitter_node.cpp
@@ -23,7 +23,8 @@ using tier4_localization_msgs::srv::PoseWithCovarianceStamped;
 class MapHeightFitterNode : public rclcpp::Node
 {
 public:
-  MapHeightFitterNode() : Node("map_height_fitter"), fitter_(this)
+  explicit MapHeightFitterNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("map_height_fitter", options), fitter_(this)
   {
     const auto on_service = [this](
                               const PoseWithCovarianceStamped::Request::SharedPtr req,
@@ -46,13 +47,5 @@ private:
   rclcpp::Service<PoseWithCovarianceStamped>::SharedPtr srv_;
 };
 
-int main(int argc, char ** argv)
-{
-  rclcpp::init(argc, argv);
-  rclcpp::executors::MultiThreadedExecutor executor;
-  auto node = std::make_shared<MapHeightFitterNode>();
-  executor.add_node(node);
-  executor.spin();
-  executor.remove_node(node);
-  rclcpp::shutdown();
-}
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(MapHeightFitterNode)


### PR DESCRIPTION
## Description

Componentize the node in `map/map_height_fitter`.
(Add glog feature to map_height_fitter)

Also, add log output and change the file name (`node.cpp` -> `map_height_fitter_node.cpp`) to match the other packages.

## Tests performed

Confirmed that terminating the `map_height_fitter` process will output logs to both the terminal and the log file.
Since it will not get launched from Autoware, directly launch the package for testing.
```Text
1717135375.6562157 [map_height_fitter_node-1] [INFO] [1717135375.655949160] [rclcpp]: signal_handler(signum=15)
1717135375.6563284 [map_height_fitter_node-1] *** Aborted at 1717135375 (unix time) try "date -d @1717135375" if you are using GNU date ***
1717135375.6568561 [map_height_fitter_node-1] PC: @                0x0 (unknown)
1717135375.6570129 [map_height_fitter_node-1] *** SIGTERM (@0x3e8000e1b20) received by PID 3059429 (TID 0x7fd7e3e36680) from PID 924448; stack trace: ***
1717135375.6575503 [map_height_fitter_node-1]     @     0x7fd7e43434d6 google::(anonymous namespace)::FailureSignalHandler()
1717135375.6579626 [map_height_fitter_node-1]     @     0x7fd7e4219ded rclcpp::SignalHandler::signal_handler()
1717135375.6582382 [map_height_fitter_node-1]     @     0x7fd7e3842520 (unknown)
1717135375.6584966 [map_height_fitter_node-1]     @     0x7fd7e3891117 (unknown)
1717135375.6587284 [map_height_fitter_node-1]     @     0x7fd7e38942dd pthread_cond_clockwait
1717135375.6593916 [map_height_fitter_node-1]     @     0x7fd7e4195315 rclcpp::node_interfaces::NodeGraph::wait_for_graph_change()
1717135375.6600718 [map_height_fitter_node-1]     @     0x7fd7e4148d97 rclcpp::ClientBase::wait_for_service_nanoseconds()
1717135375.6607256 [map_height_fitter_node-1]     @     0x7fd7e41bfcc4 rclcpp::AsyncParametersClient::wait_for_service_nanoseconds()
1717135375.6609509 [map_height_fitter_node-1]     @     0x7fd7e2795d11 map_height_fitter::MapHeightFitter::Impl::Impl()
1717135375.6611056 [map_height_fitter_node-1]     @     0x7fd7e27964ce map_height_fitter::MapHeightFitter::MapHeightFitter()
1717135375.6612787 [map_height_fitter_node-1]     @     0x7fd7e27d84f4 rclcpp_components::NodeFactoryTemplate<>::create_node_instance()
1717135375.6614225 [map_height_fitter_node-1]     @     0x561506dff26d main
1717135375.6615837 [map_height_fitter_node-1]     @     0x7fd7e3829d90 (unknown)
1717135375.6618803 [map_height_fitter_node-1]     @     0x7fd7e3829e40 __libc_start_main
1717135375.6619463 [map_height_fitter_node-1]     @     0x561506dffe45 _start
1717135375.6631048 [ERROR] [map_height_fitter_node-1]: process has died ...
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
