### PR TITLE
reafctor multi_object_tracker

### DIFF
--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -127,9 +127,9 @@ BicycleTracker::BicycleTracker(
       constexpr double p0_stddev_y = 0.5;  // in object coordinate [m]
       constexpr double p0_stddev_yaw =
         tier4_autoware_utils::deg2rad(25);  // in map coordinate [rad]
-      constexpr double p0_cov_x = std::pow(p0_stddev_x, 2.0);
-      constexpr double p0_cov_y = std::pow(p0_stddev_y, 2.0);
-      constexpr double p0_cov_yaw = std::pow(p0_stddev_yaw, 2.0);
+      constexpr double p0_cov_x = p0_stddev_x * p0_stddev_x;
+      constexpr double p0_cov_y = p0_stddev_y * p0_stddev_y;
+      constexpr double p0_cov_yaw = p0_stddev_yaw * p0_stddev_yaw;
 
       const double cos_yaw = std::cos(yaw);
       const double sin_yaw = std::sin(yaw);

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -147,9 +147,9 @@ BigVehicleTracker::BigVehicleTracker(
       constexpr double p0_stddev_y = 0.5;  // in object coordinate [m]
       constexpr double p0_stddev_yaw =
         tier4_autoware_utils::deg2rad(25);  // in map coordinate [rad]
-      constexpr double p0_cov_x = std::pow(p0_stddev_x, 2.0);
-      constexpr double p0_cov_y = std::pow(p0_stddev_y, 2.0);
-      constexpr double p0_cov_yaw = std::pow(p0_stddev_yaw, 2.0);
+      constexpr double p0_cov_x = p0_stddev_x * p0_stddev_x;
+      constexpr double p0_cov_y = p0_stddev_y * p0_stddev_y;
+      constexpr double p0_cov_yaw = p0_stddev_yaw * p0_stddev_yaw;
 
       const double cos_yaw = std::cos(yaw);
       const double sin_yaw = std::sin(yaw);

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -148,9 +148,9 @@ NormalVehicleTracker::NormalVehicleTracker(
       constexpr double p0_stddev_y = 0.3;  // in object coordinate [m]
       constexpr double p0_stddev_yaw =
         tier4_autoware_utils::deg2rad(25);  // in map coordinate [rad]
-      constexpr double p0_cov_x = std::pow(p0_stddev_x, 2.0);
-      constexpr double p0_cov_y = std::pow(p0_stddev_y, 2.0);
-      constexpr double p0_cov_yaw = std::pow(p0_stddev_yaw, 2.0);
+      constexpr double p0_cov_x = p0_stddev_x * p0_stddev_x;
+      constexpr double p0_cov_y = p0_stddev_y * p0_stddev_y;
+      constexpr double p0_cov_yaw = p0_stddev_yaw * p0_stddev_yaw;
 
       const double cos_yaw = std::cos(yaw);
       const double sin_yaw = std::sin(yaw);

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -122,9 +122,9 @@ PedestrianTracker::PedestrianTracker(
       constexpr double p0_stddev_y = 2.0;  // in object coordinate [m]
       constexpr double p0_stddev_yaw =
         tier4_autoware_utils::deg2rad(1000);  // in map coordinate [rad]
-      constexpr double p0_cov_x = std::pow(p0_stddev_x, 2.0);
-      constexpr double p0_cov_y = std::pow(p0_stddev_y, 2.0);
-      constexpr double p0_cov_yaw = std::pow(p0_stddev_yaw, 2.0);
+      constexpr double p0_cov_x = p0_stddev_x * p0_stddev_x;
+      constexpr double p0_cov_y = p0_stddev_y * p0_stddev_y;
+      constexpr double p0_cov_yaw = p0_stddev_yaw * p0_stddev_yaw;
 
       const double cos_yaw = std::cos(yaw);
       const double sin_yaw = std::sin(yaw);


### PR DESCRIPTION
## Description

This is a refactor based on clang-tidy CRITICAL warning:
```
constexpr variable 'p0_cov_x' must be initialized by a constant expression
constexpr variable 'p0_cov_y' must be initialized by a constant expression
constexpr variable 'p0_cov_yaw' must be initialized by a constant expression
```

As the warning says, the `std::pow` function is not a constexpr function yet (from C++26).

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
