### PR TITLE
fix(ndt_scan_matcher): change diag time_stamp

### DIFF
--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/diagnostics_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/diagnostics_module.hpp
@@ -34,7 +34,8 @@ public:
   void publish(const rclcpp::Time & publish_time_stamp);
 
 private:
-  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray(const rclcpp::Time & publish_time_stamp) const;
+  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray(
+    const rclcpp::Time & publish_time_stamp) const;
 
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/diagnostics_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/diagnostics_module.hpp
@@ -31,10 +31,10 @@ public:
   template <typename T>
   void addKeyValue(const std::string & key, const T & value);
   void updateLevelAndMessage(const int8_t level, const std::string & message);
-  void publish();
+  void publish(const rclcpp::Time & publish_time_stamp);
 
 private:
-  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray() const;
+  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray(const rclcpp::Time & publish_time_stamp) const;
 
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;

--- a/localization/ndt_scan_matcher/src/diagnostics_module.cpp
+++ b/localization/ndt_scan_matcher/src/diagnostics_module.cpp
@@ -90,7 +90,8 @@ void DiagnosticsModule::publish(const rclcpp::Time & publish_time_stamp)
   diagnostics_pub_->publish(createDiagnosticsArray(publish_time_stamp));
 }
 
-diagnostic_msgs::msg::DiagnosticArray DiagnosticsModule::createDiagnosticsArray(const rclcpp::Time & publish_time_stamp) const
+diagnostic_msgs::msg::DiagnosticArray DiagnosticsModule::createDiagnosticsArray(
+  const rclcpp::Time & publish_time_stamp) const
 {
   diagnostic_msgs::msg::DiagnosticArray diagnostics_msg;
   diagnostics_msg.header.stamp = publish_time_stamp;

--- a/localization/ndt_scan_matcher/src/diagnostics_module.cpp
+++ b/localization/ndt_scan_matcher/src/diagnostics_module.cpp
@@ -85,15 +85,15 @@ void DiagnosticsModule::updateLevelAndMessage(const int8_t level, const std::str
   }
 }
 
-void DiagnosticsModule::publish()
+void DiagnosticsModule::publish(const rclcpp::Time & publish_time_stamp)
 {
-  diagnostics_pub_->publish(createDiagnosticsArray());
+  diagnostics_pub_->publish(createDiagnosticsArray(publish_time_stamp));
 }
 
-diagnostic_msgs::msg::DiagnosticArray DiagnosticsModule::createDiagnosticsArray() const
+diagnostic_msgs::msg::DiagnosticArray DiagnosticsModule::createDiagnosticsArray(const rclcpp::Time & publish_time_stamp) const
 {
   diagnostic_msgs::msg::DiagnosticArray diagnostics_msg;
-  diagnostics_msg.header.stamp = clock_->now();
+  diagnostics_msg.header.stamp = publish_time_stamp;
   diagnostics_msg.status.push_back(diagnostics_status_msg_);
 
   if (diagnostics_msg.status.at(0).level == diagnostic_msgs::msg::DiagnosticStatus::OK) {

--- a/localization/ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/ndt_scan_matcher/src/map_update_module.cpp
@@ -52,8 +52,6 @@ void MapUpdateModule::callback_timer(
   const bool is_activated, const std::optional<geometry_msgs::msg::Point> & position,
   std::unique_ptr<DiagnosticsModule> & diagnostics_ptr)
 {
-  diagnostics_ptr->addKeyValue("timer_callback_time_stamp", clock_->now().nanoseconds());
-
   // check is_activated
   diagnostics_ptr->addKeyValue("is_activated", is_activated);
   if (!is_activated) {

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -193,11 +193,15 @@ NDTScanMatcher::NDTScanMatcher(const rclcpp::NodeOptions & options)
 
 void NDTScanMatcher::callback_timer()
 {
+  const rclcpp::Time now_ros_time = this->now();
+
   diagnostics_map_update_->clear();
+
+  diagnostics_map_update_->addKeyValue("timer_callback_time_stamp", now_ros_time.nanoseconds());
 
   map_update_module_->callback_timer(is_activated_, latest_ekf_position_, diagnostics_map_update_);
 
-  diagnostics_map_update_->publish(this->now());
+  diagnostics_map_update_->publish(now_ros_time);
 }
 
 void NDTScanMatcher::callback_initial_pose(
@@ -867,8 +871,10 @@ void NDTScanMatcher::service_trigger_node(
   const std_srvs::srv::SetBool::Request::SharedPtr req,
   std_srvs::srv::SetBool::Response::SharedPtr res)
 {
+  const rclcpp::Time now_ros_time = this->now();
+
   diagnostics_trigger_node_->clear();
-  diagnostics_trigger_node_->addKeyValue("service_call_time_stamp", this->now().nanoseconds());
+  diagnostics_trigger_node_->addKeyValue("service_call_time_stamp", now_ros_time.nanoseconds());
 
   is_activated_ = req->data;
   if (is_activated_) {
@@ -878,14 +884,18 @@ void NDTScanMatcher::service_trigger_node(
 
   diagnostics_trigger_node_->addKeyValue("is_activated", static_cast<bool>(is_activated_));
   diagnostics_trigger_node_->addKeyValue("is_succeed_service", res->success);
-  diagnostics_trigger_node_->publish(this->now());
+  diagnostics_trigger_node_->publish(now_ros_time);
 }
 
 void NDTScanMatcher::service_ndt_align(
   const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
   tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
 {
+  const rclcpp::Time now_ros_time = this->now();
+
   diagnostics_ndt_align_->clear();
+
+  diagnostics_ndt_align_->addKeyValue("service_call_time_stamp", now_ros_time.nanoseconds());
 
   service_ndt_align_main(req, res);
 
@@ -899,15 +909,13 @@ void NDTScanMatcher::service_ndt_align(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
   }
 
-  diagnostics_ndt_align_->publish(this->now());
+  diagnostics_ndt_align_->publish(now_ros_time);
 }
 
 void NDTScanMatcher::service_ndt_align_main(
   const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
   tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
 {
-  diagnostics_ndt_align_->addKeyValue("service_call_time_stamp", this->now().nanoseconds());
-
   // get TF from pose_frame to map_frame
   const std::string & target_frame = param_.frame.map_frame;
   const std::string & source_frame = req->pose_with_covariance.header.frame_id;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -193,15 +193,15 @@ NDTScanMatcher::NDTScanMatcher(const rclcpp::NodeOptions & options)
 
 void NDTScanMatcher::callback_timer()
 {
-  const rclcpp::Time now_ros_time = this->now();
+  const rclcpp::Time ros_time_now = this->now();
 
   diagnostics_map_update_->clear();
 
-  diagnostics_map_update_->addKeyValue("timer_callback_time_stamp", now_ros_time.nanoseconds());
+  diagnostics_map_update_->addKeyValue("timer_callback_time_stamp", ros_time_now.nanoseconds());
 
   map_update_module_->callback_timer(is_activated_, latest_ekf_position_, diagnostics_map_update_);
 
-  diagnostics_map_update_->publish(now_ros_time);
+  diagnostics_map_update_->publish(ros_time_now);
 }
 
 void NDTScanMatcher::callback_initial_pose(
@@ -871,10 +871,10 @@ void NDTScanMatcher::service_trigger_node(
   const std_srvs::srv::SetBool::Request::SharedPtr req,
   std_srvs::srv::SetBool::Response::SharedPtr res)
 {
-  const rclcpp::Time now_ros_time = this->now();
+  const rclcpp::Time ros_time_now = this->now();
 
   diagnostics_trigger_node_->clear();
-  diagnostics_trigger_node_->addKeyValue("service_call_time_stamp", now_ros_time.nanoseconds());
+  diagnostics_trigger_node_->addKeyValue("service_call_time_stamp", ros_time_now.nanoseconds());
 
   is_activated_ = req->data;
   if (is_activated_) {
@@ -884,18 +884,18 @@ void NDTScanMatcher::service_trigger_node(
 
   diagnostics_trigger_node_->addKeyValue("is_activated", static_cast<bool>(is_activated_));
   diagnostics_trigger_node_->addKeyValue("is_succeed_service", res->success);
-  diagnostics_trigger_node_->publish(now_ros_time);
+  diagnostics_trigger_node_->publish(ros_time_now);
 }
 
 void NDTScanMatcher::service_ndt_align(
   const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
   tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
 {
-  const rclcpp::Time now_ros_time = this->now();
+  const rclcpp::Time ros_time_now = this->now();
 
   diagnostics_ndt_align_->clear();
 
-  diagnostics_ndt_align_->addKeyValue("service_call_time_stamp", now_ros_time.nanoseconds());
+  diagnostics_ndt_align_->addKeyValue("service_call_time_stamp", ros_time_now.nanoseconds());
 
   service_ndt_align_main(req, res);
 
@@ -909,7 +909,7 @@ void NDTScanMatcher::service_ndt_align(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
   }
 
-  diagnostics_ndt_align_->publish(now_ros_time);
+  diagnostics_ndt_align_->publish(ros_time_now);
 }
 
 void NDTScanMatcher::service_ndt_align_main(

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -197,7 +197,7 @@ void NDTScanMatcher::callback_timer()
 
   map_update_module_->callback_timer(is_activated_, latest_ekf_position_, diagnostics_map_update_);
 
-  diagnostics_map_update_->publish();
+  diagnostics_map_update_->publish(this->now());
 }
 
 void NDTScanMatcher::callback_initial_pose(
@@ -207,7 +207,7 @@ void NDTScanMatcher::callback_initial_pose(
 
   callback_initial_pose_main(initial_pose_msg_ptr);
 
-  diagnostics_initial_pose_->publish();
+  diagnostics_initial_pose_->publish(initial_pose_msg_ptr->header.stamp);
 }
 
 void NDTScanMatcher::callback_initial_pose_main(
@@ -260,7 +260,7 @@ void NDTScanMatcher::callback_regularization_pose(
 
   regularization_pose_buffer_->push_back(pose_conv_msg_ptr);
 
-  diagnostics_regularization_pose_->publish();
+  diagnostics_regularization_pose_->publish(pose_conv_msg_ptr->header.stamp);
 }
 
 void NDTScanMatcher::callback_sensor_points(
@@ -286,7 +286,7 @@ void NDTScanMatcher::callback_sensor_points(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
   }
 
-  diagnostics_scan_points_->publish();
+  diagnostics_scan_points_->publish(sensor_points_msg_in_sensor_frame->header.stamp);
 }
 
 bool NDTScanMatcher::callback_sensor_points_main(
@@ -878,7 +878,7 @@ void NDTScanMatcher::service_trigger_node(
 
   diagnostics_trigger_node_->addKeyValue("is_activated", static_cast<bool>(is_activated_));
   diagnostics_trigger_node_->addKeyValue("is_succeed_service", res->success);
-  diagnostics_trigger_node_->publish();
+  diagnostics_trigger_node_->publish(this->now());
 }
 
 void NDTScanMatcher::service_ndt_align(
@@ -899,7 +899,7 @@ void NDTScanMatcher::service_ndt_align(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
   }
 
-  diagnostics_ndt_align_->publish();
+  diagnostics_ndt_align_->publish(this->now());
 }
 
 void NDTScanMatcher::service_ndt_align_main(


### PR DESCRIPTION
## Description

For the same reason as [this PR](https://github.com/autowarefoundation/autoware.universe/pull/7174), I changed the header stamp to match the message's timestamp

<!-- Write a brief description of this PR. -->

## Tests performed

confirmed that the header.stamp of diagnostic match the `topic_time_stamp`, `timer_callback_time_stamp` and `service_call_time_stamp`.

example
![Screenshot from 2024-05-31 14-54-04](https://github.com/autowarefoundation/autoware.universe/assets/13819566/d522cf01-efb9-4b9b-b9dd-b402d02d8ae3)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
