### PR TITLE
refactor(yabloc): use constexpr properly

### DIFF
--- a/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
+++ b/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
@@ -20,7 +20,7 @@ pcl::PointCloud<pcl::PointNormal> extract_near_line_segments(
   const pcl::PointCloud<pcl::PointNormal> & line_segments, const Sophus::SE3f & transform,
   const float max_range)
 {
-  constexpr double sqrt_two = std::sqrt(2);
+  constexpr double sqrt_two = 1.41421356237309504880;
   const Eigen::Vector3f pose_vector = transform.translation();
 
   // All line segments contained in a square with max_range on one side must be taken out,


### PR DESCRIPTION
## Description

This is a refactor based on clang-tidy CRITICAL warning:

```
constexpr variable 'sqrt_two' must be initialized by a constant expression
```

As the warning says, the std::sqrt function is not a constexpr function yet (from C++26).

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
