### PR TITLE
chore(ci): add a workflow for DCO check to avoid DCO bot system failure

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -18,4 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install -U dco-check
-          dco-check --verbose --exclude-pattern '66853113+pre-commit-ci[bot]@users.noreply.github.com'
+          dco-check --verbose --exclude-pattern '66853113+pre-commit-ci\[bot\]@users\.noreply\.github\.com'

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,21 @@
+name: DCO
+# ref: https://github.com/anchore/syft/pull/2926/files
+on:
+  pull_request:
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Check DCO
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install -U dco-check
+          dco-check --verbose

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -18,4 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install -U dco-check
-          dco-check --verbose
+          dco-check --verbose --exclude-pattern '66853113+pre-commit-ci[bot]@users.noreply.github.com'

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -18,4 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install -U dco-check
-          dco-check --verbose --exclude-pattern '66853113+pre-commit-ci\[bot\]@users\.noreply\.github\.com'
+          dco-check --verbose --exclude-pattern 'pre-commit-ci\[bot\]@users\.noreply\.github\.com'

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python 3.x
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: 3.x
 
       - name: Check DCO
         env:

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python 3.x
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Check DCO
         env:


### PR DESCRIPTION
Signed-off-by: Kotaro Yoshimoto pythagora.yoshimoto@gmail.com

## Description

DCO check is not working now.
![image](https://github.com/autowarefoundation/autoware.universe/assets/12395284/d8289cb6-23f9-4091-8ae9-32b46fc43d1a)

https://github.com/dcoapp/app/issues/211

Alternatively, I added this workflow as proposed in the issue.

## Tests performed

Well done!
https://github.com/autowarefoundation/autoware.universe/actions/runs/9377200258/job/25818372246

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
