### PR TITLE
fix(vehicle_cmd_gate): change /autoware/engage/ to transient_local

### DIFF
--- a/control/operation_mode_transition_manager/src/compatibility.cpp
+++ b/control/operation_mode_transition_manager/src/compatibility.cpp
@@ -31,7 +31,8 @@ Compatibility::Compatibility(rclcpp::Node * node) : node_(node)
     "/control/external_cmd_selector/current_selector_mode", 1,
     std::bind(&Compatibility::on_selector_mode, this, std::placeholders::_1));
 
-  pub_autoware_engage_ = node->create_publisher<AutowareEngage>("/autoware/engage", 1);
+  pub_autoware_engage_ =
+    node->create_publisher<AutowareEngage>("/autoware/engage", rclcpp::QoS(1).transient_local());
   pub_gate_mode_ = node->create_publisher<GateMode>("/control/gate_mode_cmd", 1);
   cli_selector_mode_ =
     node->create_client<SelectorModeSrv>("/control/external_cmd_selector/select_external_command");

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -90,7 +90,8 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
   gate_mode_sub_ = create_subscription<GateMode>(
     "input/gate_mode", 1, std::bind(&VehicleCmdGate::onGateMode, this, _1));
   engage_sub_ = create_subscription<EngageMsg>(
-    "input/engage", 1, std::bind(&VehicleCmdGate::onEngage, this, _1));
+    "input/engage", rclcpp::QoS(1).transient_local(),
+    std::bind(&VehicleCmdGate::onEngage, this, _1));
   kinematics_sub_ = create_subscription<Odometry>(
     "/localization/kinematic_state", 1,
     [this](Odometry::SharedPtr msg) { current_kinematics_ = *msg; });


### PR DESCRIPTION
## Description

Now `/autoware/engage` is published only when changing operation mode, so it is not always published.
We have to treat it as transient_local.

## Related links

TIERIV_INTERNAL_LINK: https://tier4.atlassian.net/browse/VEH-986

## Tests performed

I confirmed that `/autoware/engage` is published only when changing operation mode.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
