### PR TITLE
feat!: replace autoware_auto_msgs with autoware_msgs for system modules

### DIFF
--- a/system/component_state_monitor/config/topics.yaml
+++ b/system/component_state_monitor/config/topics.yaml
@@ -4,7 +4,7 @@
   args:
     node_name_suffix: vector_map
     topic: /map/vector_map
-    topic_type: autoware_auto_mapping_msgs/msg/HADMapBin
+    topic_type: autoware_map_msgs/msg/LaneletMapBin
     best_effort: false
     transient_local: true
     warn_rate: 0.0
@@ -69,7 +69,7 @@
   args:
     node_name_suffix: object_recognition_objects
     topic: /perception/object_recognition/objects
-    topic_type: autoware_auto_perception_msgs/msg/PredictedObjects
+    topic_type: autoware_perception_msgs/msg/PredictedObjects
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -82,7 +82,7 @@
   args:
     node_name_suffix: traffic_light_recognition_traffic_signals
     topic: /perception/traffic_light_recognition/traffic_signals
-    topic_type: autoware_perception_msgs/msg/TrafficSignalArray
+    topic_type: autoware_perception_msgs/msg/TrafficLightGroupArray
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -108,7 +108,7 @@
   args:
     node_name_suffix: scenario_planning_trajectory
     topic: /planning/scenario_planning/trajectory
-    topic_type: autoware_auto_planning_msgs/msg/Trajectory
+    topic_type: autoware_planning_msgs/msg/Trajectory
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -121,7 +121,7 @@
   args:
     node_name_suffix: trajectory_follower_control_cmd
     topic: /control/trajectory_follower/control_cmd
-    topic_type: autoware_auto_control_msgs/msg/AckermannControlCommand
+    topic_type: autoware_control_msgs/msg/Control
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -134,7 +134,7 @@
   args:
     node_name_suffix: control_command_control_cmd
     topic: /control/command/control_cmd
-    topic_type: autoware_auto_control_msgs/msg/AckermannControlCommand
+    topic_type: autoware_control_msgs/msg/Control
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -147,7 +147,7 @@
   args:
     node_name_suffix: vehicle_status_velocity_status
     topic: /vehicle/status/velocity_status
-    topic_type: autoware_auto_vehicle_msgs/msg/VelocityReport
+    topic_type: autoware_vehicle_msgs/msg/VelocityReport
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -160,7 +160,7 @@
   args:
     node_name_suffix: vehicle_status_steering_status
     topic: /vehicle/status/steering_status
-    topic_type: autoware_auto_vehicle_msgs/msg/SteeringReport
+    topic_type: autoware_vehicle_msgs/msg/SteeringReport
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -173,7 +173,7 @@
   args:
     node_name_suffix: system_emergency_control_cmd
     topic: /system/emergency/control_cmd
-    topic_type: autoware_auto_control_msgs/msg/AckermannControlCommand
+    topic_type: autoware_control_msgs/msg/Control
     best_effort: false
     transient_local: false
     warn_rate: 5.0

--- a/system/default_ad_api/package.xml
+++ b/system/default_ad_api/package.xml
@@ -15,10 +15,9 @@
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_adapi_version_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_system_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>
   <depend>diagnostic_graph_utils</depend>

--- a/system/default_ad_api/src/compatibility/autoware_state.hpp
+++ b/system/default_ad_api/src/compatibility/autoware_state.hpp
@@ -19,7 +19,7 @@
 #include <autoware_ad_api_specs/operation_mode.hpp>
 #include <autoware_ad_api_specs/routing.hpp>
 
-#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
+#include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <tier4_system_msgs/msg/mode_change_available.hpp>
 
@@ -44,7 +44,7 @@ private:
   Sub<autoware_ad_api::routing::RouteState> sub_routing_;
   Sub<autoware_ad_api::operation_mode::OperationModeState> sub_operation_mode_;
 
-  using AutowareState = autoware_auto_system_msgs::msg::AutowareState;
+  using AutowareState = autoware_system_msgs::msg::AutowareState;
   using LocalizationState = autoware_ad_api::localization::InitializationState::Message;
   using RoutingState = autoware_ad_api::routing::RouteState::Message;
   using OperationModeState = autoware_ad_api::operation_mode::OperationModeState::Message;

--- a/system/default_ad_api/src/perception.cpp
+++ b/system/default_ad_api/src/perception.cpp
@@ -24,7 +24,7 @@ using ObjectClassification = autoware_adapi_v1_msgs::msg::ObjectClassification;
 using DynamicObject = autoware_adapi_v1_msgs::msg::DynamicObject;
 using DynamicObjectPath = autoware_adapi_v1_msgs::msg::DynamicObjectPath;
 using API_Shape = shape_msgs::msg::SolidPrimitive;
-using Shape = autoware_auto_perception_msgs::msg::Shape;
+using Shape = autoware_perception_msgs::msg::Shape;
 
 std::unordered_map<uint8_t, uint8_t> shape_type_ = {
   {Shape::BOUNDING_BOX, API_Shape::BOX},

--- a/system/default_ad_api/src/perception.hpp
+++ b/system/default_ad_api/src/perception.hpp
@@ -22,7 +22,7 @@
 #include <autoware_adapi_v1_msgs/msg/dynamic_object.hpp>
 #include <autoware_adapi_v1_msgs/msg/dynamic_object_path.hpp>
 #include <autoware_adapi_v1_msgs/msg/object_classification.hpp>
-#include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <shape_msgs/msg/solid_primitive.hpp>
 
 #include <unordered_map>

--- a/system/emergency_handler/README.md
+++ b/system/emergency_handler/README.md
@@ -14,24 +14,24 @@ Emergency Handler is a node to select proper MRM from from system failure state 
 
 ### Input
 
-| Name                                      | Type                                                       | Description                                                                   |
-| ----------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `/system/emergency/hazard_status`         | `autoware_auto_system_msgs::msg::HazardStatusStamped`      | Used to select proper MRM from system failure state contained in HazardStatus |
-| `/control/vehicle_cmd`                    | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Used as reference when generate Emergency Control Command                     |
-| `/localization/kinematic_state`           | `nav_msgs::msg::Odometry`                                  | Used to decide whether vehicle is stopped or not                              |
-| `/vehicle/status/control_mode`            | `autoware_auto_vehicle_msgs::msg::ControlModeReport`       | Used to check vehicle mode: autonomous or manual                              |
-| `/system/api/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`                | Used to check if MRM comfortable stop operation is available                  |
-| `/system/api/mrm/emergency_stop/status`   | `tier4_system_msgs::msg::MrmBehaviorStatus`                | Used to check if MRM emergency stop operation is available                    |
+| Name                                      | Type                                             | Description                                                                   |
+| ----------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `/system/emergency/hazard_status`         | `autoware_system_msgs::msg::HazardStatusStamped` | Used to select proper MRM from system failure state contained in HazardStatus |
+| `/control/vehicle_cmd`                    | `autoware_control_msgs::msg::Control`            | Used as reference when generate Emergency Control Command                     |
+| `/localization/kinematic_state`           | `nav_msgs::msg::Odometry`                        | Used to decide whether vehicle is stopped or not                              |
+| `/vehicle/status/control_mode`            | `autoware_vehicle_msgs::msg::ControlModeReport`  | Used to check vehicle mode: autonomous or manual                              |
+| `/system/api/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`      | Used to check if MRM comfortable stop operation is available                  |
+| `/system/api/mrm/emergency_stop/status`   | `tier4_system_msgs::msg::MrmBehaviorStatus`      | Used to check if MRM emergency stop operation is available                    |
 
 ### Output
 
-| Name                                       | Type                                                   | Description                                           |
-| ------------------------------------------ | ------------------------------------------------------ | ----------------------------------------------------- |
-| `/system/emergency/shift_cmd`              | `autoware_auto_vehicle_msgs::msg::GearCommand`         | Required to execute proper MRM (send gear cmd)        |
-| `/system/emergency/hazard_cmd`             | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand` | Required to execute proper MRM (send turn signal cmd) |
-| `/api/fail_safe/mrm_state`                 | `autoware_adapi_v1_msgs::msg::MrmState`                | Inform MRM execution state and selected MRM behavior  |
-| `/system/api/mrm/comfortable_stop/operate` | `tier4_system_msgs::srv::OperateMrm`                   | Execution order for MRM comfortable stop              |
-| `/system/api/mrm/emergency_stop/operate`   | `tier4_system_msgs::srv::OperateMrm`                   | Execution order for MRM emergency stop                |
+| Name                                       | Type                                              | Description                                           |
+| ------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------- |
+| `/system/emergency/shift_cmd`              | `autoware_vehicle_msgs::msg::GearCommand`         | Required to execute proper MRM (send gear cmd)        |
+| `/system/emergency/hazard_cmd`             | `autoware_vehicle_msgs::msg::HazardLightsCommand` | Required to execute proper MRM (send turn signal cmd) |
+| `/api/fail_safe/mrm_state`                 | `autoware_adapi_v1_msgs::msg::MrmState`           | Inform MRM execution state and selected MRM behavior  |
+| `/system/api/mrm/comfortable_stop/operate` | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM comfortable stop              |
+| `/system/api/mrm/emergency_stop/operate`   | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM emergency stop                |
 
 ## Parameters
 

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -21,11 +21,11 @@
 
 // Autoware
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
-#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
-#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+#include <autoware_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
@@ -57,48 +57,43 @@ public:
 
 private:
   // Subscribers
-  rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
+  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr
     sub_hazard_status_stamped_;
-  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
-    sub_prev_control_command_;
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr sub_prev_control_command_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
-    sub_control_mode_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr sub_control_mode_;
   rclcpp::Subscription<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr
     sub_mrm_comfortable_stop_status_;
   rclcpp::Subscription<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr
     sub_mrm_emergency_stop_status_;
 
-  autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status_stamped_;
-  autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr prev_control_command_;
+  autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status_stamped_;
+  autoware_control_msgs::msg::Control::ConstSharedPtr prev_control_command_;
   nav_msgs::msg::Odometry::ConstSharedPtr odom_;
-  autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
+  autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
   tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr mrm_comfortable_stop_status_;
   tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr mrm_emergency_stop_status_;
 
   void onHazardStatusStamped(
-    const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
-  void onPrevControlCommand(
-    const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg);
+    const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
+  void onPrevControlCommand(const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
-  void onControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
+  void onControlMode(const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
   void onMrmComfortableStopStatus(
     const tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr msg);
   void onMrmEmergencyStopStatus(
     const tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
-    pub_control_command_;
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;
 
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::TurnSignal>::SharedPtr pub_turn_signal_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    pub_hazard_cmd_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr pub_hazard_cmd_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
 
-  autoware_auto_vehicle_msgs::msg::HazardLightsCommand createHazardCmdMsg();
-  autoware_auto_vehicle_msgs::msg::GearCommand createGearCmdMsg();
+  autoware_vehicle_msgs::msg::HazardLightsCommand createHazardCmdMsg();
+  autoware_vehicle_msgs::msg::GearCommand createGearCmdMsg();
   void publishControlCommands();
 
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::MrmState>::SharedPtr pub_mrm_state_;

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -13,9 +13,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
+  <depend>autoware_system_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/hazard_status_converter/package.xml
+++ b/system/hazard_status_converter/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>diagnostic_graph_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -61,7 +61,7 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
 {
   using DiagnosticStatus = diagnostic_msgs::msg::DiagnosticStatus;
   using DiagnosticLevel = DiagnosticStatus::_level_type;
-  using HazardStatus = autoware_auto_system_msgs::msg::HazardStatus;
+  using HazardStatus = autoware_system_msgs::msg::HazardStatus;
   using HazardLevel = HazardStatus::_level_type;
 
   const auto get_hazard_level = [](DiagnosticLevel unit_level, DiagnosticLevel root_level) {

--- a/system/hazard_status_converter/src/converter.hpp
+++ b/system/hazard_status_converter/src/converter.hpp
@@ -18,7 +18,7 @@
 #include <diagnostic_graph_utils/subscription.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
 
 #include <unordered_set>
 
@@ -31,7 +31,7 @@ public:
   explicit Converter(const rclcpp::NodeOptions & options);
 
 private:
-  using HazardStatusStamped = autoware_auto_system_msgs::msg::HazardStatusStamped;
+  using HazardStatusStamped = autoware_system_msgs::msg::HazardStatusStamped;
   using DiagGraph = diagnostic_graph_utils::DiagGraph;
   using DiagUnit = diagnostic_graph_utils::DiagUnit;
   void on_create(DiagGraph::ConstSharedPtr graph);

--- a/system/mrm_emergency_stop_operator/README.md
+++ b/system/mrm_emergency_stop_operator/README.md
@@ -10,18 +10,18 @@ MRM emergency stop operator is a node that generates emergency stop commands acc
 
 ### Input
 
-| Name                                 | Type                                                       | Description                                                                                                                   |
-| ------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `~/input/mrm/emergency_stop/operate` | `tier4_system_msgs::srv::OperateMrm`                       | MRM execution order                                                                                                           |
-| `~/input/control/control_cmd`        | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Control command output from the last node of the control component. Used for the initial value of the emergency stop command. |
-|                                      |                                                            |                                                                                                                               |
+| Name                                 | Type                                  | Description                                                                                                                   |
+| ------------------------------------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `~/input/mrm/emergency_stop/operate` | `tier4_system_msgs::srv::OperateMrm`  | MRM execution order                                                                                                           |
+| `~/input/control/control_cmd`        | `autoware_control_msgs::msg::Control` | Control command output from the last node of the control component. Used for the initial value of the emergency stop command. |
+|                                      |                                       |                                                                                                                               |
 
 ### Output
 
-| Name                                      | Type                                                       | Description            |
-| ----------------------------------------- | ---------------------------------------------------------- | ---------------------- |
-| `~/output/mrm/emergency_stop/status`      | `tier4_system_msgs::msg::MrmBehaviorStatus`                | MRM execution status   |
-| `~/output/mrm/emergency_stop/control_cmd` | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Emergency stop command |
+| Name                                      | Type                                        | Description            |
+| ----------------------------------------- | ------------------------------------------- | ---------------------- |
+| `~/output/mrm/emergency_stop/status`      | `tier4_system_msgs::msg::MrmBehaviorStatus` | MRM execution status   |
+| `~/output/mrm/emergency_stop/control_cmd` | `autoware_control_msgs::msg::Control`       | Emergency stop command |
 
 ## Parameters
 

--- a/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
+++ b/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 
 // Autoware
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
@@ -30,7 +30,7 @@
 #include <vector>
 namespace mrm_emergency_stop_operator
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using tier4_system_msgs::msg::MrmBehaviorStatus;
 using tier4_system_msgs::srv::OperateMrm;
 
@@ -55,9 +55,9 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
   // Subscriber
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_control_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
 
-  void onControlCommand(AckermannControlCommand::ConstSharedPtr msg);
+  void onControlCommand(Control::ConstSharedPtr msg);
 
   // Server
   rclcpp::Service<OperateMrm>::SharedPtr service_operation_;
@@ -67,10 +67,10 @@ private:
 
   // Publisher
   rclcpp::Publisher<MrmBehaviorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_control_cmd_;
+  rclcpp::Publisher<Control>::SharedPtr pub_control_cmd_;
 
   void publishStatus() const;
-  void publishControlCommand(const AckermannControlCommand & command) const;
+  void publishControlCommand(const Control & command) const;
 
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;
@@ -79,12 +79,11 @@ private:
 
   // States
   MrmBehaviorStatus status_;
-  AckermannControlCommand prev_control_cmd_;
+  Control prev_control_cmd_;
   bool is_prev_control_cmd_subscribed_;
 
   // Algorithm
-  AckermannControlCommand calcTargetAcceleration(
-    const AckermannControlCommand & prev_control_cmd) const;
+  Control calcTargetAcceleration(const Control & prev_control_cmd) const;
 };
 
 }  // namespace mrm_emergency_stop_operator

--- a/system/mrm_emergency_stop_operator/package.xml
+++ b/system/mrm_emergency_stop_operator/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
+++ b/system/mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
@@ -28,7 +28,7 @@ MrmEmergencyStopOperator::MrmEmergencyStopOperator(const rclcpp::NodeOptions & n
   params_.target_jerk = declare_parameter<double>("target_jerk", -1.5);
 
   // Subscriber
-  sub_control_cmd_ = create_subscription<AckermannControlCommand>(
+  sub_control_cmd_ = create_subscription<Control>(
     "~/input/control/control_cmd", 1,
     std::bind(&MrmEmergencyStopOperator::onControlCommand, this, std::placeholders::_1));
 
@@ -40,8 +40,7 @@ MrmEmergencyStopOperator::MrmEmergencyStopOperator(const rclcpp::NodeOptions & n
 
   // Publisher
   pub_status_ = create_publisher<MrmBehaviorStatus>("~/output/mrm/emergency_stop/status", 1);
-  pub_control_cmd_ =
-    create_publisher<AckermannControlCommand>("~/output/mrm/emergency_stop/control_cmd", 1);
+  pub_control_cmd_ = create_publisher<Control>("~/output/mrm/emergency_stop/control_cmd", 1);
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
@@ -70,7 +69,7 @@ rcl_interfaces::msg::SetParametersResult MrmEmergencyStopOperator::onParameter(
   return result;
 }
 
-void MrmEmergencyStopOperator::onControlCommand(AckermannControlCommand::ConstSharedPtr msg)
+void MrmEmergencyStopOperator::onControlCommand(Control::ConstSharedPtr msg)
 {
   if (status_.state != MrmBehaviorStatus::OPERATING) {
     prev_control_cmd_ = *msg;
@@ -97,7 +96,7 @@ void MrmEmergencyStopOperator::publishStatus() const
   pub_status_->publish(status);
 }
 
-void MrmEmergencyStopOperator::publishControlCommand(const AckermannControlCommand & command) const
+void MrmEmergencyStopOperator::publishControlCommand(const Control & command) const
 {
   pub_control_cmd_->publish(command);
 }
@@ -114,15 +113,14 @@ void MrmEmergencyStopOperator::onTimer()
   publishStatus();
 }
 
-AckermannControlCommand MrmEmergencyStopOperator::calcTargetAcceleration(
-  const AckermannControlCommand & prev_control_cmd) const
+Control MrmEmergencyStopOperator::calcTargetAcceleration(const Control & prev_control_cmd) const
 {
-  auto control_cmd = AckermannControlCommand();
+  auto control_cmd = Control();
 
   if (!is_prev_control_cmd_subscribed_) {
     control_cmd.stamp = this->now();
     control_cmd.longitudinal.stamp = this->now();
-    control_cmd.longitudinal.speed = 0.0;
+    control_cmd.longitudinal.velocity = 0.0;
     control_cmd.longitudinal.acceleration = static_cast<float>(params_.target_acceleration);
     control_cmd.longitudinal.jerk = 0.0;
     control_cmd.lateral.stamp = this->now();
@@ -136,8 +134,8 @@ AckermannControlCommand MrmEmergencyStopOperator::calcTargetAcceleration(
 
   control_cmd.stamp = this->now();
   control_cmd.longitudinal.stamp = this->now();
-  control_cmd.longitudinal.speed = static_cast<float>(std::max(
-    prev_control_cmd.longitudinal.speed + prev_control_cmd.longitudinal.acceleration * dt, 0.0));
+  control_cmd.longitudinal.velocity = static_cast<float>(std::max(
+    prev_control_cmd.longitudinal.velocity + prev_control_cmd.longitudinal.acceleration * dt, 0.0));
   control_cmd.longitudinal.acceleration = static_cast<float>(std::max(
     prev_control_cmd.longitudinal.acceleration + params_.target_jerk * dt,
     params_.target_acceleration));

--- a/system/mrm_handler/README.md
+++ b/system/mrm_handler/README.md
@@ -14,26 +14,26 @@ MRM Handler is a node to select a proper MRM from a system failure state contain
 
 ### Input
 
-| Name                                   | Type                                                 | Description                                                                                         |
-| -------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `/localization/kinematic_state`        | `nav_msgs::msg::Odometry`                            | Used to decide whether vehicle is stopped or not                                                    |
-| `/system/operation_mode/availability`  | `tier4_system_msgs::msg::OperationModeAvailability`  | Used to select proper MRM from system available mrm behavior contained in operationModeAvailability |
-| `/vehicle/status/control_mode`         | `autoware_auto_vehicle_msgs::msg::ControlModeReport` | Used to check vehicle mode: autonomous or manual                                                    |
-| `/system/mrm/emergency_stop/status`    | `tier4_system_msgs::msg::MrmBehaviorStatus`          | Used to check if MRM emergency stop operation is available                                          |
-| `/system/mrm/comfortable_stop/status`  | `tier4_system_msgs::msg::MrmBehaviorStatus`          | Used to check if MRM comfortable stop operation is available                                        |
-| `/system/mrm/pull_over_manager/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`          | Used to check if MRM pull over operation is available                                               |
-| `/api/operation_mode/state`            | `autoware_adapi_v1_msgs::msg::OperationModeState`    | Used to check whether the current operation mode is AUTO or STOP.                                   |
+| Name                                   | Type                                                | Description                                                                                         |
+| -------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `/localization/kinematic_state`        | `nav_msgs::msg::Odometry`                           | Used to decide whether vehicle is stopped or not                                                    |
+| `/system/operation_mode/availability`  | `tier4_system_msgs::msg::OperationModeAvailability` | Used to select proper MRM from system available mrm behavior contained in operationModeAvailability |
+| `/vehicle/status/control_mode`         | `autoware_vehicle_msgs::msg::ControlModeReport`     | Used to check vehicle mode: autonomous or manual                                                    |
+| `/system/mrm/emergency_stop/status`    | `tier4_system_msgs::msg::MrmBehaviorStatus`         | Used to check if MRM emergency stop operation is available                                          |
+| `/system/mrm/comfortable_stop/status`  | `tier4_system_msgs::msg::MrmBehaviorStatus`         | Used to check if MRM comfortable stop operation is available                                        |
+| `/system/mrm/pull_over_manager/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`         | Used to check if MRM pull over operation is available                                               |
+| `/api/operation_mode/state`            | `autoware_adapi_v1_msgs::msg::OperationModeState`   | Used to check whether the current operation mode is AUTO or STOP.                                   |
 
 ### Output
 
-| Name                                    | Type                                                   | Description                                           |
-| --------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------- |
-| `/system/emergency/gear_cmd`            | `autoware_auto_vehicle_msgs::msg::GearCommand`         | Required to execute proper MRM (send gear cmd)        |
-| `/system/emergency/hazard_lights_cmd`   | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand` | Required to execute proper MRM (send turn signal cmd) |
-| `/system/fail_safe/mrm_state`           | `autoware_adapi_v1_msgs::msg::MrmState`                | Inform MRM execution state and selected MRM behavior  |
-| `/system/mrm/emergency_stop/operate`    | `tier4_system_msgs::srv::OperateMrm`                   | Execution order for MRM emergency stop                |
-| `/system/mrm/comfortable_stop/operate`  | `tier4_system_msgs::srv::OperateMrm`                   | Execution order for MRM comfortable stop              |
-| `/system/mrm/pull_over_manager/operate` | `tier4_system_msgs::srv::OperateMrm`                   | Execution order for MRM pull over                     |
+| Name                                    | Type                                              | Description                                           |
+| --------------------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
+| `/system/emergency/gear_cmd`            | `autoware_vehicle_msgs::msg::GearCommand`         | Required to execute proper MRM (send gear cmd)        |
+| `/system/emergency/hazard_lights_cmd`   | `autoware_vehicle_msgs::msg::HazardLightsCommand` | Required to execute proper MRM (send turn signal cmd) |
+| `/system/fail_safe/mrm_state`           | `autoware_adapi_v1_msgs::msg::MrmState`           | Inform MRM execution state and selected MRM behavior  |
+| `/system/mrm/emergency_stop/operate`    | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM emergency stop                |
+| `/system/mrm/comfortable_stop/operate`  | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM comfortable stop              |
+| `/system/mrm/pull_over_manager/operate` | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM pull over                     |
 
 ## Parameters
 

--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -24,9 +24,9 @@
 // Autoware
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+#include <autoware_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/msg/operation_mode_availability.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
@@ -68,8 +68,7 @@ private:
 
   // Subscribers
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
-    sub_control_mode_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr sub_control_mode_;
   rclcpp::Subscription<tier4_system_msgs::msg::OperationModeAvailability>::SharedPtr
     sub_operation_mode_availability_;
   rclcpp::Subscription<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr
@@ -82,7 +81,7 @@ private:
     sub_operation_mode_state_;
 
   nav_msgs::msg::Odometry::ConstSharedPtr odom_;
-  autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
+  autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
   tier4_system_msgs::msg::OperationModeAvailability::ConstSharedPtr operation_mode_availability_;
   tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr mrm_pull_over_status_;
   tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr mrm_comfortable_stop_status_;
@@ -90,7 +89,7 @@ private:
   autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr operation_mode_state_;
 
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
-  void onControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
+  void onControlMode(const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
   void onOperationModeAvailability(
     const tier4_system_msgs::msg::OperationModeAvailability::ConstSharedPtr msg);
   void onMrmPullOverStatus(const tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr msg);
@@ -105,9 +104,8 @@ private:
 
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::TurnSignal>::SharedPtr pub_turn_signal_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    pub_hazard_cmd_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr pub_hazard_cmd_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
 
   void publishHazardCmd();
   void publishGearCmd();

--- a/system/mrm_handler/package.xml
+++ b/system/mrm_handler/package.xml
@@ -13,9 +13,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
+  <depend>autoware_system_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -40,7 +40,7 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
     "~/input/odometry", rclcpp::QoS{1}, std::bind(&MrmHandler::onOdometry, this, _1));
   // subscribe control mode
-  sub_control_mode_ = create_subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>(
+  sub_control_mode_ = create_subscription<autoware_vehicle_msgs::msg::ControlModeReport>(
     "~/input/control_mode", rclcpp::QoS{1}, std::bind(&MrmHandler::onControlMode, this, _1));
   sub_operation_mode_availability_ =
     create_subscription<tier4_system_msgs::msg::OperationModeAvailability>(
@@ -60,10 +60,10 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
     std::bind(&MrmHandler::onOperationModeState, this, _1));
 
   // Publisher
-  pub_hazard_cmd_ = create_publisher<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>(
+  pub_hazard_cmd_ = create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
     "~/output/hazard", rclcpp::QoS{1});
   pub_gear_cmd_ =
-    create_publisher<autoware_auto_vehicle_msgs::msg::GearCommand>("~/output/gear", rclcpp::QoS{1});
+    create_publisher<autoware_vehicle_msgs::msg::GearCommand>("~/output/gear", rclcpp::QoS{1});
   pub_mrm_state_ =
     create_publisher<autoware_adapi_v1_msgs::msg::MrmState>("~/output/mrm/state", rclcpp::QoS{1});
 
@@ -85,7 +85,7 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
 
   // Initialize
   odom_ = std::make_shared<const nav_msgs::msg::Odometry>();
-  control_mode_ = std::make_shared<const autoware_auto_vehicle_msgs::msg::ControlModeReport>();
+  control_mode_ = std::make_shared<const autoware_vehicle_msgs::msg::ControlModeReport>();
   mrm_pull_over_status_ = std::make_shared<const tier4_system_msgs::msg::MrmBehaviorStatus>();
   mrm_comfortable_stop_status_ =
     std::make_shared<const tier4_system_msgs::msg::MrmBehaviorStatus>();
@@ -108,7 +108,7 @@ void MrmHandler::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
 }
 
 void MrmHandler::onControlMode(
-  const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
 {
   control_mode_ = msg;
 }
@@ -167,7 +167,7 @@ void MrmHandler::onOperationModeState(
 
 void MrmHandler::publishHazardCmd()
 {
-  using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
+  using autoware_vehicle_msgs::msg::HazardLightsCommand;
   HazardLightsCommand msg;
 
   msg.stamp = this->now();
@@ -187,7 +187,7 @@ void MrmHandler::publishHazardCmd()
 
 void MrmHandler::publishGearCmd()
 {
-  using autoware_auto_vehicle_msgs::msg::GearCommand;
+  using autoware_vehicle_msgs::msg::GearCommand;
   GearCommand msg;
 
   msg.stamp = this->now();
@@ -444,7 +444,7 @@ void MrmHandler::transitionTo(const int new_state)
 void MrmHandler::updateMrmState()
 {
   using autoware_adapi_v1_msgs::msg::MrmState;
-  using autoware_auto_vehicle_msgs::msg::ControlModeReport;
+  using autoware_vehicle_msgs::msg::ControlModeReport;
 
   // Check emergency
   const bool is_emergency = isEmergency();

--- a/system/system_error_monitor/README.md
+++ b/system/system_error_monitor/README.md
@@ -90,19 +90,19 @@ endif
 
 ### Input
 
-| Name                         | Type                                                 | Description                                                                                                        |
-| ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `/diagnostics_agg`           | `diagnostic_msgs::msg::DiagnosticArray`              | Diagnostic information aggregated based [diagnostic_aggregator setting](./config/diagnostic_aggregator) is used to |
-| `/autoware/state`            | `autoware_auto_system_msgs::msg::AutowareState`      | Required to ignore error during Route, Planning and Finalizing.                                                    |
-| `/control/current_gate_mode` | `tier4_control_msgs::msg::GateMode`                  | Required to select the appropriate module from `autonomous_driving` or `external_control`                          |
-| `/vehicle/control_mode`      | `autoware_auto_vehicle_msgs::msg::ControlModeReport` | Required to not hold emergency during manual driving                                                               |
+| Name                         | Type                                            | Description                                                                                                        |
+| ---------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `/diagnostics_agg`           | `diagnostic_msgs::msg::DiagnosticArray`         | Diagnostic information aggregated based [diagnostic_aggregator setting](./config/diagnostic_aggregator) is used to |
+| `/autoware/state`            | `autoware_system_msgs::msg::AutowareState`      | Required to ignore error during Route, Planning and Finalizing.                                                    |
+| `/control/current_gate_mode` | `tier4_control_msgs::msg::GateMode`             | Required to select the appropriate module from `autonomous_driving` or `external_control`                          |
+| `/vehicle/control_mode`      | `autoware_vehicle_msgs::msg::ControlModeReport` | Required to not hold emergency during manual driving                                                               |
 
 ### Output
 
-| Name                              | Type                                                  | Description                                                                          |
-| --------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `/system/emergency/hazard_status` | `autoware_auto_system_msgs::msg::HazardStatusStamped` | HazardStatus contains system hazard level, emergency hold status and failure details |
-| `/diagnostics_err`                | `diagnostic_msgs::msg::DiagnosticArray`               | This has the same contents as HazardStatus. This is used for visualization           |
+| Name                              | Type                                             | Description                                                                          |
+| --------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `/system/emergency/hazard_status` | `autoware_system_msgs::msg::HazardStatusStamped` | HazardStatus contains system hazard level, emergency hold status and failure details |
+| `/diagnostics_err`                | `diagnostic_msgs::msg::DiagnosticArray`          | This has the same contents as HazardStatus. This is used for visualization           |
 
 ## Parameters
 

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -20,9 +20,9 @@
 #include <rclcpp/create_timer.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
-#include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
-#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
+#include <autoware_system_msgs/msg/autoware_state.hpp>
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
@@ -86,7 +86,7 @@ private:
 
   rclcpp::Time emergency_state_switch_time_;
   rclcpp::Time initialized_time_;
-  autoware_auto_system_msgs::msg::HazardStatus hazard_status_{};
+  autoware_system_msgs::msg::HazardStatus hazard_status_{};
   std::unordered_map<std::string, RequiredModules> required_modules_map_;
   std::string current_mode_;
 
@@ -101,28 +101,25 @@ private:
 
   // Subscriber
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_diag_array_;
-  rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
-    sub_autoware_state_;
+  rclcpp::Subscription<autoware_system_msgs::msg::AutowareState>::SharedPtr sub_autoware_state_;
   rclcpp::Subscription<tier4_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
-    sub_control_mode_;
-  void onAutowareState(const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg);
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr sub_control_mode_;
+  void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onCurrentGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg);
-  void onControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
+  void onControlMode(const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
   void onDiagArray(const diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg);
 
   const size_t diag_buffer_size_ = 100;
   std::unordered_map<std::string, DiagBuffer> diag_buffer_map_;
   diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr diag_array_;
-  autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
+  autoware_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
   tier4_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
-  autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
+  autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
 
   // Publisher
-  rclcpp::Publisher<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
-    pub_hazard_status_;
+  rclcpp::Publisher<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr pub_hazard_status_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_err_;
-  void publishHazardStatus(const autoware_auto_system_msgs::msg::HazardStatus & hazard_status);
+  void publishHazardStatus(const autoware_system_msgs::msg::HazardStatus & hazard_status);
 
   // Service
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_clear_emergency_;
@@ -141,14 +138,14 @@ private:
   uint8_t getHazardLevel(const DiagConfig & required_module, const int diag_level) const;
   void appendHazardDiag(
     const DiagConfig & required_module, const diagnostic_msgs::msg::DiagnosticStatus & diag,
-    autoware_auto_system_msgs::msg::HazardStatus * hazard_status) const;
-  autoware_auto_system_msgs::msg::HazardStatus judgeHazardStatus() const;
+    autoware_system_msgs::msg::HazardStatus * hazard_status) const;
+  autoware_system_msgs::msg::HazardStatus judgeHazardStatus() const;
   void updateHazardStatus();
   void updateTimeoutHazardStatus();
   bool canAutoRecovery() const;
   bool isEmergencyHoldingRequired() const;
 
-  void loggingErrors(const autoware_auto_system_msgs::msg::HazardStatus & diag_array);
+  void loggingErrors(const autoware_system_msgs::msg::HazardStatus & diag_array);
 
   std::unique_ptr<tier4_autoware_utils::LoggerLevelConfigure> logger_configure_;
 };

--- a/system/system_error_monitor/package.xml
+++ b/system/system_error_monitor/package.xml
@@ -10,8 +10,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_system_msgs</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_system_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>
   <depend>rclcpp</depend>

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -96,9 +96,9 @@ bool isOverLevel(const int & diag_level, const std::string & failure_level_str)
 }
 
 std::vector<diagnostic_msgs::msg::DiagnosticStatus> & getTargetDiagnosticsRef(
-  const int hazard_level, autoware_auto_system_msgs::msg::HazardStatus * hazard_status)
+  const int hazard_level, autoware_system_msgs::msg::HazardStatus * hazard_status)
 {
-  using autoware_auto_system_msgs::msg::HazardStatus;
+  using autoware_system_msgs::msg::HazardStatus;
 
   if (hazard_level == HazardStatus::NO_FAULT) {
     return hazard_status->diag_no_fault;
@@ -117,8 +117,7 @@ std::vector<diagnostic_msgs::msg::DiagnosticStatus> & getTargetDiagnosticsRef(
 }
 
 diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
-  rclcpp::Clock::SharedPtr clock,
-  const autoware_auto_system_msgs::msg::HazardStatus & hazard_status)
+  rclcpp::Clock::SharedPtr clock, const autoware_system_msgs::msg::HazardStatus & hazard_status)
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
 
@@ -150,11 +149,10 @@ diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
 }
 
 std::set<std::string> getErrorModules(
-  const autoware_auto_system_msgs::msg::HazardStatus & hazard_status,
-  const int emergency_hazard_level)
+  const autoware_system_msgs::msg::HazardStatus & hazard_status, const int emergency_hazard_level)
 {
   std::set<std::string> error_modules;
-  using autoware_auto_system_msgs::msg::HazardStatus;
+  using autoware_system_msgs::msg::HazardStatus;
   if (emergency_hazard_level <= HazardStatus::SINGLE_POINT_FAULT) {
     for (const auto & diag_spf : hazard_status.diag_single_point_fault) {
       error_modules.insert(diag_spf.name);
@@ -175,10 +173,10 @@ std::set<std::string> getErrorModules(
 }
 
 int isInNoFaultCondition(
-  const autoware_auto_system_msgs::msg::AutowareState & autoware_state,
+  const autoware_system_msgs::msg::AutowareState & autoware_state,
   const tier4_control_msgs::msg::GateMode & current_gate_mode)
 {
-  using autoware_auto_system_msgs::msg::AutowareState;
+  using autoware_system_msgs::msg::AutowareState;
   using tier4_control_msgs::msg::GateMode;
 
   const auto is_in_autonomous_ignore_state =
@@ -221,7 +219,7 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
   get_parameter_or<double>("hazard_recovery_timeout", params_.hazard_recovery_timeout, 5.0);
   get_parameter_or<int>(
     "emergency_hazard_level", params_.emergency_hazard_level,
-    autoware_auto_system_msgs::msg::HazardStatus::LATENT_FAULT);
+    autoware_system_msgs::msg::HazardStatus::LATENT_FAULT);
   get_parameter_or<bool>("use_emergency_hold", params_.use_emergency_hold, false);
   get_parameter_or<bool>(
     "use_emergency_hold_in_manual_driving", params_.use_emergency_hold_in_manual_driving, false);
@@ -237,15 +235,15 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
   sub_current_gate_mode_ = create_subscription<tier4_control_msgs::msg::GateMode>(
     "~/input/current_gate_mode", rclcpp::QoS{1},
     std::bind(&AutowareErrorMonitor::onCurrentGateMode, this, _1));
-  sub_autoware_state_ = create_subscription<autoware_auto_system_msgs::msg::AutowareState>(
+  sub_autoware_state_ = create_subscription<autoware_system_msgs::msg::AutowareState>(
     "~/input/autoware_state", rclcpp::QoS{1},
     std::bind(&AutowareErrorMonitor::onAutowareState, this, _1));
-  sub_control_mode_ = create_subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>(
+  sub_control_mode_ = create_subscription<autoware_vehicle_msgs::msg::ControlModeReport>(
     "~/input/control_mode", rclcpp::QoS{1},
     std::bind(&AutowareErrorMonitor::onControlMode, this, _1));
 
   // Publisher
-  pub_hazard_status_ = create_publisher<autoware_auto_system_msgs::msg::HazardStatusStamped>(
+  pub_hazard_status_ = create_publisher<autoware_system_msgs::msg::HazardStatusStamped>(
     "~/output/hazard_status", rclcpp::QoS{1});
   pub_diagnostics_err_ = create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
     "~/output/diagnostics_err", rclcpp::QoS{1});
@@ -256,10 +254,10 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
     std::bind(&AutowareErrorMonitor::onClearEmergencyService, this, _1, _2));
 
   // Initialize
-  autoware_auto_vehicle_msgs::msg::ControlModeReport vehicle_state_report;
-  vehicle_state_report.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL;
-  control_mode_ = std::make_shared<const autoware_auto_vehicle_msgs::msg::ControlModeReport>(
-    vehicle_state_report);
+  autoware_vehicle_msgs::msg::ControlModeReport vehicle_state_report;
+  vehicle_state_report.mode = autoware_vehicle_msgs::msg::ControlModeReport::MANUAL;
+  control_mode_ =
+    std::make_shared<const autoware_vehicle_msgs::msg::ControlModeReport>(vehicle_state_report);
 
   // Timer
   initialized_time_ = this->now();
@@ -363,7 +361,7 @@ void AutowareErrorMonitor::onCurrentGateMode(
 }
 
 void AutowareErrorMonitor::onAutowareState(
-  const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg)
+  const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg)
 {
   autoware_state_ = msg;
 
@@ -372,7 +370,7 @@ void AutowareErrorMonitor::onAutowareState(
 }
 
 void AutowareErrorMonitor::onControlMode(
-  const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
 {
   control_mode_ = msg;
 
@@ -486,7 +484,7 @@ boost::optional<DiagStamped> AutowareErrorMonitor::getLatestDiag(
 uint8_t AutowareErrorMonitor::getHazardLevel(
   const DiagConfig & required_module, const int diag_level) const
 {
-  using autoware_auto_system_msgs::msg::HazardStatus;
+  using autoware_system_msgs::msg::HazardStatus;
 
   if (isOverLevel(diag_level, required_module.spf_at)) {
     return HazardStatus::SINGLE_POINT_FAULT;
@@ -503,7 +501,7 @@ uint8_t AutowareErrorMonitor::getHazardLevel(
 
 void AutowareErrorMonitor::appendHazardDiag(
   const DiagConfig & required_module, const diagnostic_msgs::msg::DiagnosticStatus & hazard_diag,
-  autoware_auto_system_msgs::msg::HazardStatus * hazard_status) const
+  autoware_system_msgs::msg::HazardStatus * hazard_status) const
 {
   const auto hazard_level = getHazardLevel(required_module, hazard_diag.level);
 
@@ -520,12 +518,12 @@ void AutowareErrorMonitor::appendHazardDiag(
   hazard_status->level = std::max(hazard_status->level, hazard_level);
 }
 
-autoware_auto_system_msgs::msg::HazardStatus AutowareErrorMonitor::judgeHazardStatus() const
+autoware_system_msgs::msg::HazardStatus AutowareErrorMonitor::judgeHazardStatus() const
 {
-  using autoware_auto_system_msgs::msg::HazardStatus;
+  using autoware_system_msgs::msg::HazardStatus;
   using diagnostic_msgs::msg::DiagnosticStatus;
 
-  autoware_auto_system_msgs::msg::HazardStatus hazard_status;
+  autoware_system_msgs::msg::HazardStatus hazard_status;
   for (const auto & required_module : required_modules_map_.at(current_mode_)) {
     const auto & diag_name = required_module.name;
     const auto latest_diag = getLatestDiag(diag_name);
@@ -566,7 +564,7 @@ autoware_auto_system_msgs::msg::HazardStatus AutowareErrorMonitor::judgeHazardSt
 
   // Ignore error when vehicle is not ready to start
   if (isInNoFaultCondition(*autoware_state_, *current_gate_mode_)) {
-    hazard_status.level = autoware_auto_system_msgs::msg::HazardStatus::NO_FAULT;
+    hazard_status.level = autoware_system_msgs::msg::HazardStatus::NO_FAULT;
   }
 
   return hazard_status;
@@ -604,7 +602,7 @@ void AutowareErrorMonitor::updateTimeoutHazardStatus()
 {
   const bool prev_emergency_status = hazard_status_.emergency;
 
-  hazard_status_.level = autoware_auto_system_msgs::msg::HazardStatus::SINGLE_POINT_FAULT;
+  hazard_status_.level = autoware_system_msgs::msg::HazardStatus::SINGLE_POINT_FAULT;
   hazard_status_.emergency = true;
 
   if (hazard_status_.emergency != prev_emergency_status) {
@@ -663,7 +661,7 @@ bool AutowareErrorMonitor::isEmergencyHoldingRequired() const
 
   // Don't hold status during manual driving
   const bool is_manual_driving =
-    (control_mode_->mode == autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL);
+    (control_mode_->mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL);
   const auto no_hold_condition =
     (!params_.use_emergency_hold_in_manual_driving && is_manual_driving);
   if (no_hold_condition) {
@@ -674,9 +672,9 @@ bool AutowareErrorMonitor::isEmergencyHoldingRequired() const
 }
 
 void AutowareErrorMonitor::publishHazardStatus(
-  const autoware_auto_system_msgs::msg::HazardStatus & hazard_status)
+  const autoware_system_msgs::msg::HazardStatus & hazard_status)
 {
-  autoware_auto_system_msgs::msg::HazardStatusStamped hazard_status_stamped;
+  autoware_system_msgs::msg::HazardStatusStamped hazard_status_stamped;
   hazard_status_stamped.stamp = this->now();
   hazard_status_stamped.status = hazard_status;
   pub_hazard_status_->publish(hazard_status_stamped);
@@ -700,7 +698,7 @@ bool AutowareErrorMonitor::onClearEmergencyService(
 }
 
 void AutowareErrorMonitor::loggingErrors(
-  const autoware_auto_system_msgs::msg::HazardStatus & hazard_status)
+  const autoware_system_msgs::msg::HazardStatus & hazard_status)
 {
   if (
     autoware_state_ && current_gate_mode_ &&


### PR DESCRIPTION
## Description

This is a subset of https://github.com/autowarefoundation/autoware.universe/pull/6893 to make it easier to review.
This includes all the modification for `system` directory in the original PR. 

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/6893
https://github.com/orgs/autowarefoundation/discussions/3862

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Message types are modified according to the table in [this comment](https://github.com/orgs/autowarefoundation/discussions/3862#discussioncomment-9638820).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
