### PR TITLE
feat(motion_velocity_planner): use polling subscriber to efficiently get messages

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
@@ -103,8 +103,8 @@ autoware_perception_msgs::msg::PredictedObjects filter_predicted_objects(
   const PlannerParam & params)
 {
   autoware_perception_msgs::msg::PredictedObjects filtered_objects;
-  filtered_objects.header = planner_data->predicted_objects->header;
-  for (const auto & object : planner_data->predicted_objects->objects) {
+  filtered_objects.header = planner_data->predicted_objects.header;
+  for (const auto & object : planner_data->predicted_objects.objects) {
     const auto is_pedestrian =
       std::find_if(object.classification.begin(), object.classification.end(), [](const auto & c) {
         return c.label == autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -154,11 +154,11 @@ VelocityPlanningResult OutOfLaneModule::plan(
   tier4_autoware_utils::StopWatch<std::chrono::microseconds> stopwatch;
   stopwatch.tic();
   out_of_lane::EgoData ego_data;
-  ego_data.pose = planner_data->current_odometry.pose;
+  ego_data.pose = planner_data->current_odometry.pose.pose;
   ego_data.trajectory_points = ego_trajectory_points;
   ego_data.first_trajectory_idx =
     motion_utils::findNearestSegmentIndex(ego_trajectory_points, ego_data.pose.position);
-  ego_data.velocity = planner_data->current_velocity.twist.linear.x;
+  ego_data.velocity = planner_data->current_odometry.twist.twist.linear.x;
   ego_data.max_decel = planner_data->velocity_smoother_->getMinDecel();
   stopwatch.tic("calculate_trajectory_footprints");
   const auto current_ego_footprint =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -154,11 +154,11 @@ VelocityPlanningResult OutOfLaneModule::plan(
   tier4_autoware_utils::StopWatch<std::chrono::microseconds> stopwatch;
   stopwatch.tic();
   out_of_lane::EgoData ego_data;
-  ego_data.pose = planner_data->current_odometry->pose;
+  ego_data.pose = planner_data->current_odometry.pose;
   ego_data.trajectory_points = ego_trajectory_points;
   ego_data.first_trajectory_idx =
     motion_utils::findNearestSegmentIndex(ego_trajectory_points, ego_data.pose.position);
-  ego_data.velocity = planner_data->current_velocity->twist.linear.x;
+  ego_data.velocity = planner_data->current_velocity.twist.linear.x;
   ego_data.max_decel = planner_data->velocity_smoother_->getMinDecel();
   stopwatch.tic("calculate_trajectory_footprints");
   const auto current_ego_footprint =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware_motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware_motion_velocity_planner_common/planner_data.hpp
@@ -60,8 +60,8 @@ struct PlannerData
   }
 
   // msgs from callbacks that are used for data-ready
-  geometry_msgs::msg::PoseStamped::ConstSharedPtr current_odometry;
-  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_velocity;
+  geometry_msgs::msg::PoseStamped current_odometry{};
+  geometry_msgs::msg::TwistStamped current_velocity{};
   geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr current_acceleration;
   autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr predicted_objects;
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr no_ground_pointcloud;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware_motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware_motion_velocity_planner_common/planner_data.hpp
@@ -24,9 +24,8 @@
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <tier4_api_msgs/msg/crosswalk_status.hpp>
@@ -60,12 +59,11 @@ struct PlannerData
   }
 
   // msgs from callbacks that are used for data-ready
-  geometry_msgs::msg::PoseStamped current_odometry{};
-  geometry_msgs::msg::TwistStamped current_velocity{};
-  geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr current_acceleration;
-  autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr predicted_objects;
-  pcl::PointCloud<pcl::PointXYZ>::ConstPtr no_ground_pointcloud;
-  nav_msgs::msg::OccupancyGrid::ConstSharedPtr occupancy_grid;
+  nav_msgs::msg::Odometry current_odometry{};
+  geometry_msgs::msg::AccelWithCovarianceStamped current_acceleration{};
+  autoware_perception_msgs::msg::PredictedObjects predicted_objects{};
+  pcl::PointCloud<pcl::PointXYZ> no_ground_pointcloud{};
+  nav_msgs::msg::OccupancyGrid occupancy_grid{};
   std::shared_ptr<route_handler::RouteHandler> route_handler;
 
   // nearest search
@@ -78,7 +76,7 @@ struct PlannerData
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_raw_;
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_last_observed_;
   std::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
-  tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states;
+  tier4_v2x_msgs::msg::VirtualTrafficLightStateArray virtual_traffic_light_states;
 
   // velocity smoother
   std::shared_ptr<autoware_velocity_smoother::SmootherBase> velocity_smoother_{};

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -131,8 +131,8 @@ bool MotionVelocityPlannerNode::update_planner_data()
     constexpr auto throttle_duration = 3000;  // [ms]
     if (!ptr) {
       RCLCPP_INFO_THROTTLE(get_logger(), clock, throttle_duration, log);
-      return false;
       is_ready = false;
+      return false;
     }
     return true;
   };

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -214,8 +214,6 @@ void MotionVelocityPlannerNode::on_lanelet_map(
 void MotionVelocityPlannerNode::process_traffic_signals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-
   // clear previous observation
   planner_data_.traffic_light_id_map_raw_.clear();
   const auto traffic_light_id_map_last_observed_old =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
@@ -22,6 +22,7 @@
 #include <autoware_motion_velocity_planner_node/srv/unload_plugin.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/logger_level_configure.hpp>
+#include <tier4_autoware_utils/ros/polling_subscriber.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -63,7 +64,8 @@ private:
   rclcpp::Subscription<autoware_perception_msgs::msg::PredictedObjects>::SharedPtr
     sub_predicted_objects_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_no_ground_pointcloud_;
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_vehicle_odometry_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>
+    sub_vehicle_odometry_{this, "~/input/vehicle_odometry"};
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_acceleration_;
   rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_lanelet_map_;
   rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr
@@ -77,7 +79,6 @@ private:
   void on_predicted_objects(
     const autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr msg);
   void on_no_ground_pointcloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
-  void on_odometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
   void on_acceleration(const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr msg);
   void on_lanelet_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
   void on_traffic_signals(
@@ -118,7 +119,7 @@ private:
   std::mutex mutex_;
 
   // function
-  bool is_data_ready() const;
+  bool is_data_ready(const nav_msgs::msg::Odometry::ConstSharedPtr ego_state_ptr) const;
   void insert_stop(
     autoware_planning_msgs::msg::Trajectory & trajectory,
     const geometry_msgs::msg::Point & stop_point) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
@@ -27,6 +27,7 @@
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -61,31 +62,33 @@ private:
 
   // subscriber
   rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_trajectory_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::PredictedObjects>::SharedPtr
-    sub_predicted_objects_;
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_no_ground_pointcloud_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<
+    autoware_perception_msgs::msg::PredictedObjects>
+    sub_predicted_objects_{this, "~/input/dynamic_objects"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<sensor_msgs::msg::PointCloud2>
+    sub_no_ground_pointcloud_{this, "~/input/no_ground_pointcloud"};
   tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>
     sub_vehicle_odometry_{this, "~/input/vehicle_odometry"};
-  rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_acceleration_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<
+    geometry_msgs::msg::AccelWithCovarianceStamped>
+    sub_acceleration_{this, "~/input/accel"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::OccupancyGrid>
+    sub_occupancy_grid_{this, "~/input/occupancy_grid"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<
+    autoware_perception_msgs::msg::TrafficLightGroupArray>
+    sub_traffic_signals_{this, "~/input/traffic_signals"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<
+    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>
+    sub_virtual_traffic_light_states_{this, "~/input/virtual_traffic_light_states"};
   rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_lanelet_map_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr
-    sub_traffic_signals_;
-  rclcpp::Subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
-    sub_virtual_traffic_light_states_;
-  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr sub_occupancy_grid_;
 
   void on_trajectory(
     const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr input_trajectory_msg);
-  void on_predicted_objects(
-    const autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr msg);
-  void on_no_ground_pointcloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
-  void on_acceleration(const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr msg);
+  std::optional<pcl::PointCloud<pcl::PointXYZ>> process_no_ground_pointcloud(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
   void on_lanelet_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
-  void on_traffic_signals(
+  void process_traffic_signals(
     const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg);
-  void on_virtual_traffic_light_states(
-    const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr msg);
-  void on_occupancy_grid(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);
 
   // publishers
   rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr trajectory_pub_;
@@ -119,7 +122,9 @@ private:
   std::mutex mutex_;
 
   // function
-  bool is_data_ready(const nav_msgs::msg::Odometry::ConstSharedPtr ego_state_ptr) const;
+  /// @brief update the PlannerData instance with the latest messages received
+  /// @return false if some data is not available
+  bool update_planner_data();
   void insert_stop(
     autoware_planning_msgs::msg::Trajectory & trajectory,
     const geometry_msgs::msg::Point & stop_point) const;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Use a polling subscriber for the topics of the `motion_velocity_planner`, improving the performance of the node.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
