### PR TITLE
feat!: replace autoware_auto_msgs with autoware_msgs for simulator modules

### DIFF
--- a/simulator/dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/dummy_perception_publisher/CMakeLists.txt
@@ -7,14 +7,14 @@ autoware_package()
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/InitialState.msg"
   "msg/Object.msg"
-  DEPENDENCIES autoware_auto_perception_msgs tier4_perception_msgs geometry_msgs std_msgs unique_identifier_msgs
+  DEPENDENCIES autoware_perception_msgs tier4_perception_msgs geometry_msgs std_msgs unique_identifier_msgs
 )
 
 # See ndt_omp package for documentation on why PCL is special
 find_package(PCL REQUIRED COMPONENTS common filters)
 
 set(${PROJECT_NAME}_DEPENDENCIES
-  autoware_auto_perception_msgs
+  autoware_perception_msgs
   tier4_perception_msgs
   pcl_conversions
   rclcpp

--- a/simulator/dummy_perception_publisher/README.md
+++ b/simulator/dummy_perception_publisher/README.md
@@ -21,7 +21,7 @@ This node publishes the result of the dummy detection with the type of perceptio
 | ----------------------------------- | -------------------------------------------------------- | ----------------------- |
 | `output/dynamic_object`             | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | dummy detection objects |
 | `output/points_raw`                 | `sensor_msgs::msg::PointCloud2`                          | point cloud of objects  |
-| `output/debug/ground_truth_objects` | `autoware_auto_perception_msgs::msg::TrackedObjects`     | ground truth objects    |
+| `output/debug/ground_truth_objects` | `autoware_perception_msgs::msg::TrackedObjects`          | ground truth objects    |
 
 ## Parameters
 

--- a/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
+++ b/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
@@ -19,8 +19,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
@@ -59,7 +59,7 @@ struct ObjectInfo
   geometry_msgs::msg::PoseWithCovariance pose_covariance_;
   // convert to TrackedObject
   // (todo) currently need object input to get id and header information, but it should be removed
-  autoware_auto_perception_msgs::msg::TrackedObject toTrackedObject(
+  autoware_perception_msgs::msg::TrackedObject toTrackedObject(
     const dummy_perception_publisher::msg::Object & object) const;
 };
 
@@ -114,7 +114,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;
   rclcpp::Publisher<tier4_perception_msgs::msg::DetectedObjectsWithFeature>::SharedPtr
     detected_object_with_feature_pub_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr
     ground_truth_objects_pub_;
   rclcpp::Subscription<dummy_perception_publisher::msg::Object>::SharedPtr object_sub_;
   rclcpp::TimerBase::SharedPtr timer_;

--- a/simulator/dummy_perception_publisher/msg/Object.msg
+++ b/simulator/dummy_perception_publisher/msg/Object.msg
@@ -1,8 +1,8 @@
 std_msgs/Header header
 unique_identifier_msgs/UUID id
 dummy_perception_publisher/InitialState initial_state
-autoware_auto_perception_msgs/ObjectClassification classification
-autoware_auto_perception_msgs/Shape shape
+autoware_perception_msgs/ObjectClassification classification
+autoware_perception_msgs/Shape shape
 float32 max_velocity
 float32 min_velocity
 

--- a/simulator/dummy_perception_publisher/package.xml
+++ b/simulator/dummy_perception_publisher/package.xml
@@ -18,7 +18,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/simulator/dummy_perception_publisher/src/empty_objects_publisher.cpp
+++ b/simulator/dummy_perception_publisher/src/empty_objects_publisher.cpp
@@ -14,7 +14,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
 
 #include <memory>
 #include <utility>
@@ -24,9 +24,8 @@ class EmptyObjectsPublisher : public rclcpp::Node
 public:
   EmptyObjectsPublisher() : Node("empty_objects_publisher")
   {
-    empty_objects_pub_ =
-      this->create_publisher<autoware_auto_perception_msgs::msg::PredictedObjects>(
-        "~/output/objects", 1);
+    empty_objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::PredictedObjects>(
+      "~/output/objects", 1);
 
     using std::chrono_literals::operator""ms;
     timer_ = rclcpp::create_timer(
@@ -34,13 +33,12 @@ public:
   }
 
 private:
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::PredictedObjects>::SharedPtr
-    empty_objects_pub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::PredictedObjects>::SharedPtr empty_objects_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   void timerCallback()
   {
-    autoware_auto_perception_msgs::msg::PredictedObjects empty_objects;
+    autoware_perception_msgs::msg::PredictedObjects empty_objects;
     empty_objects.header.frame_id = "map";
     empty_objects.header.stamp = this->now();
     empty_objects_pub_->publish(empty_objects);

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -33,8 +33,8 @@
 #include <utility>
 #include <vector>
 
-using autoware_auto_perception_msgs::msg::TrackedObject;
-using autoware_auto_perception_msgs::msg::TrackedObjects;
+using autoware_perception_msgs::msg::TrackedObject;
+using autoware_perception_msgs::msg::TrackedObjects;
 
 ObjectInfo::ObjectInfo(
   const dummy_perception_publisher::msg::Object & object, const rclcpp::Time & current_time)
@@ -169,7 +169,7 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   // optional ground truth publisher
   if (publish_ground_truth_objects_) {
     ground_truth_objects_pub_ =
-      this->create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
+      this->create_publisher<autoware_perception_msgs::msg::TrackedObjects>(
         "~/output/debug/ground_truth_objects", qos);
   }
 
@@ -182,7 +182,7 @@ void DummyPerceptionPublisherNode::timerCallback()
 {
   // output msgs
   tier4_perception_msgs::msg::DetectedObjectsWithFeature output_dynamic_object_msg;
-  autoware_auto_perception_msgs::msg::TrackedObjects output_ground_truth_objects_msg;
+  autoware_perception_msgs::msg::TrackedObjects output_ground_truth_objects_msg;
   geometry_msgs::msg::PoseStamped output_moved_object_pose;
   sensor_msgs::msg::PointCloud2 output_pointcloud_msg;
   std_msgs::msg::Header header;
@@ -282,7 +282,7 @@ void DummyPerceptionPublisherNode::timerCallback()
       feature_object.object.kinematics.twist_with_covariance =
         object.initial_state.twist_covariance;
       feature_object.object.kinematics.orientation_availability =
-        autoware_auto_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
+        autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
       feature_object.object.kinematics.has_twist = false;
       tf2::toMsg(
         tf_base_link2noised_moved_object,

--- a/simulator/simple_planning_simulator/README.md
+++ b/simulator/simple_planning_simulator/README.md
@@ -18,23 +18,23 @@ The purpose of this simulator is for the integration test of planning and contro
 ### input
 
 - input/initialpose [`geometry_msgs/msg/PoseWithCovarianceStamped`] : for initial pose
-- input/ackermann_control_command [`autoware_auto_msgs/msg/AckermannControlCommand`] : target command to drive a vehicle
-- input/manual_ackermann_control_command [`autoware_auto_msgs/msg/AckermannControlCommand`] : manual target command to drive a vehicle (used when control_mode_request = Manual)
-- input/gear_command [`autoware_auto_vehicle_msgs/msg/GearCommand`] : target gear command.
-- input/manual_gear_command [`autoware_auto_vehicle_msgs/msg/GearCommand`] : target gear command (used when control_mode_request = Manual)
-- input/turn_indicators_command [`autoware_auto_vehicle_msgs/msg/TurnIndicatorsCommand`] : target turn indicator command
-- input/hazard_lights_command [`autoware_auto_vehicle_msgs/msg/HazardLightsCommand`] : target hazard lights command
+- input/ackermann_control_command [`autoware_control_msgs/msg/Control`] : target command to drive a vehicle
+- input/manual_ackermann_control_command [`autoware_control_msgs/msg/Control`] : manual target command to drive a vehicle (used when control_mode_request = Manual)
+- input/gear_command [`autoware_vehicle_msgs/msg/GearCommand`] : target gear command.
+- input/manual_gear_command [`autoware_vehicle_msgs/msg/GearCommand`] : target gear command (used when control_mode_request = Manual)
+- input/turn_indicators_command [`autoware_vehicle_msgs/msg/TurnIndicatorsCommand`] : target turn indicator command
+- input/hazard_lights_command [`autoware_vehicle_msgs/msg/HazardLightsCommand`] : target hazard lights command
 - input/control_mode_request [`tier4_vehicle_msgs::srv::ControlModeRequest`] : mode change for Auto/Manual driving
 
 ### output
 
 - /tf [`tf2_msgs/msg/TFMessage`] : simulated vehicle pose (base_link)
 - /output/odometry [`nav_msgs/msg/Odometry`] : simulated vehicle pose and twist
-- /output/steering [`autoware_auto_vehicle_msgs/msg/SteeringReport`] : simulated steering angle
-- /output/control_mode_report [`autoware_auto_vehicle_msgs/msg/ControlModeReport`] : current control mode (Auto/Manual)
-- /output/gear_report [`autoware_auto_vehicle_msgs/msg/ControlModeReport`] : simulated gear
-- /output/turn_indicators_report [`autoware_auto_vehicle_msgs/msg/ControlModeReport`] : simulated turn indicator status
-- /output/hazard_lights_report [`autoware_auto_vehicle_msgs/msg/ControlModeReport`] : simulated hazard lights status
+- /output/steering [`autoware_vehicle_msgs/msg/SteeringReport`] : simulated steering angle
+- /output/control_mode_report [`autoware_vehicle_msgs/msg/ControlModeReport`] : current control mode (Auto/Manual)
+- /output/gear_report [`autoware_vehicle_msgs/msg/ControlModeReport`] : simulated gear
+- /output/turn_indicators_report [`autoware_vehicle_msgs/msg/ControlModeReport`] : simulated turn indicator status
+- /output/hazard_lights_report [`autoware_vehicle_msgs/msg/ControlModeReport`] : simulated hazard lights status
 
 ## Inner-workings / Algorithms
 

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -20,23 +20,20 @@
 #include "simple_planning_simulator/visibility_control.hpp"
 #include "tier4_api_utils/tier4_api_utils.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
-#include "autoware_auto_geometry_msgs/msg/complex32.hpp"
-#include "autoware_auto_mapping_msgs/msg/had_map_bin.hpp"
-#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_vehicle_msgs/msg/control_mode_command.hpp"
-#include "autoware_auto_vehicle_msgs/msg/control_mode_report.hpp"
-#include "autoware_auto_vehicle_msgs/msg/engage.hpp"
-#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
-#include "autoware_auto_vehicle_msgs/msg/gear_report.hpp"
-#include "autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp"
-#include "autoware_auto_vehicle_msgs/msg/hazard_lights_report.hpp"
-#include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
-#include "autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp"
-#include "autoware_auto_vehicle_msgs/msg/turn_indicators_report.hpp"
-#include "autoware_auto_vehicle_msgs/msg/vehicle_control_command.hpp"
-#include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
-#include "autoware_auto_vehicle_msgs/srv/control_mode_command.hpp"
+#include "autoware_control_msgs/msg/control.hpp"
+#include "autoware_map_msgs/msg/lanelet_map_bin.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_vehicle_msgs/msg/control_mode_report.hpp"
+#include "autoware_vehicle_msgs/msg/engage.hpp"
+#include "autoware_vehicle_msgs/msg/gear_command.hpp"
+#include "autoware_vehicle_msgs/msg/gear_report.hpp"
+#include "autoware_vehicle_msgs/msg/hazard_lights_command.hpp"
+#include "autoware_vehicle_msgs/msg/hazard_lights_report.hpp"
+#include "autoware_vehicle_msgs/msg/steering_report.hpp"
+#include "autoware_vehicle_msgs/msg/turn_indicators_command.hpp"
+#include "autoware_vehicle_msgs/msg/turn_indicators_report.hpp"
+#include "autoware_vehicle_msgs/msg/velocity_report.hpp"
+#include "autoware_vehicle_msgs/srv/control_mode_command.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -62,22 +59,20 @@ namespace simulation
 namespace simple_planning_simulator
 {
 
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
-using autoware_auto_geometry_msgs::msg::Complex32;
-using autoware_auto_mapping_msgs::msg::HADMapBin;
-using autoware_auto_planning_msgs::msg::Trajectory;
-using autoware_auto_vehicle_msgs::msg::ControlModeReport;
-using autoware_auto_vehicle_msgs::msg::Engage;
-using autoware_auto_vehicle_msgs::msg::GearCommand;
-using autoware_auto_vehicle_msgs::msg::GearReport;
-using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
-using autoware_auto_vehicle_msgs::msg::HazardLightsReport;
-using autoware_auto_vehicle_msgs::msg::SteeringReport;
-using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
-using autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport;
-using autoware_auto_vehicle_msgs::msg::VehicleControlCommand;
-using autoware_auto_vehicle_msgs::msg::VelocityReport;
-using autoware_auto_vehicle_msgs::srv::ControlModeCommand;
+using autoware_control_msgs::msg::Control;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_vehicle_msgs::msg::ControlModeReport;
+using autoware_vehicle_msgs::msg::Engage;
+using autoware_vehicle_msgs::msg::GearCommand;
+using autoware_vehicle_msgs::msg::GearReport;
+using autoware_vehicle_msgs::msg::HazardLightsCommand;
+using autoware_vehicle_msgs::msg::HazardLightsReport;
+using autoware_vehicle_msgs::msg::SteeringReport;
+using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
+using autoware_vehicle_msgs::msg::TurnIndicatorsReport;
+using autoware_vehicle_msgs::msg::VelocityReport;
+using autoware_vehicle_msgs::srv::ControlModeCommand;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
@@ -143,10 +138,9 @@ private:
   rclcpp::Subscription<GearCommand>::SharedPtr sub_manual_gear_cmd_;
   rclcpp::Subscription<TurnIndicatorsCommand>::SharedPtr sub_turn_indicators_cmd_;
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr sub_hazard_lights_cmd_;
-  rclcpp::Subscription<VehicleControlCommand>::SharedPtr sub_vehicle_cmd_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_ackermann_cmd_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_manual_ackermann_cmd_;
-  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;
+  rclcpp::Subscription<Control>::SharedPtr sub_ackermann_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_manual_ackermann_cmd_;
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_init_pose_;
   rclcpp::Subscription<TwistStamped>::SharedPtr sub_init_twist_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
@@ -176,8 +170,8 @@ private:
   VelocityReport current_velocity_{};
   Odometry current_odometry_{};
   SteeringReport current_steer_{};
-  AckermannControlCommand current_ackermann_cmd_{};
-  AckermannControlCommand current_manual_ackermann_cmd_{};
+  Control current_ackermann_cmd_{};
+  Control current_manual_ackermann_cmd_{};
   GearCommand current_gear_cmd_{};
   GearCommand current_manual_gear_cmd_{};
   TurnIndicatorsCommand::ConstSharedPtr current_turn_indicators_cmd_ptr_{};
@@ -216,14 +210,9 @@ private:
   std::shared_ptr<SimModelInterface> vehicle_model_ptr_;  //!< @brief vehicle model pointer
 
   /**
-   * @brief set current_vehicle_cmd_ptr_ with received message
-   */
-  void on_vehicle_cmd(const VehicleControlCommand::ConstSharedPtr msg);
-
-  /**
    * @brief set input steering, velocity, and acceleration of the vehicle model
    */
-  void set_input(const AckermannControlCommand & cmd, const double acc_by_slope);
+  void set_input(const Control & cmd, const double acc_by_slope);
 
   /**
    * @brief set current_vehicle_state_ with received message
@@ -238,7 +227,7 @@ private:
   /**
    * @brief subscribe lanelet map
    */
-  void on_map(const HADMapBin::ConstSharedPtr msg);
+  void on_map(const LaneletMapBin::ConstSharedPtr msg);
 
   /**
    * @brief set initial pose for simulation with received message

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
@@ -152,7 +152,7 @@ private:
    * @brief update state considering current gear
    * @param [in] state current state
    * @param [in] prev_state previous state
-   * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
+   * @param [in] gear current gear (defined in autoware_vehicle_msgs/GearCommand)
    * @param [in] dt delta time to update state
    */
   void updateStateWithGear(

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp
@@ -200,7 +200,7 @@ private:
    * @brief update state considering current gear
    * @param [in] state current state
    * @param [in] prev_state previous state
-   * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
+   * @param [in] gear current gear (defined in autoware_msgs/GearCommand)
    * @param [in] dt delta time to update state
    */
   void updateStateWithGear(

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
@@ -107,7 +107,7 @@ private:
    * @brief update state considering current gear
    * @param [in] state current state
    * @param [in] prev_state previous state
-   * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
+   * @param [in] gear current gear (defined in autoware_vehicle_msgs/GearCommand)
    * @param [in] dt delta time to update state
    */
   void updateStateWithGear(

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
@@ -17,7 +17,7 @@
 
 #include <Eigen/Core>
 
-#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
+#include "autoware_vehicle_msgs/msg/gear_command.hpp"
 
 /**
  * @class SimModelInterface
@@ -31,8 +31,8 @@ protected:
   Eigen::VectorXd state_;  //!< @brief vehicle state vector
   Eigen::VectorXd input_;  //!< @brief vehicle input vector
 
-  //!< @brief gear command defined in autoware_auto_msgs/GearCommand
-  uint8_t gear_ = autoware_auto_vehicle_msgs::msg::GearCommand::DRIVE;
+  //!< @brief gear command defined in autoware_vehicle_msgs/GearCommand
+  uint8_t gear_ = autoware_vehicle_msgs::msg::GearCommand::DRIVE;
 
 public:
   /**
@@ -73,7 +73,7 @@ public:
 
   /**
    * @brief set gear
-   * @param [in] gear gear command defined in autoware_auto_msgs/GearCommand
+   * @param [in] gear gear command defined in autoware_vehicle_msgs/GearCommand
    */
   void setGear(const uint8_t gear);
 

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -15,12 +15,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
-
-  <depend>autoware_auto_control_msgs</depend>
-  <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_extension</depend>
@@ -38,6 +36,7 @@
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>
   <depend>vehicle_info_util</depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <exec_depend>launch_ros</exec_depend>
 

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
@@ -14,7 +14,7 @@
 
 #include "simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp"
 
-#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
+#include "autoware_vehicle_msgs/msg/gear_command.hpp"
 
 #include <algorithm>
 
@@ -160,7 +160,7 @@ void SimModelDelaySteerAccGeared::updateStateWithGear(
     state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
   };
 
-  using autoware_auto_vehicle_msgs::msg::GearCommand;
+  using autoware_vehicle_msgs::msg::GearCommand;
   if (
     gear == GearCommand::DRIVE || gear == GearCommand::DRIVE_2 || gear == GearCommand::DRIVE_3 ||
     gear == GearCommand::DRIVE_4 || gear == GearCommand::DRIVE_5 || gear == GearCommand::DRIVE_6 ||

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
@@ -14,7 +14,7 @@
 
 #include "simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp"
 
-#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
+#include "autoware_vehicle_msgs/msg/gear_command.hpp"
 
 #include <algorithm>
 
@@ -134,7 +134,7 @@ Eigen::VectorXd SimModelDelaySteerMapAccGeared::calcModel(
 void SimModelDelaySteerMapAccGeared::updateStateWithGear(
   Eigen::VectorXd & state, const Eigen::VectorXd & prev_state, const uint8_t gear, const double dt)
 {
-  using autoware_auto_vehicle_msgs::msg::GearCommand;
+  using autoware_vehicle_msgs::msg::GearCommand;
   if (
     gear == GearCommand::DRIVE || gear == GearCommand::DRIVE_2 || gear == GearCommand::DRIVE_3 ||
     gear == GearCommand::DRIVE_4 || gear == GearCommand::DRIVE_5 || gear == GearCommand::DRIVE_6 ||

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
@@ -14,7 +14,7 @@
 
 #include "simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp"
 
-#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
+#include "autoware_vehicle_msgs/msg/gear_command.hpp"
 
 #include <algorithm>
 
@@ -92,7 +92,7 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
     state(IDX::YAW) = prev_state(IDX::YAW);
   };
 
-  using autoware_auto_vehicle_msgs::msg::GearCommand;
+  using autoware_vehicle_msgs::msg::GearCommand;
   if (
     gear == GearCommand::DRIVE || gear == GearCommand::DRIVE_2 || gear == GearCommand::DRIVE_3 ||
     gear == GearCommand::DRIVE_4 || gear == GearCommand::DRIVE_5 || gear == GearCommand::DRIVE_6 ||

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -24,8 +24,8 @@
 
 #include <memory>
 
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
-using autoware_auto_vehicle_msgs::msg::GearCommand;
+using autoware_control_msgs::msg::Control;
+using autoware_vehicle_msgs::msg::GearCommand;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
@@ -51,14 +51,14 @@ public:
       "output/odometry", rclcpp::QoS{1},
       [this](const Odometry::ConstSharedPtr msg) { current_odom_ = msg; });
     pub_ackermann_command_ =
-      create_publisher<AckermannControlCommand>("input/ackermann_control_command", rclcpp::QoS{1});
+      create_publisher<Control>("input/ackermann_control_command", rclcpp::QoS{1});
     pub_initialpose_ =
       create_publisher<PoseWithCovarianceStamped>("input/initialpose", rclcpp::QoS{1});
     pub_gear_cmd_ = create_publisher<GearCommand>("input/gear_command", rclcpp::QoS{1});
   }
 
   rclcpp::Subscription<Odometry>::SharedPtr current_odom_sub_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_ackermann_command_;
+  rclcpp::Publisher<Control>::SharedPtr pub_ackermann_command_;
   rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_cmd_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_initialpose_;
 
@@ -66,7 +66,7 @@ public:
 };
 
 /**
- * @brief Generate an AckermannControlCommand message
+ * @brief Generate an Control message
  * @param [in] t timestamp
  * @param [in] steer [rad] steering
  * @param [in] steer_rate [rad/s] steering rotation rate
@@ -74,17 +74,17 @@ public:
  * @param [in] acc [m/s²] acceleration
  * @param [in] jerk [m/s3] jerk
  */
-AckermannControlCommand cmdGen(
+Control cmdGen(
   const builtin_interfaces::msg::Time & t, double steer, double steer_rate, double vel, double acc,
   double jerk)
 {
-  AckermannControlCommand cmd;
+  Control cmd;
   cmd.stamp = t;
   cmd.lateral.stamp = t;
   cmd.lateral.steering_tire_angle = steer;
   cmd.lateral.steering_tire_rotation_rate = steer_rate;
   cmd.longitudinal.stamp = t;
-  cmd.longitudinal.speed = vel;
+  cmd.longitudinal.velocity = vel;
   cmd.longitudinal.acceleration = acc;
   cmd.longitudinal.jerk = jerk;
   return cmd;
@@ -125,8 +125,7 @@ void sendGear(
  * @param [in] pub_sub_node pointer to the node used for communication
  */
 void sendCommand(
-  const AckermannControlCommand & cmd, rclcpp::Node::SharedPtr sim_node,
-  std::shared_ptr<PubSubNode> pub_sub_node)
+  const Control & cmd, rclcpp::Node::SharedPtr sim_node, std::shared_ptr<PubSubNode> pub_sub_node)
 {
   for (int i = 0; i < 150; ++i) {
     pub_sub_node->pub_ackermann_command_->publish(cmd);


### PR DESCRIPTION
## Description

This is a subset of https://github.com/autowarefoundation/autoware.universe/pull/6893 to make it easier to review.
This includes all the modification for `simulator` directory in the original PR. 

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/6893
https://github.com/orgs/autowarefoundation/discussions/3862

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Message types are modified according to the table in [this comment](https://github.com/orgs/autowarefoundation/discussions/3862#discussioncomment-9638820).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
