### PR TITLE
fix(map_tf_generator): add log output

### DIFF
--- a/map/map_tf_generator/launch/map_tf_generator.launch.xml
+++ b/map/map_tf_generator/launch/map_tf_generator.launch.xml
@@ -3,7 +3,7 @@
 
   <arg name="input_vector_map_topic" default="/map/vector_map"/>
 
-  <node pkg="map_tf_generator" exec="vector_map_tf_generator" name="vector_map_tf_generator">
+  <node pkg="map_tf_generator" exec="vector_map_tf_generator" name="vector_map_tf_generator" output="both">
     <remap from="vector_map" to="$(var input_vector_map_topic)"/>
 
     <param from="$(var param_file)"/>


### PR DESCRIPTION
## Description

Add log output to `map/map_tf_generator`.
It is set to "both",  which outputs to both the terminal and the log file.

## Tests performed

I checked that both the terminal and the log file will receive the log output.

The log file when the running process get killed:
```Text
...
1717144765.1524458 [vector_map_tf_generator-1] [INFO] [1717144765.151681543] [rclcpp]: signal_handler(signum=15)
1717144765.1528726 [vector_map_tf_generator-1] *** Aborted at 1717144765 (unix time) try "date -d @1717144765" if you are using GNU date ***
1717144765.1554124 [vector_map_tf_generator-1] PC: @                0x0 (unknown)
1717144765.1563036 [vector_map_tf_generator-1] *** SIGTERM (@0x3e8000e1b20) received by PID 3203430 (TID 0x7f11b08f1680) from PID 924448; stack trace: ***
1717144765.1571054 [vector_map_tf_generator-1]     @     0x7f11b118d4d6 google::(anonymous namespace)::FailureSignalHandler()
1717144765.1575267 [vector_map_tf_generator-1]     @     0x7f11b1019ded rclcpp::SignalHandler::signal_handler()
1717144765.1577001 [vector_map_tf_generator-1]     @     0x7f11b0642520 (unknown)
1717144765.1579843 [vector_map_tf_generator-1]     @     0x7f11b0691117 (unknown)
1717144765.1581409 [vector_map_tf_generator-1]     @     0x7f11b0693a41 pthread_cond_wait
1717144765.1584232 [vector_map_tf_generator-1]     @     0x7f11b0584a8d ddsrt_cond_wait
1717144765.1585999 [vector_map_tf_generator-1]     @     0x7f11b0584b55 ddsrt_cond_waituntil
1717144765.1588149 [vector_map_tf_generator-1]     @     0x7f11b056b45d (unknown)
1717144765.1591182 [vector_map_tf_generator-1]     @     0x7f11b089a74f rmw_wait
1717144765.1594777 [vector_map_tf_generator-1]     @     0x7f11b0dd0848 rcl_wait
1717144765.1598823 [vector_map_tf_generator-1]     @     0x7f11b0f611b6 rclcpp::Executor::wait_for_work()
1717144765.1603644 [vector_map_tf_generator-1]     @     0x7f11b0f616d3 rclcpp::Executor::get_next_executable()
1717144765.1607649 [vector_map_tf_generator-1]     @     0x7f11b0f65c81 rclcpp::executors::SingleThreadedExecutor::spin()
1717144765.1609008 [vector_map_tf_generator-1]     @     0x5579df453486 main
1717144765.1610382 [vector_map_tf_generator-1]     @     0x7f11b0629d90 (unknown)
1717144765.1611900 [vector_map_tf_generator-1]     @     0x7f11b0629e40 __libc_start_main
1717144765.1612430 [vector_map_tf_generator-1]     @     0x5579df453e35 _start
1717144765.1622496 [ERROR] [vector_map_tf_generator-1]: process has died ...
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
