### PR TITLE
feat(autoware_velocity_smoother): use polling subscriber

### DIFF
--- a/planning/autoware_velocity_smoother/include/autoware_velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware_velocity_smoother/node.hpp
@@ -31,6 +31,7 @@
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 #include "tier4_autoware_utils/math/unit_conversion.hpp"
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
+#include "tier4_autoware_utils/ros/polling_subscriber.hpp"
 #include "tier4_autoware_utils/ros/self_pose_listener.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 
@@ -86,11 +87,15 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_virtual_wall_;
   rclcpp::Publisher<StopSpeedExceeded>::SharedPtr pub_over_stop_velocity_;
-  rclcpp::Subscription<Odometry>::SharedPtr sub_current_odometry_;
-  rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr sub_current_acceleration_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_current_trajectory_;
-  rclcpp::Subscription<VelocityLimit>::SharedPtr sub_external_velocity_limit_;
-  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
+    this, "/localization/kinematic_state"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
+    sub_current_acceleration_{this, "~/input/acceleration"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<VelocityLimit> sub_external_velocity_limit_{
+    this, "~/input/external_velocity_limit_mps"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
+    this, "~/input/operation_mode_state"};
 
   Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
   AccelWithCovarianceStamped::ConstSharedPtr current_acceleration_ptr_;
@@ -180,11 +185,7 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
   // topic callback
-  void onCurrentOdometry(const Odometry::ConstSharedPtr msg);
-
   void onCurrentTrajectory(const Trajectory::ConstSharedPtr msg);
-
-  void onExternalVelocityLimit(const VelocityLimit::ConstSharedPtr msg);
 
   void calcExternalVelocityLimit();
 


### PR DESCRIPTION
## Description
The same as [this PR](https://github.com/autowarefoundation/autoware.universe/pull/6997) based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612), the polling subscriber is used in the obstacle_avoidance_planner.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing but more efficient CPU usage

<!-- Describe how this PR affects the system behavior. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
