### PR TITLE
fix(yabloc): fix bug in capturing in lambda function

### DIFF
--- a/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
+++ b/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
@@ -25,7 +25,7 @@ pcl::PointCloud<pcl::PointNormal> extract_near_line_segments(
 
   // All line segments contained in a square with max_range on one side must be taken out,
   // so pick up those that are closer than the **diagonals** of the square.
-  auto check_intersection = [max_range, pose_vector](const pcl::PointNormal & pn) -> bool {
+  auto check_intersection = [sqrt_two, max_range, pose_vector](const pcl::PointNormal & pn) -> bool {
     const Eigen::Vector3f from = pn.getVector3fMap() - pose_vector;
     const Eigen::Vector3f to = pn.getNormalVector3fMap() - pose_vector;
 

--- a/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
+++ b/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
@@ -25,7 +25,8 @@ pcl::PointCloud<pcl::PointNormal> extract_near_line_segments(
 
   // All line segments contained in a square with max_range on one side must be taken out,
   // so pick up those that are closer than the **diagonals** of the square.
-  auto check_intersection = [sqrt_two, max_range, pose_vector](const pcl::PointNormal & pn) -> bool {
+  auto check_intersection = [sqrt_two, max_range,
+                             pose_vector](const pcl::PointNormal & pn) -> bool {
     const Eigen::Vector3f from = pn.getVector3fMap() - pose_vector;
     const Eigen::Vector3f to = pn.getNormalVector3fMap() - pose_vector;
 


### PR DESCRIPTION
## Description

This is a refactor based on clang-tidy CRITICAL warning:
```
variable 'sqrt_two' cannot be implicitly captured in a lambda with no capture-default specified
```
As the warning says, `sqrt_two` is not captured.

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
