### PR TITLE
refactor(simple_planning_simulator): remove static odom tf publisher

### DIFF
--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -14,7 +14,6 @@
 
 import launch
 from launch.actions import DeclareLaunchArgument
-from launch.actions import GroupAction
 from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -78,22 +77,7 @@ def launch_setup(context, *args, **kwargs):
         ],
     )
 
-    map_to_odom_tf_publisher = Node(
-        package="tf2_ros",
-        executable="static_transform_publisher",
-        name="static_map_to_odom_tf_publisher",
-        output="screen",
-        arguments=[
-            "--frame-id",
-            "map",
-            "--child-frame-id",
-            "odom",
-        ],
-    )
-
-    group = GroupAction([simple_planning_simulator_node, map_to_odom_tf_publisher])
-
-    return [group]
+    return [simple_planning_simulator_node]
 
 
 def generate_launch_description():


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The `odom` frame is not used in Autoware so this PR removes the `odom` static publisher from the `simple_planning_simulator` launch file.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
