### PR TITLE
chore(topic_state_monitor): enrich error log message

### DIFF
--- a/system/topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -154,8 +154,8 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   const auto print_warn = [&](const std::string & msg) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 3000, "%s", msg.c_str());
   };
-  const auto print_debug = [&](const std::string & msg) {
-    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), 3000, "%s", msg.c_str());
+  const auto print_info = [&](const std::string & msg) {
+    RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 3000, "%s", msg.c_str());
   };
 
   // Judge level
@@ -166,19 +166,21 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   } else if (topic_status == TopicStatus::NotReceived) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "NotReceived");
-    print_debug(node_param_.topic + " has not received.");
+    print_info(node_param_.topic + " has not received. Set ERROR in diagnostics.");
   } else if (topic_status == TopicStatus::WarnRate) {
     level = DiagnosticStatus::WARN;
     stat.add("status", "WarnRate");
-    print_warn(node_param_.topic + " topic rate has dropped to the warning level.");
+    print_warn(
+      node_param_.topic + " topic rate has dropped to the warning level. Set WARN in diagnostics.");
   } else if (topic_status == TopicStatus::ErrorRate) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "ErrorRate");
-    print_warn(node_param_.topic + " topic rate has dropped to the error level.");
+    print_warn(
+      node_param_.topic + " topic rate has dropped to the error level. Set ERROR in diagnostics.");
   } else if (topic_status == TopicStatus::Timeout) {
     level = DiagnosticStatus::ERROR;
     stat.add("status", "Timeout");
-    print_warn(node_param_.topic + " topic is timeout.");
+    print_warn(node_param_.topic + " topic is timeout. Set ERROR in diagnostics.");
   }
 
   // Add key-value


### PR DESCRIPTION
## Description

Now, there is no easy way to check why the AUTO mode is prohibited. I updated the logging message, making it easy to see the cause of the blocker of the AUTO mode transition.

## Tests performed

Run with AWSIM, change topicname of traffic light, see the message will appear.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/60e52707-ee15-4d27-be4d-67114180fa06)

## Effects on system behavior

The message will show up on terminal when the required topic is not published.

## Interface changes

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
