### PR TITLE
feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules

### DIFF
--- a/evaluator/kinematic_evaluator/package.xml
+++ b/evaluator/kinematic_evaluator/package.xml
@@ -17,8 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/evaluator/localization_evaluator/package.xml
+++ b/evaluator/localization_evaluator/package.xml
@@ -12,8 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/evaluator/perception_online_evaluator/README.md
+++ b/evaluator/perception_online_evaluator/README.md
@@ -155,11 +155,11 @@ where:
 
 ## Inputs / Outputs
 
-| Name              | Type                                                   | Description                                       |
-| ----------------- | ------------------------------------------------------ | ------------------------------------------------- |
-| `~/input/objects` | `autoware_auto_perception_msgs::msg::PredictedObjects` | The predicted objects to evaluate.                |
-| `~/metrics`       | `diagnostic_msgs::msg::DiagnosticArray`                | Diagnostic information about perception accuracy. |
-| `~/markers`       | `visualization_msgs::msg::MarkerArray`                 | Visual markers for debugging and visualization.   |
+| Name              | Type                                              | Description                                       |
+| ----------------- | ------------------------------------------------- | ------------------------------------------------- |
+| `~/input/objects` | `autoware_perception_msgs::msg::PredictedObjects` | The predicted objects to evaluate.                |
+| `~/metrics`       | `diagnostic_msgs::msg::DiagnosticArray`           | Diagnostic information about perception accuracy. |
+| `~/markers`       | `visualization_msgs::msg::MarkerArray`            | Visual markers for debugging and visualization.   |
 
 ## Parameters
 

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/detection_count.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/detection_count.hpp
@@ -21,8 +21,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include "autoware_auto_perception_msgs/msg/object_classification.hpp"
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
+#include "autoware_perception_msgs/msg/object_classification.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <iomanip>
@@ -37,8 +37,8 @@ namespace perception_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObjects;
 
 struct DetectionRange
 {

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/deviation_metrics.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/deviation_metrics.hpp
@@ -17,7 +17,7 @@
 
 #include "perception_online_evaluator/stat.hpp"
 
-#include <autoware_auto_perception_msgs/msg/predicted_path.hpp>
+#include <autoware_perception_msgs/msg/predicted_path.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <vector>
@@ -26,7 +26,7 @@ namespace perception_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_perception_msgs::msg::PredictedPath;
+using autoware_perception_msgs::msg::PredictedPath;
 using geometry_msgs::msg::Pose;
 
 /**

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics_calculator.hpp
@@ -25,8 +25,8 @@
 
 #include <rclcpp/time.hpp>
 
-#include "autoware_auto_perception_msgs/msg/object_classification.hpp"
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
+#include "autoware_perception_msgs/msg/object_classification.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
@@ -41,8 +41,8 @@
 
 namespace perception_diagnostics
 {
-using autoware_auto_perception_msgs::msg::PredictedObject;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using metrics::DetectionCounter;

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
@@ -22,7 +22,7 @@
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
@@ -35,8 +35,8 @@
 
 namespace perception_diagnostics
 {
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObjects;
 using diagnostic_msgs::msg::DiagnosticArray;
 using diagnostic_msgs::msg::DiagnosticStatus;
 using nav_msgs::msg::Odometry;

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/marker_utils.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/marker_utils.hpp
@@ -17,7 +17,7 @@
 
 #include <vehicle_info_util/vehicle_info.hpp>
 
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include <geometry_msgs/msg/polygon.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -30,7 +30,7 @@
 namespace marker_utils
 {
 
-using autoware_auto_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObject;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using std_msgs::msg::ColorRGBA;

--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/objects_filtering.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/utils/objects_filtering.hpp
@@ -17,9 +17,9 @@
 
 #include "perception_online_evaluator/parameters.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/predicted_object.hpp>
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/predicted_object.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
 
 #include <cmath>
 #include <memory>
@@ -34,9 +34,9 @@
 namespace perception_diagnostics
 {
 
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::PredictedObject;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
 
 using ClassObjectsMap = std::unordered_map<uint8_t, PredictedObjects>;
 

--- a/evaluator/perception_online_evaluator/test/test_perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/test/test_perception_online_evaluator_node.cpp
@@ -19,8 +19,8 @@
 #include <perception_online_evaluator/perception_online_evaluator_node.hpp>
 #include <tier4_autoware_utils/ros/uuid_helper.hpp>
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -35,11 +35,11 @@
 #include <vector>
 
 using EvalNode = perception_diagnostics::PerceptionOnlineEvaluatorNode;
-using PredictedObjects = autoware_auto_perception_msgs::msg::PredictedObjects;
-using PredictedObject = autoware_auto_perception_msgs::msg::PredictedObject;
+using PredictedObjects = autoware_perception_msgs::msg::PredictedObjects;
+using PredictedObject = autoware_perception_msgs::msg::PredictedObject;
 using DiagnosticArray = diagnostic_msgs::msg::DiagnosticArray;
 using MarkerArray = visualization_msgs::msg::MarkerArray;
-using ObjectClassification = autoware_auto_perception_msgs::msg::ObjectClassification;
+using ObjectClassification = autoware_perception_msgs::msg::ObjectClassification;
 using nav_msgs::msg::Odometry;
 using TFMessage = tf2_msgs::msg::TFMessage;
 
@@ -172,7 +172,7 @@ protected:
     object.kinematics.initial_twist_with_covariance.twist.linear.y = 0.0;
     object.kinematics.initial_twist_with_covariance.twist.linear.z = 0.0;
 
-    autoware_auto_perception_msgs::msg::PredictedPath path;
+    autoware_perception_msgs::msg::PredictedPath path;
     for (size_t i = 0; i < predicted_path.size(); ++i) {
       geometry_msgs::msg::Pose pose;
       pose.position.x = predicted_path[i].first;

--- a/evaluator/planning_evaluator/README.md
+++ b/evaluator/planning_evaluator/README.md
@@ -48,11 +48,11 @@ Adding a new metric `M` requires the following steps:
 
 ### Inputs
 
-| Name                           | Type                                                   | Description                                       |
-| ------------------------------ | ------------------------------------------------------ | ------------------------------------------------- |
-| `~/input/trajectory`           | `autoware_auto_planning_msgs::msg::Trajectory`         | Main trajectory to evaluate                       |
-| `~/input/reference_trajectory` | `autoware_auto_planning_msgs::msg::Trajectory`         | Reference trajectory to use for deviation metrics |
-| `~/input/objects`              | `autoware_auto_perception_msgs::msg::PredictedObjects` | Obstacles                                         |
+| Name                           | Type                                              | Description                                       |
+| ------------------------------ | ------------------------------------------------- | ------------------------------------------------- |
+| `~/input/trajectory`           | `autoware_planning_msgs::msg::Trajectory`         | Main trajectory to evaluate                       |
+| `~/input/reference_trajectory` | `autoware_planning_msgs::msg::Trajectory`         | Reference trajectory to use for deviation metrics |
+| `~/input/objects`              | `autoware_perception_msgs::msg::PredictedObjects` | Obstacles                                         |
 
 ### Outputs
 

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/deviation_metrics.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/deviation_metrics.hpp
@@ -17,15 +17,15 @@
 
 #include "planning_evaluator/stat.hpp"
 
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
 namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/metrics_utils.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/metrics_utils.hpp
@@ -17,8 +17,8 @@
 
 #include "planning_evaluator/stat.hpp"
 
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
 namespace planning_diagnostics
 {
@@ -26,7 +26,7 @@ namespace metrics
 {
 namespace utils
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::Trajectory;
 
 /**
  * @brief find the index in the trajectory at the given distance of the given index

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/obstacle_metrics.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/obstacle_metrics.hpp
@@ -17,15 +17,15 @@
 
 #include "planning_evaluator/stat.hpp"
 
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
 
 namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_planning_msgs::msg::Trajectory;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_planning_msgs::msg::Trajectory;
 
 /**
  * @brief calculate the distance to the closest obstacle at each point of the trajectory

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/stability_metrics.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/stability_metrics.hpp
@@ -17,13 +17,13 @@
 
 #include "planning_evaluator/stat.hpp"
 
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
 
 namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::Trajectory;
 
 /**
  * @brief calculate the discrete Frechet distance between two trajectories

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/trajectory_metrics.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/trajectory_metrics.hpp
@@ -17,15 +17,15 @@
 
 #include "planning_evaluator/stat.hpp"
 
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
 namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 
 /**
  * @brief calculate relative angle metric (angle between successive points)

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics_calculator.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics_calculator.hpp
@@ -18,20 +18,20 @@
 #include "planning_evaluator/parameters.hpp"
 #include "planning_evaluator/stat.hpp"
 
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 
 #include <optional>
 
 namespace planning_diagnostics
 {
-using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::PoseWithUuidStamped;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 

--- a/evaluator/planning_evaluator/include/planning_evaluator/motion_evaluator_node.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/motion_evaluator_node.hpp
@@ -21,8 +21,8 @@
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -33,8 +33,8 @@
 
 namespace planning_diagnostics
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 
 /**
  * @brief Node for planning evaluation

--- a/evaluator/planning_evaluator/include/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/planning_evaluator_node.hpp
@@ -21,10 +21,10 @@
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 
@@ -36,14 +36,13 @@
 
 namespace planning_diagnostics
 {
-using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::PoseWithUuidStamped;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 using diagnostic_msgs::msg::DiagnosticArray;
 using diagnostic_msgs::msg::DiagnosticStatus;
 using nav_msgs::msg::Odometry;
-
 /**
  * @brief Node for planning evaluation
  */

--- a/evaluator/planning_evaluator/package.xml
+++ b/evaluator/planning_evaluator/package.xml
@@ -13,8 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>

--- a/evaluator/planning_evaluator/src/metrics/deviation_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/deviation_metrics.cpp
@@ -22,8 +22,8 @@ namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 
 Stat<double> calcLateralDeviation(const Trajectory & ref, const Trajectory & traj)
 {

--- a/evaluator/planning_evaluator/src/metrics/metrics_utils.cpp
+++ b/evaluator/planning_evaluator/src/metrics/metrics_utils.cpp
@@ -20,8 +20,8 @@ namespace metrics
 {
 namespace utils
 {
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_autoware_utils::calcDistance2d;
 
 size_t getIndexAfterDistance(const Trajectory & traj, const size_t curr_id, const double distance)

--- a/evaluator/planning_evaluator/src/metrics/obstacle_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/obstacle_metrics.cpp
@@ -18,7 +18,7 @@
 
 #include <Eigen/Core>
 
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -27,7 +27,7 @@ namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_autoware_utils::calcDistance2d;
 
 Stat<double> calcDistanceToObstacle(const PredictedObjects & obstacles, const Trajectory & traj)

--- a/evaluator/planning_evaluator/src/metrics/stability_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/stability_metrics.cpp
@@ -19,7 +19,7 @@
 
 #include <Eigen/Core>
 
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
 #include <algorithm>
 
@@ -27,7 +27,7 @@ namespace planning_diagnostics
 {
 namespace metrics
 {
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 
 Stat<double> calcFrechetDistance(const Trajectory & traj1, const Trajectory & traj2)
 {

--- a/evaluator/planning_evaluator/test/test_planning_evaluator_node.cpp
+++ b/evaluator/planning_evaluator/test/test_planning_evaluator_node.cpp
@@ -20,8 +20,8 @@
 
 #include <planning_evaluator/planning_evaluator_node.hpp>
 
-#include "autoware_auto_perception_msgs/msg/predicted_objects.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_perception_msgs/msg/predicted_objects.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 
@@ -33,9 +33,9 @@
 #include <vector>
 
 using EvalNode = planning_diagnostics::PlanningEvaluatorNode;
-using Trajectory = autoware_auto_planning_msgs::msg::Trajectory;
-using TrajectoryPoint = autoware_auto_planning_msgs::msg::TrajectoryPoint;
-using Objects = autoware_auto_perception_msgs::msg::PredictedObjects;
+using Trajectory = autoware_planning_msgs::msg::Trajectory;
+using TrajectoryPoint = autoware_planning_msgs::msg::TrajectoryPoint;
+using Objects = autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::PoseWithUuidStamped;
 using diagnostic_msgs::msg::DiagnosticArray;
 using nav_msgs::msg::Odometry;
@@ -409,7 +409,7 @@ TEST_F(EvalTest, TestObstacleDistance)
 {
   setTargetMetric(planning_diagnostics::Metric::obstacle_distance);
   Objects objs;
-  autoware_auto_perception_msgs::msg::PredictedObject obj;
+  autoware_perception_msgs::msg::PredictedObject obj;
   obj.kinematics.initial_pose_with_covariance.pose.position.x = 0.0;
   obj.kinematics.initial_pose_with_covariance.pose.position.y = 0.0;
   objs.objects.push_back(obj);
@@ -425,7 +425,7 @@ TEST_F(EvalTest, TestObstacleTTC)
 {
   setTargetMetric(planning_diagnostics::Metric::obstacle_ttc);
   Objects objs;
-  autoware_auto_perception_msgs::msg::PredictedObject obj;
+  autoware_perception_msgs::msg::PredictedObject obj;
   obj.kinematics.initial_pose_with_covariance.pose.position.x = 0.0;
   obj.kinematics.initial_pose_with_covariance.pose.position.y = 0.0;
   objs.objects.push_back(obj);


### PR DESCRIPTION
## Description

This is subset of https://github.com/autowarefoundation/autoware.universe/pull/6893 to make it easier to review.
This includes all the modification for `evaluator` directory in the original PR. 

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/6893
https://github.com/orgs/autowarefoundation/discussions/3862

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Message types are modified according to the table in [this comment](https://github.com/orgs/autowarefoundation/discussions/3862#discussioncomment-9638820).
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
