### PR TITLE
fix(mission_planner): fix combine lanelets logic

### DIFF
--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -69,11 +69,8 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
     if (left_shared_shoulder) {
       // if exist, add left bound of SHOULDER lanelet to lefts
       add_bound(left_shared_shoulder->leftBound(), lefts);
-    } else if (
+    } else {
       // if not exist, add left bound of lanelet to lefts
-      // if the **left** of this lanelet does not match any of the **right** bounds of `lanelets`,
-      // then its left bound constitutes the left boundary of the entire merged lanelet
-      std::count(right_bound_ids.begin(), right_bound_ids.end(), llt.leftBound().id()) < 1) {
       add_bound(llt.leftBound(), lefts);
     }
 
@@ -82,11 +79,8 @@ lanelet::ConstLanelet combine_lanelets_with_shoulder(
     if (right_shared_shoulder) {
       // if exist, add right bound of SHOULDER lanelet to rights
       add_bound(right_shared_shoulder->rightBound(), rights);
-    } else if (
+    } else {
       // if not exist, add right bound of lanelet to rights
-      // if the **right** of this lanelet does not match any of the **left** bounds of `lanelets`,
-      // then its right bound constitutes the right boundary of the entire merged lanelet
-      std::count(left_bound_ids.begin(), left_bound_ids.end(), llt.rightBound().id()) < 1) {
       add_bound(llt.rightBound(), rights);
     }
   }


### PR DESCRIPTION
## Description
To fix route planning when setting the goal position on a bidirectional lanelet.

## Related links
#6803

## Tests performed
**Test Scenarios:** [overlap11.osm.txt](https://github.com/user-attachments/files/15573529/overlap11.osm.txt)
Two scenes are constructed to reproduce the bug. The left (Scene 1) and the right (Scene 2) are similar scenes. There is a tiny difference - Scene 2 has a longer bidirectional segment (with one more bidirectional lanelet) than Scene 1.
![image](https://github.com/autowarefoundation/autoware.universe/assets/103234047/80ca6a82-534b-4231-a7f2-93e9ecf89fff)

**Before:** 
![image](https://github.com/autowarefoundation/autoware.universe/assets/103234047/64734296-add9-428a-bcc0-44d056c8045f)

[Overlap_Bug_Before_Fix.webm](https://github.com/autowarefoundation/autoware.universe/assets/103234047/fc30feb9-a9e5-4b54-b428-9903226eb18e)

**After:**
![image](https://github.com/autowarefoundation/autoware.universe/assets/103234047/f1c58a37-b80c-4692-a78e-df3be2634137)

[Overlap_Bug_After_Fix.webm](https://github.com/autowarefoundation/autoware.universe/assets/103234047/f07c9e29-02bd-4bc5-af04-6347f2dd0e88)


## Notes for reviewers
A new bug is traced and posted in #7272.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
