### PR TITLE
feat!: replace autoware_auto_msgs with autoware_msgs for perception modules

### DIFF
--- a/perception/bytetrack/package.xml
+++ b/perception/bytetrack/package.xml
@@ -15,7 +15,7 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>cuda_utils</depend>
   <depend>cv_bridge</depend>
   <depend>eigen</depend>

--- a/perception/bytetrack/src/bytetrack_node.cpp
+++ b/perception/bytetrack/src/bytetrack_node.cpp
@@ -17,7 +17,7 @@
 #include <bytetrack/bytetrack_node.hpp>
 #include <rclcpp/qos.hpp>
 
-#include "autoware_auto_perception_msgs/msg/object_classification.hpp"
+#include "autoware_perception_msgs/msg/object_classification.hpp"
 
 #include <rmw/qos_profiles.h>
 
@@ -62,7 +62,7 @@ void ByteTrackNode::on_connect()
 void ByteTrackNode::on_rect(
   const tier4_perception_msgs::msg::DetectedObjectsWithFeature::ConstSharedPtr msg)
 {
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  using Label = autoware_perception_msgs::msg::ObjectClassification;
 
   tier4_perception_msgs::msg::DetectedObjectsWithFeature out_objects;
   tier4_perception_msgs::msg::DynamicObjectArray out_objects_uuid;
@@ -97,7 +97,7 @@ void ByteTrackNode::on_rect(
     object.feature.roi.height = static_cast<uint32_t>(output_height);
     object.object.existence_probability = tracked_object.score;
     object.object.classification.emplace_back(
-      autoware_auto_perception_msgs::build<Label>().label(tracked_object.type).probability(1.0f));
+      autoware_perception_msgs::build<Label>().label(tracked_object.type).probability(1.0f));
 
     out_objects.feature_objects.push_back(object);
 

--- a/perception/cluster_merger/README.md
+++ b/perception/cluster_merger/README.md
@@ -19,9 +19,9 @@ The clusters of merged topics are simply concatenated from clusters of input top
 
 ### Output
 
-| Name              | Type                                                  | Description     |
-| ----------------- | ----------------------------------------------------- | --------------- |
-| `output/clusters` | `autoware_auto_perception_msgs::msg::DetectedObjects` | merged clusters |
+| Name              | Type                                                     | Description     |
+| ----------------- | -------------------------------------------------------- | --------------- |
+| `output/clusters` | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | merged clusters |
 
 ## Parameters
 

--- a/perception/crosswalk_traffic_light_estimator/README.md
+++ b/perception/crosswalk_traffic_light_estimator/README.md
@@ -8,17 +8,17 @@
 
 ### Input
 
-| Name                                 | Type                                                | Description        |
-| ------------------------------------ | --------------------------------------------------- | ------------------ |
-| `~/input/vector_map`                 | `autoware_auto_mapping_msgs::msg::HADMapBin`        | vector map         |
-| `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`         | route              |
-| `~/input/classified/traffic_signals` | `autoware_perception_msgs::msg::TrafficSignalArray` | classified signals |
+| Name                                 | Type                                             | Description        |
+| ------------------------------------ | ------------------------------------------------ | ------------------ |
+| `~/input/vector_map`                 | `autoware_map_msgs::msg::LaneletMapBin`          | vector map         |
+| `~/input/route`                      | `autoware_planning_msgs::msg::LaneletRoute`      | route              |
+| `~/input/classified/traffic_signals` | `tier4_perception_msgs::msg::TrafficSignalArray` | classified signals |
 
 ### Output
 
 | Name                       | Type                                                | Description                                               |
 | -------------------------- | --------------------------------------------------- | --------------------------------------------------------- |
-| `~/output/traffic_signals` | `autoware_perception_msgs::msg::TrafficSignalArray` | output that contains estimated pedestrian traffic signals |
+| `~/output/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | output that contains estimated pedestrian traffic signals |
 
 ## Parameters
 

--- a/perception/crosswalk_traffic_light_estimator/README.md
+++ b/perception/crosswalk_traffic_light_estimator/README.md
@@ -16,8 +16,8 @@
 
 ### Output
 
-| Name                       | Type                                                | Description                                               |
-| -------------------------- | --------------------------------------------------- | --------------------------------------------------------- |
+| Name                       | Type                                                    | Description                                               |
+| -------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
 | `~/output/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | output that contains estimated pedestrian traffic signals |
 
 ## Parameters

--- a/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
@@ -19,8 +19,8 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <tier4_debug_msgs/msg/float64_stamped.hpp>
 
@@ -39,14 +39,14 @@
 namespace traffic_light
 {
 
-using autoware_auto_mapping_msgs::msg::HADMapBin;
+using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_planning_msgs::msg::LaneletRoute;
 using tier4_autoware_utils::DebugPublisher;
 using tier4_autoware_utils::StopWatch;
 using tier4_debug_msgs::msg::Float64Stamped;
-using TrafficSignal = autoware_perception_msgs::msg::TrafficSignal;
-using TrafficSignalArray = autoware_perception_msgs::msg::TrafficSignalArray;
-using TrafficSignalElement = autoware_perception_msgs::msg::TrafficSignalElement;
+using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
+using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+using TrafficSignalElement = autoware_perception_msgs::msg::TrafficLightElement;
 using TrafficSignalAndTime = std::pair<TrafficSignal, rclcpp::Time>;
 using TrafficLightIdMap = std::unordered_map<lanelet::Id, TrafficSignalAndTime>;
 
@@ -58,7 +58,7 @@ public:
   explicit CrosswalkTrafficLightEstimatorNode(const rclcpp::NodeOptions & options);
 
 private:
-  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr sub_traffic_light_array_;
   rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_traffic_light_array_;
@@ -70,7 +70,7 @@ private:
 
   lanelet::ConstLanelets conflicting_crosswalks_;
 
-  void onMap(const HADMapBin::ConstSharedPtr msg);
+  void onMap(const LaneletMapBin::ConstSharedPtr msg);
   void onRoute(const LaneletRoute::ConstSharedPtr msg);
   void onTrafficLightArray(const TrafficSignalArray::ConstSharedPtr msg);
 

--- a/perception/crosswalk_traffic_light_estimator/package.xml
+++ b/perception/crosswalk_traffic_light_estimator/package.xml
@@ -12,8 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>lanelet2_extension</depend>

--- a/perception/detected_object_feature_remover/README.md
+++ b/perception/detected_object_feature_remover/README.md
@@ -16,9 +16,9 @@ The `detected_object_feature_remover` is a package to convert topic-type from `D
 
 ### Output
 
-| Name       | Type                                                  | Description      |
-| ---------- | ----------------------------------------------------- | ---------------- |
-| `~/output` | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects |
+| Name       | Type                                             | Description      |
+| ---------- | ------------------------------------------------ | ---------------- |
+| `~/output` | `autoware_perception_msgs::msg::DetectedObjects` | detected objects |
 
 ## Parameters
 

--- a/perception/detected_object_feature_remover/include/detected_object_feature_remover/detected_object_feature_remover.hpp
+++ b/perception/detected_object_feature_remover/include/detected_object_feature_remover/detected_object_feature_remover.hpp
@@ -18,14 +18,14 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
 #include <memory>
 
 namespace detected_object_feature_remover
 {
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObjects;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 
 class DetectedObjectFeatureRemover : public rclcpp::Node

--- a/perception/detected_object_feature_remover/package.xml
+++ b/perception/detected_object_feature_remover/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_autoware_utils</depend>

--- a/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
@@ -87,8 +87,7 @@ private:
   bool isSameDirectionWithLanelets(
     const lanelet::ConstLanelets & lanelets,
     const autoware_perception_msgs::msg::DetectedObject & object);
-  geometry_msgs::msg::Polygon setFootprint(
-    const autoware_perception_msgs::msg::DetectedObject &);
+  geometry_msgs::msg::Polygon setFootprint(const autoware_perception_msgs::msg::DetectedObject &);
 
   std::unique_ptr<tier4_autoware_utils::PublishedTimePublisher> published_time_publisher_;
 };

--- a/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_lanelet_filter.hpp
@@ -23,8 +23,8 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <tf2_ros/buffer.h>
@@ -46,12 +46,12 @@ public:
   explicit ObjectLaneletFilterNode(const rclcpp::NodeOptions & node_options);
 
 private:
-  void objectCallback(const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr);
-  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr);
+  void objectCallback(const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr);
+  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr);
 
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr object_pub_;
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_sub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr object_sub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr object_pub_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr object_sub_;
   std::unique_ptr<tier4_autoware_utils::DebugPublisher> debug_publisher_{nullptr};
 
   lanelet::LaneletMapPtr lanelet_map_ptr_;
@@ -72,23 +72,23 @@ private:
   } filter_settings_;
 
   bool filterObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object,
-    const autoware_auto_perception_msgs::msg::DetectedObject & input_object,
+    const autoware_perception_msgs::msg::DetectedObject & transformed_object,
+    const autoware_perception_msgs::msg::DetectedObject & input_object,
     const lanelet::ConstLanelets & intersected_road_lanelets,
     const lanelet::ConstLanelets & intersected_shoulder_lanelets,
-    autoware_auto_perception_msgs::msg::DetectedObjects & output_object_msg);
-  LinearRing2d getConvexHull(const autoware_auto_perception_msgs::msg::DetectedObjects &);
+    autoware_perception_msgs::msg::DetectedObjects & output_object_msg);
+  LinearRing2d getConvexHull(const autoware_perception_msgs::msg::DetectedObjects &);
   lanelet::ConstLanelets getIntersectedLanelets(
     const LinearRing2d &, const lanelet::ConstLanelets &);
   bool isObjectOverlapLanelets(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const lanelet::ConstLanelets & intersected_lanelets);
   bool isPolygonOverlapLanelets(const Polygon2d &, const lanelet::ConstLanelets &);
   bool isSameDirectionWithLanelets(
     const lanelet::ConstLanelets & lanelets,
-    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+    const autoware_perception_msgs::msg::DetectedObject & object);
   geometry_msgs::msg::Polygon setFootprint(
-    const autoware_auto_perception_msgs::msg::DetectedObject &);
+    const autoware_perception_msgs::msg::DetectedObject &);
 
   std::unique_ptr<tier4_autoware_utils::PublishedTimePublisher> published_time_publisher_;
 };

--- a/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_position_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/detected_object_filter/object_position_filter.hpp
@@ -21,8 +21,8 @@
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -39,10 +39,10 @@ public:
   explicit ObjectPositionFilterNode(const rclcpp::NodeOptions & node_options);
 
 private:
-  void objectCallback(const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr);
+  void objectCallback(const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr);
 
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr object_pub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr object_sub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr object_pub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr object_sub_;
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
@@ -52,7 +52,7 @@ private:
   float lower_bound_x_;
   float lower_bound_y_;
   utils::FilterTargetLabel filter_target_;
-  bool isObjectInBounds(const autoware_auto_perception_msgs::msg::DetectedObject & object) const;
+  bool isObjectInBounds(const autoware_perception_msgs::msg::DetectedObject & object) const;
 
   std::unique_ptr<tier4_autoware_utils::PublishedTimePublisher> published_time_publisher_;
 };

--- a/perception/detected_object_validation/include/detected_object_validation/obstacle_pointcloud_based_validator/debugger.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/obstacle_pointcloud_based_validator/debugger.hpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/point_cloud.h>
@@ -36,9 +36,8 @@ public:
   : neighbor_pointcloud_(new pcl::PointCloud<pcl::PointXYZ>),
     pointcloud_within_polygon_(new pcl::PointCloud<pcl::PointXYZ>)
   {
-    removed_objects_pub_ =
-      node->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-        "~/debug/removed_objects", 1);
+    removed_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+      "~/debug/removed_objects", 1);
     neighbor_pointcloud_pub_ =
       node->create_publisher<sensor_msgs::msg::PointCloud2>("~/debug/neighbor_pointcloud", 1);
     pointcloud_within_polygon_pub_ =
@@ -46,7 +45,7 @@ public:
   }
 
   ~Debugger() {}
-  void publishRemovedObjects(const autoware_auto_perception_msgs::msg::DetectedObjects & input)
+  void publishRemovedObjects(const autoware_perception_msgs::msg::DetectedObjects & input)
   {
     removed_objects_pub_->publish(input);
   }
@@ -92,8 +91,7 @@ public:
   }
 
 private:
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
-    removed_objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr removed_objects_pub_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr neighbor_pointcloud_pub_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_within_polygon_pub_;
   pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud_;

--- a/perception/detected_object_validation/include/detected_object_validation/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -23,7 +23,7 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <message_filters/subscriber.h>
@@ -70,10 +70,10 @@ public:
   virtual bool setKdtreeInputCloud(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud) = 0;
   virtual bool validate_object(
-    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object) = 0;
+    const autoware_perception_msgs::msg::DetectedObject & transformed_object) = 0;
   virtual std::optional<float> getMaxRadius(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object) = 0;
-  size_t getThresholdPointCloud(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+    const autoware_perception_msgs::msg::DetectedObject & object) = 0;
+  size_t getThresholdPointCloud(const autoware_perception_msgs::msg::DetectedObject & object);
   virtual pcl::PointCloud<pcl::PointXYZ>::Ptr getDebugNeighborPointCloud() = 0;
 };
 
@@ -95,12 +95,10 @@ public:
   }
 
   bool setKdtreeInputCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_cloud);
-  bool validate_object(
-    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object);
-  std::optional<float> getMaxRadius(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool validate_object(const autoware_perception_msgs::msg::DetectedObject & transformed_object);
+  std::optional<float> getMaxRadius(const autoware_perception_msgs::msg::DetectedObject & object);
   std::optional<size_t> getPointCloudWithinObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const pcl::PointCloud<pcl::PointXY>::Ptr neighbor_pointcloud);
 };
 class Validator3D : public Validator
@@ -117,12 +115,10 @@ public:
     return neighbor_pointcloud_;
   }
   bool setKdtreeInputCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_cloud);
-  bool validate_object(
-    const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object);
-  std::optional<float> getMaxRadius(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool validate_object(const autoware_perception_msgs::msg::DetectedObject & transformed_object);
+  std::optional<float> getMaxRadius(const autoware_perception_msgs::msg::DetectedObject & object);
   std::optional<size_t> getPointCloudWithinObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud);
 };
 
@@ -132,15 +128,15 @@ public:
   explicit ObstaclePointCloudBasedValidator(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
-  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> objects_sub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> objects_sub_;
   message_filters::Subscriber<sensor_msgs::msg::PointCloud2> obstacle_pointcloud_sub_;
   std::unique_ptr<tier4_autoware_utils::DebugPublisher> debug_publisher_{nullptr};
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
   typedef message_filters::sync_policies::ApproximateTime<
-    autoware_auto_perception_msgs::msg::DetectedObjects, sensor_msgs::msg::PointCloud2>
+    autoware_perception_msgs::msg::DetectedObjects, sensor_msgs::msg::PointCloud2>
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
@@ -153,7 +149,7 @@ private:
 
 private:
   void onObjectsAndObstaclePointCloud(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud);
 };
 }  // namespace obstacle_pointcloud_based_validator

--- a/perception/detected_object_validation/include/detected_object_validation/occupancy_grid_based_validator/occupancy_grid_based_validator.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/occupancy_grid_based_validator/occupancy_grid_based_validator.hpp
@@ -21,7 +21,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 
 #include <message_filters/subscriber.h>
@@ -38,15 +38,15 @@ public:
   explicit OccupancyGridBasedValidator(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
-  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> objects_sub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> objects_sub_;
   message_filters::Subscriber<nav_msgs::msg::OccupancyGrid> occ_grid_sub_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   std::unique_ptr<tier4_autoware_utils::PublishedTimePublisher> published_time_publisher_;
 
   typedef message_filters::sync_policies::ApproximateTime<
-    autoware_auto_perception_msgs::msg::DetectedObjects, nav_msgs::msg::OccupancyGrid>
+    autoware_perception_msgs::msg::DetectedObjects, nav_msgs::msg::OccupancyGrid>
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
@@ -54,19 +54,19 @@ private:
   bool enable_debug_;
 
   void onObjectsAndOccGrid(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
     const nav_msgs::msg::OccupancyGrid::ConstSharedPtr & input_occ_grid);
 
   cv::Mat fromOccupancyGrid(const nav_msgs::msg::OccupancyGrid & occupancy_grid);
   std::optional<cv::Mat> getMask(
     const nav_msgs::msg::OccupancyGrid & occupancy_grid,
-    const autoware_auto_perception_msgs::msg::DetectedObject & object);
+    const autoware_perception_msgs::msg::DetectedObject & object);
   std::optional<cv::Mat> getMask(
     const nav_msgs::msg::OccupancyGrid & occupancy_grid,
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, cv::Mat mask);
+    const autoware_perception_msgs::msg::DetectedObject & object, cv::Mat mask);
   void showDebugImage(
     const nav_msgs::msg::OccupancyGrid & ros_occ_grid,
-    const autoware_auto_perception_msgs::msg::DetectedObjects & objects, const cv::Mat & occ_grid);
+    const autoware_perception_msgs::msg::DetectedObjects & objects, const cv::Mat & occ_grid);
 };
 }  // namespace occupancy_grid_based_validator
 

--- a/perception/detected_object_validation/include/detected_object_validation/utils/utils.hpp
+++ b/perception/detected_object_validation/include/detected_object_validation/utils/utils.hpp
@@ -15,7 +15,7 @@
 #ifndef DETECTED_OBJECT_VALIDATION__UTILS__UTILS_HPP_
 #define DETECTED_OBJECT_VALIDATION__UTILS__UTILS_HPP_
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <cstdint>
 namespace utils
@@ -33,13 +33,13 @@ struct FilterTargetLabel
   bool isTarget(const uint8_t label) const;
 };  // struct FilterTargetLabel
 
-inline bool hasBoundingBox(const autoware_auto_perception_msgs::msg::DetectedObject & object)
+inline bool hasBoundingBox(const autoware_perception_msgs::msg::DetectedObject & object)
 {
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     return true;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     return true;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     return false;
   } else {
     // unknown shape type.

--- a/perception/detected_object_validation/object-lanelet-filter.md
+++ b/perception/detected_object_validation/object-lanelet-filter.md
@@ -11,16 +11,16 @@ The objects only inside of the vector map will be published.
 
 ### Input
 
-| Name               | Type                                                  | Description            |
-| ------------------ | ----------------------------------------------------- | ---------------------- |
-| `input/vector_map` | `autoware_auto_mapping_msgs::msg::HADMapBin`          | vector map             |
-| `input/object`     | `autoware_auto_perception_msgs::msg::DetectedObjects` | input detected objects |
+| Name               | Type                                             | Description            |
+| ------------------ | ------------------------------------------------ | ---------------------- |
+| `input/vector_map` | `autoware_map_msgs::msg::LaneletMapBin`          | vector map             |
+| `input/object`     | `autoware_perception_msgs::msg::DetectedObjects` | input detected objects |
 
 ### Output
 
-| Name            | Type                                                  | Description               |
-| --------------- | ----------------------------------------------------- | ------------------------- |
-| `output/object` | `autoware_auto_perception_msgs::msg::DetectedObjects` | filtered detected objects |
+| Name            | Type                                             | Description               |
+| --------------- | ------------------------------------------------ | ------------------------- |
+| `output/object` | `autoware_perception_msgs::msg::DetectedObjects` | filtered detected objects |
 
 ## Parameters
 

--- a/perception/detected_object_validation/object-position-filter.md
+++ b/perception/detected_object_validation/object-position-filter.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `object_position_filter` is a node that filters detected object based on x,y values.  
+The `object_position_filter` is a node that filters detected object based on x,y values.
 The objects only inside of the x, y bound will be published.
 
 ## Inner-workings / Algorithms
@@ -11,15 +11,15 @@ The objects only inside of the x, y bound will be published.
 
 ### Input
 
-| Name           | Type                                                  | Description            |
-| -------------- | ----------------------------------------------------- | ---------------------- |
-| `input/object` | `autoware_auto_perception_msgs::msg::DetectedObjects` | input detected objects |
+| Name           | Type                                             | Description            |
+| -------------- | ------------------------------------------------ | ---------------------- |
+| `input/object` | `autoware_perception_msgs::msg::DetectedObjects` | input detected objects |
 
 ### Output
 
-| Name            | Type                                                  | Description               |
-| --------------- | ----------------------------------------------------- | ------------------------- |
-| `output/object` | `autoware_auto_perception_msgs::msg::DetectedObjects` | filtered detected objects |
+| Name            | Type                                             | Description               |
+| --------------- | ------------------------------------------------ | ------------------------- |
+| `output/object` | `autoware_perception_msgs::msg::DetectedObjects` | filtered detected objects |
 
 ## Parameters
 

--- a/perception/detected_object_validation/obstacle-pointcloud-based-validator.md
+++ b/perception/detected_object_validation/obstacle-pointcloud-based-validator.md
@@ -13,16 +13,16 @@ In the debug image above, the red DetectedObject is the validated object. The bl
 
 ### Input
 
-| Name                          | Type                                                  | Description                             |
-| ----------------------------- | ----------------------------------------------------- | --------------------------------------- |
-| `~/input/detected_objects`    | `autoware_auto_perception_msgs::msg::DetectedObjects` | DetectedObjects                         |
-| `~/input/obstacle_pointcloud` | `sensor_msgs::msg::PointCloud2`                       | Obstacle point cloud of dynamic objects |
+| Name                          | Type                                             | Description                             |
+| ----------------------------- | ------------------------------------------------ | --------------------------------------- |
+| `~/input/detected_objects`    | `autoware_perception_msgs::msg::DetectedObjects` | DetectedObjects                         |
+| `~/input/obstacle_pointcloud` | `sensor_msgs::msg::PointCloud2`                  | Obstacle point cloud of dynamic objects |
 
 ### Output
 
-| Name               | Type                                                  | Description               |
-| ------------------ | ----------------------------------------------------- | ------------------------- |
-| `~/output/objects` | `autoware_auto_perception_msgs::msg::DetectedObjects` | validated DetectedObjects |
+| Name               | Type                                             | Description               |
+| ------------------ | ------------------------------------------------ | ------------------------- |
+| `~/output/objects` | `autoware_perception_msgs::msg::DetectedObjects` | validated DetectedObjects |
 
 ## Parameters
 

--- a/perception/detected_object_validation/occupancy-grid-based-validator.md
+++ b/perception/detected_object_validation/occupancy-grid-based-validator.md
@@ -15,16 +15,16 @@ If the percentage is low, it is deleted.
 
 ### Input
 
-| Name                         | Type                                                  | Description                                                 |
-| ---------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| `~/input/detected_objects`   | `autoware_auto_perception_msgs::msg::DetectedObjects` | DetectedObjects                                             |
-| `~/input/occupancy_grid_map` | `nav_msgs::msg::OccupancyGrid`                        | OccupancyGrid with no time series calculation is preferred. |
+| Name                         | Type                                             | Description                                                 |
+| ---------------------------- | ------------------------------------------------ | ----------------------------------------------------------- |
+| `~/input/detected_objects`   | `autoware_perception_msgs::msg::DetectedObjects` | DetectedObjects                                             |
+| `~/input/occupancy_grid_map` | `nav_msgs::msg::OccupancyGrid`                   | OccupancyGrid with no time series calculation is preferred. |
 
 ### Output
 
-| Name               | Type                                                  | Description               |
-| ------------------ | ----------------------------------------------------- | ------------------------- |
-| `~/output/objects` | `autoware_auto_perception_msgs::msg::DetectedObjects` | validated DetectedObjects |
+| Name               | Type                                             | Description               |
+| ------------------ | ------------------------------------------------ | ------------------------- |
+| `~/output/objects` | `autoware_perception_msgs::msg::DetectedObjects` | validated DetectedObjects |
 
 ## Parameters
 

--- a/perception/detected_object_validation/package.xml
+++ b/perception/detected_object_validation/package.xml
@@ -17,8 +17,8 @@
 
   <build_depend>libopencv-dev</build_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>message_filters</depend>

--- a/perception/detected_object_validation/src/object_position_filter.cpp
+++ b/perception/detected_object_validation/src/object_position_filter.cpp
@@ -38,20 +38,20 @@ ObjectPositionFilterNode::ObjectPositionFilterNode(const rclcpp::NodeOptions & n
   filter_target_.PEDESTRIAN = declare_parameter<bool>("filter_target_label.PEDESTRIAN", false);
 
   // Set publisher/subscriber
-  object_sub_ = this->create_subscription<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  object_sub_ = this->create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
     "input/object", rclcpp::QoS{1}, std::bind(&ObjectPositionFilterNode::objectCallback, this, _1));
-  object_pub_ = this->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  object_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "output/object", rclcpp::QoS{1});
   published_time_publisher_ = std::make_unique<tier4_autoware_utils::PublishedTimePublisher>(this);
 }
 
 void ObjectPositionFilterNode::objectCallback(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_msg)
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_msg)
 {
   // Guard
   if (object_pub_->get_subscription_count() < 1) return;
 
-  autoware_auto_perception_msgs::msg::DetectedObjects output_object_msg;
+  autoware_perception_msgs::msg::DetectedObjects output_object_msg;
   output_object_msg.header = input_msg->header;
 
   for (const auto & object : input_msg->objects) {
@@ -70,7 +70,7 @@ void ObjectPositionFilterNode::objectCallback(
 }
 
 bool ObjectPositionFilterNode::isObjectInBounds(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object) const
+  const autoware_perception_msgs::msg::DetectedObject & object) const
 {
   const auto & position = object.kinematics.pose_with_covariance.pose.position;
   return position.x > lower_bound_x_ && position.x < upper_bound_x_ &&

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -32,7 +32,7 @@
 namespace obstacle_pointcloud_based_validator
 {
 namespace bg = boost::geometry;
-using Shape = autoware_auto_perception_msgs::msg::Shape;
+using Shape = autoware_perception_msgs::msg::Shape;
 using Polygon2d = tier4_autoware_utils::Polygon2d;
 
 Validator::Validator(PointsNumThresholdParam & points_num_threshold_param)
@@ -44,7 +44,7 @@ Validator::Validator(PointsNumThresholdParam & points_num_threshold_param)
 }
 
 size_t Validator::getThresholdPointCloud(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   const auto object_label_id = object.classification.front().label;
   const auto object_distance = std::hypot(
@@ -91,7 +91,7 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr Validator2D::convertToXYZ(
 }
 
 std::optional<size_t> Validator2D::getPointCloudWithinObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const pcl::PointCloud<pcl::PointXY>::Ptr pointcloud)
 {
   std::vector<pcl::Vertices> vertices_array;
@@ -119,7 +119,7 @@ std::optional<size_t> Validator2D::getPointCloudWithinObject(
 }
 
 bool Validator2D::validate_object(
-  const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object)
+  const autoware_perception_msgs::msg::DetectedObject & transformed_object)
 {
   // get neighbor_pointcloud of object
   neighbor_pointcloud_.reset(new pcl::PointCloud<pcl::PointXY>);
@@ -148,7 +148,7 @@ bool Validator2D::validate_object(
 }
 
 std::optional<float> Validator2D::getMaxRadius(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   if (object.shape.type == Shape::BOUNDING_BOX || object.shape.type == Shape::CYLINDER) {
     return std::hypot(object.shape.dimensions.x * 0.5f, object.shape.dimensions.y * 0.5f);
@@ -182,7 +182,7 @@ bool Validator3D::setKdtreeInputCloud(
   return true;
 }
 std::optional<float> Validator3D::getMaxRadius(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   if (object.shape.type == Shape::BOUNDING_BOX || object.shape.type == Shape::CYLINDER) {
     auto square_radius = (object.shape.dimensions.x * 0.5f) * (object.shape.dimensions.x * 0.5f) +
@@ -202,7 +202,7 @@ std::optional<float> Validator3D::getMaxRadius(
 }
 
 std::optional<size_t> Validator3D::getPointCloudWithinObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const pcl::PointCloud<pcl::PointXYZ>::Ptr neighbor_pointcloud)
 {
   std::vector<pcl::Vertices> vertices_array;
@@ -242,7 +242,7 @@ std::optional<size_t> Validator3D::getPointCloudWithinObject(
 }
 
 bool Validator3D::validate_object(
-  const autoware_auto_perception_msgs::msg::DetectedObject & transformed_object)
+  const autoware_perception_msgs::msg::DetectedObject & transformed_object)
 {
   neighbor_pointcloud_.reset(new pcl::PointCloud<pcl::PointXYZ>);
   std::vector<int> indices;
@@ -302,7 +302,7 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
     validator_ = std::make_unique<Validator3D>(points_num_threshold_param_);
   }
 
-  objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  objects_pub_ = create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS{1});
   debug_publisher_ = std::make_unique<tier4_autoware_utils::DebugPublisher>(
     this, "obstacle_pointcloud_based_validator");
@@ -312,15 +312,15 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   published_time_publisher_ = std::make_unique<tier4_autoware_utils::PublishedTimePublisher>(this);
 }
 void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud)
 {
-  autoware_auto_perception_msgs::msg::DetectedObjects output, removed_objects;
+  autoware_perception_msgs::msg::DetectedObjects output, removed_objects;
   output.header = input_objects->header;
   removed_objects.header = input_objects->header;
 
   // Transform to pointcloud frame
-  autoware_auto_perception_msgs::msg::DetectedObjects transformed_objects;
+  autoware_perception_msgs::msg::DetectedObjects transformed_objects;
   if (!object_recognition_utils::transformObjects(
         *input_objects, input_obstacle_pointcloud->header.frame_id, tf_buffer_,
         transformed_objects)) {

--- a/perception/detected_object_validation/src/occupancy_grid_based_validator.cpp
+++ b/perception/detected_object_validation/src/occupancy_grid_based_validator.cpp
@@ -32,7 +32,7 @@
 
 namespace occupancy_grid_based_validator
 {
-using Shape = autoware_auto_perception_msgs::msg::Shape;
+using Shape = autoware_perception_msgs::msg::Shape;
 using Polygon2d = tier4_autoware_utils::Polygon2d;
 
 OccupancyGridBasedValidator::OccupancyGridBasedValidator(const rclcpp::NodeOptions & node_options)
@@ -47,7 +47,7 @@ OccupancyGridBasedValidator::OccupancyGridBasedValidator(const rclcpp::NodeOptio
   using std::placeholders::_2;
   sync_.registerCallback(
     std::bind(&OccupancyGridBasedValidator::onObjectsAndOccGrid, this, _1, _2));
-  objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  objects_pub_ = create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS{1});
 
   mean_threshold_ = declare_parameter<float>("mean_threshold", 0.6);
@@ -56,14 +56,14 @@ OccupancyGridBasedValidator::OccupancyGridBasedValidator(const rclcpp::NodeOptio
 }
 
 void OccupancyGridBasedValidator::onObjectsAndOccGrid(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
   const nav_msgs::msg::OccupancyGrid::ConstSharedPtr & input_occ_grid)
 {
-  autoware_auto_perception_msgs::msg::DetectedObjects output;
+  autoware_perception_msgs::msg::DetectedObjects output;
   output.header = input_objects->header;
 
   // Transform to occ grid frame
-  autoware_auto_perception_msgs::msg::DetectedObjects transformed_objects;
+  autoware_perception_msgs::msg::DetectedObjects transformed_objects;
   if (!object_recognition_utils::transformObjects(
         *input_objects, input_occ_grid->header.frame_id, tf_buffer_, transformed_objects))
     return;
@@ -93,7 +93,7 @@ void OccupancyGridBasedValidator::onObjectsAndOccGrid(
 
 std::optional<cv::Mat> OccupancyGridBasedValidator::getMask(
   const nav_msgs::msg::OccupancyGrid & occupancy_grid,
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   cv::Mat mask = cv::Mat::zeros(occupancy_grid.info.height, occupancy_grid.info.width, CV_8UC1);
   return getMask(occupancy_grid, object, mask);
@@ -101,7 +101,7 @@ std::optional<cv::Mat> OccupancyGridBasedValidator::getMask(
 
 std::optional<cv::Mat> OccupancyGridBasedValidator::getMask(
   const nav_msgs::msg::OccupancyGrid & occupancy_grid,
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, cv::Mat mask)
+  const autoware_perception_msgs::msg::DetectedObject & object, cv::Mat mask)
 {
   const auto & resolution = occupancy_grid.info.resolution;
   const auto & origin = occupancy_grid.info.origin;
@@ -145,7 +145,7 @@ cv::Mat OccupancyGridBasedValidator::fromOccupancyGrid(
 
 void OccupancyGridBasedValidator::showDebugImage(
   const nav_msgs::msg::OccupancyGrid & ros_occ_grid,
-  const autoware_auto_perception_msgs::msg::DetectedObjects & objects, const cv::Mat & occ_grid)
+  const autoware_perception_msgs::msg::DetectedObjects & objects, const cv::Mat & occ_grid)
 {
   cv::namedWindow("removed_objects_image", cv::WINDOW_NORMAL);
   cv::namedWindow("passed_objects_image", cv::WINDOW_NORMAL);

--- a/perception/detected_object_validation/src/utils.cpp
+++ b/perception/detected_object_validation/src/utils.cpp
@@ -14,11 +14,11 @@
 
 #include "detected_object_validation/utils/utils.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 
 namespace utils
 {
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 bool FilterTargetLabel::isTarget(const uint8_t label) const
 {

--- a/perception/detected_object_validation/test/test_utils.cpp
+++ b/perception/detected_object_validation/test/test_utils.cpp
@@ -14,11 +14,11 @@
 
 #include "detected_object_validation/utils/utils.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 
 #include <gtest/gtest.h>
 
-using AutowareLabel = autoware_auto_perception_msgs::msg::ObjectClassification;
+using AutowareLabel = autoware_perception_msgs::msg::ObjectClassification;
 
 utils::FilterTargetLabel createFilterTargetAll()
 {

--- a/perception/detection_by_tracker/README.md
+++ b/perception/detection_by_tracker/README.md
@@ -40,9 +40,9 @@ Simply looking at the overlap between the unknown object and the tracker does no
 
 ### Output
 
-| Name       | Type                                                  | Description |
-| ---------- | ----------------------------------------------------- | ----------- |
-| `~/output` | `autoware_auto_perception_msgs::msg::DetectedObjects` | objects     |
+| Name       | Type                                             | Description |
+| ---------- | ------------------------------------------------ | ----------- |
+| `~/output` | `autoware_perception_msgs::msg::DetectedObjects` | objects     |
 
 ## Parameters
 

--- a/perception/detection_by_tracker/include/detection_by_tracker/debugger.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/debugger.hpp
@@ -23,8 +23,8 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
@@ -51,18 +51,14 @@ class Debugger
 public:
   explicit Debugger(rclcpp::Node * node)
   {
-    initial_objects_pub_ =
-      node->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-        "debug/initial_objects", 1);
-    tracked_objects_pub_ =
-      node->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-        "debug/tracked_objects", 1);
-    merged_objects_pub_ =
-      node->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-        "debug/merged_objects", 1);
-    divided_objects_pub_ =
-      node->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-        "debug/divided_objects", 1);
+    initial_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+      "debug/initial_objects", 1);
+    tracked_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+      "debug/tracked_objects", 1);
+    merged_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+      "debug/merged_objects", 1);
+    divided_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+      "debug/divided_objects", 1);
     processing_time_publisher_ =
       std::make_unique<tier4_autoware_utils::DebugPublisher>(node, "detection_by_tracker");
     stop_watch_ptr_ =
@@ -75,7 +71,7 @@ public:
   {
     initial_objects_pub_->publish(removeFeature(input));
   }
-  void publishTrackedObjects(const autoware_auto_perception_msgs::msg::DetectedObjects & input)
+  void publishTrackedObjects(const autoware_perception_msgs::msg::DetectedObjects & input)
   {
     tracked_objects_pub_->publish(input);
   }
@@ -102,22 +98,18 @@ public:
   }
 
 private:
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
-    initial_objects_pub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
-    tracked_objects_pub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
-    merged_objects_pub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
-    divided_objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr initial_objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr tracked_objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr merged_objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr divided_objects_pub_;
   // debug publisher
   std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<tier4_autoware_utils::DebugPublisher> processing_time_publisher_;
 
-  autoware_auto_perception_msgs::msg::DetectedObjects removeFeature(
+  autoware_perception_msgs::msg::DetectedObjects removeFeature(
     const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input)
   {
-    autoware_auto_perception_msgs::msg::DetectedObjects objects;
+    autoware_perception_msgs::msg::DetectedObjects objects;
     objects.header = input.header;
     for (const auto & feature_object : input.feature_objects) {
       objects.objects.push_back(feature_object.object);

--- a/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
@@ -25,8 +25,8 @@
 #include <shape_estimation/shape_estimator.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
@@ -51,14 +51,14 @@
 class TrackerHandler
 {
 private:
-  std::deque<autoware_auto_perception_msgs::msg::TrackedObjects> objects_buffer_;
+  std::deque<autoware_perception_msgs::msg::TrackedObjects> objects_buffer_;
 
 public:
   TrackerHandler() = default;
   void onTrackedObjects(
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr input_objects_msg);
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr input_objects_msg);
   bool estimateTrackedObjects(
-    const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObjects & output);
+    const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObjects & output);
 };
 
 class DetectionByTracker : public rclcpp::Node
@@ -67,8 +67,8 @@ public:
   explicit DetectionByTracker(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr trackers_sub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr trackers_sub_;
   rclcpp::Subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>::SharedPtr
     initial_objects_sub_;
 
@@ -92,20 +92,20 @@ private:
     const tier4_perception_msgs::msg::DetectedObjectsWithFeature::ConstSharedPtr input_msg);
 
   void divideUnderSegmentedObjects(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & tracked_objects,
+    const autoware_perception_msgs::msg::DetectedObjects & tracked_objects,
     const tier4_perception_msgs::msg::DetectedObjectsWithFeature & in_objects,
-    autoware_auto_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
+    autoware_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
     tier4_perception_msgs::msg::DetectedObjectsWithFeature & out_objects);
 
   float optimizeUnderSegmentedObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & target_object,
+    const autoware_perception_msgs::msg::DetectedObject & target_object,
     const sensor_msgs::msg::PointCloud2 & under_segmented_cluster,
     tier4_perception_msgs::msg::DetectedObjectWithFeature & output);
 
   void mergeOverSegmentedObjects(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & tracked_objects,
+    const autoware_perception_msgs::msg::DetectedObjects & tracked_objects,
     const tier4_perception_msgs::msg::DetectedObjectsWithFeature & in_objects,
-    autoware_auto_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
+    autoware_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
     tier4_perception_msgs::msg::DetectedObjectsWithFeature & out_objects);
 };
 

--- a/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
@@ -29,7 +29,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 namespace
 {
 void setClusterInObjectWithFeature(
@@ -41,10 +41,10 @@ void setClusterInObjectWithFeature(
   ros_pointcloud.header = header;
   feature_object.feature.cluster = ros_pointcloud;
 }
-autoware_auto_perception_msgs::msg::Shape extendShape(
-  const autoware_auto_perception_msgs::msg::Shape & shape, const float scale)
+autoware_perception_msgs::msg::Shape extendShape(
+  const autoware_perception_msgs::msg::Shape & shape, const float scale)
 {
-  autoware_auto_perception_msgs::msg::Shape output = shape;
+  autoware_perception_msgs::msg::Shape output = shape;
   output.dimensions.x *= scale;
   output.dimensions.y *= scale;
   output.dimensions.z *= scale;
@@ -68,7 +68,7 @@ boost::optional<ReferenceYawInfo> getReferenceYawInfo(const uint8_t label, const
 }
 
 boost::optional<ReferenceShapeSizeInfo> getReferenceShapeSizeInfo(
-  const uint8_t label, const autoware_auto_perception_msgs::msg::Shape & shape)
+  const uint8_t label, const autoware_perception_msgs::msg::Shape & shape)
 {
   const bool is_vehicle =
     Label::CAR == label || Label::TRUCK == label || Label::BUS == label || Label::TRAILER == label;
@@ -81,7 +81,7 @@ boost::optional<ReferenceShapeSizeInfo> getReferenceShapeSizeInfo(
 }  // namespace
 
 void TrackerHandler::onTrackedObjects(
-  const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr msg)
+  const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr msg)
 {
   constexpr size_t max_buffer_size = 10;
 
@@ -95,7 +95,7 @@ void TrackerHandler::onTrackedObjects(
 }
 
 bool TrackerHandler::estimateTrackedObjects(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObjects & output)
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObjects & output)
 {
   if (objects_buffer_.empty()) {
     return false;
@@ -105,8 +105,8 @@ bool TrackerHandler::estimateTrackedObjects(
   const auto target_objects_iter = std::min_element(
     objects_buffer_.cbegin(), objects_buffer_.cend(),
     [&time](
-      autoware_auto_perception_msgs::msg::TrackedObjects first,
-      autoware_auto_perception_msgs::msg::TrackedObjects second) {
+      autoware_perception_msgs::msg::TrackedObjects first,
+      autoware_perception_msgs::msg::TrackedObjects second) {
       return std::fabs((time - first.header.stamp).seconds()) <
              std::fabs((time - second.header.stamp).seconds());
     });
@@ -126,7 +126,7 @@ bool TrackerHandler::estimateTrackedObjects(
     const float & wz = twist.angular.z;
 
     // build output
-    autoware_auto_perception_msgs::msg::TrackedObject estimated_object;
+    autoware_perception_msgs::msg::TrackedObject estimated_object;
     estimated_object.object_id = object.object_id;
     estimated_object.existence_probability = object.existence_probability;
     estimated_object.classification = object.classification;
@@ -150,15 +150,15 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
   tf_listener_(tf_buffer_)
 {
   // Create publishers and subscribers
-  trackers_sub_ = create_subscription<autoware_auto_perception_msgs::msg::TrackedObjects>(
+  trackers_sub_ = create_subscription<autoware_perception_msgs::msg::TrackedObjects>(
     "~/input/tracked_objects", rclcpp::QoS{1},
     std::bind(&TrackerHandler::onTrackedObjects, &tracker_handler_, std::placeholders::_1));
   initial_objects_sub_ =
     create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
       "~/input/initial_objects", rclcpp::QoS{1},
       std::bind(&DetectionByTracker::onObjects, this, std::placeholders::_1));
-  objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-    "~/output", rclcpp::QoS{1});
+  objects_pub_ =
+    create_publisher<autoware_perception_msgs::msg::DetectedObjects>("~/output", rclcpp::QoS{1});
 
   // Set parameters
   tracker_ignore_.UNKNOWN = declare_parameter<bool>("tracker_ignore_label.UNKNOWN");
@@ -182,7 +182,7 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
 
 void DetectionByTracker::setMaxSearchRange()
 {
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  using Label = autoware_perception_msgs::msg::ObjectClassification;
   // set max search distance for merger
   max_search_distance_for_merger_[Label::UNKNOWN] = 5.0;
   max_search_distance_for_merger_[Label::CAR] = 5.0;
@@ -208,13 +208,13 @@ void DetectionByTracker::onObjects(
   const tier4_perception_msgs::msg::DetectedObjectsWithFeature::ConstSharedPtr input_msg)
 {
   debugger_->startMeasureProcessingTime();
-  autoware_auto_perception_msgs::msg::DetectedObjects detected_objects;
+  autoware_perception_msgs::msg::DetectedObjects detected_objects;
   detected_objects.header = input_msg->header;
 
   // get objects from tracking module
-  autoware_auto_perception_msgs::msg::DetectedObjects tracked_objects;
+  autoware_perception_msgs::msg::DetectedObjects tracked_objects;
   {
-    autoware_auto_perception_msgs::msg::TrackedObjects objects, transformed_objects;
+    autoware_perception_msgs::msg::TrackedObjects objects, transformed_objects;
     const bool available_trackers =
       tracker_handler_.estimateTrackedObjects(input_msg->header.stamp, objects);
     if (
@@ -233,13 +233,13 @@ void DetectionByTracker::onObjects(
 
   // merge over segmented objects
   tier4_perception_msgs::msg::DetectedObjectsWithFeature merged_objects;
-  autoware_auto_perception_msgs::msg::DetectedObjects no_found_tracked_objects;
+  autoware_perception_msgs::msg::DetectedObjects no_found_tracked_objects;
   mergeOverSegmentedObjects(tracked_objects, *input_msg, no_found_tracked_objects, merged_objects);
   debugger_->publishMergedObjects(merged_objects);
 
   // divide under segmented objects
   tier4_perception_msgs::msg::DetectedObjectsWithFeature divided_objects;
-  autoware_auto_perception_msgs::msg::DetectedObjects temp_no_found_tracked_objects;
+  autoware_perception_msgs::msg::DetectedObjects temp_no_found_tracked_objects;
   divideUnderSegmentedObjects(
     no_found_tracked_objects, *input_msg, temp_no_found_tracked_objects, divided_objects);
   debugger_->publishDividedObjects(divided_objects);
@@ -258,9 +258,9 @@ void DetectionByTracker::onObjects(
 }
 
 void DetectionByTracker::divideUnderSegmentedObjects(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & tracked_objects,
+  const autoware_perception_msgs::msg::DetectedObjects & tracked_objects,
   const tier4_perception_msgs::msg::DetectedObjectsWithFeature & in_cluster_objects,
-  autoware_auto_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
+  autoware_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
   tier4_perception_msgs::msg::DetectedObjectsWithFeature & out_objects)
 {
   constexpr float recall_min_threshold = 0.4;
@@ -321,7 +321,7 @@ void DetectionByTracker::divideUnderSegmentedObjects(
 }
 
 float DetectionByTracker::optimizeUnderSegmentedObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & target_object,
+  const autoware_perception_msgs::msg::DetectedObject & target_object,
   const sensor_msgs::msg::PointCloud2 & under_segmented_cluster,
   tier4_perception_msgs::msg::DetectedObjectWithFeature & output)
 {
@@ -397,9 +397,9 @@ float DetectionByTracker::optimizeUnderSegmentedObject(
 }
 
 void DetectionByTracker::mergeOverSegmentedObjects(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & tracked_objects,
+  const autoware_perception_msgs::msg::DetectedObjects & tracked_objects,
   const tier4_perception_msgs::msg::DetectedObjectsWithFeature & in_cluster_objects,
-  autoware_auto_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
+  autoware_perception_msgs::msg::DetectedObjects & out_no_found_tracked_objects,
   tier4_perception_msgs::msg::DetectedObjectsWithFeature & out_objects)
 {
   constexpr float precision_threshold = 0.5;
@@ -414,7 +414,7 @@ void DetectionByTracker::mergeOverSegmentedObjects(
     const float max_search_range = max_search_distance_for_merger_[label];
 
     // extend shape
-    autoware_auto_perception_msgs::msg::DetectedObject extended_tracked_object = tracked_object;
+    autoware_perception_msgs::msg::DetectedObject extended_tracked_object = tracked_object;
     extended_tracked_object.shape = extendShape(tracked_object.shape, /*scale*/ 1.1);
 
     pcl::PointCloud<pcl::PointXYZ> pcl_merged_cluster;

--- a/perception/detection_by_tracker/src/utils.cpp
+++ b/perception/detection_by_tracker/src/utils.cpp
@@ -14,13 +14,13 @@
 
 #include "detection_by_tracker/utils.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 
 namespace detection_by_tracker
 {
 namespace utils
 {
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 bool TrackerIgnoreLabel::isIgnore(const uint8_t label) const
 {

--- a/perception/elevation_map_loader/README.md
+++ b/perception/elevation_map_loader/README.md
@@ -23,7 +23,7 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | Name                            | Type                                            | Description                                |
 | ------------------------------- | ----------------------------------------------- | ------------------------------------------ |
 | `input/pointcloud_map`          | `sensor_msgs::msg::PointCloud2`                 | The point cloud map                        |
-| `input/vector_map`              | `autoware_auto_mapping_msgs::msg::HADMapBin`    | (Optional) The binary data of lanelet2 map |
+| `input/vector_map`              | `autoware_map_msgs::msg::LaneletMapBin`         | (Optional) The binary data of lanelet2 map |
 | `input/pointcloud_map_metadata` | `autoware_map_msgs::msg::PointCloudMapMetaData` | (Optional) The metadata of point cloud map |
 
 ### Output

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -23,7 +23,7 @@
 #include <tier4_autoware_utils/geometry/boost_geometry.hpp>
 
 #include "tier4_external_api_msgs/msg/map_hash.hpp"
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_map_msgs/msg/point_cloud_map_meta_data.hpp>
 #include <autoware_map_msgs/srv/get_selected_point_cloud_map.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -64,7 +64,7 @@ public:
 
 private:
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pointcloud_map_;
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_vector_map_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_vector_map_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::MapHash>::SharedPtr sub_map_hash_;
   rclcpp::Subscription<autoware_map_msgs::msg::PointCloudMapMetaData>::SharedPtr
     sub_pointcloud_metadata_;
@@ -76,7 +76,7 @@ private:
   void onPointcloudMap(const sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_map);
   void onMapHash(const tier4_external_api_msgs::msg::MapHash::ConstSharedPtr map_hash);
   void timerCallback();
-  void onVectorMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map);
+  void onVectorMap(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr vector_map);
   void onPointCloudMapMetaData(
     const autoware_map_msgs::msg::PointCloudMapMetaData pointcloud_map_metadata);
   void receiveMap();

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>grid_map_cv</depend>
   <depend>grid_map_pcl</depend>

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -93,7 +93,7 @@ ElevationMapLoaderNode::ElevationMapLoaderNode(const rclcpp::NodeOptions & optio
   sub_map_hash_ = create_subscription<tier4_external_api_msgs::msg::MapHash>(
     "/api/autoware/get/map/info/hash", durable_qos,
     std::bind(&ElevationMapLoaderNode::onMapHash, this, _1));
-  sub_vector_map_ = this->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  sub_vector_map_ = this->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "input/vector_map", durable_qos, std::bind(&ElevationMapLoaderNode::onVectorMap, this, _1));
   if (use_sequential_load) {
     {
@@ -237,7 +237,7 @@ void ElevationMapLoaderNode::onPointCloudMapMetaData(
 }
 
 void ElevationMapLoaderNode::onVectorMap(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map)
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr vector_map)
 {
   RCLCPP_INFO(this->get_logger(), "subscribe vector_map");
   data_manager_.lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();

--- a/perception/euclidean_cluster/lib/utils.cpp
+++ b/perception/euclidean_cluster/lib/utils.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "euclidean_cluster/utils.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tier4_perception_msgs/msg/detected_object_with_feature.hpp>
@@ -55,8 +55,8 @@ void convertPointCloudClusters2Msg(
     feature_object.feature.cluster = ros_pointcloud;
     feature_object.object.kinematics.pose_with_covariance.pose.position =
       getCentroid(ros_pointcloud);
-    autoware_auto_perception_msgs::msg::ObjectClassification classification;
-    classification.label = autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+    autoware_perception_msgs::msg::ObjectClassification classification;
+    classification.label = autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
     classification.probability = 1.0f;
     feature_object.object.classification.emplace_back(classification);
     msg.feature_objects.push_back(feature_object);
@@ -73,8 +73,8 @@ void convertPointCloudClusters2Msg(
     feature_object.feature.cluster = ros_pointcloud;
     feature_object.object.kinematics.pose_with_covariance.pose.position =
       getCentroid(ros_pointcloud);
-    autoware_auto_perception_msgs::msg::ObjectClassification classification;
-    classification.label = autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+    autoware_perception_msgs::msg::ObjectClassification classification;
+    classification.label = autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
     classification.probability = 1.0f;
     feature_object.object.classification.emplace_back(classification);
     msg.feature_objects.push_back(feature_object);

--- a/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -149,8 +149,8 @@ bool VoxelGridBasedEuclideanCluster::cluster(
 
       feature_object.object.kinematics.pose_with_covariance.pose.position =
         getCentroid(feature_object.feature.cluster);
-      autoware_auto_perception_msgs::msg::ObjectClassification classification;
-      classification.label = autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+      autoware_perception_msgs::msg::ObjectClassification classification;
+      classification.label = autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
       classification.probability = 1.0f;
       feature_object.object.classification.emplace_back(classification);
 

--- a/perception/euclidean_cluster/package.xml
+++ b/perception/euclidean_cluster/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>compare_map_segmentation</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>

--- a/perception/image_projection_based_fusion/docs/pointpainting-fusion.md
+++ b/perception/image_projection_based_fusion/docs/pointpainting-fusion.md
@@ -23,11 +23,11 @@ The lidar points are projected onto the output of an image-only 2d object detect
 
 ### Output
 
-| Name                     | Type                                                  | Description              |
-| ------------------------ | ----------------------------------------------------- | ------------------------ |
-| `output`                 | `sensor_msgs::msg::PointCloud2`                       | painted pointcloud       |
-| `~/output/objects`       | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects         |
-| `~/debug/image_raw[0-7]` | `sensor_msgs::msg::Image`                             | images for visualization |
+| Name                     | Type                                             | Description              |
+| ------------------------ | ------------------------------------------------ | ------------------------ |
+| `output`                 | `sensor_msgs::msg::PointCloud2`                  | painted pointcloud       |
+| `~/output/objects`       | `autoware_perception_msgs::msg::DetectedObjects` | detected objects         |
+| `~/debug/image_raw[0-7]` | `sensor_msgs::msg::Image`                        | images for visualization |
 
 ## Parameters
 

--- a/perception/image_projection_based_fusion/docs/roi-detected-object-fusion.md
+++ b/perception/image_projection_based_fusion/docs/roi-detected-object-fusion.md
@@ -23,19 +23,19 @@ The DetectedObject has three possible shape choices/implementations, where the p
 
 | Name                     | Type                                                     | Description                                                |
 | ------------------------ | -------------------------------------------------------- | ---------------------------------------------------------- |
-| `input`                  | `autoware_auto_perception_msgs::msg::DetectedObjects`    | input detected objects                                     |
+| `input`                  | `autoware_perception_msgs::msg::DetectedObjects`         | input detected objects                                     |
 | `input/camera_info[0-7]` | `sensor_msgs::msg::CameraInfo`                           | camera information to project 3d points onto image planes. |
 | `input/rois[0-7]`        | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | ROIs from each image.                                      |
 | `input/image_raw[0-7]`   | `sensor_msgs::msg::Image`                                | images for visualization.                                  |
 
 ### Output
 
-| Name                      | Type                                                  | Description                |
-| ------------------------- | ----------------------------------------------------- | -------------------------- |
-| `output`                  | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects           |
-| `~/debug/image_raw[0-7]`  | `sensor_msgs::msg::Image`                             | images for visualization,  |
-| `~/debug/fused_objects`   | `autoware_auto_perception_msgs::msg::DetectedObjects` | fused detected objects     |
-| `~/debug/ignored_objects` | `autoware_auto_perception_msgs::msg::DetectedObjects` | not fused detected objects |
+| Name                      | Type                                             | Description                |
+| ------------------------- | ------------------------------------------------ | -------------------------- |
+| `output`                  | `autoware_perception_msgs::msg::DetectedObjects` | detected objects           |
+| `~/debug/image_raw[0-7]`  | `sensor_msgs::msg::Image`                        | images for visualization,  |
+| `~/debug/fused_objects`   | `autoware_perception_msgs::msg::DetectedObjects` | fused detected objects     |
+| `~/debug/ignored_objects` | `autoware_perception_msgs::msg::DetectedObjects` | not fused detected objects |
 
 ## Parameters
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/fusion_node.hpp
@@ -20,7 +20,7 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
@@ -46,15 +46,15 @@
 
 namespace image_projection_based_fusion
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 using sensor_msgs::msg::CameraInfo;
 using sensor_msgs::msg::Image;
 using sensor_msgs::msg::PointCloud2;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using tier4_perception_msgs::msg::DetectedObjectWithFeature;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
-using autoware_auto_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::ObjectClassification;
 
 template <class TargetMsg3D, class ObjType, class Msg2D>
 class FusionNode : public rclcpp::Node

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/pointpainting_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/pointpainting_fusion/node.hpp
@@ -31,7 +31,7 @@
 
 namespace image_projection_based_fusion
 {
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 class PointPaintingFusionNode
 : public FusionNode<sensor_msgs::msg::PointCloud2, DetectedObjects, DetectedObjectsWithFeature>

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_detected_object_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_detected_object_fusion/node.hpp
@@ -18,7 +18,7 @@
 #include "image_projection_based_fusion/fusion_node.hpp"
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
 
-#include "autoware_auto_perception_msgs/msg/object_classification.hpp"
+#include "autoware_perception_msgs/msg/object_classification.hpp"
 
 #include <map>
 #include <memory>

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/geometry.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/geometry.hpp
@@ -20,7 +20,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <sensor_msgs/msg/region_of_interest.hpp>
 
@@ -29,7 +29,7 @@
 namespace image_projection_based_fusion
 {
 
-using autoware_auto_perception_msgs::msg::Shape;
+using autoware_perception_msgs::msg::Shape;
 using geometry_msgs::msg::Pose;
 
 double calcIoU(

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/utils.hpp
@@ -39,7 +39,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 
-#include "autoware_auto_perception_msgs/msg/shape.hpp"
+#include "autoware_perception_msgs/msg/shape.hpp"
 #include "tier4_perception_msgs/msg/detected_object_with_feature.hpp"
 
 #include <pcl/point_cloud.h>

--- a/perception/image_projection_based_fusion/package.xml
+++ b/perception/image_projection_based_fusion/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>cv_bridge</depend>
   <depend>euclidean_cluster</depend>

--- a/perception/image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -54,42 +54,42 @@ inline bool isInsideBbox(
 
 inline bool isVehicle(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::CAR ||
-         label2d == autoware_auto_perception_msgs::msg::ObjectClassification::TRUCK ||
-         label2d == autoware_auto_perception_msgs::msg::ObjectClassification::TRAILER ||
-         label2d == autoware_auto_perception_msgs::msg::ObjectClassification::BUS;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::CAR ||
+         label2d == autoware_perception_msgs::msg::ObjectClassification::TRUCK ||
+         label2d == autoware_perception_msgs::msg::ObjectClassification::TRAILER ||
+         label2d == autoware_perception_msgs::msg::ObjectClassification::BUS;
 }
 
 inline bool isCar(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::CAR;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::CAR;
 }
 
 inline bool isTruck(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::TRUCK ||
-         label2d == autoware_auto_perception_msgs::msg::ObjectClassification::TRAILER;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::TRUCK ||
+         label2d == autoware_perception_msgs::msg::ObjectClassification::TRAILER;
 }
 
 inline bool isBus(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::BUS;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::BUS;
 }
 
 inline bool isPedestrian(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::PEDESTRIAN;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN;
 }
 
 inline bool isBicycle(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::BICYCLE ||
-         label2d == autoware_auto_perception_msgs::msg::ObjectClassification::MOTORCYCLE;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::BICYCLE ||
+         label2d == autoware_perception_msgs::msg::ObjectClassification::MOTORCYCLE;
 }
 
 inline bool isUnknown(int label2d)
 {
-  return label2d == autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+  return label2d == autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
 }
 
 PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & options)
@@ -398,15 +398,15 @@ void PointPaintingFusionNode::postprocess(sensor_msgs::msg::PointCloud2 & painte
     return;
   }
 
-  std::vector<autoware_auto_perception_msgs::msg::DetectedObject> raw_objects;
+  std::vector<autoware_perception_msgs::msg::DetectedObject> raw_objects;
   raw_objects.reserve(det_boxes3d.size());
   for (const auto & box3d : det_boxes3d) {
-    autoware_auto_perception_msgs::msg::DetectedObject obj;
+    autoware_perception_msgs::msg::DetectedObject obj;
     box3DToDetectedObject(box3d, class_names_, has_twist_, has_variance_, obj);
     raw_objects.emplace_back(obj);
   }
 
-  autoware_auto_perception_msgs::msg::DetectedObjects output_msg;
+  autoware_perception_msgs::msg::DetectedObjects output_msg;
   output_msg.header = painted_pointcloud_msg.header;
   output_msg.objects = iou_bev_nms_.apply(raw_objects);
 

--- a/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -53,7 +53,7 @@ void RoiClusterFusionNode::preprocess(DetectedObjectsWithFeature & output_cluste
   if (!use_cluster_semantic_type_) {
     for (auto & feature_object : output_cluster_msg.feature_objects) {
       feature_object.object.classification.front().label =
-        autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+        autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
       feature_object.object.existence_probability = 0.0;
     }
   }
@@ -68,7 +68,7 @@ void RoiClusterFusionNode::postprocess(DetectedObjectsWithFeature & output_clust
   known_objects.feature_objects.reserve(output_cluster_msg.feature_objects.size());
   for (auto & feature_object : output_cluster_msg.feature_objects) {
     bool is_roi_label_known = feature_object.object.classification.front().label !=
-                              autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+                              autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
     if (
       is_roi_label_known ||
       feature_object.object.existence_probability >= min_roi_existence_prob_) {

--- a/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -87,7 +87,7 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
   for (const auto & feature_obj : input_roi_msg.feature_objects) {
     if (fuse_unknown_only_) {
       bool is_roi_label_unknown = feature_obj.object.classification.front().label ==
-                                  autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+                                  autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
       if (is_roi_label_unknown) {
         output_objs.push_back(feature_obj);
       }

--- a/perception/image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/image_projection_based_fusion/src/utils/utils.cpp
@@ -204,7 +204,7 @@ void addShapeAndKinematic(
   polygon_centroid.x = polygon_centroid.x / static_cast<double>(cluster2d_convex.size());
   polygon_centroid.y = polygon_centroid.y / static_cast<double>(cluster2d_convex.size());
 
-  autoware_auto_perception_msgs::msg::Shape shape;
+  autoware_perception_msgs::msg::Shape shape;
   for (size_t i = 0; i < cluster2d_convex.size(); ++i) {
     geometry_msgs::msg::Point32 point;
     point.x = cluster2d_convex.at(i).x / 1000.0;
@@ -212,7 +212,7 @@ void addShapeAndKinematic(
     point.z = 0.0;
     shape.footprint.points.push_back(point);
   }
-  shape.type = autoware_auto_perception_msgs::msg::Shape::POLYGON;
+  shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
   constexpr float eps = 0.01;
   shape.dimensions.x = 0;
   shape.dimensions.y = 0;

--- a/perception/image_projection_based_fusion/test/test_geometry.cpp
+++ b/perception/image_projection_based_fusion/test/test_geometry.cpp
@@ -30,7 +30,7 @@ TEST(objectToVertices, test_objectToVertices)
   pose.orientation.z = std::sin(angle);
   pose.orientation.w = std::cos(angle);
   {
-    autoware_auto_perception_msgs::msg::Shape shape;
+    autoware_perception_msgs::msg::Shape shape;
     shape.type = 0;
     shape.dimensions.x = 4.0;
     shape.dimensions.y = 6.0;
@@ -50,7 +50,7 @@ TEST(objectToVertices, test_objectToVertices)
 
   {
     // Test at Shape::CYLINDER
-    autoware_auto_perception_msgs::msg::Shape shape;
+    autoware_perception_msgs::msg::Shape shape;
     shape.type = 1;
     shape.dimensions.x = 4.0;
     shape.dimensions.y = 6.0;
@@ -70,7 +70,7 @@ TEST(objectToVertices, test_objectToVertices)
 
   {
     // Test at Shape::POLYGON (Nothing to do)
-    autoware_auto_perception_msgs::msg::Shape shape;
+    autoware_perception_msgs::msg::Shape shape;
     shape.type = 2;
     std::vector<Eigen::Vector3d> vertices;
 

--- a/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 project(lidar_apollo_instance_segmentation)
 
 find_package(ament_cmake REQUIRED)
+find_package(autoware_perception_msgs REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -40,6 +41,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   ${cuda_utils_INCLUDE_DIRS}
   ${pcl_conversions_INCLUDE_DIRS}
   ${tier4_autoware_utils_INCLUDE_DIRS}
+  ${autoware_perception_msgs_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/perception/lidar_apollo_instance_segmentation/package.xml
+++ b/perception/lidar_apollo_instance_segmentation/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>cuda_utils</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/perception/lidar_apollo_instance_segmentation/src/cluster2d.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/cluster2d.cpp
@@ -46,8 +46,8 @@
 
 #include "lidar_apollo_instance_segmentation/cluster2d.hpp"
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
 #ifdef ROS_DISTRO_GALACTIC
@@ -252,14 +252,14 @@ void Cluster2D::classify(const float * inferred_data)
 tier4_perception_msgs::msg::DetectedObjectWithFeature Cluster2D::obstacleToObject(
   const Obstacle & in_obstacle, const std_msgs::msg::Header & in_header)
 {
-  using autoware_auto_perception_msgs::msg::DetectedObjectKinematics;
-  using autoware_auto_perception_msgs::msg::ObjectClassification;
+  using autoware_perception_msgs::msg::DetectedObjectKinematics;
+  using autoware_perception_msgs::msg::ObjectClassification;
 
   tier4_perception_msgs::msg::DetectedObjectWithFeature resulting_object;
   // pcl::PointCloud<pcl::PointXYZI> in_cluster = *(in_obstacle.cloud_ptr);
 
   resulting_object.object.classification.emplace_back(
-    autoware_auto_perception_msgs::build<ObjectClassification>()
+    autoware_perception_msgs::build<ObjectClassification>()
       .label(ObjectClassification::UNKNOWN)
       .probability(in_obstacle.score));
   if (in_obstacle.meta_type == MetaType::META_PEDESTRIAN) {

--- a/perception/lidar_apollo_instance_segmentation/src/debugger.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/debugger.cpp
@@ -14,7 +14,7 @@
 
 #include "lidar_apollo_instance_segmentation/debugger.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/point_cloud.h>
@@ -32,7 +32,7 @@ Debugger::Debugger(rclcpp::Node * node)
 void Debugger::publishColoredPointCloud(
   const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input)
 {
-  using autoware_auto_perception_msgs::msg::ObjectClassification;
+  using autoware_perception_msgs::msg::ObjectClassification;
   pcl::PointCloud<pcl::PointXYZRGB> colored_pointcloud;
   for (size_t i = 0; i < input.feature_objects.size(); i++) {
     pcl::PointCloud<pcl::PointXYZI> object_pointcloud;

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/cluster2d.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/cluster2d.hpp
@@ -19,7 +19,6 @@
 #include <lidar_apollo_segmentation_tvm/util.hpp>
 #include <lidar_apollo_segmentation_tvm/visibility_control.hpp>
 
-#include <autoware_auto_perception_msgs/msg/point_clusters.hpp>
 #include <tier4_perception_msgs/msg/detected_object_with_feature.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 

--- a/perception/lidar_apollo_segmentation_tvm/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm/package.xml
@@ -13,7 +13,7 @@
 
   <build_depend>libpcl-all-dev</build_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>

--- a/perception/lidar_apollo_segmentation_tvm/src/cluster2d.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/cluster2d.cpp
@@ -14,7 +14,7 @@
 
 #include <lidar_apollo_segmentation_tvm/cluster2d.hpp>
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <geometry_msgs/msg/point32.hpp>
 
 #include <pcl/PCLPointCloud2.h>
@@ -235,13 +235,13 @@ void Cluster2D::classify(const float * inferred_data)
 tier4_perception_msgs::msg::DetectedObjectWithFeature Cluster2D::obstacleToObject(
   const Obstacle & in_obstacle) const
 {
-  using autoware_auto_perception_msgs::msg::DetectedObjectKinematics;
-  using autoware_auto_perception_msgs::msg::ObjectClassification;
+  using autoware_perception_msgs::msg::DetectedObjectKinematics;
+  using autoware_perception_msgs::msg::ObjectClassification;
 
   tier4_perception_msgs::msg::DetectedObjectWithFeature resulting_object;
 
   resulting_object.object.classification.emplace_back(
-    autoware_auto_perception_msgs::build<ObjectClassification>()
+    autoware_perception_msgs::build<ObjectClassification>()
       .label(ObjectClassification::UNKNOWN)
       .probability(in_obstacle.score));
   if (in_obstacle.meta_type == MetaType::META_PEDESTRIAN) {

--- a/perception/lidar_centerpoint/README.md
+++ b/perception/lidar_centerpoint/README.md
@@ -20,11 +20,11 @@ We trained the models using <https://github.com/open-mmlab/mmdetection3d>.
 
 ### Output
 
-| Name                       | Type                                                  | Description          |
-| -------------------------- | ----------------------------------------------------- | -------------------- |
-| `~/output/objects`         | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects     |
-| `debug/cyclic_time_ms`     | `tier4_debug_msgs::msg::Float64Stamped`               | cyclic time (msg)    |
-| `debug/processing_time_ms` | `tier4_debug_msgs::msg::Float64Stamped`               | processing time (ms) |
+| Name                       | Type                                             | Description          |
+| -------------------------- | ------------------------------------------------ | -------------------- |
+| `~/output/objects`         | `autoware_perception_msgs::msg::DetectedObjects` | detected objects     |
+| `debug/cyclic_time_ms`     | `tier4_debug_msgs::msg::Float64Stamped`          | cyclic time (msg)    |
+| `debug/processing_time_ms` | `tier4_debug_msgs::msg::Float64Stamped`          | processing time (ms) |
 
 ## Parameters
 

--- a/perception/lidar_centerpoint/include/lidar_centerpoint/detection_class_remapper.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/detection_class_remapper.hpp
@@ -17,10 +17,10 @@
 
 #include <Eigen/Core>
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <vector>
 
@@ -33,7 +33,7 @@ public:
   void setParameters(
     const std::vector<int64_t> & allow_remapping_by_area_matrix,
     const std::vector<double> & min_area_matrix, const std::vector<double> & max_area_matrix);
-  void mapClasses(autoware_auto_perception_msgs::msg::DetectedObjects & msg);
+  void mapClasses(autoware_perception_msgs::msg::DetectedObjects & msg);
 
 protected:
   Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic> allow_remapping_by_area_matrix_;

--- a/perception/lidar_centerpoint/include/lidar_centerpoint/node.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/node.hpp
@@ -24,10 +24,10 @@
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <memory>
@@ -49,7 +49,7 @@ private:
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
 
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
 
   float score_threshold_{0.0};
   std::vector<std::string> class_names_;

--- a/perception/lidar_centerpoint/include/lidar_centerpoint/postprocess/non_maximum_suppression.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/postprocess/non_maximum_suppression.hpp
@@ -19,14 +19,14 @@
 
 #include <Eigen/Eigen>
 
-#include "autoware_auto_perception_msgs/msg/detected_object.hpp"
+#include "autoware_perception_msgs/msg/detected_object.hpp"
 
 #include <string>
 #include <vector>
 
 namespace centerpoint
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObject;
 
 // TODO(yukke42): now only support IoU_BEV
 enum class NMS_TYPE {

--- a/perception/lidar_centerpoint/include/lidar_centerpoint/ros_utils.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/ros_utils.hpp
@@ -19,10 +19,10 @@
 
 #include <lidar_centerpoint/utils.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <string>
 #include <vector>
@@ -32,7 +32,7 @@ namespace centerpoint
 
 void box3DToDetectedObject(
   const Box3D & box3d, const std::vector<std::string> & class_names, const bool has_twist,
-  const bool has_variance, autoware_auto_perception_msgs::msg::DetectedObject & obj);
+  const bool has_variance, autoware_perception_msgs::msg::DetectedObject & obj);
 
 uint8_t getSemanticType(const std::string & class_name);
 

--- a/perception/lidar_centerpoint/lib/detection_class_remapper.cpp
+++ b/perception/lidar_centerpoint/lib/detection_class_remapper.cpp
@@ -48,7 +48,7 @@ void DetectionClassRemapper::setParameters(
     [](double v) { return std::isfinite(v) ? v : std::numeric_limits<double>::max(); });
 }
 
-void DetectionClassRemapper::mapClasses(autoware_auto_perception_msgs::msg::DetectedObjects & msg)
+void DetectionClassRemapper::mapClasses(autoware_perception_msgs::msg::DetectedObjects & msg)
 {
   for (auto & object : msg.objects) {
     const float bev_area = object.shape.dimensions.x * object.shape.dimensions.y;

--- a/perception/lidar_centerpoint/lib/ros_utils.cpp
+++ b/perception/lidar_centerpoint/lib/ros_utils.cpp
@@ -21,17 +21,17 @@
 namespace centerpoint
 {
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 void box3DToDetectedObject(
   const Box3D & box3d, const std::vector<std::string> & class_names, const bool has_twist,
-  const bool has_variance, autoware_auto_perception_msgs::msg::DetectedObject & obj)
+  const bool has_variance, autoware_perception_msgs::msg::DetectedObject & obj)
 {
   // TODO(yukke42): the value of classification confidence of DNN, not probability.
   obj.existence_probability = box3d.score;
 
   // classification
-  autoware_auto_perception_msgs::msg::ObjectClassification classification;
+  autoware_perception_msgs::msg::ObjectClassification classification;
   classification.probability = 1.0f;
   if (box3d.label >= 0 && static_cast<size_t>(box3d.label) < class_names.size()) {
     classification.label = getSemanticType(class_names[box3d.label]);
@@ -43,7 +43,7 @@ void box3DToDetectedObject(
 
   if (object_recognition_utils::isCarLikeVehicle(classification.label)) {
     obj.kinematics.orientation_availability =
-      autoware_auto_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
+      autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
   }
 
   obj.classification.emplace_back(classification);
@@ -55,7 +55,7 @@ void box3DToDetectedObject(
     tier4_autoware_utils::createPoint(box3d.x, box3d.y, box3d.z);
   obj.kinematics.pose_with_covariance.pose.orientation =
     tier4_autoware_utils::createQuaternionFromYaw(yaw);
-  obj.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  obj.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   obj.shape.dimensions =
     tier4_autoware_utils::createTranslation(box3d.length, box3d.width, box3d.height);
   if (has_variance) {

--- a/perception/lidar_centerpoint/package.xml
+++ b/perception/lidar_centerpoint/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>object_recognition_utils</depend>
   <depend>pcl_ros</depend>
   <depend>python3-open3d</depend>

--- a/perception/lidar_centerpoint/src/node.cpp
+++ b/perception/lidar_centerpoint/src/node.cpp
@@ -112,7 +112,7 @@ LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_opti
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "~/input/pointcloud", rclcpp::SensorDataQoS{}.keep_last(1),
     std::bind(&LidarCenterPointNode::pointCloudCallback, this, std::placeholders::_1));
-  objects_pub_ = this->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS{1});
 
   // initialize debug tool
@@ -151,15 +151,15 @@ void LidarCenterPointNode::pointCloudCallback(
     return;
   }
 
-  std::vector<autoware_auto_perception_msgs::msg::DetectedObject> raw_objects;
+  std::vector<autoware_perception_msgs::msg::DetectedObject> raw_objects;
   raw_objects.reserve(det_boxes3d.size());
   for (const auto & box3d : det_boxes3d) {
-    autoware_auto_perception_msgs::msg::DetectedObject obj;
+    autoware_perception_msgs::msg::DetectedObject obj;
     box3DToDetectedObject(box3d, class_names_, has_twist_, has_variance_, obj);
     raw_objects.emplace_back(obj);
   }
 
-  autoware_auto_perception_msgs::msg::DetectedObjects output_msg;
+  autoware_perception_msgs::msg::DetectedObjects output_msg;
   output_msg.header = input_pointcloud_msg->header;
   output_msg.objects = iou_bev_nms_.apply(raw_objects);
 

--- a/perception/lidar_centerpoint/test/test_detection_class_remapper.cpp
+++ b/perception/lidar_centerpoint/test/test_detection_class_remapper.cpp
@@ -33,11 +33,11 @@ TEST(DetectionClassRemapperTest, MapClasses)
   remapper.setParameters(allow_remapping_by_area_matrix, min_area_matrix, max_area_matrix);
 
   // Create a DetectedObjects message with some objects
-  autoware_auto_perception_msgs::msg::DetectedObjects msg;
+  autoware_perception_msgs::msg::DetectedObjects msg;
 
   // CAR with area 4.0, which is out of the range for remapping
-  autoware_auto_perception_msgs::msg::DetectedObject obj1;
-  autoware_auto_perception_msgs::msg::ObjectClassification obj1_classification;
+  autoware_perception_msgs::msg::DetectedObject obj1;
+  autoware_perception_msgs::msg::ObjectClassification obj1_classification;
   obj1.shape.dimensions.x = 2.0;
   obj1.shape.dimensions.y = 2.0;
   obj1_classification.label = 0;
@@ -46,8 +46,8 @@ TEST(DetectionClassRemapperTest, MapClasses)
   msg.objects.push_back(obj1);
 
   // TRUCK with area 16.0, which is in the range for remapping to TRAILER
-  autoware_auto_perception_msgs::msg::DetectedObject obj2;
-  autoware_auto_perception_msgs::msg::ObjectClassification obj2_classification;
+  autoware_perception_msgs::msg::DetectedObject obj2;
+  autoware_perception_msgs::msg::ObjectClassification obj2_classification;
   obj2.shape.dimensions.x = 8.0;
   obj2.shape.dimensions.y = 2.0;
   obj2_classification.label = 1;
@@ -56,8 +56,8 @@ TEST(DetectionClassRemapperTest, MapClasses)
   msg.objects.push_back(obj2);
 
   // TRAILER with area 9.0, which is in the range for remapping to TRUCK
-  autoware_auto_perception_msgs::msg::DetectedObject obj3;
-  autoware_auto_perception_msgs::msg::ObjectClassification obj3_classification;
+  autoware_perception_msgs::msg::DetectedObject obj3;
+  autoware_perception_msgs::msg::ObjectClassification obj3_classification;
   obj3.shape.dimensions.x = 3.0;
   obj3.shape.dimensions.y = 3.0;
   obj3_classification.label = 2;
@@ -66,8 +66,8 @@ TEST(DetectionClassRemapperTest, MapClasses)
   msg.objects.push_back(obj3);
 
   // TRAILER with area 12.0, which is out of the range for remapping
-  autoware_auto_perception_msgs::msg::DetectedObject obj4;
-  autoware_auto_perception_msgs::msg::ObjectClassification obj4_classification;
+  autoware_perception_msgs::msg::DetectedObject obj4;
+  autoware_perception_msgs::msg::ObjectClassification obj4_classification;
   obj4.shape.dimensions.x = 4.0;
   obj4.shape.dimensions.y = 3.0;
   obj4_classification.label = 2;

--- a/perception/lidar_centerpoint/test/test_nms.cpp
+++ b/perception/lidar_centerpoint/test/test_nms.cpp
@@ -29,7 +29,7 @@ TEST(NonMaximumSuppressionTest, Apply)
   std::vector<centerpoint::DetectedObject> input_objects(4);
 
   // Object 1
-  autoware_auto_perception_msgs::msg::ObjectClassification obj1_classification;
+  autoware_perception_msgs::msg::ObjectClassification obj1_classification;
   obj1_classification.label = 0;  // Assuming "car" has label 0
   obj1_classification.probability = 1.0;
   input_objects[0].classification = {obj1_classification};  // Assuming "car" has label 0
@@ -39,12 +39,12 @@ TEST(NonMaximumSuppressionTest, Apply)
   input_objects[0].kinematics.pose_with_covariance.pose.orientation.y = 0.0;
   input_objects[0].kinematics.pose_with_covariance.pose.orientation.z = 0.0;
   input_objects[0].kinematics.pose_with_covariance.pose.orientation.w = 1.0;
-  input_objects[0].shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  input_objects[0].shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   input_objects[0].shape.dimensions.x = 4.0;
   input_objects[0].shape.dimensions.y = 2.0;
 
   // Object 2 (overlaps with Object 1)
-  autoware_auto_perception_msgs::msg::ObjectClassification obj2_classification;
+  autoware_perception_msgs::msg::ObjectClassification obj2_classification;
   obj2_classification.label = 0;  // Assuming "car" has label 0
   obj2_classification.probability = 1.0;
   input_objects[1].classification = {obj2_classification};  // Assuming "car" has label 0
@@ -54,12 +54,12 @@ TEST(NonMaximumSuppressionTest, Apply)
   input_objects[1].kinematics.pose_with_covariance.pose.orientation.y = 0.0;
   input_objects[1].kinematics.pose_with_covariance.pose.orientation.z = 0.0;
   input_objects[1].kinematics.pose_with_covariance.pose.orientation.w = 1.0;
-  input_objects[1].shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  input_objects[1].shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   input_objects[1].shape.dimensions.x = 4.0;
   input_objects[1].shape.dimensions.y = 2.0;
 
   // Object 3
-  autoware_auto_perception_msgs::msg::ObjectClassification obj3_classification;
+  autoware_perception_msgs::msg::ObjectClassification obj3_classification;
   obj3_classification.label = 0;  // Assuming "car" has label 0
   obj3_classification.probability = 1.0;
   input_objects[2].classification = {obj3_classification};  // Assuming "car" has label 0
@@ -69,12 +69,12 @@ TEST(NonMaximumSuppressionTest, Apply)
   input_objects[2].kinematics.pose_with_covariance.pose.orientation.y = 0.0;
   input_objects[2].kinematics.pose_with_covariance.pose.orientation.z = 0.0;
   input_objects[2].kinematics.pose_with_covariance.pose.orientation.w = 1.0;
-  input_objects[2].shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  input_objects[2].shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   input_objects[2].shape.dimensions.x = 4.0;
   input_objects[2].shape.dimensions.y = 2.0;
 
   // Object 4 (different class)
-  autoware_auto_perception_msgs::msg::ObjectClassification obj4_classification;
+  autoware_perception_msgs::msg::ObjectClassification obj4_classification;
   obj4_classification.label = 1;  // Assuming "pedestrian" has label 1
   obj4_classification.probability = 1.0;
   input_objects[3].classification = {obj4_classification};  // Assuming "pedestrian" has label 1
@@ -84,7 +84,7 @@ TEST(NonMaximumSuppressionTest, Apply)
   input_objects[3].kinematics.pose_with_covariance.pose.orientation.y = 0.0;
   input_objects[3].kinematics.pose_with_covariance.pose.orientation.z = 0.0;
   input_objects[3].kinematics.pose_with_covariance.pose.orientation.w = 1.0;
-  input_objects[3].shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  input_objects[3].shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   input_objects[3].shape.dimensions.x = 0.5;
   input_objects[3].shape.dimensions.y = 0.5;
 

--- a/perception/lidar_centerpoint/test/test_ros_utils.cpp
+++ b/perception/lidar_centerpoint/test/test_ros_utils.cpp
@@ -42,12 +42,12 @@ TEST(TestSuite, box3DToDetectedObject)
     box3d.vel_x_variance = 0.5;
     box3d.vel_y_variance = 0.6;
 
-    autoware_auto_perception_msgs::msg::DetectedObject obj;
+    autoware_perception_msgs::msg::DetectedObject obj;
     centerpoint::box3DToDetectedObject(box3d, class_names, true, true, obj);
 
     EXPECT_FLOAT_EQ(obj.existence_probability, 0.8f);
     EXPECT_EQ(
-      obj.classification[0].label, autoware_auto_perception_msgs::msg::ObjectClassification::CAR);
+      obj.classification[0].label, autoware_perception_msgs::msg::ObjectClassification::CAR);
     EXPECT_FLOAT_EQ(obj.kinematics.pose_with_covariance.pose.position.x, 1.0);
     EXPECT_FLOAT_EQ(obj.kinematics.pose_with_covariance.pose.position.y, 2.0);
     EXPECT_FLOAT_EQ(obj.kinematics.pose_with_covariance.pose.position.z, 3.0);
@@ -65,13 +65,12 @@ TEST(TestSuite, box3DToDetectedObject)
     box3d.score = 0.5f;
     box3d.label = 10;  // Invalid
 
-    autoware_auto_perception_msgs::msg::DetectedObject obj;
+    autoware_perception_msgs::msg::DetectedObject obj;
     centerpoint::box3DToDetectedObject(box3d, class_names, false, false, obj);
 
     EXPECT_FLOAT_EQ(obj.existence_probability, 0.5f);
     EXPECT_EQ(
-      obj.classification[0].label,
-      autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN);
+      obj.classification[0].label, autoware_perception_msgs::msg::ObjectClassification::UNKNOWN);
     EXPECT_FALSE(obj.kinematics.has_position_covariance);
     EXPECT_FALSE(obj.kinematics.has_twist);
     EXPECT_FALSE(obj.kinematics.has_twist_covariance);
@@ -81,29 +80,27 @@ TEST(TestSuite, box3DToDetectedObject)
 TEST(TestSuite, getSemanticType)
 {
   EXPECT_EQ(
-    centerpoint::getSemanticType("CAR"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::CAR);
+    centerpoint::getSemanticType("CAR"), autoware_perception_msgs::msg::ObjectClassification::CAR);
   EXPECT_EQ(
     centerpoint::getSemanticType("TRUCK"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::TRUCK);
+    autoware_perception_msgs::msg::ObjectClassification::TRUCK);
   EXPECT_EQ(
-    centerpoint::getSemanticType("BUS"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::BUS);
+    centerpoint::getSemanticType("BUS"), autoware_perception_msgs::msg::ObjectClassification::BUS);
   EXPECT_EQ(
     centerpoint::getSemanticType("TRAILER"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::TRAILER);
+    autoware_perception_msgs::msg::ObjectClassification::TRAILER);
   EXPECT_EQ(
     centerpoint::getSemanticType("BICYCLE"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::BICYCLE);
+    autoware_perception_msgs::msg::ObjectClassification::BICYCLE);
   EXPECT_EQ(
     centerpoint::getSemanticType("MOTORBIKE"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::MOTORCYCLE);
+    autoware_perception_msgs::msg::ObjectClassification::MOTORCYCLE);
   EXPECT_EQ(
     centerpoint::getSemanticType("PEDESTRIAN"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
+    autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
   EXPECT_EQ(
     centerpoint::getSemanticType("UNKNOWN"),
-    autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN);
+    autoware_perception_msgs::msg::ObjectClassification::UNKNOWN);
 }
 
 TEST(TestSuite, convertPoseCovarianceMatrix)

--- a/perception/lidar_centerpoint_tvm/README.md
+++ b/perception/lidar_centerpoint_tvm/README.md
@@ -28,11 +28,11 @@ It defaults to `llvm`.
 
 ### Output
 
-| Name                       | Type                                                  | Description          |
-| -------------------------- | ----------------------------------------------------- | -------------------- |
-| `~/output/objects`         | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects     |
-| `debug/cyclic_time_ms`     | `tier4_debug_msgs::msg::Float64Stamped`               | cyclic time (msg)    |
-| `debug/processing_time_ms` | `tier4_debug_msgs::msg::Float64Stamped`               | processing time (ms) |
+| Name                       | Type                                             | Description          |
+| -------------------------- | ------------------------------------------------ | -------------------- |
+| `~/output/objects`         | `autoware_perception_msgs::msg::DetectedObjects` | detected objects     |
+| `debug/cyclic_time_ms`     | `tier4_debug_msgs::msg::Float64Stamped`          | cyclic time (msg)    |
+| `debug/processing_time_ms` | `tier4_debug_msgs::msg::Float64Stamped`          | processing time (ms) |
 
 ## Parameters
 

--- a/perception/lidar_centerpoint_tvm/include/lidar_centerpoint_tvm/node.hpp
+++ b/perception/lidar_centerpoint_tvm/include/lidar_centerpoint_tvm/node.hpp
@@ -21,10 +21,10 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <memory>
@@ -49,7 +49,7 @@ private:
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
 
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
 
   float score_threshold_{0.0};
   std::vector<std::string> class_names_;

--- a/perception/lidar_centerpoint_tvm/include/lidar_centerpoint_tvm/ros_utils.hpp
+++ b/perception/lidar_centerpoint_tvm/include/lidar_centerpoint_tvm/ros_utils.hpp
@@ -17,10 +17,10 @@
 
 #include <lidar_centerpoint_tvm/utils.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <string>
 #include <vector>
@@ -34,7 +34,7 @@ namespace lidar_centerpoint_tvm
 void box3DToDetectedObject(
   const Box3D & box3d, const std::vector<std::string> & class_names,
   const bool rename_car_to_truck_and_bus, const bool has_twist,
-  autoware_auto_perception_msgs::msg::DetectedObject & obj);
+  autoware_perception_msgs::msg::DetectedObject & obj);
 
 uint8_t getSemanticType(const std::string & class_name);
 

--- a/perception/lidar_centerpoint_tvm/include/lidar_centerpoint_tvm/single_inference_node.hpp
+++ b/perception/lidar_centerpoint_tvm/include/lidar_centerpoint_tvm/single_inference_node.hpp
@@ -20,10 +20,10 @@
 #include <lidar_centerpoint_tvm/visibility_control.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <memory>
 #include <string>
@@ -43,9 +43,9 @@ public:
 private:
   void detect(const std::string & pcd_path, const std::string & detections_path);
   std::vector<Eigen::Vector3d> getVertices(
-    const autoware_auto_perception_msgs::msg::Shape & shape, const Eigen::Affine3d & pose) const;
+    const autoware_perception_msgs::msg::Shape & shape, const Eigen::Affine3d & pose) const;
   void dumpDetectionsAsMesh(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & objects_msg,
+    const autoware_perception_msgs::msg::DetectedObjects & objects_msg,
     const std::string & output_path) const;
 
   tf2_ros::Buffer tf_buffer_;

--- a/perception/lidar_centerpoint_tvm/lib/ros_utils.cpp
+++ b/perception/lidar_centerpoint_tvm/lib/ros_utils.cpp
@@ -24,18 +24,18 @@ namespace perception
 namespace lidar_centerpoint_tvm
 {
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 void box3DToDetectedObject(
   const Box3D & box3d, const std::vector<std::string> & class_names,
   const bool rename_car_to_truck_and_bus, const bool has_twist,
-  autoware_auto_perception_msgs::msg::DetectedObject & obj)
+  autoware_perception_msgs::msg::DetectedObject & obj)
 {
   // TODO(yukke42): the value of classification confidence of DNN, not probability.
   obj.existence_probability = box3d.score;
 
   // classification
-  autoware_auto_perception_msgs::msg::ObjectClassification classification;
+  autoware_perception_msgs::msg::ObjectClassification classification;
   classification.probability = 1.0f;
   if (box3d.label >= 0 && static_cast<size_t>(box3d.label) < class_names.size()) {
     classification.label = getSemanticType(class_names[box3d.label]);
@@ -58,7 +58,7 @@ void box3DToDetectedObject(
 
   if (isCarLikeVehicleLabel(classification.label)) {
     obj.kinematics.orientation_availability =
-      autoware_auto_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
+      autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
   }
 
   obj.classification.emplace_back(classification);
@@ -70,7 +70,7 @@ void box3DToDetectedObject(
     tier4_autoware_utils::createPoint(box3d.x, box3d.y, box3d.z);
   obj.kinematics.pose_with_covariance.pose.orientation =
     tier4_autoware_utils::createQuaternionFromYaw(yaw);
-  obj.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  obj.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   obj.shape.dimensions =
     tier4_autoware_utils::createTranslation(box3d.length, box3d.width, box3d.height);
 

--- a/perception/lidar_centerpoint_tvm/package.xml
+++ b/perception/lidar_centerpoint_tvm/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/lidar_centerpoint_tvm/src/node.cpp
+++ b/perception/lidar_centerpoint_tvm/src/node.cpp
@@ -89,7 +89,7 @@ LidarCenterPointTVMNode::LidarCenterPointTVMNode(const rclcpp::NodeOptions & nod
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "~/input/pointcloud", rclcpp::SensorDataQoS{}.keep_last(1),
     std::bind(&LidarCenterPointTVMNode::pointCloudCallback, this, std::placeholders::_1));
-  objects_pub_ = this->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS{1});
 
   // initialize debug tool
@@ -122,10 +122,10 @@ void LidarCenterPointTVMNode::pointCloudCallback(
     return;
   }
 
-  autoware_auto_perception_msgs::msg::DetectedObjects output_msg;
+  autoware_perception_msgs::msg::DetectedObjects output_msg;
   output_msg.header = input_pointcloud_msg->header;
   for (const auto & box3d : det_boxes3d) {
-    autoware_auto_perception_msgs::msg::DetectedObject obj;
+    autoware_perception_msgs::msg::DetectedObject obj;
     box3DToDetectedObject(box3d, class_names_, rename_car_to_truck_and_bus_, has_twist_, obj);
     output_msg.objects.emplace_back(obj);
   }

--- a/perception/lidar_centerpoint_tvm/src/single_inference_node.cpp
+++ b/perception/lidar_centerpoint_tvm/src/single_inference_node.cpp
@@ -95,7 +95,7 @@ SingleInferenceLidarCenterPointNode::SingleInferenceLidarCenterPointNode(
 }
 
 std::vector<Eigen::Vector3d> SingleInferenceLidarCenterPointNode::getVertices(
-  const autoware_auto_perception_msgs::msg::Shape & shape, const Eigen::Affine3d & pose) const
+  const autoware_perception_msgs::msg::Shape & shape, const Eigen::Affine3d & pose) const
 {
   std::vector<Eigen::Vector3d> vertices;
   Eigen::Vector3d vertex;
@@ -159,10 +159,10 @@ void SingleInferenceLidarCenterPointNode::detect(
     return;
   }
 
-  autoware_auto_perception_msgs::msg::DetectedObjects output_msg;
+  autoware_perception_msgs::msg::DetectedObjects output_msg;
   output_msg.header = msg.header;
   for (const auto & box3d : det_boxes3d) {
-    autoware_auto_perception_msgs::msg::DetectedObject obj;
+    autoware_perception_msgs::msg::DetectedObject obj;
     box3DToDetectedObject(box3d, class_names_, rename_car_to_truck_and_bus_, has_twist_, obj);
     output_msg.objects.emplace_back(obj);
   }
@@ -175,7 +175,7 @@ void SingleInferenceLidarCenterPointNode::detect(
 }
 
 void SingleInferenceLidarCenterPointNode::dumpDetectionsAsMesh(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & objects_msg,
+  const autoware_perception_msgs::msg::DetectedObjects & objects_msg,
   const std::string & output_path) const
 {
   std::ofstream ofs(output_path, std::ofstream::out);

--- a/perception/map_based_prediction/README.md
+++ b/perception/map_based_prediction/README.md
@@ -210,21 +210,21 @@ If the target object is inside the road or crosswalk, this module outputs one or
 
 ### Input
 
-| Name                                                     | Type                                                 | Description                                                |
-| -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
-| `~/perception/object_recognition/tracking/objects`       | `autoware_auto_perception_msgs::msg::TrackedObjects` | tracking objects without predicted path.                   |
-| `~/vector_map`                                           | `autoware_auto_mapping_msgs::msg::HADMapBin`         | binary data of Lanelet2 Map.                               |
-| '~/perception/traffic_light_recognition/traffic_signals' | 'autoware_perception_msgs::msg::TrafficSignalArray;' | rearranged information on the corresponding traffic lights |
+| Name                                                     | Type                                                    | Description                                                |
+| -------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------- |
+| `~/perception/object_recognition/tracking/objects`       | `autoware_perception_msgs::msg::TrackedObjects`         | tracking objects without predicted path.                   |
+| `~/vector_map`                                           | `autoware_map_msgs::msg::LaneletMapBin`                 | binary data of Lanelet2 Map.                               |
+| `~/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | rearranged information on the corresponding traffic lights |
 
 ### Output
 
-| Name                         | Type                                                   | Description                                                                           |
-| ---------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| `~/input/objects`            | `autoware_auto_perception_msgs::msg::TrackedObjects`   | tracking objects. Default is set to `/perception/object_recognition/tracking/objects` |
-| `~/output/objects`           | `autoware_auto_perception_msgs::msg::PredictedObjects` | tracking objects with predicted path.                                                 |
-| `~/objects_path_markers`     | `visualization_msgs::msg::MarkerArray`                 | marker for visualization.                                                             |
-| `~/debug/processing_time_ms` | `std_msgs::msg::Float64`                               | processing time of this module.                                                       |
-| `~/debug/cyclic_time_ms`     | `std_msgs::msg::Float64`                               | cyclic time of this module.                                                           |
+| Name                         | Type                                              | Description                                                                           |
+| ---------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `~/input/objects`            | `autoware_perception_msgs::msg::TrackedObjects`   | tracking objects. Default is set to `/perception/object_recognition/tracking/objects` |
+| `~/output/objects`           | `autoware_perception_msgs::msg::PredictedObjects` | tracking objects with predicted path.                                                 |
+| `~/objects_path_markers`     | `visualization_msgs::msg::MarkerArray`            | marker for visualization.                                                             |
+| `~/debug/processing_time_ms` | `std_msgs::msg::Float64`                          | processing time of this module.                                                       |
+| `~/debug/cyclic_time_ms`     | `std_msgs::msg::Float64`                          | cyclic time of this module.                                                           |
 
 ## Parameters
 

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -27,11 +27,10 @@
 #include <tier4_autoware_utils/ros/uuid_helper.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
-#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
@@ -89,7 +88,7 @@ struct ObjectData
 struct CrosswalkUserData
 {
   std_msgs::msg::Header header;
-  autoware_auto_perception_msgs::msg::TrackedObject tracked_object;
+  autoware_perception_msgs::msg::TrackedObject tracked_object;
 };
 
 struct LaneletData
@@ -116,19 +115,19 @@ struct PredictionTimeHorizon
 
 using LaneletsData = std::vector<LaneletData>;
 using ManeuverProbability = std::unordered_map<Maneuver, float>;
-using autoware_auto_mapping_msgs::msg::HADMapBin;
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::PredictedObject;
-using autoware_auto_perception_msgs::msg::PredictedObjectKinematics;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_perception_msgs::msg::PredictedPath;
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjectKinematics;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
-using autoware_auto_planning_msgs::msg::TrajectoryPoint;
-using autoware_perception_msgs::msg::TrafficSignal;
-using autoware_perception_msgs::msg::TrafficSignalArray;
-using autoware_perception_msgs::msg::TrafficSignalElement;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjectKinematics;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::PredictedPath;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjectKinematics;
+using autoware_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_autoware_utils::StopWatch;
 using tier4_debug_msgs::msg::StringStamped;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
@@ -142,8 +141,8 @@ private:
   rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_markers_;
   rclcpp::Subscription<TrackedObjects>::SharedPtr sub_objects_;
-  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;
-  rclcpp::Subscription<TrafficSignalArray>::SharedPtr sub_traffic_signals_;
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr sub_traffic_signals_;
 
   // debug publisher
   std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
@@ -160,7 +159,7 @@ private:
   std::shared_ptr<lanelet::routing::RoutingGraph> routing_graph_ptr_;
   std::shared_ptr<lanelet::traffic_rules::TrafficRules> traffic_rules_ptr_;
 
-  std::unordered_map<lanelet::Id, TrafficSignal> traffic_signal_id_map_;
+  std::unordered_map<lanelet::Id, TrafficLightGroup> traffic_signal_id_map_;
 
   // parameter update
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;
@@ -223,8 +222,8 @@ private:
   std::unique_ptr<tier4_autoware_utils::PublishedTimePublisher> published_time_publisher_;
 
   // Member Functions
-  void mapCallback(const HADMapBin::ConstSharedPtr msg);
-  void trafficSignalsCallback(const TrafficSignalArray::ConstSharedPtr msg);
+  void mapCallback(const LaneletMapBin::ConstSharedPtr msg);
+  void trafficSignalsCallback(const TrafficLightGroupArray::ConstSharedPtr msg);
   void objectsCallback(const TrackedObjects::ConstSharedPtr in_objects);
 
   bool doesPathCrossAnyFence(const PredictedPath & predicted_path);
@@ -293,7 +292,7 @@ private:
   bool isDuplicated(
     const PredictedPath & predicted_path, const std::vector<PredictedPath> & predicted_paths);
   std::optional<lanelet::Id> getTrafficSignalId(const lanelet::ConstLanelet & way_lanelet);
-  std::optional<TrafficSignalElement> getTrafficSignalElement(const lanelet::Id & id);
+  std::optional<TrafficLightElement> getTrafficSignalElement(const lanelet::Id & id);
   bool calcIntentionToCrossWithTrafficSignal(
     const TrackedObject & object, const lanelet::ConstLanelet & crosswalk,
     const lanelet::Id & signal_id);

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -18,8 +18,8 @@
 #include <Eigen/Eigen>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
@@ -30,14 +30,14 @@
 
 namespace map_based_prediction
 {
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::PredictedObject;
-using autoware_auto_perception_msgs::msg::PredictedObjectKinematics;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_perception_msgs::msg::PredictedPath;
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjectKinematics;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjectKinematics;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::PredictedPath;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjectKinematics;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 struct FrenetPoint
 {

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>glog</depend>
   <depend>interpolation</depend>

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -911,12 +911,7 @@ PredictedObject MapBasedPredictionNode::convertToPredictedObject(
 {
   PredictedObject predicted_object;
   predicted_object.kinematics = convertToPredictedKinematics(tracked_object.kinematics);
-  autoware_perception_msgs::msg::ObjectClassification classification;
-  for (size_t i = 0; i < tracked_object.classification.size(); i++) {
-    classification.label = tracked_object.classification[i].label;
-    classification.probability = tracked_object.classification[i].probability;
-    predicted_object.classification.push_back(classification);
-  }
+  predicted_object.classification = tracked_object.classification;
   predicted_object.object_id = tracked_object.object_id;
   predicted_object.shape.type = tracked_object.shape.type;
   predicted_object.shape.footprint = tracked_object.shape.footprint;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -25,7 +25,7 @@
 #include <tier4_autoware_utils/math/normalization.hpp>
 #include <tier4_autoware_utils/math/unit_conversion.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
@@ -851,10 +851,10 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   sub_objects_ = this->create_subscription<TrackedObjects>(
     "~/input/objects", 1,
     std::bind(&MapBasedPredictionNode::objectsCallback, this, std::placeholders::_1));
-  sub_map_ = this->create_subscription<HADMapBin>(
+  sub_map_ = this->create_subscription<LaneletMapBin>(
     "/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&MapBasedPredictionNode::mapCallback, this, std::placeholders::_1));
-  sub_traffic_signals_ = this->create_subscription<TrafficSignalArray>(
+  sub_traffic_signals_ = this->create_subscription<TrafficLightGroupArray>(
     "/traffic_signals", 1,
     std::bind(&MapBasedPredictionNode::trafficSignalsCallback, this, std::placeholders::_1));
 
@@ -911,15 +911,22 @@ PredictedObject MapBasedPredictionNode::convertToPredictedObject(
 {
   PredictedObject predicted_object;
   predicted_object.kinematics = convertToPredictedKinematics(tracked_object.kinematics);
-  predicted_object.classification = tracked_object.classification;
+  autoware_perception_msgs::msg::ObjectClassification classification;
+  for (size_t i = 0; i < tracked_object.classification.size(); i++) {
+    classification.label = tracked_object.classification[i].label;
+    classification.probability = tracked_object.classification[i].probability;
+    predicted_object.classification.push_back(classification);
+  }
   predicted_object.object_id = tracked_object.object_id;
-  predicted_object.shape = tracked_object.shape;
+  predicted_object.shape.type = tracked_object.shape.type;
+  predicted_object.shape.footprint = tracked_object.shape.footprint;
+  predicted_object.shape.dimensions = tracked_object.shape.dimensions;
   predicted_object.existence_probability = tracked_object.existence_probability;
 
   return predicted_object;
 }
 
-void MapBasedPredictionNode::mapCallback(const HADMapBin::ConstSharedPtr msg)
+void MapBasedPredictionNode::mapCallback(const LaneletMapBin::ConstSharedPtr msg)
 {
   RCLCPP_DEBUG(get_logger(), "[Map Based Prediction]: Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
@@ -934,11 +941,12 @@ void MapBasedPredictionNode::mapCallback(const HADMapBin::ConstSharedPtr msg)
   crosswalks_.insert(crosswalks_.end(), walkways.begin(), walkways.end());
 }
 
-void MapBasedPredictionNode::trafficSignalsCallback(const TrafficSignalArray::ConstSharedPtr msg)
+void MapBasedPredictionNode::trafficSignalsCallback(
+  const TrafficLightGroupArray::ConstSharedPtr msg)
 {
   traffic_signal_id_map_.clear();
-  for (const auto & signal : msg->signals) {
-    traffic_signal_id_map_[signal.traffic_signal_id] = signal;
+  for (const auto & signal : msg->traffic_light_groups) {
+    traffic_signal_id_map_[signal.traffic_light_group_id] = signal;
   }
 }
 
@@ -1113,7 +1121,7 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         TrackedObject yaw_fixed_transformed_object = transformed_object;
         if (
           transformed_object.kinematics.orientation_availability ==
-          autoware_auto_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE) {
+          autoware_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE) {
           replaceObjectYawWithLaneletsYaw(current_lanelets, yaw_fixed_transformed_object);
         }
         // Generate Predicted Path
@@ -1473,7 +1481,7 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
 {
   if (
     object.kinematics.orientation_availability ==
-    autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
+    autoware_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
     return;
   }
 
@@ -1494,7 +1502,7 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
   if (abs_object_speed < min_abs_speed) return;
 
   switch (object.kinematics.orientation_availability) {
-    case autoware_auto_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN: {
+    case autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN: {
       const auto original_yaw =
         tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
       // flip the angle
@@ -1523,7 +1531,7 @@ void MapBasedPredictionNode::removeStaleTrafficLightInfo(
   for (auto it = stopped_times_against_green_.begin(); it != stopped_times_against_green_.end();) {
     const bool isDisappeared = std::none_of(
       in_objects->objects.begin(), in_objects->objects.end(),
-      [&it](autoware_auto_perception_msgs::msg::TrackedObject obj) {
+      [&it](autoware_perception_msgs::msg::TrackedObject obj) {
         return tier4_autoware_utils::toHexString(obj.object_id) == it->first.first;
       });
     if (isDisappeared) {
@@ -2414,7 +2422,7 @@ std::optional<lanelet::Id> MapBasedPredictionNode::getTrafficSignalId(
   return traffic_light_reg_elems.front()->id();
 }
 
-std::optional<TrafficSignalElement> MapBasedPredictionNode::getTrafficSignalElement(
+std::optional<TrafficLightElement> MapBasedPredictionNode::getTrafficSignalElement(
   const lanelet::Id & id)
 {
   if (traffic_signal_id_map_.count(id) != 0) {
@@ -2435,12 +2443,12 @@ bool MapBasedPredictionNode::calcIntentionToCrossWithTrafficSignal(
 {
   const auto signal_color = [&] {
     const auto elem_opt = getTrafficSignalElement(signal_id);
-    return elem_opt ? elem_opt.value().color : TrafficSignalElement::UNKNOWN;
+    return elem_opt ? elem_opt.value().color : TrafficLightElement::UNKNOWN;
   }();
 
   const auto key = std::make_pair(tier4_autoware_utils::toHexString(object.object_id), signal_id);
   if (
-    signal_color == TrafficSignalElement::GREEN &&
+    signal_color == TrafficLightElement::GREEN &&
     tier4_autoware_utils::calcNorm(object.kinematics.twist_with_covariance.twist.linear) <
       threshold_velocity_assumed_as_stopping_) {
     stopped_times_against_green_.try_emplace(key, this->get_clock()->now());
@@ -2485,7 +2493,7 @@ bool MapBasedPredictionNode::calcIntentionToCrossWithTrafficSignal(
     // If the pedestrian disappears, another function erases the old data.
   }
 
-  if (signal_color == TrafficSignalElement::RED) {
+  if (signal_color == TrafficLightElement::RED) {
     return false;
   }
 

--- a/perception/map_based_prediction/test/map_based_prediction/test_path_generator.cpp
+++ b/perception/map_based_prediction/test/map_based_prediction/test_path_generator.cpp
@@ -17,14 +17,14 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::PredictedObject;
-using autoware_auto_perception_msgs::msg::PredictedObjectKinematics;
-using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_perception_msgs::msg::PredictedPath;
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjectKinematics;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjectKinematics;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::PredictedPath;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjectKinematics;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 TrackedObject generate_static_object(const int label)
 {

--- a/perception/multi_object_tracker/README.md
+++ b/perception/multi_object_tracker/README.md
@@ -57,9 +57,9 @@ Multiple inputs are pre-defined in the input channel parameters (described below
 
 ### Output
 
-| Name       | Type                                                 | Description     |
-| ---------- | ---------------------------------------------------- | --------------- |
-| `~/output` | `autoware_auto_perception_msgs::msg::TrackedObjects` | tracked objects |
+| Name       | Type                                            | Description     |
+| ---------- | ----------------------------------------------- | --------------- |
+| `~/output` | `autoware_perception_msgs::msg::TrackedObjects` | tracked objects |
 
 ## Parameters
 
@@ -67,13 +67,13 @@ Multiple inputs are pre-defined in the input channel parameters (described below
 
 Available input channels are defined in [input_channels.param.yaml](config/input_channels.param.yaml).
 
-| Name                              | Type                                                  | Description                           |
-| --------------------------------- | ----------------------------------------------------- | ------------------------------------- |
-| `<channel>`                       |                                                       | the name of channel                   |
-| `<channel>.topic`                 | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects                      |
-| `<channel>.can_spawn_new_tracker` | `bool`                                                | a switch allow to spawn a new tracker |
-| `<channel>.optional.name`         | `std::string`                                         | channel name for analysis             |
-| `<channel>.optional.short_name`   | `std::string`                                         | short name for visualization          |
+| Name                              | Type                                             | Description                           |
+| --------------------------------- | ------------------------------------------------ | ------------------------------------- |
+| `<channel>`                       |                                                  | the name of channel                   |
+| `<channel>.topic`                 | `autoware_perception_msgs::msg::DetectedObjects` | detected objects                      |
+| `<channel>.can_spawn_new_tracker` | `bool`                                           | a switch allow to spawn a new tracker |
+| `<channel>.optional.name`         | `std::string`                                    | channel name for analysis             |
+| `<channel>.optional.short_name`   | `std::string`                                    | short name for visualization          |
 
 ### Core Parameters
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/data_association/data_association.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/data_association/data_association.hpp
@@ -31,7 +31,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 class DataAssociation
 {
@@ -55,7 +55,7 @@ public:
     const Eigen::MatrixXd & src, std::unordered_map<int, int> & direct_assignment,
     std::unordered_map<int, int> & reverse_assignment);
   Eigen::MatrixXd calcScoreMatrix(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & measurements,
+    const autoware_perception_msgs::msg::DetectedObjects & measurements,
     const std::list<std::shared_ptr<Tracker>> & trackers);
   virtual ~DataAssociation() {}
 };

--- a/perception/multi_object_tracker/include/multi_object_tracker/debugger/debug_object.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/debugger/debug_object.hpp
@@ -21,8 +21,8 @@
 #include <tier4_autoware_utils/ros/uuid_helper.hpp>
 
 #include "unique_identifier_msgs/msg/uuid.hpp"
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -87,7 +87,7 @@ public:
   void collect(
     const rclcpp::Time & message_time, const std::list<std::shared_ptr<Tracker>> & list_tracker,
     const uint & channel_index,
-    const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+    const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
     const std::unordered_map<int, int> & direct_assignment,
     const std::unordered_map<int, int> & reverse_assignment);
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/debugger/debugger.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/debugger/debugger.hpp
@@ -23,8 +23,8 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
 #include <list>
@@ -54,7 +54,7 @@ private:
 
   // ROS node, publishers
   rclcpp::Node & node_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr
     debug_tentative_objects_pub_;
   std::unique_ptr<tier4_autoware_utils::DebugPublisher> processing_time_publisher_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_objects_markers_pub_;
@@ -80,7 +80,7 @@ public:
   // Object publishing
   bool shouldPublishTentativeObjects() const { return debug_settings_.publish_tentative_objects; }
   void publishTentativeObjects(
-    const autoware_auto_perception_msgs::msg::TrackedObjects & tentative_objects) const;
+    const autoware_perception_msgs::msg::TrackedObjects & tentative_objects) const;
 
   // Time measurement
   void startMeasurementTime(
@@ -98,7 +98,7 @@ public:
   void collectObjectInfo(
     const rclcpp::Time & message_time, const std::list<std::shared_ptr<Tracker>> & list_tracker,
     const uint & channel_index,
-    const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+    const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
     const std::unordered_map<int, int> & direct_assignment,
     const std::unordered_map<int, int> & reverse_assignment);
   void publishObjectsMarkers();

--- a/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
@@ -27,8 +27,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
 #include <tf2/LinearMath/Transform.h>
@@ -55,9 +55,9 @@
 namespace multi_object_tracker
 {
 
-using DetectedObject = autoware_auto_perception_msgs::msg::DetectedObject;
-using DetectedObjects = autoware_auto_perception_msgs::msg::DetectedObjects;
-using TrackedObjects = autoware_auto_perception_msgs::msg::TrackedObjects;
+using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
+using DetectedObjects = autoware_perception_msgs::msg::DetectedObjects;
+using TrackedObjects = autoware_perception_msgs::msg::TrackedObjects;
 
 class MultiObjectTracker : public rclcpp::Node
 {

--- a/perception/multi_object_tracker/include/multi_object_tracker/processor/input_manager.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/processor/input_manager.hpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <deque>
 #include <functional>
@@ -28,7 +28,7 @@
 
 namespace multi_object_tracker
 {
-using DetectedObjects = autoware_auto_perception_msgs::msg::DetectedObjects;
+using DetectedObjects = autoware_perception_msgs::msg::DetectedObjects;
 using ObjectsList = std::vector<std::pair<uint, DetectedObjects>>;
 
 struct InputChannel
@@ -52,7 +52,7 @@ public:
     func_trigger_ = func_trigger;
   }
 
-  void onMessage(const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr msg);
+  void onMessage(const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr msg);
   void updateTimingStatus(const rclcpp::Time & now, const rclcpp::Time & objects_time);
 
   bool isTimeInitialized() const { return initial_count_ > 0; }

--- a/perception/multi_object_tracker/include/multi_object_tracker/processor/processor.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/processor/processor.hpp
@@ -19,8 +19,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <list>
 #include <map>
@@ -39,11 +39,11 @@ public:
   // tracker processes
   void predict(const rclcpp::Time & time);
   void update(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & transformed_objects,
+    const autoware_perception_msgs::msg::DetectedObjects & transformed_objects,
     const geometry_msgs::msg::Transform & self_transform,
     const std::unordered_map<int, int> & direct_assignment, const uint & channel_index);
   void spawn(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+    const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
     const geometry_msgs::msg::Transform & self_transform,
     const std::unordered_map<int, int> & reverse_assignment, const uint & channel_index);
   void prune(const rclcpp::Time & time);
@@ -52,10 +52,10 @@ public:
   bool isConfidentTracker(const std::shared_ptr<Tracker> & tracker) const;
   void getTrackedObjects(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObjects & tracked_objects) const;
+    autoware_perception_msgs::msg::TrackedObjects & tracked_objects) const;
   void getTentativeObjects(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObjects & tentative_objects) const;
+    autoware_perception_msgs::msg::TrackedObjects & tentative_objects) const;
 
   void getExistenceProbabilities(std::vector<std::vector<float>> & existence_vectors) const;
 
@@ -74,7 +74,7 @@ private:
   void removeOldTracker(const rclcpp::Time & time);
   void removeOverlappedTracker(const rclcpp::Time & time);
   std::shared_ptr<Tracker> createNewTracker(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform, const uint & channel_index) const;
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/bicycle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/bicycle_tracker.hpp
@@ -27,7 +27,7 @@
 class BicycleTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -55,22 +55,22 @@ private:
 
 public:
   BicycleTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
-  autoware_auto_perception_msgs::msg::DetectedObject getUpdatingObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  autoware_perception_msgs::msg::DetectedObject getUpdatingObject(
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithPose(const autoware_auto_perception_msgs::msg::DetectedObject & object);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~BicycleTracker() {}
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
@@ -27,7 +27,7 @@
 class BigVehicleTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -60,22 +60,22 @@ private:
 
 public:
   BigVehicleTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
-  autoware_auto_perception_msgs::msg::DetectedObject getUpdatingObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  autoware_perception_msgs::msg::DetectedObject getUpdatingObject(
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithPose(const autoware_auto_perception_msgs::msg::DetectedObject & object);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~BigVehicleTracker() {}
 
 private:

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/multiple_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/multiple_vehicle_tracker.hpp
@@ -34,17 +34,17 @@ private:
 
 public:
   MultipleVehicleTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~MultipleVehicleTracker() {}
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
@@ -27,7 +27,7 @@
 class NormalVehicleTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -60,22 +60,22 @@ private:
 
 public:
   NormalVehicleTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
-  autoware_auto_perception_msgs::msg::DetectedObject getUpdatingObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  autoware_perception_msgs::msg::DetectedObject getUpdatingObject(
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithPose(const autoware_auto_perception_msgs::msg::DetectedObject & object);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~NormalVehicleTracker() {}
 
 private:

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pass_through_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pass_through_tracker.hpp
@@ -26,23 +26,23 @@
 class PassThroughTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
-  autoware_auto_perception_msgs::msg::DetectedObject prev_observed_object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject prev_observed_object_;
   rclcpp::Logger logger_;
   rclcpp::Time last_update_time_;
 
 public:
   PassThroughTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~PassThroughTracker() {}
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_and_bicycle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_and_bicycle_tracker.hpp
@@ -33,17 +33,17 @@ private:
 
 public:
   PedestrianAndBicycleTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~PedestrianAndBicycleTracker() {}
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
@@ -29,7 +29,7 @@
 class PedestrianTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -63,22 +63,22 @@ private:
 
 public:
   PedestrianTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
-  autoware_auto_perception_msgs::msg::DetectedObject getUpdatingObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  autoware_perception_msgs::msg::DetectedObject getUpdatingObject(
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithPose(const autoware_auto_perception_msgs::msg::DetectedObject & object);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~PedestrianTracker() {}
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/tracker_base.hpp
@@ -26,8 +26,8 @@
 #include <Eigen/Core>
 #include <rclcpp/rclcpp.hpp>
 
-#include "autoware_auto_perception_msgs/msg/detected_object.hpp"
-#include "autoware_auto_perception_msgs/msg/tracked_object.hpp"
+#include "autoware_perception_msgs/msg/detected_object.hpp"
+#include "autoware_perception_msgs/msg/tracked_object.hpp"
 #include "geometry_msgs/msg/point.hpp"
 #include "unique_identifier_msgs/msg/uuid.hpp"
 
@@ -39,7 +39,7 @@ private:
   unique_identifier_msgs::msg::UUID uuid_;
 
   // classification
-  std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> classification_;
+  std::vector<autoware_perception_msgs::msg::ObjectClassification> classification_;
 
   // existence states
   int no_measurement_count_;
@@ -52,7 +52,7 @@ private:
 public:
   Tracker(
     const rclcpp::Time & time,
-    const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification,
+    const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification,
     const size_t & channel_size);
   virtual ~Tracker() {}
 
@@ -64,13 +64,13 @@ public:
     return existence_vector.size() > 0;
   }
   bool updateWithMeasurement(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const rclcpp::Time & measurement_time, const geometry_msgs::msg::Transform & self_transform,
     const uint & channel_index);
   bool updateWithoutMeasurement(const rclcpp::Time & now);
 
   // classification
-  std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> getClassification() const
+  std::vector<autoware_perception_msgs::msg::ObjectClassification> getClassification() const
   {
     return classification_;
   }
@@ -91,12 +91,12 @@ public:
 protected:
   unique_identifier_msgs::msg::UUID getUUID() const { return uuid_; }
   void setClassification(
-    const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification)
+    const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
   {
     classification_ = classification;
   }
   void updateClassification(
-    const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification);
+    const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification);
 
   // virtual functions
 public:
@@ -105,13 +105,12 @@ public:
 
 protected:
   virtual bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) = 0;
 
 public:
   virtual bool getTrackedObject(
-    const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const = 0;
+    const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const = 0;
   virtual bool predict(const rclcpp::Time & time) = 0;
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/unknown_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/unknown_tracker.hpp
@@ -27,7 +27,7 @@
 class UnknownTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -48,22 +48,22 @@ private:
 
 public:
   UnknownTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
     const uint & channel_index);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
-  autoware_auto_perception_msgs::msg::DetectedObject getUpdatingObject(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  autoware_perception_msgs::msg::DetectedObject getUpdatingObject(
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithPose(const autoware_auto_perception_msgs::msg::DetectedObject & object);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~UnknownTracker() {}
 };
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
@@ -22,9 +22,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/detected_object.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/transform.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
@@ -97,7 +97,7 @@ enum BBOX_IDX {
  */
 inline bool isLargeVehicleLabel(const uint8_t label)
 {
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  using Label = autoware_perception_msgs::msg::ObjectClassification;
   return label == Label::BUS || label == Label::TRUCK || label == Label::TRAILER;
 }
 
@@ -163,11 +163,11 @@ inline int getNearestCornerOrSurface(
  * @return nearest corner or surface index
  */
 inline int getNearestCornerOrSurfaceFromObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const double & yaw,
+  const autoware_perception_msgs::msg::DetectedObject & object, const double & yaw,
   const geometry_msgs::msg::Transform & self_transform)
 {
   // only work for BBOX shape
-  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     return BBOX_IDX::INVALID;
   }
 
@@ -263,9 +263,8 @@ inline Eigen::Vector2d recoverFromTrackingPoint(
  */
 inline void calcAnchorPointOffset(
   const double w, const double l, const int indx,
-  const autoware_auto_perception_msgs::msg::DetectedObject & input_object, const double & yaw,
-  autoware_auto_perception_msgs::msg::DetectedObject & offset_object,
-  Eigen::Vector2d & tracking_offset)
+  const autoware_perception_msgs::msg::DetectedObject & input_object, const double & yaw,
+  autoware_perception_msgs::msg::DetectedObject & offset_object, Eigen::Vector2d & tracking_offset)
 {
   // copy value
   offset_object = input_object;
@@ -296,8 +295,8 @@ inline void calcAnchorPointOffset(
  * @param output_object: output bounding box objects
  */
 inline bool convertConvexHullToBoundingBox(
-  const autoware_auto_perception_msgs::msg::DetectedObject & input_object,
-  autoware_auto_perception_msgs::msg::DetectedObject & output_object)
+  const autoware_perception_msgs::msg::DetectedObject & input_object,
+  autoware_perception_msgs::msg::DetectedObject & output_object)
 {
   // check footprint size
   if (input_object.shape.footprint.points.size() < 3) {
@@ -340,7 +339,7 @@ inline bool convertConvexHullToBoundingBox(
   output_object.kinematics.pose_with_covariance.pose.position.x = new_center.x();
   output_object.kinematics.pose_with_covariance.pose.position.y = new_center.y();
 
-  output_object.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  output_object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   output_object.shape.dimensions.x = length;
   output_object.shape.dimensions.y = width;
   output_object.shape.dimensions.z = height;
@@ -349,7 +348,7 @@ inline bool convertConvexHullToBoundingBox(
 }
 
 inline bool getMeasurementYaw(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const double & predicted_yaw,
+  const autoware_perception_msgs::msg::DetectedObject & object, const double & predicted_yaw,
   double & measurement_yaw)
 {
   measurement_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
@@ -358,7 +357,7 @@ inline bool getMeasurementYaw(
   double limiting_delta_yaw = M_PI_2;
   if (
     object.kinematics.orientation_availability ==
-    autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
+    autoware_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
     limiting_delta_yaw = M_PI;
   }
   // limiting delta yaw, even the availability is unknown
@@ -371,7 +370,7 @@ inline bool getMeasurementYaw(
   }
   // return false if the orientation is unknown
   return object.kinematics.orientation_availability !=
-         autoware_auto_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
+         autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
 }
 
 }  // namespace utils

--- a/perception/multi_object_tracker/package.xml
+++ b/perception/multi_object_tracker/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>glog</depend>

--- a/perception/multi_object_tracker/src/data_association/data_association.cpp
+++ b/perception/multi_object_tracker/src/data_association/data_association.cpp
@@ -147,7 +147,7 @@ void DataAssociation::assign(
 }
 
 Eigen::MatrixXd DataAssociation::calcScoreMatrix(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & measurements,
+  const autoware_perception_msgs::msg::DetectedObjects & measurements,
   const std::list<std::shared_ptr<Tracker>> & trackers)
 {
   Eigen::MatrixXd score_matrix =
@@ -159,14 +159,14 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
 
     for (size_t measurement_idx = 0; measurement_idx < measurements.objects.size();
          ++measurement_idx) {
-      const autoware_auto_perception_msgs::msg::DetectedObject & measurement_object =
+      const autoware_perception_msgs::msg::DetectedObject & measurement_object =
         measurements.objects.at(measurement_idx);
       const std::uint8_t measurement_label =
         object_recognition_utils::getHighestProbLabel(measurement_object.classification);
 
       double score = 0.0;
       if (can_assign_matrix_(tracker_label, measurement_label)) {
-        autoware_auto_perception_msgs::msg::TrackedObject tracked_object;
+        autoware_perception_msgs::msg::TrackedObject tracked_object;
         (*tracker_itr)->getTrackedObject(measurements.header.stamp, tracked_object);
 
         const double max_dist = max_dist_matrix_(tracker_label, measurement_label);

--- a/perception/multi_object_tracker/src/debugger/debug_object.cpp
+++ b/perception/multi_object_tracker/src/debugger/debug_object.cpp
@@ -14,7 +14,7 @@
 
 #include "multi_object_tracker/debugger/debug_object.hpp"
 
-#include "autoware_auto_perception_msgs/msg/tracked_object.hpp"
+#include "autoware_perception_msgs/msg/tracked_object.hpp"
 
 #include <boost/uuid/uuid.hpp>
 
@@ -75,7 +75,7 @@ void TrackerObjectDebugger::reset()
 void TrackerObjectDebugger::collect(
   const rclcpp::Time & message_time, const std::list<std::shared_ptr<Tracker>> & list_tracker,
   const uint & channel_index,
-  const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+  const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
   const std::unordered_map<int, int> & direct_assignment,
   const std::unordered_map<int, int> & /*reverse_assignment*/)
 {
@@ -90,7 +90,7 @@ void TrackerObjectDebugger::collect(
     object_data.time = message_time;
     object_data.channel_id = channel_index;
 
-    autoware_auto_perception_msgs::msg::TrackedObject tracked_object;
+    autoware_perception_msgs::msg::TrackedObject tracked_object;
     (*(tracker_itr))->getTrackedObject(message_time, tracked_object);
     object_data.uuid = uuidToBoostUuid(tracked_object.object_id);
     object_data.uuid_int = uuidToInt(object_data.uuid);

--- a/perception/multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/multi_object_tracker/src/debugger/debugger.cpp
@@ -29,7 +29,7 @@ TrackerDebugger::TrackerDebugger(rclcpp::Node & node, const std::string & frame_
 
   if (debug_settings_.publish_tentative_objects) {
     debug_tentative_objects_pub_ =
-      node_.create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
+      node_.create_publisher<autoware_perception_msgs::msg::TrackedObjects>(
         "~/debug/tentative_objects", rclcpp::QoS{1});
   }
 
@@ -83,7 +83,7 @@ void TrackerDebugger::setupDiagnostics()
 // Object publishing functions
 
 void TrackerDebugger::publishTentativeObjects(
-  const autoware_auto_perception_msgs::msg::TrackedObjects & tentative_objects) const
+  const autoware_perception_msgs::msg::TrackedObjects & tentative_objects) const
 {
   if (debug_settings_.publish_tentative_objects) {
     debug_tentative_objects_pub_->publish(tentative_objects);
@@ -181,7 +181,7 @@ void TrackerDebugger::endPublishTime(const rclcpp::Time & now, const rclcpp::Tim
 void TrackerDebugger::collectObjectInfo(
   const rclcpp::Time & message_time, const std::list<std::shared_ptr<Tracker>> & list_tracker,
   const uint & channel_index,
-  const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+  const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
   const std::unordered_map<int, int> & direct_assignment,
   const std::unordered_map<int, int> & reverse_assignment)
 {

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -67,7 +67,7 @@ boost::optional<geometry_msgs::msg::Transform> getTransformAnonymous(
 
 namespace multi_object_tracker
 {
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 : rclcpp::Node("multi_object_tracker", node_options),

--- a/perception/multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/multi_object_tracker/src/processor/input_manager.cpp
@@ -58,7 +58,7 @@ bool InputStream::getTimestamps(
 }
 
 void InputStream::onMessage(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr msg)
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr msg)
 {
   const DetectedObjects objects = *msg;
   objects_que_.push_back(objects);

--- a/perception/multi_object_tracker/src/processor/processor.cpp
+++ b/perception/multi_object_tracker/src/processor/processor.cpp
@@ -17,11 +17,11 @@
 #include "multi_object_tracker/tracker/tracker.hpp"
 #include "object_recognition_utils/object_recognition_utils.hpp"
 
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <iterator>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 TrackerProcessor::TrackerProcessor(
   const std::map<std::uint8_t, std::string> & tracker_map, const size_t & channel_size)
@@ -47,7 +47,7 @@ void TrackerProcessor::predict(const rclcpp::Time & time)
 }
 
 void TrackerProcessor::update(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+  const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
   const geometry_msgs::msg::Transform & self_transform,
   const std::unordered_map<int, int> & direct_assignment, const uint & channel_index)
 {
@@ -67,7 +67,7 @@ void TrackerProcessor::update(
 }
 
 void TrackerProcessor::spawn(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & detected_objects,
+  const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
   const geometry_msgs::msg::Transform & self_transform,
   const std::unordered_map<int, int> & reverse_assignment, const uint & channel_index)
 {
@@ -84,7 +84,7 @@ void TrackerProcessor::spawn(
 }
 
 std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform, const uint & channel_index) const
 {
   const std::uint8_t label = object_recognition_utils::getHighestProbLabel(object.classification);
@@ -143,12 +143,12 @@ void TrackerProcessor::removeOverlappedTracker(const rclcpp::Time & time)
 {
   // Iterate through the list of trackers
   for (auto itr1 = list_tracker_.begin(); itr1 != list_tracker_.end(); ++itr1) {
-    autoware_auto_perception_msgs::msg::TrackedObject object1;
+    autoware_perception_msgs::msg::TrackedObject object1;
     if (!(*itr1)->getTrackedObject(time, object1)) continue;
 
     // Compare the current tracker with the remaining trackers
     for (auto itr2 = std::next(itr1); itr2 != list_tracker_.end(); ++itr2) {
-      autoware_auto_perception_msgs::msg::TrackedObject object2;
+      autoware_perception_msgs::msg::TrackedObject object2;
       if (!(*itr2)->getTrackedObject(time, object2)) continue;
 
       // Calculate the distance between the two objects
@@ -220,15 +220,14 @@ bool TrackerProcessor::isConfidentTracker(const std::shared_ptr<Tracker> & track
 }
 
 void TrackerProcessor::getTrackedObjects(
-  const rclcpp::Time & time,
-  autoware_auto_perception_msgs::msg::TrackedObjects & tracked_objects) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObjects & tracked_objects) const
 {
   tracked_objects.header.stamp = time;
   for (const auto & tracker : list_tracker_) {
     // Skip if the tracker is not confident
     if (!isConfidentTracker(tracker)) continue;
     // Get the tracked object, extrapolated to the given time
-    autoware_auto_perception_msgs::msg::TrackedObject tracked_object;
+    autoware_perception_msgs::msg::TrackedObject tracked_object;
     if (tracker->getTrackedObject(time, tracked_object)) {
       tracked_objects.objects.push_back(tracked_object);
     }
@@ -237,12 +236,12 @@ void TrackerProcessor::getTrackedObjects(
 
 void TrackerProcessor::getTentativeObjects(
   const rclcpp::Time & time,
-  autoware_auto_perception_msgs::msg::TrackedObjects & tentative_objects) const
+  autoware_perception_msgs::msg::TrackedObjects & tentative_objects) const
 {
   tentative_objects.header.stamp = time;
   for (const auto & tracker : list_tracker_) {
     if (!isConfidentTracker(tracker)) {
-      autoware_auto_perception_msgs::msg::TrackedObject tracked_object;
+      autoware_perception_msgs::msg::TrackedObject tracked_object;
       if (tracker->getTrackedObject(time, tracked_object)) {
         tentative_objects.objects.push_back(tracked_object);
       }

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -40,10 +40,10 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 BicycleTracker::BicycleTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/, const size_t channel_size,
   const uint & channel_index)
 : Tracker(time, object.classification, channel_size),
@@ -65,7 +65,7 @@ BicycleTracker::BicycleTracker(
   ekf_params_.r_cov_yaw = std::pow(r_stddev_yaw, 2.0);
 
   // OBJECT SHAPE MODEL
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
       object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
   } else {
@@ -165,15 +165,15 @@ bool BicycleTracker::predict(const rclcpp::Time & time)
   return motion_model_.predictState(time);
 }
 
-autoware_auto_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+autoware_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingObject(
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject updating_object;
+  autoware_perception_msgs::msg::DetectedObject updating_object;
 
   // OBJECT SHAPE MODEL
   // convert to bounding box if input is convex shape
-  if (object.shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     if (!utils::convertConvexHullToBoundingBox(object, updating_object)) {
       updating_object = object;
     }
@@ -195,8 +195,7 @@ autoware_auto_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingOb
   return updating_object;
 }
 
-bool BicycleTracker::measureWithPose(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+bool BicycleTracker::measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object)
 {
   // get measurement yaw angle to update
   const double tracked_yaw = motion_model_.getStateElement(IDX::YAW);
@@ -227,11 +226,10 @@ bool BicycleTracker::measureWithPose(
   return is_updated;
 }
 
-bool BicycleTracker::measureWithShape(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+bool BicycleTracker::measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject bbox_object;
-  if (!object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  autoware_perception_msgs::msg::DetectedObject bbox_object;
+  if (!object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     // do not update shape if the input is not a bounding box
     return false;
   }
@@ -270,7 +268,7 @@ bool BicycleTracker::measureWithShape(
 }
 
 bool BicycleTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   // keep the latest input object
@@ -293,7 +291,7 @@ bool BicycleTracker::measure(
   }
 
   // update object
-  const autoware_auto_perception_msgs::msg::DetectedObject updating_object =
+  const autoware_perception_msgs::msg::DetectedObject updating_object =
     getUpdatingObject(object, self_transform);
   measureWithPose(updating_object);
   measureWithShape(updating_object);
@@ -302,7 +300,7 @@ bool BicycleTracker::measure(
 }
 
 bool BicycleTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
   object = object_recognition_utils::toTrackedObject(object_);
   object.object_id = getUUID();

--- a/perception/multi_object_tracker/src/tracker/model/multiple_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/multiple_vehicle_tracker.cpp
@@ -18,10 +18,10 @@
 
 #include "multi_object_tracker/tracker/model/multiple_vehicle_tracker.hpp"
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 MultipleVehicleTracker::MultipleVehicleTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
   const uint & channel_index)
 : Tracker(time, object.classification, channel_size),
@@ -40,7 +40,7 @@ bool MultipleVehicleTracker::predict(const rclcpp::Time & time)
 }
 
 bool MultipleVehicleTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   big_vehicle_tracker_.measure(object, time, self_transform);
@@ -51,9 +51,9 @@ bool MultipleVehicleTracker::measure(
 }
 
 bool MultipleVehicleTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  using Label = autoware_perception_msgs::msg::ObjectClassification;
   const uint8_t label = getHighestProbLabel();
 
   if (label == Label::CAR) {

--- a/perception/multi_object_tracker/src/tracker/model/pass_through_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pass_through_tracker.cpp
@@ -36,7 +36,7 @@
 #include <Eigen/Geometry>
 
 PassThroughTracker::PassThroughTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/, const size_t channel_size,
   const uint & channel_index)
 : Tracker(time, object.classification, channel_size),
@@ -62,7 +62,7 @@ bool PassThroughTracker::predict(const rclcpp::Time & time)
 }
 
 bool PassThroughTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   prev_observed_object_ = object_;
@@ -84,7 +84,7 @@ bool PassThroughTracker::measure(
 }
 
 bool PassThroughTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
   object = object_recognition_utils::toTrackedObject(object_);
   object.object_id = getUUID();

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_and_bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_and_bicycle_tracker.cpp
@@ -18,10 +18,10 @@
 
 #include "multi_object_tracker/tracker/model/pedestrian_and_bicycle_tracker.hpp"
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 PedestrianAndBicycleTracker::PedestrianAndBicycleTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & self_transform, const size_t channel_size,
   const uint & channel_index)
 : Tracker(time, object.classification, channel_size),
@@ -40,7 +40,7 @@ bool PedestrianAndBicycleTracker::predict(const rclcpp::Time & time)
 }
 
 bool PedestrianAndBicycleTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   pedestrian_tracker_.measure(object, time, self_transform);
@@ -51,9 +51,9 @@ bool PedestrianAndBicycleTracker::measure(
 }
 
 bool PedestrianAndBicycleTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  using Label = autoware_perception_msgs::msg::ObjectClassification;
   const uint8_t label = getHighestProbLabel();
 
   if (label == Label::PEDESTRIAN) {

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -40,10 +40,10 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 PedestrianTracker::PedestrianTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/, const size_t channel_size,
   const uint & channel_index)
 : Tracker(time, object.classification, channel_size),
@@ -67,12 +67,12 @@ PedestrianTracker::PedestrianTracker(
   // OBJECT SHAPE MODEL
   bounding_box_ = {0.5, 0.5, 1.7};
   cylinder_ = {0.5, 1.7};
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
       object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_ = {object.shape.dimensions.x, object.shape.dimensions.z};
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     // do not update polygon shape
   }
   // set maximum and minimum size
@@ -160,11 +160,11 @@ bool PedestrianTracker::predict(const rclcpp::Time & time)
   return motion_model_.predictState(time);
 }
 
-autoware_auto_perception_msgs::msg::DetectedObject PedestrianTracker::getUpdatingObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+autoware_perception_msgs::msg::DetectedObject PedestrianTracker::getUpdatingObject(
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject updating_object = object;
+  autoware_perception_msgs::msg::DetectedObject updating_object = object;
 
   // UNCERTAINTY MODEL
   if (!object.kinematics.has_position_covariance) {
@@ -186,7 +186,7 @@ autoware_auto_perception_msgs::msg::DetectedObject PedestrianTracker::getUpdatin
 }
 
 bool PedestrianTracker::measureWithPose(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   // update motion model
   bool is_updated = false;
@@ -207,12 +207,12 @@ bool PedestrianTracker::measureWithPose(
 }
 
 bool PedestrianTracker::measureWithShape(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   constexpr double gain = 0.1;
   constexpr double gain_inv = 1.0 - gain;
 
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     // check bound box size abnormality
     constexpr double size_max = 30.0;  // [m]
     constexpr double size_min = 0.1;   // [m]
@@ -229,7 +229,7 @@ bool PedestrianTracker::measureWithShape(
     bounding_box_.length = gain_inv * bounding_box_.length + gain * object.shape.dimensions.x;
     bounding_box_.width = gain_inv * bounding_box_.width + gain * object.shape.dimensions.y;
     bounding_box_.height = gain_inv * bounding_box_.height + gain * object.shape.dimensions.z;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     // check cylinder size abnormality
     constexpr double size_max = 30.0;  // [m]
     constexpr double size_min = 0.1;   // [m]
@@ -258,7 +258,7 @@ bool PedestrianTracker::measureWithShape(
 }
 
 bool PedestrianTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   // keep the latest input object
@@ -280,7 +280,7 @@ bool PedestrianTracker::measure(
   }
 
   // update object
-  const autoware_auto_perception_msgs::msg::DetectedObject updating_object =
+  const autoware_perception_msgs::msg::DetectedObject updating_object =
     getUpdatingObject(object, self_transform);
   measureWithPose(updating_object);
   measureWithShape(updating_object);
@@ -290,7 +290,7 @@ bool PedestrianTracker::measure(
 }
 
 bool PedestrianTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
   object = object_recognition_utils::toTrackedObject(object_);
   object.object_id = getUUID();
@@ -311,15 +311,15 @@ bool PedestrianTracker::getTrackedObject(
   pose_with_cov.pose.position.z = z_;
 
   // set shape
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     object.shape.dimensions.x = bounding_box_.length;
     object.shape.dimensions.y = bounding_box_.width;
     object.shape.dimensions.z = bounding_box_.height;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     object.shape.dimensions.x = cylinder_.width;
     object.shape.dimensions.y = cylinder_.width;
     object.shape.dimensions.z = cylinder_.height;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     const auto origin_yaw = tf2::getYaw(object_.kinematics.pose_with_covariance.pose.orientation);
     const auto ekf_pose_yaw = tf2::getYaw(pose_with_cov.pose.orientation);
     object.shape.footprint =

--- a/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/tracker_base.cpp
@@ -31,7 +31,7 @@ float updateProbability(float prior, float true_positive, float false_positive)
 
 Tracker::Tracker(
   const rclcpp::Time & time,
-  const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification,
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification,
   const size_t & channel_size)
 : classification_(classification),
   no_measurement_count_(0),
@@ -62,7 +62,7 @@ void Tracker::initializeExistenceProbabilities(
 }
 
 bool Tracker::updateWithMeasurement(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const rclcpp::Time & measurement_time, const geometry_msgs::msg::Transform & self_transform,
   const uint & channel_index)
 {
@@ -122,7 +122,7 @@ bool Tracker::updateWithoutMeasurement(const rclcpp::Time & now)
 }
 
 void Tracker::updateClassification(
-  const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification)
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
 {
   // classification algorithm:
   // 0. Normalize the input classification
@@ -139,7 +139,7 @@ void Tracker::updateClassification(
 
   // Normalization function
   auto normalizeProbabilities =
-    [](std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification) {
+    [](std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification) {
       double sum = 0.0;
       for (const auto & class_ : classification) {
         sum += class_.probability;
@@ -185,7 +185,7 @@ void Tracker::updateClassification(
 geometry_msgs::msg::PoseWithCovariance Tracker::getPoseWithCovariance(
   const rclcpp::Time & time) const
 {
-  autoware_auto_perception_msgs::msg::TrackedObject object;
+  autoware_perception_msgs::msg::TrackedObject object;
   getTrackedObject(time, object);
   return object.kinematics.pose_with_covariance;
 }

--- a/perception/multi_object_tracker/src/tracker/model/unknown_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/unknown_tracker.cpp
@@ -37,7 +37,7 @@
 #include <Eigen/Geometry>
 
 UnknownTracker::UnknownTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/, const size_t channel_size,
   const uint & channel_index)
 : Tracker(time, object.classification, channel_size),
@@ -140,11 +140,11 @@ bool UnknownTracker::predict(const rclcpp::Time & time)
   return motion_model_.predictState(time);
 }
 
-autoware_auto_perception_msgs::msg::DetectedObject UnknownTracker::getUpdatingObject(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+autoware_perception_msgs::msg::DetectedObject UnknownTracker::getUpdatingObject(
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & /*self_transform*/)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject updating_object = object;
+  autoware_perception_msgs::msg::DetectedObject updating_object = object;
 
   // UNCERTAINTY MODEL
   if (!object.kinematics.has_position_covariance) {
@@ -165,8 +165,7 @@ autoware_auto_perception_msgs::msg::DetectedObject UnknownTracker::getUpdatingOb
   return updating_object;
 }
 
-bool UnknownTracker::measureWithPose(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+bool UnknownTracker::measureWithPose(const autoware_perception_msgs::msg::DetectedObject & object)
 {
   // update motion model
   bool is_updated = false;
@@ -187,7 +186,7 @@ bool UnknownTracker::measureWithPose(
 }
 
 bool UnknownTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   // keep the latest input object
@@ -204,7 +203,7 @@ bool UnknownTracker::measure(
   }
 
   // update object
-  const autoware_auto_perception_msgs::msg::DetectedObject updating_object =
+  const autoware_perception_msgs::msg::DetectedObject updating_object =
     getUpdatingObject(object, self_transform);
   measureWithPose(updating_object);
 
@@ -212,7 +211,7 @@ bool UnknownTracker::measure(
 }
 
 bool UnknownTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
   object = object_recognition_utils::toTrackedObject(object_);
   object.object_id = getUUID();

--- a/perception/object_merger/README.md
+++ b/perception/object_merger/README.md
@@ -12,29 +12,29 @@ The successive shortest path algorithm is used to solve the data association pro
 
 ### Input
 
-| Name            | Type                                                  | Description       |
-| --------------- | ----------------------------------------------------- | ----------------- |
-| `input/object0` | `autoware_auto_perception_msgs::msg::DetectedObjects` | detection objects |
-| `input/object1` | `autoware_auto_perception_msgs::msg::DetectedObjects` | detection objects |
+| Name            | Type                                             | Description       |
+| --------------- | ------------------------------------------------ | ----------------- |
+| `input/object0` | `autoware_perception_msgs::msg::DetectedObjects` | detection objects |
+| `input/object1` | `autoware_perception_msgs::msg::DetectedObjects` | detection objects |
 
 ### Output
 
-| Name            | Type                                                  | Description      |
-| --------------- | ----------------------------------------------------- | ---------------- |
-| `output/object` | `autoware_auto_perception_msgs::msg::DetectedObjects` | modified Objects |
+| Name            | Type                                             | Description      |
+| --------------- | ------------------------------------------------ | ---------------- |
+| `output/object` | `autoware_perception_msgs::msg::DetectedObjects` | modified Objects |
 
 ## Parameters
 
-| Name                        | Type                  | Description                                                                                                                                                                                                                           |
-| --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `can_assign_matrix`         | double                | Assignment table for data association                                                                                                                                                                                                 |
-| `max_dist_matrix`           | double                | Maximum distance table for data association                                                                                                                                                                                           |
-| `max_area_matrix`           | double                | Maximum area table for data association                                                                                                                                                                                               |
-| `min_area_matrix`           | double                | Minimum area table for data association                                                                                                                                                                                               |
-| `max_rad_matrix`            | double                | Maximum angle table for data association                                                                                                                                                                                              |
-| `base_link_frame_id`        | double                | association frame                                                                                                                                                                                                                     |
-| `distance_threshold_list`   | `std::vector<double>` | Distance threshold for each class used in judging overlap. The class order depends on [ObjectClassification](https://github.com/tier4/autoware_auto_msgs/blob/tier4/main/autoware_auto_perception_msgs/msg/ObjectClassification.idl). |
-| `generalized_iou_threshold` | `std::vector<double>` | Generalized IoU threshold for each class                                                                                                                                                                                              |
+| Name                        | Type                  | Description                                                                                                                                                                                                                        |
+| --------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `can_assign_matrix`         | double                | Assignment table for data association                                                                                                                                                                                              |
+| `max_dist_matrix`           | double                | Maximum distance table for data association                                                                                                                                                                                        |
+| `max_area_matrix`           | double                | Maximum area table for data association                                                                                                                                                                                            |
+| `min_area_matrix`           | double                | Minimum area table for data association                                                                                                                                                                                            |
+| `max_rad_matrix`            | double                | Maximum angle table for data association                                                                                                                                                                                           |
+| `base_link_frame_id`        | double                | association frame                                                                                                                                                                                                                  |
+| `distance_threshold_list`   | `std::vector<double>` | Distance threshold for each class used in judging overlap. The class order depends on [ObjectClassification](https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_perception_msgs/msg/ObjectClassification.msg). |
+| `generalized_iou_threshold` | `std::vector<double>` | Generalized IoU threshold for each class                                                                                                                                                                                           |
 
 ## Tips
 

--- a/perception/object_merger/include/object_merger/data_association/data_association.hpp
+++ b/perception/object_merger/include/object_merger/data_association/data_association.hpp
@@ -30,7 +30,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 class DataAssociation
 {
@@ -51,8 +51,8 @@ public:
     const Eigen::MatrixXd & src, std::unordered_map<int, int> & direct_assignment,
     std::unordered_map<int, int> & reverse_assignment);
   Eigen::MatrixXd calcScoreMatrix(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & objects0,
-    const autoware_auto_perception_msgs::msg::DetectedObjects & objects1);
+    const autoware_perception_msgs::msg::DetectedObjects & objects0,
+    const autoware_perception_msgs::msg::DetectedObjects & objects1);
   virtual ~DataAssociation() {}
 };
 

--- a/perception/object_merger/include/object_merger/node.hpp
+++ b/perception/object_merger/include/object_merger/node.hpp
@@ -22,7 +22,7 @@
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
@@ -55,19 +55,17 @@ public:
 
 private:
   void objectsCallback(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_object0_msg,
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_object1_msg);
+    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_object0_msg,
+    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_object1_msg);
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
-    merged_object_pub_;
-  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> object0_sub_{};
-  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> object1_sub_{};
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr merged_object_pub_;
+  message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> object0_sub_{};
+  message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> object1_sub_{};
 
   using SyncPolicy = message_filters::sync_policies::ApproximateTime<
-    autoware_auto_perception_msgs::msg::DetectedObjects,
-    autoware_auto_perception_msgs::msg::DetectedObjects>;
+    autoware_perception_msgs::msg::DetectedObjects, autoware_perception_msgs::msg::DetectedObjects>;
   using Sync = message_filters::Synchronizer<SyncPolicy>;
   typename std::shared_ptr<Sync> sync_ptr_;
 

--- a/perception/object_merger/include/object_merger/utils/utils.hpp
+++ b/perception/object_merger/include/object_merger/utils/utils.hpp
@@ -19,8 +19,8 @@
 #ifndef OBJECT_MERGER__UTILS__UTILS_HPP_
 #define OBJECT_MERGER__UTILS__UTILS_HPP_
 
-#include <autoware_auto_perception_msgs/msg/detected_object.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 

--- a/perception/object_merger/package.xml
+++ b/perception/object_merger/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>mussp</depend>
   <depend>object_recognition_utils</depend>

--- a/perception/object_merger/src/object_association_merger/data_association/data_association.cpp
+++ b/perception/object_merger/src/object_association_merger/data_association/data_association.cpp
@@ -113,19 +113,19 @@ void DataAssociation::assign(
 }
 
 Eigen::MatrixXd DataAssociation::calcScoreMatrix(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & objects0,
-  const autoware_auto_perception_msgs::msg::DetectedObjects & objects1)
+  const autoware_perception_msgs::msg::DetectedObjects & objects0,
+  const autoware_perception_msgs::msg::DetectedObjects & objects1)
 {
   Eigen::MatrixXd score_matrix =
     Eigen::MatrixXd::Zero(objects1.objects.size(), objects0.objects.size());
   for (size_t objects1_idx = 0; objects1_idx < objects1.objects.size(); ++objects1_idx) {
-    const autoware_auto_perception_msgs::msg::DetectedObject & object1 =
+    const autoware_perception_msgs::msg::DetectedObject & object1 =
       objects1.objects.at(objects1_idx);
     const std::uint8_t object1_label =
       object_recognition_utils::getHighestProbLabel(object1.classification);
 
     for (size_t objects0_idx = 0; objects0_idx < objects0.objects.size(); ++objects0_idx) {
-      const autoware_auto_perception_msgs::msg::DetectedObject & object0 =
+      const autoware_perception_msgs::msg::DetectedObject & object0 =
         objects0.objects.at(objects0_idx);
       const std::uint8_t object0_label =
         object_recognition_utils::getHighestProbLabel(object0.classification);

--- a/perception/object_merger/src/object_association_merger/node.cpp
+++ b/perception/object_merger/src/object_association_merger/node.cpp
@@ -27,13 +27,13 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 namespace
 {
 bool isUnknownObjectOverlapped(
-  const autoware_auto_perception_msgs::msg::DetectedObject & unknown_object,
-  const autoware_auto_perception_msgs::msg::DetectedObject & known_object,
+  const autoware_perception_msgs::msg::DetectedObject & unknown_object,
+  const autoware_perception_msgs::msg::DetectedObject & known_object,
   const double precision_threshold, const double recall_threshold,
   std::map<int, double> distance_threshold_map,
   const std::map<int, double> generalized_iou_threshold_map)
@@ -116,7 +116,7 @@ ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptio
   sync_ptr_->registerCallback(
     std::bind(&ObjectAssociationMergerNode::objectsCallback, this, _1, _2));
 
-  merged_object_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  merged_object_pub_ = create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "output/object", rclcpp::QoS{1});
 
   // Debug publisher
@@ -129,8 +129,8 @@ ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptio
 }
 
 void ObjectAssociationMergerNode::objectsCallback(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects0_msg,
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects1_msg)
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects0_msg,
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects1_msg)
 {
   // Guard
   if (merged_object_pub_->get_subscription_count() < 1) {
@@ -139,7 +139,7 @@ void ObjectAssociationMergerNode::objectsCallback(
   stop_watch_ptr_->toc("processing_time", true);
 
   /* transform to base_link coordinate */
-  autoware_auto_perception_msgs::msg::DetectedObjects transformed_objects0, transformed_objects1;
+  autoware_perception_msgs::msg::DetectedObjects transformed_objects0, transformed_objects1;
   if (
     !object_recognition_utils::transformObjects(
       *input_objects0_msg, base_link_frame_id_, tf_buffer_, transformed_objects0) ||
@@ -149,7 +149,7 @@ void ObjectAssociationMergerNode::objectsCallback(
   }
 
   // build output msg
-  autoware_auto_perception_msgs::msg::DetectedObjects output_msg;
+  autoware_perception_msgs::msg::DetectedObjects output_msg;
   output_msg.header = input_objects0_msg->header;
 
   /* global nearest neighbor */
@@ -192,7 +192,7 @@ void ObjectAssociationMergerNode::objectsCallback(
 
   // Remove overlapped unknown object
   if (remove_overlapped_unknown_objects_) {
-    std::vector<autoware_auto_perception_msgs::msg::DetectedObject> unknown_objects, known_objects;
+    std::vector<autoware_perception_msgs::msg::DetectedObject> unknown_objects, known_objects;
     unknown_objects.reserve(output_msg.objects.size());
     known_objects.reserve(output_msg.objects.size());
     for (const auto & object : output_msg.objects) {

--- a/perception/object_range_splitter/README.md
+++ b/perception/object_range_splitter/README.md
@@ -30,16 +30,16 @@ Example:
 
 ### Input
 
-| Name           | Type                                                  | Description      |
-| -------------- | ----------------------------------------------------- | ---------------- |
-| `input/object` | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects |
+| Name           | Type                                             | Description      |
+| -------------- | ------------------------------------------------ | ---------------- |
+| `input/object` | `autoware_perception_msgs::msg::DetectedObjects` | detected objects |
 
 ### Output
 
-| Name                        | Type                                                  | Description                  |
-| --------------------------- | ----------------------------------------------------- | ---------------------------- |
-| `output/long_range_object`  | `autoware_auto_perception_msgs::msg::DetectedObjects` | long range detected objects  |
-| `output/short_range_object` | `autoware_auto_perception_msgs::msg::DetectedObjects` | short range detected objects |
+| Name                        | Type                                             | Description                  |
+| --------------------------- | ------------------------------------------------ | ---------------------------- |
+| `output/long_range_object`  | `autoware_perception_msgs::msg::DetectedObjects` | long range detected objects  |
+| `output/short_range_object` | `autoware_perception_msgs::msg::DetectedObjects` | short range detected objects |
 
 ## Parameters
 

--- a/perception/object_range_splitter/include/object_range_splitter/node.hpp
+++ b/perception/object_range_splitter/include/object_range_splitter/node.hpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <memory>
 
@@ -30,13 +30,13 @@ public:
 
 private:
   void objectCallback(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_msg);
+    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_msg);
 
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
     long_range_object_pub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
     short_range_object_pub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr sub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr sub_;
 
   // ROS Parameters
   float spilt_range_;

--- a/perception/object_range_splitter/package.xml
+++ b/perception/object_range_splitter/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/perception/object_range_splitter/src/node.cpp
+++ b/perception/object_range_splitter/src/node.cpp
@@ -21,18 +21,16 @@ ObjectRangeSplitterNode::ObjectRangeSplitterNode(const rclcpp::NodeOptions & nod
 {
   using std::placeholders::_1;
   spilt_range_ = declare_parameter<double>("split_range");
-  sub_ = this->create_subscription<autoware_auto_perception_msgs::msg::DetectedObjects>(
+  sub_ = this->create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
     "input/object", rclcpp::QoS{1}, std::bind(&ObjectRangeSplitterNode::objectCallback, this, _1));
-  long_range_object_pub_ =
-    this->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-      "output/long_range_object", rclcpp::QoS{1});
-  short_range_object_pub_ =
-    this->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
-      "output/short_range_object", rclcpp::QoS{1});
+  long_range_object_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+    "output/long_range_object", rclcpp::QoS{1});
+  short_range_object_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+    "output/short_range_object", rclcpp::QoS{1});
 }
 
 void ObjectRangeSplitterNode::objectCallback(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_msg)
+  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_msg)
 {
   // Guard
   if (
@@ -41,7 +39,7 @@ void ObjectRangeSplitterNode::objectCallback(
     return;
   }
   // build output msg
-  autoware_auto_perception_msgs::msg::DetectedObjects output_long_range_object_msg,
+  autoware_perception_msgs::msg::DetectedObjects output_long_range_object_msg,
     output_short_range_object_msg;
   output_long_range_object_msg.header = input_msg->header;
   output_short_range_object_msg.header = input_msg->header;

--- a/perception/object_velocity_splitter/README.md
+++ b/perception/object_velocity_splitter/README.md
@@ -1,20 +1,20 @@
 # object_velocity_splitter
 
-This package contains a object filter module for [autoware_auto_perception_msgs/msg/DetectedObject](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/DetectedObject.idl).
+This package contains a object filter module for [autoware_perception_msgs/msg/DetectedObject](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/DetectedObject.idl).
 This package can split DetectedObjects into two messages by object's speed.
 
 ## Interface
 
 ### Input
 
-- `~/input/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/input/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - 3D detected objects
 
 ### Output
 
-- `~/output/low_speed_objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/low_speed_objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Objects with low speed
-- `~/output/high_speed_objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/high_speed_objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Objects with high speed
 
 ### Parameters

--- a/perception/object_velocity_splitter/include/object_velocity_splitter/object_velocity_splitter_node.hpp
+++ b/perception/object_velocity_splitter/include/object_velocity_splitter/object_velocity_splitter_node.hpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <chrono>
 #include <memory>
@@ -26,8 +26,8 @@
 
 namespace object_velocity_splitter
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 class ObjectVelocitySplitterNode : public rclcpp::Node
 {

--- a/perception/object_velocity_splitter/package.xml
+++ b/perception/object_velocity_splitter/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/object_velocity_splitter/src/object_velocity_splitter_node/object_velocity_splitter_node.cpp
+++ b/perception/object_velocity_splitter/src/object_velocity_splitter_node/object_velocity_splitter_node.cpp
@@ -42,8 +42,8 @@ bool update_param(
 
 namespace object_velocity_splitter
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 ObjectVelocitySplitterNode::ObjectVelocitySplitterNode(const rclcpp::NodeOptions & node_options)
 : Node("object_velocity_splitter", node_options)

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>image_transport</depend>
   <depend>lanelet2_extension</depend>

--- a/perception/radar_crossing_objects_noise_filter/README.md
+++ b/perception/radar_crossing_objects_noise_filter/README.md
@@ -1,6 +1,6 @@
 # radar_crossing_objects_noise_filter
 
-This package contains a radar noise filter module for [autoware_auto_perception_msgs/msg/DetectedObject](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/DetectedObject.idl).
+This package contains a radar noise filter module for [autoware_perception_msgs/msg/DetectedObject](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/DetectedObject.idl).
 This package can filter the noise objects which cross to the ego vehicle.
 
 ## Design
@@ -55,14 +55,14 @@ To filter the objects crossing to ego vehicle, this package filter the objects a
 
 ### Input
 
-- `~/input/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/input/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Input radar objects
 
 ### Output
 
-- `~/output/noise_objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/noise_objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Noise objects
-- `~/output/filtered_objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/filtered_objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Filtered objects
 
 ### Parameters

--- a/perception/radar_crossing_objects_noise_filter/include/radar_crossing_objects_noise_filter/radar_crossing_objects_noise_filter_node.hpp
+++ b/perception/radar_crossing_objects_noise_filter/include/radar_crossing_objects_noise_filter/radar_crossing_objects_noise_filter_node.hpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <chrono>
 #include <memory>
@@ -25,8 +25,8 @@
 
 namespace radar_crossing_objects_noise_filter
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 class RadarCrossingObjectsNoiseFilterNode : public rclcpp::Node
 {

--- a/perception/radar_crossing_objects_noise_filter/package.xml
+++ b/perception/radar_crossing_objects_noise_filter/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/radar_crossing_objects_noise_filter/src/radar_crossing_objects_noise_filter_node/radar_crossing_objects_noise_filter_node.cpp
+++ b/perception/radar_crossing_objects_noise_filter/src/radar_crossing_objects_noise_filter_node/radar_crossing_objects_noise_filter_node.cpp
@@ -52,8 +52,8 @@ bool update_param(
 
 namespace radar_crossing_objects_noise_filter
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 RadarCrossingObjectsNoiseFilterNode::RadarCrossingObjectsNoiseFilterNode(
   const rclcpp::NodeOptions & node_options)

--- a/perception/radar_crossing_objects_noise_filter/test/test_radar_crossing_objects_noise_filter/test_radar_crossing_objects_filter_is_noise.cpp
+++ b/perception/radar_crossing_objects_noise_filter/test/test_radar_crossing_objects_noise_filter/test_radar_crossing_objects_filter_is_noise.cpp
@@ -33,11 +33,11 @@ std::shared_ptr<radar_crossing_objects_noise_filter::RadarCrossingObjectsNoiseFi
   return node;
 }
 
-autoware_auto_perception_msgs::msg::DetectedObject get_object(
+autoware_perception_msgs::msg::DetectedObject get_object(
   geometry_msgs::msg::Vector3 velocity, geometry_msgs::msg::Point position,
   geometry_msgs::msg::Quaternion orientation)
 {
-  autoware_auto_perception_msgs::msg::DetectedObject object;
+  autoware_perception_msgs::msg::DetectedObject object;
   object.kinematics.twist_with_covariance.twist.linear = velocity;
   object.kinematics.pose_with_covariance.pose.position = position;
   object.kinematics.pose_with_covariance.pose.orientation = orientation;

--- a/perception/radar_fusion_to_detected_object/README.md
+++ b/perception/radar_fusion_to_detected_object/README.md
@@ -110,16 +110,16 @@ ros2 launch radar_fusion_to_detected_object radar_object_to_detected_object.laun
 
 ### Input
 
-- `~/input/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/input/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - 3D detected objects.
-- `~/input/radar_objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/input/radar_objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Radar objects. Note that frame_id need to be same as `~/input/objects`
 
 ### Output
 
-- `~/output/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - 3D detected object with twist.
-- `~/debug/low_confidence_objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/debug/low_confidence_objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - 3D detected object that doesn't output as `~/output/objects` because of low confidence
 
 ### Parameters

--- a/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object/radar_fusion_to_detected_object.hpp
+++ b/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object/radar_fusion_to_detected_object.hpp
@@ -21,7 +21,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "geometry_msgs/msg/pose_with_covariance.hpp"
 #include "geometry_msgs/msg/twist_with_covariance.hpp"
 // #include "std_msgs/msg/header.hpp"
@@ -32,8 +32,8 @@
 
 namespace radar_fusion_to_detected_object
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::Twist;

--- a/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object/radar_fusion_to_detected_object_node.hpp
+++ b/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object/radar_fusion_to_detected_object_node.hpp
@@ -22,7 +22,7 @@
 #include "radar_fusion_to_detected_object/radar_fusion_to_detected_object.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <chrono>
 #include <memory>
@@ -31,8 +31,8 @@
 
 namespace radar_fusion_to_detected_object
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 class RadarObjectFusionToDetectedObjectNode : public rclcpp::Node
 {

--- a/perception/radar_fusion_to_detected_object/package.xml
+++ b/perception/radar_fusion_to_detected_object/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>message_filters</depend>

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -29,8 +29,8 @@
 
 namespace radar_fusion_to_detected_object
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::Twist;

--- a/perception/radar_fusion_to_detected_object/src/radar_object_fusion_to_detected_object_node/radar_object_fusion_to_detected_object_node.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_object_fusion_to_detected_object_node/radar_object_fusion_to_detected_object_node.cpp
@@ -48,8 +48,8 @@ bool update_param(
 
 namespace radar_fusion_to_detected_object
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 RadarObjectFusionToDetectedObjectNode::RadarObjectFusionToDetectedObjectNode(
   const rclcpp::NodeOptions & node_options)

--- a/perception/radar_object_clustering/README.md
+++ b/perception/radar_object_clustering/README.md
@@ -1,6 +1,6 @@
 # radar_object_clustering
 
-This package contains a radar object clustering for [autoware_auto_perception_msgs/msg/DetectedObject](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/DetectedObject.idl) input.
+This package contains a radar object clustering for [autoware_perception_msgs/msg/DetectedObject](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/DetectedObject.idl) input.
 
 This package can make clustered objects from radar DetectedObjects, the objects which is converted from RadarTracks by [radar_tracks_msgs_converter](https://github.com/autowarefoundation/autoware.universe/tree/main/perception/radar_tracks_msgs_converter) and is processed by noise filter.
 In other word, this package can combine multiple radar detections from one object into one and adjust class and size.
@@ -55,12 +55,12 @@ So `is_fixed_size` parameter is recommended to set `true`, and size parameters i
 
 ### Input
 
-- `~/input/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/input/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Radar objects
 
 ### Output
 
-- `~/output/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Output objects
 
 ### Parameter

--- a/perception/radar_object_clustering/include/radar_object_clustering/radar_object_clustering_node.hpp
+++ b/perception/radar_object_clustering/include/radar_object_clustering/radar_object_clustering_node.hpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <chrono>
 #include <memory>
@@ -26,8 +26,8 @@
 
 namespace radar_object_clustering
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 class RadarObjectClusteringNode : public rclcpp::Node
 {

--- a/perception/radar_object_clustering/package.xml
+++ b/perception/radar_object_clustering/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>object_recognition_utils</depend>
   <depend>rclcpp</depend>

--- a/perception/radar_object_clustering/src/radar_object_clustering_node/radar_object_clustering_node.cpp
+++ b/perception/radar_object_clustering/src/radar_object_clustering_node/radar_object_clustering_node.cpp
@@ -50,7 +50,7 @@ bool update_param(
   return true;
 }
 
-double get_distance(const autoware_auto_perception_msgs::msg::DetectedObject & object)
+double get_distance(const autoware_perception_msgs::msg::DetectedObject & object)
 {
   const auto & position = object.kinematics.pose_with_covariance.pose.position;
   return std::hypot(position.x, position.y);
@@ -60,8 +60,8 @@ double get_distance(const autoware_auto_perception_msgs::msg::DetectedObject & o
 
 namespace radar_object_clustering
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 RadarObjectClusteringNode::RadarObjectClusteringNode(const rclcpp::NodeOptions & node_options)
 : Node("radar_object_clustering", node_options)
@@ -166,7 +166,7 @@ void RadarObjectClusteringNode::onObjects(const DetectedObjects::ConstSharedPtr 
 
     // Fixed size correction
     if (node_param_.is_fixed_size) {
-      clustered_output_object.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+      clustered_output_object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
       clustered_output_object.shape.dimensions.x = node_param_.size_x;
       clustered_output_object.shape.dimensions.y = node_param_.size_y;
       clustered_output_object.shape.dimensions.z = node_param_.size_z;

--- a/perception/radar_object_tracker/README.md
+++ b/perception/radar_object_tracker/README.md
@@ -26,16 +26,16 @@ See more details in the [models.md](models.md).
 
 ### Input
 
-| Name          | Type                                                  | Description      |
-| ------------- | ----------------------------------------------------- | ---------------- |
-| `~/input`     | `autoware_auto_perception_msgs::msg::DetectedObjects` | Detected objects |
-| `/vector/map` | `autoware_auto_msgs::msg::HADMapBin`                  | Map data         |
+| Name          | Type                                             | Description      |
+| ------------- | ------------------------------------------------ | ---------------- |
+| `~/input`     | `autoware_perception_msgs::msg::DetectedObjects` | Detected objects |
+| `/vector/map` | `autoware_map_msgs::msg::LaneletMapBin`          | Map data         |
 
 ### Output
 
-| Name       | Type                                                 | Description     |
-| ---------- | ---------------------------------------------------- | --------------- |
-| `~/output` | `autoware_auto_perception_msgs::msg::TrackedObjects` | Tracked objects |
+| Name       | Type                                            | Description     |
+| ---------- | ----------------------------------------------- | --------------- |
+| `~/output` | `autoware_perception_msgs::msg::TrackedObjects` | Tracked objects |
 
 ## Parameters
 

--- a/perception/radar_object_tracker/include/radar_object_tracker/data_association/data_association.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/data_association/data_association.hpp
@@ -32,7 +32,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 
 #include <string>
 class DataAssociation
@@ -57,7 +57,7 @@ public:
     const Eigen::MatrixXd & src, std::unordered_map<int, int> & direct_assignment,
     std::unordered_map<int, int> & reverse_assignment);
   Eigen::MatrixXd calcScoreMatrix(
-    const autoware_auto_perception_msgs::msg::DetectedObjects & measurements,
+    const autoware_perception_msgs::msg::DetectedObjects & measurements,
     const std::list<std::shared_ptr<Tracker>> & trackers, const bool debug_log,
     const std::string & file_name);
   virtual ~DataAssociation() {}

--- a/perception/radar_object_tracker/include/radar_object_tracker/radar_object_tracker_node/radar_object_tracker_node.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/radar_object_tracker_node/radar_object_tracker_node.hpp
@@ -19,8 +19,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
 #include <tf2/LinearMath/Transform.h>
@@ -51,11 +51,11 @@
 #include <memory>
 #include <string>
 
-using autoware_auto_mapping_msgs::msg::HADMapBin;
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 class RadarObjectTrackerNode : public rclcpp::Node
 {
@@ -64,12 +64,11 @@ public:
 
 private:
   // pub-sub
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
-    tracked_objects_pub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr tracked_objects_pub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
     detected_object_sub_;
-  rclcpp::TimerBase::SharedPtr publish_timer_;          // publish timer
-  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;  // map subscriber
+  rclcpp::TimerBase::SharedPtr publish_timer_;              // publish timer
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;  // map subscriber
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
@@ -79,9 +78,9 @@ private:
   int measurement_count_threshold_;
 
   void onMeasurement(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_objects_msg);
+    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr input_objects_msg);
   void onTimer();
-  void onMap(const HADMapBin::ConstSharedPtr map_msg);
+  void onMap(const LaneletMapBin::ConstSharedPtr map_msg);
 
   std::string world_frame_id_;  // tracking frame
   std::string tracker_config_directory_;
@@ -126,7 +125,7 @@ private:
     std::list<std::shared_ptr<Tracker>> & list_tracker, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform);
   std::shared_ptr<Tracker> createNewTracker(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) const;
 
   void publish(const rclcpp::Time & time) const;

--- a/perception/radar_object_tracker/include/radar_object_tracker/tracker/model/constant_turn_rate_motion_tracker.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/tracker/model/constant_turn_rate_motion_tracker.hpp
@@ -21,11 +21,11 @@
 
 #include <string>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 class ConstantTurnRateMotionTracker : public Tracker  // means constant turn rate motion tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -90,22 +90,22 @@ private:
 
 public:
   ConstantTurnRateMotionTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const std::string & tracker_param_file, const std::uint8_t & label);
 
   static void loadDefaultModelParameters(const std::string & path);
   bool predict(const rclcpp::Time & time) override;
   bool predict(const double dt, KalmanFilter & ekf) const;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
   bool measureWithPose(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~ConstantTurnRateMotionTracker() {}
 };
 

--- a/perception/radar_object_tracker/include/radar_object_tracker/tracker/model/linear_motion_tracker.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/tracker/model/linear_motion_tracker.hpp
@@ -21,11 +21,11 @@
 
 #include <string>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 class LinearMotionTracker : public Tracker
 {
 private:
-  autoware_auto_perception_msgs::msg::DetectedObject object_;
+  autoware_perception_msgs::msg::DetectedObject object_;
   rclcpp::Logger logger_;
 
 private:
@@ -93,22 +93,22 @@ private:
 
 public:
   LinearMotionTracker(
-    const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
     const std::string & tracker_param_file, const std::uint8_t & label);
 
   static void loadDefaultModelParameters(const std::string & path);
   bool predict(const rclcpp::Time & time) override;
   bool predict(const double dt, KalmanFilter & ekf) const;
   bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) override;
   bool measureWithPose(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const geometry_msgs::msg::Transform & self_transform);
-  bool measureWithShape(const autoware_auto_perception_msgs::msg::DetectedObject & object);
+  bool measureWithShape(const autoware_perception_msgs::msg::DetectedObject & object);
   bool getTrackedObject(
     const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const override;
+    autoware_perception_msgs::msg::TrackedObject & object) const override;
   virtual ~LinearMotionTracker() {}
 };
 

--- a/perception/radar_object_tracker/include/radar_object_tracker/tracker/model/tracker_base.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/tracker/model/tracker_base.hpp
@@ -26,8 +26,8 @@
 #include <Eigen/Core>
 #include <rclcpp/rclcpp.hpp>
 
-#include "autoware_auto_perception_msgs/msg/detected_object.hpp"
-#include "autoware_auto_perception_msgs/msg/tracked_object.hpp"
+#include "autoware_perception_msgs/msg/detected_object.hpp"
+#include "autoware_perception_msgs/msg/tracked_object.hpp"
 #include "geometry_msgs/msg/point.hpp"
 #include "unique_identifier_msgs/msg/uuid.hpp"
 
@@ -38,14 +38,14 @@ class Tracker
 protected:
   unique_identifier_msgs::msg::UUID getUUID() const { return uuid_; }
   void setClassification(
-    const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification)
+    const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
   {
     classification_ = classification;
   }
 
 private:
   unique_identifier_msgs::msg::UUID uuid_;
-  std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> classification_;
+  std::vector<autoware_perception_msgs::msg::ObjectClassification> classification_;
   int no_measurement_count_;
   int total_no_measurement_count_;
   int total_measurement_count_;
@@ -54,13 +54,13 @@ private:
 public:
   Tracker(
     const rclcpp::Time & time,
-    const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification);
+    const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification);
   virtual ~Tracker() {}
   bool updateWithMeasurement(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object,
+    const autoware_perception_msgs::msg::DetectedObject & object,
     const rclcpp::Time & measurement_time, const geometry_msgs::msg::Transform & self_transform);
   bool updateWithoutMeasurement();
-  std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> getClassification() const
+  std::vector<autoware_perception_msgs::msg::ObjectClassification> getClassification() const
   {
     return classification_;
   }
@@ -84,13 +84,12 @@ public:
 
 protected:
   virtual bool measure(
-    const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+    const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform) = 0;
 
 public:
   virtual bool getTrackedObject(
-    const rclcpp::Time & time,
-    autoware_auto_perception_msgs::msg::TrackedObject & object) const = 0;
+    const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const = 0;
   virtual bool predict(const rclcpp::Time & time) = 0;
 };
 

--- a/perception/radar_object_tracker/include/radar_object_tracker/utils/radar_object_tracker_utils.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/utils/radar_object_tracker_utils.hpp
@@ -38,7 +38,7 @@
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/math/unit_conversion.hpp>
 
-#include <autoware_auto_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
 
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
@@ -60,16 +60,16 @@ bool isDuplicated(
 
 bool checkCloseLaneletCondition(
   const std::pair<double, lanelet::Lanelet> & lanelet,
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
-  const double max_distance_from_lane, const double max_angle_diff_from_lane);
+  const autoware_perception_msgs::msg::TrackedObject & object, const double max_distance_from_lane,
+  const double max_angle_diff_from_lane);
 
 lanelet::ConstLanelets getClosestValidLanelets(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
+  const autoware_perception_msgs::msg::TrackedObject & object,
   const lanelet::LaneletMapPtr & lanelet_map_ptr, const double max_distance_from_lane,
   const double max_angle_diff_from_lane);
 
 bool hasValidVelocityDirectionToLanelet(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
+  const autoware_perception_msgs::msg::TrackedObject & object,
   const lanelet::ConstLanelets & lanelets, const double max_lateral_velocity);
 
 }  // namespace radar_object_tracker_utils

--- a/perception/radar_object_tracker/include/radar_object_tracker/utils/utils.hpp
+++ b/perception/radar_object_tracker/include/radar_object_tracker/utils/utils.hpp
@@ -23,9 +23,9 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/detected_object.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 

--- a/perception/radar_object_tracker/package.xml
+++ b/perception/radar_object_tracker/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>glog</depend>
   <depend>kalman_filter</depend>

--- a/perception/radar_object_tracker/src/data_association/data_association.cpp
+++ b/perception/radar_object_tracker/src/data_association/data_association.cpp
@@ -150,7 +150,7 @@ void DataAssociation::assign(
 }
 
 Eigen::MatrixXd DataAssociation::calcScoreMatrix(
-  const autoware_auto_perception_msgs::msg::DetectedObjects & measurements,
+  const autoware_perception_msgs::msg::DetectedObjects & measurements,
   const std::list<std::shared_ptr<Tracker>> & trackers, const bool debug_log,
   const std::string & file_name)
 {
@@ -173,14 +173,14 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
 
     for (size_t measurement_idx = 0; measurement_idx < measurements.objects.size();
          ++measurement_idx) {
-      const autoware_auto_perception_msgs::msg::DetectedObject & measurement_object =
+      const autoware_perception_msgs::msg::DetectedObject & measurement_object =
         measurements.objects.at(measurement_idx);
       const std::uint8_t measurement_label =
         object_recognition_utils::getHighestProbLabel(measurement_object.classification);
       // Create a JSON object to hold the log data for this pair
       nlohmann::json pair_log_data;
 
-      autoware_auto_perception_msgs::msg::TrackedObject tracked_object;
+      autoware_perception_msgs::msg::TrackedObject tracked_object;
       (*tracker_itr)->getTrackedObject(measurements.header.stamp, tracked_object);
 
       std::vector<double> tracker_pose = {

--- a/perception/radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp
+++ b/perception/radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp
@@ -42,7 +42,7 @@
 
 #include <yaml-cpp/yaml.h>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 // initialize static parameter
 bool LinearMotionTracker::is_initialized_ = false;
@@ -57,7 +57,7 @@ bool LinearMotionTracker::trust_twist_input_;
 bool LinearMotionTracker::use_polar_coordinate_in_measurement_noise_;
 
 LinearMotionTracker::LinearMotionTracker(
-  const rclcpp::Time & time, const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const rclcpp::Time & time, const autoware_perception_msgs::msg::DetectedObject & object,
   const std::string & tracker_param_file, const std::uint8_t & /*label*/)
 : Tracker(time, object.classification),
   logger_(rclcpp::get_logger("LinearMotionTracker")),
@@ -161,10 +161,10 @@ LinearMotionTracker::LinearMotionTracker(
   P.block<2, 2>(IDX::AX, IDX::AX) = P_a_xy;
 
   // init shape
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
       object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_ = {object.shape.dimensions.x, object.shape.dimensions.z};
   }
 
@@ -350,7 +350,7 @@ bool LinearMotionTracker::predict(const double dt, KalmanFilter & ekf) const
 }
 
 bool LinearMotionTracker::measureWithPose(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const geometry_msgs::msg::Transform & self_transform)
 {
   // Observation pattern will be:
@@ -509,16 +509,16 @@ bool LinearMotionTracker::measureWithPose(
 }
 
 bool LinearMotionTracker::measureWithShape(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object)
 {
   // just use first order low pass filter
   const float gain = filter_tau_ / (filter_tau_ + filter_dt_);
 
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
     bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
     bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_.width = gain * cylinder_.width + (1.0 - gain) * object.shape.dimensions.x;
     cylinder_.height = gain * cylinder_.height + (1.0 - gain) * object.shape.dimensions.z;
   } else {
@@ -529,7 +529,7 @@ bool LinearMotionTracker::measureWithShape(
 }
 
 bool LinearMotionTracker::measure(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
+  const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform)
 {
   const auto & current_classification = getClassification();
@@ -552,7 +552,7 @@ bool LinearMotionTracker::measure(
 }
 
 bool LinearMotionTracker::getTrackedObject(
-  const rclcpp::Time & time, autoware_auto_perception_msgs::msg::TrackedObject & object) const
+  const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObject & object) const
 {
   object = object_recognition_utils::toTrackedObject(object_);
   object.object_id = getUUID();
@@ -595,10 +595,10 @@ bool LinearMotionTracker::getTrackedObject(
     pose_with_cov.pose.orientation.w = filtered_quaternion.w();
     if (trust_yaw_input_) {
       object.kinematics.orientation_availability =
-        autoware_auto_perception_msgs::msg::TrackedObjectKinematics::SIGN_UNKNOWN;
+        autoware_perception_msgs::msg::TrackedObjectKinematics::SIGN_UNKNOWN;
     } else {
       object.kinematics.orientation_availability =
-        autoware_auto_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
+        autoware_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
     }
   }
   // twist
@@ -670,15 +670,15 @@ bool LinearMotionTracker::getTrackedObject(
   acceleration_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = no_info_cov;
 
   // set shape
-  if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     object.shape.dimensions.x = bounding_box_.length;
     object.shape.dimensions.y = bounding_box_.width;
     object.shape.dimensions.z = bounding_box_.height;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     object.shape.dimensions.x = cylinder_.width;
     object.shape.dimensions.y = cylinder_.width;
     object.shape.dimensions.z = cylinder_.height;
-  } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     const auto origin_yaw = tf2::getYaw(object_.kinematics.pose_with_covariance.pose.orientation);
     const auto ekf_pose_yaw = tf2::getYaw(pose_with_cov.pose.orientation);
     object.shape.footprint =

--- a/perception/radar_object_tracker/src/tracker/model/tracker_base.cpp
+++ b/perception/radar_object_tracker/src/tracker/model/tracker_base.cpp
@@ -23,7 +23,7 @@
 
 Tracker::Tracker(
   const rclcpp::Time & time,
-  const std::vector<autoware_auto_perception_msgs::msg::ObjectClassification> & classification)
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
 : classification_(classification),
   no_measurement_count_(0),
   total_no_measurement_count_(0),
@@ -37,7 +37,7 @@ Tracker::Tracker(
 }
 
 bool Tracker::updateWithMeasurement(
-  const autoware_auto_perception_msgs::msg::DetectedObject & object,
+  const autoware_perception_msgs::msg::DetectedObject & object,
   const rclcpp::Time & measurement_time, const geometry_msgs::msg::Transform & self_transform)
 {
   no_measurement_count_ = 0;
@@ -57,7 +57,7 @@ bool Tracker::updateWithoutMeasurement()
 geometry_msgs::msg::PoseWithCovariance Tracker::getPoseWithCovariance(
   const rclcpp::Time & time) const
 {
-  autoware_auto_perception_msgs::msg::TrackedObject object;
+  autoware_perception_msgs::msg::TrackedObject object;
   getTrackedObject(time, object);
   return object.kinematics.pose_with_covariance;
 }

--- a/perception/radar_object_tracker/src/utils/radar_object_tracker_utils.cpp
+++ b/perception/radar_object_tracker/src/utils/radar_object_tracker_utils.cpp
@@ -58,8 +58,8 @@ bool isDuplicated(
 
 bool checkCloseLaneletCondition(
   const std::pair<double, lanelet::Lanelet> & lanelet,
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
-  const double max_distance_from_lane, const double max_angle_diff_from_lane)
+  const autoware_perception_msgs::msg::TrackedObject & object, const double max_distance_from_lane,
+  const double max_angle_diff_from_lane)
 {
   if (lanelet.second.centerline().size() <= 1) {
     return false;
@@ -95,7 +95,7 @@ bool checkCloseLaneletCondition(
 }
 
 lanelet::ConstLanelets getClosestValidLanelets(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
+  const autoware_perception_msgs::msg::TrackedObject & object,
   const lanelet::LaneletMapPtr & lanelet_map_ptr, const double max_distance_from_lane,
   const double max_angle_diff_from_lane)
 {
@@ -126,7 +126,7 @@ lanelet::ConstLanelets getClosestValidLanelets(
 }
 
 bool hasValidVelocityDirectionToLanelet(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
+  const autoware_perception_msgs::msg::TrackedObject & object,
   const lanelet::ConstLanelets & lanelets, const double max_lateral_velocity)
 {
   const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);

--- a/perception/radar_object_tracker/test/test_radar_object_tracker_utils.cpp
+++ b/perception/radar_object_tracker/test/test_radar_object_tracker_utils.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-using autoware_auto_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObject;
 using radar_object_tracker_utils::checkCloseLaneletCondition;
 
 // helper function to create a dummy straight lanelet

--- a/perception/radar_tracks_msgs_converter/README.md
+++ b/perception/radar_tracks_msgs_converter/README.md
@@ -1,6 +1,6 @@
 # radar_tracks_msgs_converter
 
-This package converts from [radar_msgs/msg/RadarTracks](https://github.com/ros-perception/radar_msgs/blob/ros2/msg/RadarTracks.msg) into [autoware_auto_perception_msgs/msg/DetectedObject](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/DetectedObject.idl) and [autoware_auto_perception_msgs/msg/TrackedObject](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/TrackedObject.idl).
+This package converts from [radar_msgs/msg/RadarTracks](https://github.com/ros-perception/radar_msgs/blob/ros2/msg/RadarTracks.msg) into [autoware_perception_msgs/msg/DetectedObject]<https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/DetectedObject.msg)> and [autoware_perception_msgs/msg/TrackedObject](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/TrackedObject.msg).
 
 - Calculation cost is O(n).
   - n: The number of radar objects
@@ -10,7 +10,7 @@ This package converts from [radar_msgs/msg/RadarTracks](https://github.com/ros-p
 ### Background
 
 Autoware uses [radar_msgs/msg/RadarTracks.msg](https://github.com/ros-perception/radar_msgs/blob/ros2/msg/RadarTracks.msg) as radar objects input data.
-To use radar objects data for Autoware perception module easily, `radar_tracks_msgs_converter` converts message type from `radar_msgs/msg/RadarTracks.msg` to `autoware_auto_perception_msgs/msg/DetectedObject`.
+To use radar objects data for Autoware perception module easily, `radar_tracks_msgs_converter` converts message type from `radar_msgs/msg/RadarTracks.msg` to `autoware_perception_msgs/msg/DetectedObject`.
 In addition, because many detection module have an assumption on base_link frame, `radar_tracks_msgs_converter` provide the functions of transform frame_id.
 
 ### Note
@@ -30,7 +30,7 @@ Label id is defined as below.
 | PEDESTRIAN | 32007      | 7        |
 
 Additional vendor-specific classifications are permitted starting from 32000 in [radar_msgs/msg/RadarTrack.msg](https://github.com/ros-perception/radar_msgs/blob/ros2/msg/RadarTrack.msg).
-Autoware objects label is defined in [ObjectClassification.idl](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/ObjectClassification.idl)
+Autoware objects label is defined in [ObjectClassification](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/ObjectClassification.msg)
 
 ## Interface
 
@@ -43,10 +43,10 @@ Autoware objects label is defined in [ObjectClassification.idl](https://gitlab.c
 
 ### Output
 
-- `~/output/radar_detected_objects` (`autoware_auto_perception_msgs/msg/DetectedObject.idl`)
+- `~/output/radar_detected_objects` (`autoware_perception_msgs/msg/DetectedObject.idl`)
   - DetectedObject topic converted to Autoware message.
   - This is used for radar sensor fusion detection and radar detection.
-- `~/output/radar_tracked_objects` (`autoware_auto_perception_msgs/msg/TrackedObject.idl`)
+- `~/output/radar_tracked_objects` (`autoware_perception_msgs/msg/TrackedObject.idl`)
   - TrackedObject topic converted to Autoware message.
   - This is used for tracking layer sensor fusion.
 

--- a/perception/radar_tracks_msgs_converter/include/radar_tracks_msgs_converter/radar_tracks_msgs_converter_node.hpp
+++ b/perception/radar_tracks_msgs_converter/include/radar_tracks_msgs_converter/radar_tracks_msgs_converter_node.hpp
@@ -18,12 +18,12 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
-#include "autoware_auto_perception_msgs/msg/object_classification.hpp"
-#include "autoware_auto_perception_msgs/msg/shape.hpp"
-#include "autoware_auto_perception_msgs/msg/tracked_object.hpp"
-#include "autoware_auto_perception_msgs/msg/tracked_object_kinematics.hpp"
-#include "autoware_auto_perception_msgs/msg/tracked_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/object_classification.hpp"
+#include "autoware_perception_msgs/msg/shape.hpp"
+#include "autoware_perception_msgs/msg/tracked_object.hpp"
+#include "autoware_perception_msgs/msg/tracked_object_kinematics.hpp"
+#include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "radar_msgs/msg/radar_tracks.hpp"
 
@@ -34,14 +34,14 @@
 
 namespace radar_tracks_msgs_converter
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjectKinematics;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
-using autoware_auto_perception_msgs::msg::ObjectClassification;
-using autoware_auto_perception_msgs::msg::Shape;
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjectKinematics;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjectKinematics;
+using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::Shape;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjectKinematics;
+using autoware_perception_msgs::msg::TrackedObjects;
 using nav_msgs::msg::Odometry;
 using radar_msgs::msg::RadarTrack;
 using radar_msgs::msg::RadarTracks;

--- a/perception/radar_tracks_msgs_converter/package.xml
+++ b/perception/radar_tracks_msgs_converter/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>radar_msgs</depend>

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -183,7 +183,7 @@ DetectedObjects RadarTracksMsgsConverterNode::convertTrackedObjectsToDetectedObj
     // kinematics setting
     DetectedObjectKinematics kinematics;
     kinematics.orientation_availability =
-      autoware_auto_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
+      autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
     kinematics.has_twist = true;
     kinematics.has_twist_covariance = true;
     kinematics.twist_with_covariance = object.kinematics.twist_with_covariance;

--- a/perception/shape_estimation/README.md
+++ b/perception/shape_estimation/README.md
@@ -30,9 +30,9 @@ This node calculates a refined object shape (bounding box, cylinder, convex hull
 
 ### Output
 
-| Name             | Type                                                  | Description                         |
-| ---------------- | ----------------------------------------------------- | ----------------------------------- |
-| `output/objects` | `autoware_auto_perception_msgs::msg::DetectedObjects` | detected objects with refined shape |
+| Name             | Type                                             | Description                         |
+| ---------------- | ------------------------------------------------ | ----------------------------------- |
+| `output/objects` | `autoware_perception_msgs::msg::DetectedObjects` | detected objects with refined shape |
 
 ## Parameters
 

--- a/perception/shape_estimation/include/shape_estimation/corrector/corrector_interface.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/corrector_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef SHAPE_ESTIMATION__CORRECTOR__CORRECTOR_INTERFACE_HPP_
 #define SHAPE_ESTIMATION__CORRECTOR__CORRECTOR_INTERFACE_HPP_
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <string>
@@ -28,7 +28,7 @@ public:
   virtual ~ShapeEstimationCorrectorInterface() {}
 
   virtual bool correct(
-    autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) = 0;
+    autoware_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) = 0;
 };
 
 #endif  // SHAPE_ESTIMATION__CORRECTOR__CORRECTOR_INTERFACE_HPP_

--- a/perception/shape_estimation/include/shape_estimation/corrector/no_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/no_corrector.hpp
@@ -26,7 +26,7 @@ public:
   ~NoCorrector() {}
 
   bool correct(
-    autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) override;
+    autoware_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) override;
 };
 
 #endif  // SHAPE_ESTIMATION__CORRECTOR__NO_CORRECTOR_HPP_

--- a/perception/shape_estimation/include/shape_estimation/corrector/reference_shape_size_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/reference_shape_size_corrector.hpp
@@ -32,7 +32,7 @@ public:
   virtual ~ReferenceShapeBasedVehicleCorrector() = default;
 
   bool correct(
-    autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) override
+    autoware_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) override
   {
     return corrector_utils::correctWithReferenceYawAndShapeSize(ref_shape_size_info_, shape, pose);
   }

--- a/perception/shape_estimation/include/shape_estimation/corrector/utils.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/utils.hpp
@@ -17,7 +17,7 @@
 
 #include "shape_estimation/shape_estimator.hpp"
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 namespace corrector_utils
@@ -33,15 +33,15 @@ struct CorrectionBBParameters
 };
 
 bool correctWithDefaultValue(
-  const CorrectionBBParameters & param, autoware_auto_perception_msgs::msg::Shape & shape_output,
+  const CorrectionBBParameters & param, autoware_perception_msgs::msg::Shape & shape_output,
   geometry_msgs::msg::Pose & pose_output);
 
 bool correctWithReferenceYawAndShapeSize(
   const ReferenceShapeSizeInfo & ref_shape_size_info,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output);
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output);
 
 bool correctWithReferenceYaw(
-  const CorrectionBBParameters & param, autoware_auto_perception_msgs::msg::Shape & shape_output,
+  const CorrectionBBParameters & param, autoware_perception_msgs::msg::Shape & shape_output,
   geometry_msgs::msg::Pose & pose_output);
 
 }  // namespace corrector_utils

--- a/perception/shape_estimation/include/shape_estimation/corrector/vehicle_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/vehicle_corrector.hpp
@@ -33,7 +33,7 @@ public:
   virtual ~VehicleCorrector() = default;
 
   bool correct(
-    autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) override
+    autoware_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose) override
   {
     // Guard
     if (!params_) return false;

--- a/perception/shape_estimation/include/shape_estimation/filter/bus_filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/bus_filter.hpp
@@ -26,7 +26,7 @@ public:
   ~BusFilter() = default;
 
   bool filter(
-    const autoware_auto_perception_msgs::msg::Shape & shape_output,
+    const autoware_perception_msgs::msg::Shape & shape_output,
     const geometry_msgs::msg::Pose & pose_output) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/filter/car_filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/car_filter.hpp
@@ -26,7 +26,7 @@ public:
   ~CarFilter() = default;
 
   bool filter(
-    const autoware_auto_perception_msgs::msg::Shape & shape,
+    const autoware_perception_msgs::msg::Shape & shape,
     const geometry_msgs::msg::Pose & pose) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/filter/filter_interface.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/filter_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef SHAPE_ESTIMATION__FILTER__FILTER_INTERFACE_HPP_
 #define SHAPE_ESTIMATION__FILTER__FILTER_INTERFACE_HPP_
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <string>
@@ -28,8 +28,7 @@ public:
   virtual ~ShapeEstimationFilterInterface() {}
 
   virtual bool filter(
-    const autoware_auto_perception_msgs::msg::Shape & shape,
-    const geometry_msgs::msg::Pose & pose) = 0;
+    const autoware_perception_msgs::msg::Shape & shape, const geometry_msgs::msg::Pose & pose) = 0;
 };
 
 #endif  // SHAPE_ESTIMATION__FILTER__FILTER_INTERFACE_HPP_

--- a/perception/shape_estimation/include/shape_estimation/filter/no_filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/no_filter.hpp
@@ -25,7 +25,7 @@ public:
   ~NoFilter() = default;
 
   bool filter(
-    const autoware_auto_perception_msgs::msg::Shape & shape,
+    const autoware_perception_msgs::msg::Shape & shape,
     const geometry_msgs::msg::Pose & pose) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/filter/trailer_filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/trailer_filter.hpp
@@ -26,7 +26,7 @@ public:
   ~TrailerFilter() = default;
 
   bool filter(
-    const autoware_auto_perception_msgs::msg::Shape & shape,
+    const autoware_perception_msgs::msg::Shape & shape,
     const geometry_msgs::msg::Pose & pose) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/filter/truck_filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/truck_filter.hpp
@@ -26,7 +26,7 @@ public:
   ~TruckFilter() = default;
 
   bool filter(
-    const autoware_auto_perception_msgs::msg::Shape & shape,
+    const autoware_perception_msgs::msg::Shape & shape,
     const geometry_msgs::msg::Pose & pose) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/filter/utils.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/utils.hpp
@@ -15,13 +15,13 @@
 #ifndef SHAPE_ESTIMATION__FILTER__UTILS_HPP_
 #define SHAPE_ESTIMATION__FILTER__UTILS_HPP_
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 namespace utils
 {
 bool filterVehicleBoundingBox(
-  const autoware_auto_perception_msgs::msg::Shape & shape, const float min_width,
-  const float max_width, const float max_length);
+  const autoware_perception_msgs::msg::Shape & shape, const float min_width, const float max_width,
+  const float max_length);
 }  // namespace utils
 
 #endif  // SHAPE_ESTIMATION__FILTER__UTILS_HPP_

--- a/perception/shape_estimation/include/shape_estimation/model/bounding_box.hpp
+++ b/perception/shape_estimation/include/shape_estimation/model/bounding_box.hpp
@@ -25,8 +25,7 @@ class BoundingBoxShapeModel : public ShapeEstimationModelInterface
 private:
   bool fitLShape(
     const pcl::PointCloud<pcl::PointXYZ> & cluster, const float min_angle, const float max_angle,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
-    geometry_msgs::msg::Pose & pose_output);
+    autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output);
   float calcClosenessCriterion(const std::vector<float> & C_1, const std::vector<float> & C_2);
   float optimize(
     const pcl::PointCloud<pcl::PointXYZ> & cluster, const float min_angle, const float max_angle);
@@ -44,7 +43,7 @@ public:
 
   bool estimate(
     const pcl::PointCloud<pcl::PointXYZ> & cluster,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
+    autoware_perception_msgs::msg::Shape & shape_output,
     geometry_msgs::msg::Pose & pose_output) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/model/convex_hull.hpp
+++ b/perception/shape_estimation/include/shape_estimation/model/convex_hull.hpp
@@ -26,7 +26,7 @@ public:
 
   bool estimate(
     const pcl::PointCloud<pcl::PointXYZ> & cluster,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
+    autoware_perception_msgs::msg::Shape & shape_output,
     geometry_msgs::msg::Pose & pose_output) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/model/cylinder.hpp
+++ b/perception/shape_estimation/include/shape_estimation/model/cylinder.hpp
@@ -29,7 +29,7 @@ public:
    */
   bool estimate(
     const pcl::PointCloud<pcl::PointXYZ> & cluster,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
+    autoware_perception_msgs::msg::Shape & shape_output,
     geometry_msgs::msg::Pose & pose_output) override;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/model/model_interface.hpp
+++ b/perception/shape_estimation/include/shape_estimation/model/model_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef SHAPE_ESTIMATION__MODEL__MODEL_INTERFACE_HPP_
 #define SHAPE_ESTIMATION__MODEL__MODEL_INTERFACE_HPP_
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <pcl/point_cloud.h>
@@ -33,7 +33,7 @@ public:
 
   virtual bool estimate(
     const pcl::PointCloud<pcl::PointXYZ> & cluster,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
+    autoware_perception_msgs::msg::Shape & shape_output,
     geometry_msgs::msg::Pose & pose_output) = 0;
 };
 

--- a/perception/shape_estimation/include/shape_estimation/shape_estimator.hpp
+++ b/perception/shape_estimation/include/shape_estimation/shape_estimator.hpp
@@ -15,8 +15,8 @@
 #ifndef SHAPE_ESTIMATION__SHAPE_ESTIMATOR_HPP_
 #define SHAPE_ESTIMATION__SHAPE_ESTIMATOR_HPP_
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <boost/optional.hpp>
@@ -35,7 +35,7 @@ struct ReferenceYawInfo
 
 struct ReferenceShapeSizeInfo
 {
-  autoware_auto_perception_msgs::msg::Shape shape;
+  autoware_perception_msgs::msg::Shape shape;
   /**
    * @brief
    * Fix mode : use the reference shape size as fixed value.
@@ -51,15 +51,14 @@ private:
   bool estimateOriginalShapeAndPose(
     const uint8_t label, const pcl::PointCloud<pcl::PointXYZ> & cluster,
     const boost::optional<ReferenceYawInfo> & ref_yaw_info,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
-    geometry_msgs::msg::Pose & pose_output);
+    autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output);
   bool applyFilter(
-    const uint8_t label, const autoware_auto_perception_msgs::msg::Shape & shape,
+    const uint8_t label, const autoware_perception_msgs::msg::Shape & shape,
     const geometry_msgs::msg::Pose & pose);
   bool applyCorrector(
     const uint8_t label, const bool use_reference_yaw,
     const boost::optional<ReferenceShapeSizeInfo> & ref_shape_size_info,
-    autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose);
+    autoware_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose);
 
   bool use_corrector_;
   bool use_filter_;
@@ -74,8 +73,7 @@ public:
     const uint8_t label, const pcl::PointCloud<pcl::PointXYZ> & cluster,
     const boost::optional<ReferenceYawInfo> & ref_yaw_info,
     const boost::optional<ReferenceShapeSizeInfo> & ref_shape_size_info,
-    autoware_auto_perception_msgs::msg::Shape & shape_output,
-    geometry_msgs::msg::Pose & pose_output);
+    autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output);
 };
 
 #endif  // SHAPE_ESTIMATION__SHAPE_ESTIMATOR_HPP_

--- a/perception/shape_estimation/lib/corrector/no_corrector.cpp
+++ b/perception/shape_estimation/lib/corrector/no_corrector.cpp
@@ -15,7 +15,7 @@
 #include "shape_estimation/corrector/no_corrector.hpp"
 
 bool NoCorrector::correct(
-  [[maybe_unused]] autoware_auto_perception_msgs::msg::Shape & shape_output,
+  [[maybe_unused]] autoware_perception_msgs::msg::Shape & shape_output,
   [[maybe_unused]] geometry_msgs::msg::Pose & pose_output)
 {
   return true;

--- a/perception/shape_estimation/lib/corrector/utils.cpp
+++ b/perception/shape_estimation/lib/corrector/utils.cpp
@@ -38,7 +38,7 @@
 namespace corrector_utils
 {
 bool correctWithDefaultValue(
-  const CorrectionBBParameters & param, autoware_auto_perception_msgs::msg::Shape & shape,
+  const CorrectionBBParameters & param, autoware_perception_msgs::msg::Shape & shape,
   geometry_msgs::msg::Pose & pose)
 {
   // TODO(Yukihiro Saito): refactor following code
@@ -258,7 +258,7 @@ bool correctWithDefaultValue(
 }
 
 bool correctWithReferenceYaw(
-  const CorrectionBBParameters & param, autoware_auto_perception_msgs::msg::Shape & shape,
+  const CorrectionBBParameters & param, autoware_perception_msgs::msg::Shape & shape,
   geometry_msgs::msg::Pose & pose)
 {
   // TODO(Taichi Higashide): refactor following code
@@ -329,8 +329,8 @@ bool correctWithReferenceYaw(
 }
 
 bool correctWithReferenceYawAndShapeSize(
-  const ReferenceShapeSizeInfo & ref_shape_size_info,
-  autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose)
+  const ReferenceShapeSizeInfo & ref_shape_size_info, autoware_perception_msgs::msg::Shape & shape,
+  geometry_msgs::msg::Pose & pose)
 {
   /*
   c1 is nearest point and other points are arranged like below

--- a/perception/shape_estimation/lib/filter/bus_filter.cpp
+++ b/perception/shape_estimation/lib/filter/bus_filter.cpp
@@ -15,7 +15,7 @@
 #include "shape_estimation/filter/bus_filter.hpp"
 
 bool BusFilter::filter(
-  const autoware_auto_perception_msgs::msg::Shape & shape,
+  const autoware_perception_msgs::msg::Shape & shape,
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 2.0;

--- a/perception/shape_estimation/lib/filter/car_filter.cpp
+++ b/perception/shape_estimation/lib/filter/car_filter.cpp
@@ -15,7 +15,7 @@
 #include "shape_estimation/filter/car_filter.hpp"
 
 bool CarFilter::filter(
-  const autoware_auto_perception_msgs::msg::Shape & shape,
+  const autoware_perception_msgs::msg::Shape & shape,
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 1.2;

--- a/perception/shape_estimation/lib/filter/no_filter.cpp
+++ b/perception/shape_estimation/lib/filter/no_filter.cpp
@@ -15,7 +15,7 @@
 #include "shape_estimation/filter/no_filter.hpp"
 
 bool NoFilter::filter(
-  [[maybe_unused]] const autoware_auto_perception_msgs::msg::Shape & shape,
+  [[maybe_unused]] const autoware_perception_msgs::msg::Shape & shape,
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   return true;

--- a/perception/shape_estimation/lib/filter/trailer_filter.cpp
+++ b/perception/shape_estimation/lib/filter/trailer_filter.cpp
@@ -15,7 +15,7 @@
 #include "shape_estimation/filter/trailer_filter.hpp"
 
 bool TrailerFilter::filter(
-  const autoware_auto_perception_msgs::msg::Shape & shape,
+  const autoware_perception_msgs::msg::Shape & shape,
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 1.5;

--- a/perception/shape_estimation/lib/filter/truck_filter.cpp
+++ b/perception/shape_estimation/lib/filter/truck_filter.cpp
@@ -15,7 +15,7 @@
 #include "shape_estimation/filter/truck_filter.hpp"
 
 bool TruckFilter::filter(
-  const autoware_auto_perception_msgs::msg::Shape & shape,
+  const autoware_perception_msgs::msg::Shape & shape,
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 1.5;

--- a/perception/shape_estimation/lib/filter/utils.cpp
+++ b/perception/shape_estimation/lib/filter/utils.cpp
@@ -17,14 +17,14 @@
 namespace utils
 {
 bool filterVehicleBoundingBox(
-  const autoware_auto_perception_msgs::msg::Shape & shape, const float min_width,
-  const float max_width, const float max_length)
+  const autoware_perception_msgs::msg::Shape & shape, const float min_width, const float max_width,
+  const float max_length)
 {
   const float x = shape.dimensions.x;
   const float y = shape.dimensions.y;
   const float s = x * y;
 
-  if (shape.type != autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+  if (shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     return true;
   }
   if (x < min_width && y < min_width) {

--- a/perception/shape_estimation/lib/model/bounding_box.cpp
+++ b/perception/shape_estimation/lib/model/bounding_box.cpp
@@ -18,7 +18,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <boost/math/tools/minima.hpp>
 
@@ -57,7 +57,7 @@ BoundingBoxShapeModel::BoundingBoxShapeModel(
 
 bool BoundingBoxShapeModel::estimate(
   const pcl::PointCloud<pcl::PointXYZ> & cluster,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
 {
   float min_angle, max_angle;
   if (ref_yaw_info_) {
@@ -72,7 +72,7 @@ bool BoundingBoxShapeModel::estimate(
 
 bool BoundingBoxShapeModel::fitLShape(
   const pcl::PointCloud<pcl::PointXYZ> & cluster, const float min_angle, const float max_angle,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
 {
   // calc min and max z for height
   float min_z = cluster.empty() ? 0.0 : cluster.at(0).z;
@@ -147,7 +147,7 @@ bool BoundingBoxShapeModel::fitLShape(
   quat.setEuler(/* roll */ 0, /* pitch */ 0, /* yaw */ std::atan2(e_1_star.y(), e_1_star.x()));
 
   // output
-  shape_output.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  shape_output.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   shape_output.dimensions.x = std::fabs(e_x.dot(diagonal_vec));
   shape_output.dimensions.y = std::fabs(e_y.dot(diagonal_vec));
   shape_output.dimensions.z = std::max((max_z - min_z), epsilon);

--- a/perception/shape_estimation/lib/model/convex_hull.cpp
+++ b/perception/shape_estimation/lib/model/convex_hull.cpp
@@ -18,7 +18,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/point32.hpp>
 
 #include <pcl/point_cloud.h>
@@ -30,7 +30,7 @@
 
 bool ConvexHullShapeModel::estimate(
   const pcl::PointCloud<pcl::PointXYZ> & cluster,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
 {
   // calc centroid point for convex hull height(z)
   pcl::PointXYZ centroid;
@@ -81,7 +81,7 @@ bool ConvexHullShapeModel::estimate(
   }
 
   constexpr float ep = 0.001;
-  shape_output.type = autoware_auto_perception_msgs::msg::Shape::POLYGON;
+  shape_output.type = autoware_perception_msgs::msg::Shape::POLYGON;
   shape_output.dimensions.x = 0.0;
   shape_output.dimensions.y = 0.0;
   shape_output.dimensions.z = std::max((max_z - min_z), ep);

--- a/perception/shape_estimation/lib/model/cylinder.cpp
+++ b/perception/shape_estimation/lib/model/cylinder.cpp
@@ -18,7 +18,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -28,7 +28,7 @@
 
 bool CylinderShapeModel::estimate(
   const pcl::PointCloud<pcl::PointXYZ> & cluster,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
 {
   // calc min and max z for cylinder length
   float min_z = cluster.empty() ? 0.0 : cluster.at(0).z;
@@ -50,7 +50,7 @@ bool CylinderShapeModel::estimate(
   constexpr float ep = 0.001;
   radius = std::max(radius, static_cast<float>(ep));
 
-  shape_output.type = autoware_auto_perception_msgs::msg::Shape::CYLINDER;
+  shape_output.type = autoware_perception_msgs::msg::Shape::CYLINDER;
   shape_output.dimensions.x = static_cast<float>(radius) * 2.0;
   shape_output.dimensions.y = static_cast<float>(radius) * 2.0;
   shape_output.dimensions.z = std::max((max_z - min_z), ep);

--- a/perception/shape_estimation/lib/shape_estimator.cpp
+++ b/perception/shape_estimation/lib/shape_estimator.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <memory>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 ShapeEstimator::ShapeEstimator(bool use_corrector, bool use_filter, bool use_boost_bbox_optimizer)
 : use_corrector_(use_corrector),
@@ -34,9 +34,9 @@ bool ShapeEstimator::estimateShapeAndPose(
   const uint8_t label, const pcl::PointCloud<pcl::PointXYZ> & cluster,
   const boost::optional<ReferenceYawInfo> & ref_yaw_info,
   const boost::optional<ReferenceShapeSizeInfo> & ref_shape_size_info,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
 {
-  autoware_auto_perception_msgs::msg::Shape shape;
+  autoware_perception_msgs::msg::Shape shape;
   geometry_msgs::msg::Pose pose;
   // estimate shape
   bool reverse_to_unknown = false;
@@ -72,7 +72,7 @@ bool ShapeEstimator::estimateShapeAndPose(
 bool ShapeEstimator::estimateOriginalShapeAndPose(
   const uint8_t label, const pcl::PointCloud<pcl::PointXYZ> & cluster,
   const boost::optional<ReferenceYawInfo> & ref_yaw_info,
-  autoware_auto_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
+  autoware_perception_msgs::msg::Shape & shape_output, geometry_msgs::msg::Pose & pose_output)
 {
   // estimate shape
   std::unique_ptr<ShapeEstimationModelInterface> model_ptr;
@@ -90,7 +90,7 @@ bool ShapeEstimator::estimateOriginalShapeAndPose(
 }
 
 bool ShapeEstimator::applyFilter(
-  const uint8_t label, const autoware_auto_perception_msgs::msg::Shape & shape,
+  const uint8_t label, const autoware_perception_msgs::msg::Shape & shape,
   const geometry_msgs::msg::Pose & pose)
 {
   std::unique_ptr<ShapeEstimationFilterInterface> filter_ptr;
@@ -112,7 +112,7 @@ bool ShapeEstimator::applyFilter(
 bool ShapeEstimator::applyCorrector(
   const uint8_t label, const bool use_reference_yaw,
   const boost::optional<ReferenceShapeSizeInfo> & ref_shape_size_info,
-  autoware_auto_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose)
+  autoware_perception_msgs::msg::Shape & shape, geometry_msgs::msg::Pose & pose)
 {
   std::unique_ptr<ShapeEstimationCorrectorInterface> corrector_ptr;
 

--- a/perception/shape_estimation/package.xml
+++ b/perception/shape_estimation/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>libopencv-dev</depend>
   <depend>libpcl-all-dev</depend>

--- a/perception/shape_estimation/src/node.cpp
+++ b/perception/shape_estimation/src/node.cpp
@@ -17,7 +17,7 @@
 #include <node.hpp>
 #include <tier4_autoware_utils/math/unit_conversion.hpp>
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
@@ -32,7 +32,7 @@
 #include <memory>
 #include <string>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 ShapeEstimationNode::ShapeEstimationNode(const rclcpp::NodeOptions & node_options)
 : Node("shape_estimation", node_options)
@@ -61,8 +61,8 @@ ShapeEstimationNode::ShapeEstimationNode(const rclcpp::NodeOptions & node_option
   published_time_publisher_ = std::make_unique<tier4_autoware_utils::PublishedTimePublisher>(this);
 }
 
-static autoware_auto_perception_msgs::msg::ObjectClassification::_label_type get_label(
-  const autoware_auto_perception_msgs::msg::DetectedObject::_classification_type & classification)
+static autoware_perception_msgs::msg::ObjectClassification::_label_type get_label(
+  const autoware_perception_msgs::msg::DetectedObject::_classification_type & classification)
 {
   if (classification.empty()) {
     return Label::UNKNOWN;
@@ -71,7 +71,7 @@ static autoware_auto_perception_msgs::msg::ObjectClassification::_label_type get
 }
 
 static bool label_is_vehicle(
-  const autoware_auto_perception_msgs::msg::ObjectClassification::_label_type & label)
+  const autoware_perception_msgs::msg::ObjectClassification::_label_type & label)
 {
   return Label::CAR == label || Label::TRUCK == label || Label::BUS == label ||
          Label::TRAILER == label;
@@ -105,7 +105,7 @@ void ShapeEstimationNode::callback(const DetectedObjectsWithFeature::ConstShared
     }
 
     // estimate shape and pose
-    autoware_auto_perception_msgs::msg::Shape shape;
+    autoware_perception_msgs::msg::Shape shape;
     geometry_msgs::msg::Pose pose;
     boost::optional<ReferenceYawInfo> ref_yaw_info = boost::none;
     boost::optional<ReferenceShapeSizeInfo> ref_shape_size_info = boost::none;

--- a/perception/shape_estimation/src/node.hpp
+++ b/perception/shape_estimation/src/node.hpp
@@ -22,12 +22,12 @@
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
 #include <memory>
 
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObjects;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 class ShapeEstimationNode : public rclcpp::Node
 {

--- a/perception/shape_estimation/test/shape_estimation/test_shape_estimator.cpp
+++ b/perception/shape_estimation/test/shape_estimation/test_shape_estimator.cpp
@@ -81,7 +81,7 @@ TEST(BoundingBoxShapeModel, test_estimateShape)
     createLShapeCluster(length, width, height, 0.0, 0.0, 0.0);
 
   // Generate shape and pose output
-  autoware_auto_perception_msgs::msg::Shape shape_output;
+  autoware_perception_msgs::msg::Shape shape_output;
   geometry_msgs::msg::Pose pose_output;
 
   // Test estimateShape
@@ -89,7 +89,7 @@ TEST(BoundingBoxShapeModel, test_estimateShape)
   EXPECT_TRUE(result);
 
   // Check shape_output
-  EXPECT_EQ(shape_output.type, autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_EQ(shape_output.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
   EXPECT_NEAR(shape_output.dimensions.x, length, length * 0.1);
   EXPECT_NEAR(shape_output.dimensions.y, width, width * 0.1);
   EXPECT_NEAR(shape_output.dimensions.z, height, height * 0.1);
@@ -125,7 +125,7 @@ TEST(BoundingBoxShapeModel, test_estimateShape_rotated)
     BoundingBoxShapeModel(ref_yaw_info, use_boost_bbox_optimizer);
 
   // Generate shape and pose output
-  autoware_auto_perception_msgs::msg::Shape shape_output;
+  autoware_perception_msgs::msg::Shape shape_output;
   geometry_msgs::msg::Pose pose_output;
 
   // Test estimateShape
@@ -133,7 +133,7 @@ TEST(BoundingBoxShapeModel, test_estimateShape_rotated)
   EXPECT_TRUE(result);
 
   // Check shape_output
-  EXPECT_EQ(shape_output.type, autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_EQ(shape_output.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
   EXPECT_NEAR(shape_output.dimensions.x, length, length * 0.1);
   EXPECT_NEAR(shape_output.dimensions.y, width, width * 0.1);
   EXPECT_NEAR(shape_output.dimensions.z, height, height * 0.1);
@@ -157,7 +157,7 @@ TEST(CylinderShapeModel, test_estimateShape)
   // Generate cluster
   pcl::PointCloud<pcl::PointXYZ> cluster = createLShapeCluster(4.0, 2.0, 1.0, 0.0, 0.0, 0.0);
   // Generate shape and pose output
-  autoware_auto_perception_msgs::msg::Shape shape_output;
+  autoware_perception_msgs::msg::Shape shape_output;
   geometry_msgs::msg::Pose pose_output;
 
   // Test estimateShape
@@ -175,7 +175,7 @@ TEST(ConvexHullShapeModel, test_estimateShape)
   pcl::PointCloud<pcl::PointXYZ> cluster = createLShapeCluster(2.0, 1.0, 1.0, 0.0, 0.0, 0.0);
 
   // Generate shape and pose output
-  autoware_auto_perception_msgs::msg::Shape shape_output;
+  autoware_perception_msgs::msg::Shape shape_output;
   geometry_msgs::msg::Pose pose_output;
 
   // Test estimateShape
@@ -208,10 +208,10 @@ TEST(ShapeEstimator, test_estimateShapeAndPose)
   boost::optional<ReferenceShapeSizeInfo> ref_shape_size_info = boost::none;
 
   ref_yaw_info = ReferenceYawInfo{static_cast<float>(yaw), static_cast<float>(deg2rad(10.0))};
-  const auto label = autoware_auto_perception_msgs::msg::ObjectClassification::CAR;
+  const auto label = autoware_perception_msgs::msg::ObjectClassification::CAR;
 
   // Generate shape and pose output
-  autoware_auto_perception_msgs::msg::Shape shape_output;
+  autoware_perception_msgs::msg::Shape shape_output;
   geometry_msgs::msg::Pose pose_output;
 
   // Test estimateShapeAndPose
@@ -220,7 +220,7 @@ TEST(ShapeEstimator, test_estimateShapeAndPose)
   EXPECT_TRUE(result);
 
   // Check shape_output
-  EXPECT_EQ(shape_output.type, autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_EQ(shape_output.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
   EXPECT_NEAR(shape_output.dimensions.x, length, length * 0.1);
   EXPECT_NEAR(shape_output.dimensions.y, width, width * 0.1);
   EXPECT_NEAR(shape_output.dimensions.z, height, height * 0.1);

--- a/perception/simple_object_merger/README.md
+++ b/perception/simple_object_merger/README.md
@@ -1,6 +1,6 @@
 # simple_object_merger
 
-This package can merge multiple topics of [autoware_auto_perception_msgs/msg/DetectedObject](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_perception_msgs/msg/DetectedObject.idl) with low calculation cost.
+This package can merge multiple topics of [autoware_perception_msgs/msg/DetectedObject](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_perception_msgs/msg/DetectedObject.msg) with low calculation cost.
 
 ## Design
 
@@ -31,11 +31,11 @@ Because this package does not have matching processing, there are overlapping ob
 
 ### Input
 
-Input topics is defined by the parameter of `input_topics` (List[string]). The type of input topics is `std::vector<autoware_auto_perception_msgs/msg/DetectedObjects.msg>`.
+Input topics is defined by the parameter of `input_topics` (List[string]). The type of input topics is `std::vector<autoware_perception_msgs/msg/DetectedObjects.msg>`.
 
 ### Output
 
-- `~/output/objects` (`autoware_auto_perception_msgs/msg/DetectedObjects.msg`)
+- `~/output/objects` (`autoware_perception_msgs/msg/DetectedObjects.msg`)
   - Merged objects combined from input topics.
 
 ### Parameters

--- a/perception/simple_object_merger/include/simple_object_merger/simple_object_merger_node.hpp
+++ b/perception/simple_object_merger/include/simple_object_merger/simple_object_merger_node.hpp
@@ -18,7 +18,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
 
-#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <chrono>
 #include <memory>
@@ -27,8 +27,8 @@
 
 namespace simple_object_merger
 {
-using autoware_auto_perception_msgs::msg::DetectedObject;
-using autoware_auto_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 class SimpleObjectMergerNode : public rclcpp::Node
 {

--- a/perception/simple_object_merger/package.xml
+++ b/perception/simple_object_merger/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/simple_object_merger/src/simple_object_merger_node/simple_object_merger_node.cpp
+++ b/perception/simple_object_merger/src/simple_object_merger_node/simple_object_merger_node.cpp
@@ -39,13 +39,13 @@ bool update_param(
   return true;
 }
 
-autoware_auto_perception_msgs::msg::DetectedObjects::SharedPtr getTransformedObjects(
-  autoware_auto_perception_msgs::msg::DetectedObjects::ConstSharedPtr objects,
+autoware_perception_msgs::msg::DetectedObjects::SharedPtr getTransformedObjects(
+  autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr objects,
   const std::string & target_frame_id,
   geometry_msgs::msg::TransformStamped::ConstSharedPtr transform)
 {
-  autoware_auto_perception_msgs::msg::DetectedObjects::SharedPtr output_objects =
-    std::const_pointer_cast<autoware_auto_perception_msgs::msg::DetectedObjects>(objects);
+  autoware_perception_msgs::msg::DetectedObjects::SharedPtr output_objects =
+    std::const_pointer_cast<autoware_perception_msgs::msg::DetectedObjects>(objects);
 
   if (objects->header.frame_id == target_frame_id) {
     return output_objects;

--- a/perception/tensorrt_yolox/package.xml
+++ b/perception/tensorrt_yolox/package.xml
@@ -18,7 +18,7 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>cuda_utils</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>

--- a/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -16,7 +16,7 @@
 
 #include "object_recognition_utils/object_classification.hpp"
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 
 #include <algorithm>
 #include <memory>

--- a/perception/tracking_object_merger/README.md
+++ b/perception/tracking_object_merger/README.md
@@ -79,12 +79,12 @@ tracker_state_parameter:
 
 #### input/parameters
 
-| topic name                      | message type                                    | description                                                                           |
-| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `~input/main_object`            | `autoware_auto_perception_msgs::TrackedObjects` | Dominant tracking objects. Output will be published with this dominant object stamps. |
-| `~input/sub_object`             | `autoware_auto_perception_msgs::TrackedObjects` | Sub tracking objects.                                                                 |
-| `output/object`                 | `autoware_auto_perception_msgs::TrackedObjects` | Merged tracking objects.                                                              |
-| `debug/interpolated_sub_object` | `autoware_auto_perception_msgs::TrackedObjects` | Interpolated sub tracking objects.                                                    |
+| topic name                      | message type                               | description                                                                           |
+| ------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `~input/main_object`            | `autoware_perception_msgs::TrackedObjects` | Dominant tracking objects. Output will be published with this dominant object stamps. |
+| `~input/sub_object`             | `autoware_perception_msgs::TrackedObjects` | Sub tracking objects.                                                                 |
+| `output/object`                 | `autoware_perception_msgs::TrackedObjects` | Merged tracking objects.                                                              |
+| `debug/interpolated_sub_object` | `autoware_perception_msgs::TrackedObjects` | Interpolated sub tracking objects.                                                    |
 
 Default parameters are set in [config/decorative_tracker_merger.param.yaml](./config/decorative_tracker_merger.param.yaml).
 

--- a/perception/tracking_object_merger/include/tracking_object_merger/data_association/data_association.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/data_association/data_association.hpp
@@ -31,8 +31,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <string>
 
@@ -57,14 +57,14 @@ public:
     const Eigen::MatrixXd & src, std::unordered_map<int, int> & direct_assignment,
     std::unordered_map<int, int> & reverse_assignment);
   Eigen::MatrixXd calcScoreMatrix(
-    const autoware_auto_perception_msgs::msg::TrackedObjects & objects0,
-    const autoware_auto_perception_msgs::msg::TrackedObjects & objects1);
+    const autoware_perception_msgs::msg::TrackedObjects & objects0,
+    const autoware_perception_msgs::msg::TrackedObjects & objects1);
   Eigen::MatrixXd calcScoreMatrix(
-    const autoware_auto_perception_msgs::msg::TrackedObjects & objects0,
+    const autoware_perception_msgs::msg::TrackedObjects & objects0,
     const std::vector<TrackerState> & trackers);
   double calcScoreBetweenObjects(
-    const autoware_auto_perception_msgs::msg::TrackedObject & object0,
-    const autoware_auto_perception_msgs::msg::TrackedObject & object1) const;
+    const autoware_perception_msgs::msg::TrackedObject & object0,
+    const autoware_perception_msgs::msg::TrackedObject & object1) const;
   virtual ~DataAssociation() {}
 };
 

--- a/perception/tracking_object_merger/include/tracking_object_merger/decorative_tracker_merger.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/decorative_tracker_merger.hpp
@@ -24,7 +24,7 @@
 #include <tier4_autoware_utils/ros/published_time_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <std_msgs/msg/header.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
@@ -58,37 +58,33 @@ private:
     std::unordered_map<std::string, std::unique_ptr<DataAssociation>> & data_association_map);
 
   void mainObjectsCallback(
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg);
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg);
   void subObjectsCallback(
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg);
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg);
 
   bool decorativeMerger(
     const MEASUREMENT_STATE input_index,
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg);
-  autoware_auto_perception_msgs::msg::TrackedObjects predictFutureState(
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg,
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg);
+  autoware_perception_msgs::msg::TrackedObjects predictFutureState(
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg,
     const std_msgs::msg::Header & header);
-  std::optional<autoware_auto_perception_msgs::msg::TrackedObjects> interpolateObjectState(
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg1,
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg2,
+  std::optional<autoware_perception_msgs::msg::TrackedObjects> interpolateObjectState(
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg1,
+    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & input_object_msg2,
     const std_msgs::msg::Header & header);
   TrackedObjects getTrackedObjects(const std_msgs::msg::Header & header);
   TrackerState createNewTracker(
     const MEASUREMENT_STATE input_index, rclcpp::Time current_time,
-    const autoware_auto_perception_msgs::msg::TrackedObject & input_object);
+    const autoware_perception_msgs::msg::TrackedObject & input_object);
 
 private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
-    merged_object_pub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
-    sub_main_objects_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
-    sub_sub_objects_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr merged_object_pub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr sub_main_objects_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr sub_sub_objects_;
   // debug object publisher
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
-    debug_object_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr debug_object_pub_;
   bool publish_interpolated_sub_objects_;
   std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<tier4_autoware_utils::DebugPublisher> processing_time_publisher_;
@@ -103,8 +99,7 @@ private:
   std::string target_frame_;
   std::string base_link_frame_id_;
   // buffer to save the sub objects
-  std::vector<autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr>
-    sub_objects_buffer_;
+  std::vector<autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr> sub_objects_buffer_;
   double sub_object_timeout_sec_;
   double time_sync_threshold_;
 

--- a/perception/tracking_object_merger/include/tracking_object_merger/utils/tracker_state.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/utils/tracker_state.hpp
@@ -19,10 +19,10 @@
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/tracked_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
@@ -32,8 +32,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 // Enum classes to distinguish input sources
 enum class MEASUREMENT_STATE : int {
@@ -94,7 +94,7 @@ public:
     const TrackedObject & tracked_object);
   TrackerState(
     const MEASUREMENT_STATE input_source, const rclcpp::Time & last_update_time,
-    const autoware_auto_perception_msgs::msg::TrackedObject & tracked_object,
+    const autoware_perception_msgs::msg::TrackedObject & tracked_object,
     const unique_identifier_msgs::msg::UUID & uuid);
 
   ~TrackerState();

--- a/perception/tracking_object_merger/include/tracking_object_merger/utils/utils.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/utils/utils.hpp
@@ -22,11 +22,11 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object_kinematics.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/tracked_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -42,8 +42,8 @@
 #include <tuple>
 #include <vector>
 
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 namespace utils
 {
 enum MSG_COV_IDX {
@@ -107,7 +107,7 @@ namespace merger_utils
 enum MergePolicy : int { SKIP = 0, OVERWRITE = 1, FUSION = 2 };
 
 // object kinematics velocity merger
-autoware_auto_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMerger(
+autoware_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMerger(
   const TrackedObject & main_obj, const TrackedObject & sub_obj, const MergePolicy policy);
 
 // object classification merger
@@ -118,7 +118,7 @@ TrackedObject objectClassificationMerger(
 float probabilityMerger(const float main_prob, const float sub_prob, const MergePolicy policy);
 
 // shape merger
-autoware_auto_perception_msgs::msg::Shape shapeMerger(
+autoware_perception_msgs::msg::Shape shapeMerger(
   const TrackedObject & main_obj, const TrackedObject & sub_obj, const MergePolicy policy);
 
 // update tracked object

--- a/perception/tracking_object_merger/package.xml
+++ b/perception/tracking_object_merger/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>glog</depend>
   <depend>mussp</depend>

--- a/perception/tracking_object_merger/src/data_association/data_association.cpp
+++ b/perception/tracking_object_merger/src/data_association/data_association.cpp
@@ -129,8 +129,8 @@ void DataAssociation::assign(
  * @return Eigen::MatrixXd
  */
 Eigen::MatrixXd DataAssociation::calcScoreMatrix(
-  const autoware_auto_perception_msgs::msg::TrackedObjects & objects0,
-  const autoware_auto_perception_msgs::msg::TrackedObjects & objects1)
+  const autoware_perception_msgs::msg::TrackedObjects & objects0,
+  const autoware_perception_msgs::msg::TrackedObjects & objects1)
 {
   Eigen::MatrixXd score_matrix =
     Eigen::MatrixXd::Zero(objects1.objects.size(), objects0.objects.size());
@@ -154,7 +154,7 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
  * @return Eigen::MatrixXd
  */
 Eigen::MatrixXd DataAssociation::calcScoreMatrix(
-  const autoware_auto_perception_msgs::msg::TrackedObjects & objects0,
+  const autoware_perception_msgs::msg::TrackedObjects & objects0,
   const std::vector<TrackerState> & trackers)
 {
   Eigen::MatrixXd score_matrix = Eigen::MatrixXd::Zero(trackers.size(), objects0.objects.size());
@@ -172,8 +172,8 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
 }
 
 double DataAssociation::calcScoreBetweenObjects(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object0,
-  const autoware_auto_perception_msgs::msg::TrackedObject & object1) const
+  const autoware_perception_msgs::msg::TrackedObject & object0,
+  const autoware_perception_msgs::msg::TrackedObject & object1) const
 {
   const std::uint8_t object1_label =
     object_recognition_utils::getHighestProbLabel(object1.classification);

--- a/perception/tracking_object_merger/src/decorative_tracker_merger.cpp
+++ b/perception/tracking_object_merger/src/decorative_tracker_merger.cpp
@@ -29,13 +29,13 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 namespace tracking_object_merger
 {
 
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 // get unix time from header
 double getUnixTime(const std_msgs::msg::Header & header)
@@ -46,7 +46,7 @@ double getUnixTime(const std_msgs::msg::Header & header)
 // calc association score matrix
 Eigen::MatrixXd calcScoreMatrixForAssociation(
   const MEASUREMENT_STATE measurement_state,
-  const autoware_auto_perception_msgs::msg::TrackedObjects & objects0,
+  const autoware_perception_msgs::msg::TrackedObjects & objects0,
   const std::vector<TrackerState> & trackers,
   const std::unordered_map<std::string, std::unique_ptr<DataAssociation>> & data_association_map
   // const bool debug_log, const std::string & file_name // do not logging for now
@@ -395,7 +395,7 @@ TrackedObjects DecorativeTrackerMergerNode::getTrackedObjects(const std_msgs::ms
 // create new tracker
 TrackerState DecorativeTrackerMergerNode::createNewTracker(
   const MEASUREMENT_STATE input_index, rclcpp::Time current_time,
-  const autoware_auto_perception_msgs::msg::TrackedObject & input_object)
+  const autoware_perception_msgs::msg::TrackedObject & input_object)
 {
   // check if object id is not included in inner_tracker_objects_
   for (const auto & object : inner_tracker_objects_) {

--- a/perception/tracking_object_merger/src/utils/tracker_state.cpp
+++ b/perception/tracking_object_merger/src/utils/tracker_state.cpp
@@ -16,8 +16,8 @@
 
 #include "tracking_object_merger/utils/utils.hpp"
 
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 /**
  * @brief Construct a new Tracker State:: Tracker State object
@@ -28,7 +28,7 @@ using autoware_auto_perception_msgs::msg::TrackedObjects;
  */
 TrackerState::TrackerState(
   const MEASUREMENT_STATE input_source, const rclcpp::Time & last_update_time,
-  const autoware_auto_perception_msgs::msg::TrackedObject & tracked_object)
+  const autoware_perception_msgs::msg::TrackedObject & tracked_object)
 : tracked_object_(tracked_object),
   last_update_time_(last_update_time),
   const_uuid_(tracked_object.object_id),
@@ -41,7 +41,7 @@ TrackerState::TrackerState(
 
 TrackerState::TrackerState(
   const MEASUREMENT_STATE input_source, const rclcpp::Time & last_update_time,
-  const autoware_auto_perception_msgs::msg::TrackedObject & tracked_object,
+  const autoware_perception_msgs::msg::TrackedObject & tracked_object,
   const unique_identifier_msgs::msg::UUID & uuid)
 : tracked_object_(tracked_object),
   last_update_time_(last_update_time),

--- a/perception/tracking_object_merger/src/utils/utils.cpp
+++ b/perception/tracking_object_merger/src/utils/utils.cpp
@@ -14,17 +14,17 @@
 
 #include "tracking_object_merger/utils/utils.hpp"
 
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_object.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <string>
 #include <unordered_map>
 
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 namespace utils
 {
 
@@ -92,14 +92,14 @@ TrackedObject linearInterpolationForTrackedObject(
   if (shape1.type != shape2.type) {
     // if shape type is different, return obj1
   } else {
-    if (shape1.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    if (shape1.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
       auto & output_shape = output.shape;
       output_shape.dimensions.x = shape1.dimensions.x * (1 - weight) + shape2.dimensions.x * weight;
       output_shape.dimensions.y = shape1.dimensions.y * (1 - weight) + shape2.dimensions.y * weight;
       output_shape.dimensions.z = shape1.dimensions.z * (1 - weight) + shape2.dimensions.z * weight;
-    } else if (shape1.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+    } else if (shape1.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
       // (TODO) implement
-    } else if (shape1.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) {
       // (TODO) implement
     } else {
       // when type is unknown, print warning and do nothing
@@ -317,10 +317,10 @@ bool objectsYawIsReverted(const TrackedObject & main_obj, const TrackedObject & 
 
 // object kinematics merger
 // currently only support velocity fusion
-autoware_auto_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMerger(
+autoware_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMerger(
   const TrackedObject & main_obj, const TrackedObject & sub_obj, const MergePolicy policy)
 {
-  autoware_auto_perception_msgs::msg::TrackedObjectKinematics output_kinematics;
+  autoware_perception_msgs::msg::TrackedObjectKinematics output_kinematics;
   // copy main object at first
   output_kinematics = main_obj.kinematics;
   auto sub_obj_ = sub_obj;
@@ -425,11 +425,11 @@ float probabilityMerger(const float main_prob, const float sub_prob, const Merge
 }
 
 // shape merger
-autoware_auto_perception_msgs::msg::Shape shapeMerger(
-  const autoware_auto_perception_msgs::msg::Shape & main_obj_shape,
-  const autoware_auto_perception_msgs::msg::Shape & sub_obj_shape, const MergePolicy policy)
+autoware_perception_msgs::msg::Shape shapeMerger(
+  const autoware_perception_msgs::msg::Shape & main_obj_shape,
+  const autoware_perception_msgs::msg::Shape & sub_obj_shape, const MergePolicy policy)
 {
-  autoware_auto_perception_msgs::msg::Shape output_shape;
+  autoware_perception_msgs::msg::Shape output_shape;
   // copy main object at first
   output_shape = main_obj_shape;
 
@@ -444,17 +444,17 @@ autoware_auto_perception_msgs::msg::Shape shapeMerger(
     return sub_obj_shape;
   } else if (policy == MergePolicy::FUSION) {
     // write down fusion method for each shape type
-    if (main_obj_shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    if (main_obj_shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
       // if shape type is bounding box, merge bounding box
       output_shape.dimensions.x = mean(main_obj_shape.dimensions.x, sub_obj_shape.dimensions.x);
       output_shape.dimensions.y = mean(main_obj_shape.dimensions.y, sub_obj_shape.dimensions.y);
       output_shape.dimensions.z = mean(main_obj_shape.dimensions.z, sub_obj_shape.dimensions.z);
       return output_shape;
-    } else if (main_obj_shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+    } else if (main_obj_shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
       // if shape type is cylinder, merge cylinder
       // (TODO) implement
       return output_shape;
-    } else if (main_obj_shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+    } else if (main_obj_shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
       // if shape type is polygon, merge polygon
       // (TODO)
       return output_shape;

--- a/perception/traffic_light_arbiter/README.md
+++ b/perception/traffic_light_arbiter/README.md
@@ -25,17 +25,17 @@ The table below outlines how the matching process determines the output based on
 
 #### Input
 
-| Name                             | Type                                              | Description                                              |
-| -------------------------------- | ------------------------------------------------- | -------------------------------------------------------- |
-| ~/sub/vector_map                 | autoware_auto_mapping_msgs::msg::HADMapBin        | The vector map to get valid traffic signal ids.          |
-| ~/sub/perception_traffic_signals | autoware_perception_msgs::msg::TrafficSignalArray | The traffic signals from the image recognition pipeline. |
-| ~/sub/external_traffic_signals   | autoware_perception_msgs::msg::TrafficSignalArray | The traffic signals from an external system.             |
+| Name                             | Type                                                  | Description                                              |
+| -------------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| ~/sub/vector_map                 | autoware_map_msgs::msg::LaneletMapBin                 | The vector map to get valid traffic signal ids.          |
+| ~/sub/perception_traffic_signals | autoware_perception_msgs::msg::TrafficLightGroupArray | The traffic signals from the image recognition pipeline. |
+| ~/sub/external_traffic_signals   | autoware_perception_msgs::msg::TrafficLightGroupArray | The traffic signals from an external system.             |
 
 #### Output
 
-| Name                  | Type                                              | Description                      |
-| --------------------- | ------------------------------------------------- | -------------------------------- |
-| ~/pub/traffic_signals | autoware_perception_msgs::msg::TrafficSignalArray | The merged traffic signal state. |
+| Name                  | Type                                                  | Description                      |
+| --------------------- | ----------------------------------------------------- | -------------------------------- |
+| ~/pub/traffic_signals | autoware_perception_msgs::msg::TrafficLightGroupArray | The merged traffic signal state. |
 
 ## Parameters
 

--- a/perception/traffic_light_arbiter/include/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/traffic_light_arbiter/include/traffic_light_arbiter/signal_match_validator.hpp
@@ -18,7 +18,7 @@
 #include <lanelet2_extension/utility/query.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 
@@ -38,9 +38,9 @@
 class SignalMatchValidator
 {
 public:
-  using TrafficSignalArray = autoware_perception_msgs::msg::TrafficSignalArray;
-  using TrafficSignal = autoware_perception_msgs::msg::TrafficSignal;
-  using TrafficSignalElement = autoware_perception_msgs::msg::TrafficSignalElement;
+  using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+  using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
+  using TrafficSignalElement = autoware_perception_msgs::msg::TrafficLightElement;
   using TrafficLightConstPtr = lanelet::TrafficLightConstPtr;
 
   /**

--- a/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -18,8 +18,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <traffic_light_arbiter/signal_match_validator.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <lanelet2_core/Forward.h>
 
@@ -32,10 +32,10 @@ public:
   explicit TrafficLightArbiter(const rclcpp::NodeOptions & options);
 
 private:
-  using Element = autoware_perception_msgs::msg::TrafficSignalElement;
-  using LaneletMapBin = autoware_auto_mapping_msgs::msg::HADMapBin;
-  using TrafficSignalArray = autoware_perception_msgs::msg::TrafficSignalArray;
-  using TrafficSignal = autoware_perception_msgs::msg::TrafficSignal;
+  using Element = autoware_perception_msgs::msg::TrafficLightElement;
+  using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
+  using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+  using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
 
   rclcpp::Subscription<LaneletMapBin>::SharedPtr map_sub_;
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr perception_tlr_sub_;

--- a/perception/traffic_light_arbiter/package.xml
+++ b/perception/traffic_light_arbiter/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_extension</depend>

--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -119,7 +119,7 @@ void TrafficLightArbiter::onPerceptionMsg(const TrafficSignalArray::ConstSharedP
   if (
     (rclcpp::Time(msg->stamp) - rclcpp::Time(latest_external_msg_.stamp)).seconds() >
     external_time_tolerance_) {
-    latest_external_msg_.signals.clear();
+    latest_external_msg_.traffic_light_groups.clear();
   }
 
   arbitrateAndPublish(msg->stamp);
@@ -132,7 +132,7 @@ void TrafficLightArbiter::onExternalMsg(const TrafficSignalArray::ConstSharedPtr
   if (
     (rclcpp::Time(msg->stamp) - rclcpp::Time(latest_perception_msg_.stamp)).seconds() >
     perception_time_tolerance_) {
-    latest_perception_msg_.signals.clear();
+    latest_perception_msg_.traffic_light_groups.clear();
   }
 
   arbitrateAndPublish(msg->stamp);
@@ -158,7 +158,7 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
   }
 
   auto add_signal_function = [&](const auto & signal, bool priority) {
-    const auto id = signal.traffic_signal_id;
+    const auto id = signal.traffic_light_group_id;
     if (!map_regulatory_elements_set_->count(id)) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), 5000,
@@ -175,15 +175,15 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
   if (enable_signal_matching_) {
     const auto validated_signals =
       signal_match_validator_->validateSignals(latest_perception_msg_, latest_external_msg_);
-    for (const auto & signal : validated_signals.signals) {
+    for (const auto & signal : validated_signals.traffic_light_groups) {
       add_signal_function(signal, false);
     }
   } else {
-    for (const auto & signal : latest_perception_msg_.signals) {
+    for (const auto & signal : latest_perception_msg_.traffic_light_groups) {
       add_signal_function(signal, false);
     }
 
-    for (const auto & signal : latest_external_msg_.signals) {
+    for (const auto & signal : latest_external_msg_.traffic_light_groups) {
       add_signal_function(signal, external_priority_);
     }
   }
@@ -217,13 +217,13 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
       return highest_score_elements_vector;
     };
 
-  output_signals_msg.signals.reserve(regulatory_element_signals_map.size());
+  output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
 
   for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {
     TrafficSignal signal_msg;
-    signal_msg.traffic_signal_id = regulatory_element_id;
+    signal_msg.traffic_light_group_id = regulatory_element_id;
     signal_msg.elements = get_highest_confidence_elements(elements);
-    output_signals_msg.signals.emplace_back(signal_msg);
+    output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
   }
 
   pub_->publish(output_signals_msg);

--- a/perception/traffic_light_classifier/README.md
+++ b/perception/traffic_light_classifier/README.md
@@ -8,8 +8,8 @@ traffic_light_classifier is a package for classifying traffic light labels using
 
 ### cnn_classifier
 
-Traffic light labels are classified by EfficientNet-b1 or MobileNet-v2.  
-Totally 83400 (58600 for training, 14800 for evaluation and 10000 for test) TIER IV internal images of Japanese traffic lights were used for fine-tuning.  
+Traffic light labels are classified by EfficientNet-b1 or MobileNet-v2.
+Totally 83400 (58600 for training, 14800 for evaluation and 10000 for test) TIER IV internal images of Japanese traffic lights were used for fine-tuning.
 The information of the models is listed here:
 
 | Name            | Input Size | Test Accuracy |

--- a/perception/traffic_light_map_based_detector/README.md
+++ b/perception/traffic_light_map_based_detector/README.md
@@ -15,7 +15,7 @@ If the node receives no route information, it looks at a radius of 200 meters an
 
 | Name                 | Type                                  | Description             |
 | -------------------- | ------------------------------------- | ----------------------- |
-| `~input/vector_map`  | autoware_auto_mapping_msgs::HADMapBin | vector map              |
+| `~input/vector_map`  | autoware_map_msgs::msg::LaneletMapBin | vector map              |
 | `~input/camera_info` | sensor_msgs::CameraInfo               | target camera parameter |
 | `~input/route`       | autoware_planning_msgs::LaneletRoute  | optional: route         |
 

--- a/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -18,7 +18,7 @@
 #include <lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -72,7 +72,7 @@ private:
   };
 
 private:
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_sub_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_sub_;
   rclcpp::Subscription<autoware_planning_msgs::msg::LaneletRoute>::SharedPtr route_sub_;
   /**
@@ -120,7 +120,7 @@ private:
    *
    * @param input_msg
    */
-  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_msg);
+  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
   /**
    * @brief callback function for the camera info message. The main process function of the node
    *

--- a/perception/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_map_based_detector/package.xml
@@ -13,8 +13,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>image_geometry</depend>

--- a/perception/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_map_based_detector/src/node.cpp
@@ -162,7 +162,7 @@ MapBasedDetector::MapBasedDetector(const rclcpp::NodeOptions & node_options)
   }
 
   // subscribers
-  map_sub_ = create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&MapBasedDetector::mapCallback, this, _1));
   camera_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>(
@@ -389,7 +389,7 @@ bool MapBasedDetector::getTrafficLightRoi(
 }
 
 void MapBasedDetector::mapCallback(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_msg)
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
 

--- a/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp
+++ b/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp
@@ -17,8 +17,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
@@ -71,8 +71,8 @@ public:
   typedef tier4_perception_msgs::msg::TrafficLightArray SignalArrayType;
   typedef tier4_perception_msgs::msg::TrafficLightRoiArray RoiArrayType;
   typedef tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type IdType;
-  typedef autoware_perception_msgs::msg::TrafficSignal NewSignalType;
-  typedef autoware_perception_msgs::msg::TrafficSignalArray NewSignalArrayType;
+  typedef autoware_perception_msgs::msg::TrafficLightGroup NewSignalType;
+  typedef autoware_perception_msgs::msg::TrafficLightGroupArray NewSignalArrayType;
 
   typedef std::pair<RoiArrayType, SignalArrayType> RecordArrayType;
 
@@ -83,7 +83,7 @@ private:
     const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
     const SignalArrayType::ConstSharedPtr signal_msg);
 
-  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_msg);
+  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
 
   void multiCameraFusion(std::map<IdType, FusionRecord> & fused_record_map);
 
@@ -105,7 +105,7 @@ private:
   std::vector<std::unique_ptr<mf::Subscriber<CamInfoType>>> cam_info_subs_;
   std::vector<std::unique_ptr<ExactSync>> exact_sync_subs_;
   std::vector<std::unique_ptr<ApproximateSync>> approximate_sync_subs_;
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_sub_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
 
   rclcpp::Publisher<NewSignalArrayType>::SharedPtr signal_pub_;
   /*

--- a/perception/traffic_light_multi_camera_fusion/package.xml
+++ b/perception/traffic_light_multi_camera_fusion/package.xml
@@ -12,7 +12,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>

--- a/perception/traffic_light_multi_camera_fusion/src/node.cpp
+++ b/perception/traffic_light_multi_camera_fusion/src/node.cpp
@@ -96,11 +96,11 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
   return map.count(key) ? map.at(key) : value;
 }
 
-autoware_perception_msgs::msg::TrafficSignalElement convert(
+autoware_perception_msgs::msg::TrafficLightElement convert(
   const tier4_perception_msgs::msg::TrafficLightElement & input)
 {
   typedef tier4_perception_msgs::msg::TrafficLightElement OldElem;
-  typedef autoware_perception_msgs::msg::TrafficSignalElement NewElem;
+  typedef autoware_perception_msgs::msg::TrafficLightElement NewElem;
   static const std::unordered_map<OldElem::_color_type, NewElem::_color_type> color_map(
     {{OldElem::RED, NewElem::RED},
      {OldElem::AMBER, NewElem::AMBER},
@@ -172,7 +172,7 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
     }
   }
 
-  map_sub_ = create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&MultiCameraFusion::mapCallback, this, _1));
   signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
@@ -201,7 +201,7 @@ void MultiCameraFusion::trafficSignalRoiCallback(
 }
 
 void MultiCameraFusion::mapCallback(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_msg)
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
   lanelet::LaneletMapPtr lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();
 
@@ -223,16 +223,16 @@ void MultiCameraFusion::mapCallback(
 void MultiCameraFusion::convertOutputMsg(
   const std::map<IdType, FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
 {
-  msg_out.signals.clear();
+  msg_out.traffic_light_groups.clear();
   for (const auto & p : grouped_record_map) {
     IdType reg_ele_id = p.first;
     const SignalType & signal = p.second.signal;
     NewSignalType signal_out;
-    signal_out.traffic_signal_id = reg_ele_id;
+    signal_out.traffic_light_group_id = reg_ele_id;
     for (const auto & ele : signal.elements) {
       signal_out.elements.push_back(convert(ele));
     }
-    msg_out.signals.push_back(signal_out);
+    msg_out.traffic_light_groups.push_back(signal_out);
   }
 }
 

--- a/perception/traffic_light_occlusion_predictor/README.md
+++ b/perception/traffic_light_occlusion_predictor/README.md
@@ -12,18 +12,18 @@ If no point cloud is received or all point clouds have very large stamp differen
 
 ## Input topics
 
-| Name                 | Type                                                | Description              |
-| -------------------- | --------------------------------------------------- | ------------------------ |
-| `~input/vector_map`  | autoware_auto_mapping_msgs::HADMapBin               | vector map               |
-| `~/input/rois`       | autoware_auto_perception_msgs::TrafficLightRoiArray | traffic light detections |
-| `~input/camera_info` | sensor_msgs::CameraInfo                             | target camera parameter  |
-| `~/input/cloud`      | sensor_msgs::PointCloud2                            | LiDAR point cloud        |
+| Name                 | Type                                           | Description              |
+| -------------------- | ---------------------------------------------- | ------------------------ |
+| `~input/vector_map`  | autoware_map_msgs::msg::LaneletMapBin          | vector map               |
+| `~/input/rois`       | autoware_perception_msgs::TrafficLightRoiArray | traffic light detections |
+| `~input/camera_info` | sensor_msgs::CameraInfo                        | target camera parameter  |
+| `~/input/cloud`      | sensor_msgs::PointCloud2                       | LiDAR point cloud        |
 
 ## Output topics
 
-| Name                 | Type                                                      | Description                  |
-| -------------------- | --------------------------------------------------------- | ---------------------------- |
-| `~/output/occlusion` | autoware_auto_perception_msgs::TrafficLightOcclusionArray | occlusion ratios of each roi |
+| Name                 | Type                                                 | Description                  |
+| -------------------- | ---------------------------------------------------- | ---------------------------- |
+| `~/output/occlusion` | autoware_perception_msgs::TrafficLightOcclusionArray | occlusion ratios of each roi |
 
 ## Node parameters
 

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
@@ -20,7 +20,7 @@
 #include <traffic_light_occlusion_predictor/occlusion_predictor.hpp>
 #include <traffic_light_utils/traffic_light_utils.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -63,7 +63,7 @@ private:
    *
    * @param input_msg
    */
-  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_msg);
+  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
   /**
    * @brief subscribers
    *
@@ -75,7 +75,7 @@ private:
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr in_cloud_msg,
     const uint8_t traffic_light_type);
 
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_sub_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
   /**
    * @brief publishers
    *

--- a/perception/traffic_light_occlusion_predictor/package.xml
+++ b/perception/traffic_light_occlusion_predictor/package.xml
@@ -12,7 +12,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>image_geometry</depend>
   <depend>lanelet2_extension</depend>

--- a/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
+++ b/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
@@ -51,7 +51,7 @@ TrafficLightOcclusionPredictorNodelet::TrafficLightOcclusionPredictorNodelet(
   using std::placeholders::_4;
 
   // subscribers
-  map_sub_ = create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrafficLightOcclusionPredictorNodelet::mapCallback, this, _1));
 
@@ -97,7 +97,7 @@ TrafficLightOcclusionPredictorNodelet::TrafficLightOcclusionPredictorNodelet(
 }
 
 void TrafficLightOcclusionPredictorNodelet::mapCallback(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_msg)
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
   traffic_light_position_map_.clear();
   auto lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();

--- a/perception/traffic_light_visualization/README.md
+++ b/perception/traffic_light_visualization/README.md
@@ -17,10 +17,10 @@ The `traffic_light_visualization` is a package that includes two visualizing nod
 
 #### Input
 
-| Name                 | Type                                            | Description              |
-| -------------------- | ----------------------------------------------- | ------------------------ |
-| `~/input/tl_state`   | `tier4_perception_msgs::msg::TrafficLightArray` | status of traffic lights |
-| `~/input/vector_map` | `autoware_auto_mapping_msgs::msg::HADMapBin`    | vector map               |
+| Name                 | Type                                                 | Description              |
+| -------------------- | ---------------------------------------------------- | ------------------------ |
+| `~/input/tl_state`   | `tier4_perception_msgs::msg::TrafficLightGroupArray` | status of traffic lights |
+| `~/input/vector_map` | `autoware_map_msgs::msg::LaneletMapBin`              | vector map               |
 
 #### Output
 

--- a/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_map_visualizer/node.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_map_visualizer/node.hpp
@@ -18,8 +18,8 @@
 #include <lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
@@ -34,15 +34,15 @@ public:
   TrafficLightMapVisualizerNode(const std::string & node_name, const rclcpp::NodeOptions & options);
   ~TrafficLightMapVisualizerNode() = default;
   void trafficSignalsCallback(
-    const autoware_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr
+    const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr
       input_traffic_signals_msg);
-  void binMapCallback(
-    const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_map_msg);
+  void binMapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_map_msg);
 
 private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr light_marker_pub_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficSignalArray>::SharedPtr tl_state_sub_;
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr vector_map_sub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr
+    tl_state_sub_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr vector_map_sub_;
 
   std::vector<lanelet::AutowareTrafficLightConstPtr> aw_tl_reg_elems_;
 };

--- a/perception/traffic_light_visualization/src/traffic_light_map_visualizer/node.cpp
+++ b/perception/traffic_light_visualization/src/traffic_light_map_visualizer/node.cpp
@@ -113,15 +113,15 @@ TrafficLightMapVisualizerNode::TrafficLightMapVisualizerNode(
 {
   light_marker_pub_ =
     create_publisher<visualization_msgs::msg::MarkerArray>("~/output/traffic_light", 1);
-  tl_state_sub_ = create_subscription<autoware_perception_msgs::msg::TrafficSignalArray>(
+  tl_state_sub_ = create_subscription<autoware_perception_msgs::msg::TrafficLightGroupArray>(
     "~/input/tl_state", 1,
     std::bind(&TrafficLightMapVisualizerNode::trafficSignalsCallback, this, _1));
-  vector_map_sub_ = create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  vector_map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrafficLightMapVisualizerNode::binMapCallback, this, _1));
 }
 void TrafficLightMapVisualizerNode::trafficSignalsCallback(
-  const autoware_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr input_traffic_signals)
+  const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr input_traffic_signals)
 {
   visualization_msgs::msg::MarkerArray output_msg;
   const auto current_time = now();
@@ -157,8 +157,8 @@ void TrafficLightMapVisualizerNode::trafficSignalsCallback(
       if (!ls.hasAttribute("traffic_light_id")) {
         continue;
       }
-      for (const auto & input_traffic_signal : input_traffic_signals->signals) {
-        if ((*tli)->id() == input_traffic_signal.traffic_signal_id) {
+      for (const auto & input_traffic_signal : input_traffic_signals->traffic_light_groups) {
+        if ((*tli)->id() == input_traffic_signal.traffic_light_group_id) {
           // if (isAttributeValue(ls, "traffic_light_id", input_traffic_signal.map_primitive_id)) {
           for (auto pt : ls) {
             if (!pt.hasAttribute("color")) {
@@ -169,18 +169,18 @@ void TrafficLightMapVisualizerNode::trafficSignalsCallback(
               visualization_msgs::msg::Marker marker;
               if (
                 isAttributeValue(pt, "color", "red") &&
-                elem.color == autoware_perception_msgs::msg::TrafficSignalElement::RED) {
+                elem.color == autoware_perception_msgs::msg::TrafficLightElement::RED) {
                 lightAsMarker(
                   get_node_logging_interface(), pt, &marker, "traffic_light", current_time);
               } else if (  // NOLINT
                 isAttributeValue(pt, "color", "green") &&
-                elem.color == autoware_perception_msgs::msg::TrafficSignalElement::GREEN) {
+                elem.color == autoware_perception_msgs::msg::TrafficLightElement::GREEN) {
                 lightAsMarker(
                   get_node_logging_interface(), pt, &marker, "traffic_light", current_time);
 
               } else if (  // NOLINT
                 isAttributeValue(pt, "color", "yellow") &&
-                elem.color == autoware_perception_msgs::msg::TrafficSignalElement::AMBER) {
+                elem.color == autoware_perception_msgs::msg::TrafficLightElement::AMBER) {
                 lightAsMarker(
                   get_node_logging_interface(), pt, &marker, "traffic_light", current_time);
               } else {
@@ -198,7 +198,7 @@ void TrafficLightMapVisualizerNode::trafficSignalsCallback(
 }
 
 void TrafficLightMapVisualizerNode::binMapCallback(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr input_map_msg)
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_map_msg)
 {
   lanelet::LaneletMapPtr viz_lanelet_map(new lanelet::LaneletMap);
 


### PR DESCRIPTION
## Description

This is subset of https://github.com/autowarefoundation/autoware.universe/pull/6893 to make it easier to review.
This includes all the modification for `perception` directory in the original PR. 

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/6893
https://github.com/orgs/autowarefoundation/discussions/3862

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Message types are modified according to the table in [this comment](https://github.com/orgs/autowarefoundation/discussions/3862#discussioncomment-9638820).
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
