### PR TITLE
feat(object_recognition_utils): fix failing test

### DIFF
--- a/common/object_recognition_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/object_recognition_utils/test/src/test_predicted_path_utils.cpp
@@ -174,7 +174,7 @@ TEST(predicted_path_utils, resamplePredictedPath_by_vector)
     }
   }
 
-  // Resample which exceeds the maximum size
+  // Resample the path with morethan 100 points
   {
     std::vector<double> resampling_vec(101);
     for (size_t i = 0; i < 101; ++i) {
@@ -186,7 +186,7 @@ TEST(predicted_path_utils, resamplePredictedPath_by_vector)
     EXPECT_EQ(resampled_path.path.size(), resampled_path.path.max_size());
     EXPECT_NEAR(path.confidence, resampled_path.confidence, epsilon);
 
-    for (size_t i = 0; i < resampled_path.path.max_size(); ++i) {
+    for (size_t i = 0; i < resampled_path.path.size(); ++i) {
       EXPECT_NEAR(resampled_path.path.at(i).position.x, resampling_vec.at(i), epsilon);
       EXPECT_NEAR(resampled_path.path.at(i).position.y, 0.0, epsilon);
       EXPECT_NEAR(resampled_path.path.at(i).position.z, 0.0, epsilon);

--- a/common/object_recognition_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/object_recognition_utils/test/src/test_predicted_path_utils.cpp
@@ -174,7 +174,7 @@ TEST(predicted_path_utils, resamplePredictedPath_by_vector)
     }
   }
 
-  // Resample the path with morethan 100 points
+  // Resample the path with more than 100 points
   {
     std::vector<double> resampling_vec(101);
     for (size_t i = 0; i < 101; ++i) {


### PR DESCRIPTION
## Description

This fixes the failing test for object_recognition_utils caused by [migration to autoware_msgs](https://github.com/orgs/autowarefoundation/discussions/4803).
New autoware_msgs does not have the bound limit for predicted path so there are tests that are no longer needed.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
