### PR TITLE
fix(gnss_poser): change log output from screen to both

### DIFF
--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -7,7 +7,7 @@
   <arg name="output_topic_gnss_pose_cov" default="gnss_pose_cov"/>
   <arg name="output_topic_gnss_fixed" default="gnss_fixed"/>
 
-  <node pkg="gnss_poser" exec="gnss_poser" name="gnss_poser" output="screen">
+  <node pkg="gnss_poser" exec="gnss_poser" name="gnss_poser" output="both">
     <remap from="fix" to="$(var input_topic_fix)"/>
     <remap from="autoware_orientation" to="$(var input_topic_orientation)"/>
     <remap from="gnss_pose" to="$(var output_topic_gnss_pose)"/>


### PR DESCRIPTION
## Description

Change the log output of `sensing/gnss_poser` from screen to both, which outputs to both the terminal and the log file.

## Tests performed

I checked both the terminal and the log file will receive the log output.

The log file when the running process get killed:
```
...
1717146883.2361288 [gnss_poser-37] [INFO] [1717146883.235703527] [rclcpp]: signal_handler(signum=15)
1717146883.2367308 [gnss_poser-37] *** Aborted at 1717146883 (unix time) try "date -d @1717146883" if you are using GNU date ***
1717146883.2371097 [gnss_poser-37] PC: @                0x0 (unknown)
1717146883.2371683 [gnss_poser-37] *** SIGTERM (@0x3e8000e1b20) received by PID 3219247 (TID 0x7f6aa6c3d680) from PID 924448; stack trace: ***
1717146883.2375939 [gnss_poser-37]     @     0x7f6aa72324d6 google::(anonymous namespace)::FailureSignalHandler()
1717146883.2380390 [gnss_poser-37]     @     0x7f6aa7019ded rclcpp::SignalHandler::signal_handler()
1717146883.2385318 [gnss_poser-37]     @     0x7f6aa6642520 (unknown)
1717146883.2389481 [gnss_poser-37]     @     0x7f6aa6691117 (unknown)
1717146883.2390058 [gnss_poser-37]     @     0x7f6aa6693a41 pthread_cond_wait
1717146883.2394307 [gnss_poser-37]     @     0x7f6aa6584a8d ddsrt_cond_wait
1717146883.2394867 [gnss_poser-37]     @     0x7f6aa6584b55 ddsrt_cond_waituntil
1717146883.2399225 [gnss_poser-37]     @     0x7f6aa656b45d (unknown)
1717146883.2402885 [gnss_poser-37]     @     0x7f6aa693e74f rmw_wait
1717146883.2407224 [gnss_poser-37]     @     0x7f6aa7136848 rcl_wait
1717146883.2410882 [gnss_poser-37]     @     0x7f6aa6f611b6 rclcpp::Executor::wait_for_work()
1717146883.2415187 [gnss_poser-37]     @     0x7f6aa6f616d3 rclcpp::Executor::get_next_executable()
1717146883.2419903 [gnss_poser-37]     @     0x7f6aa6f65c81 rclcpp::executors::SingleThreadedExecutor::spin()
1717146883.2420495 [gnss_poser-37]     @     0x55590ccb5486 main
1717146883.2425632 [gnss_poser-37]     @     0x7f6aa6629d90 (unknown)
1717146883.2426353 [gnss_poser-37]     @     0x7f6aa6629e40 __libc_start_main
1717146883.2426944 [gnss_poser-37]     @     0x55590ccb5e35 _start
1717146883.2444336 [ERROR] [gnss_poser-37]: process has died ...
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
