### PR TITLE
docs: added odometry input in README.md

### DIFF
--- a/planning/autoware_mission_planner/README.md
+++ b/planning/autoware_mission_planner/README.md
@@ -53,6 +53,7 @@ It distributes route requests and planning results according to current MRM oper
 | `input/vector_map`           | autoware_map_msgs/msg/LaneletMapBin       | vector map of Lanelet2 |
 | `input/modified_goal`        | geometry_msgs/PoseWithUuidStamped         | modified goal pose     |
 | `input/operation_mode_state` | autoware_adapi_v1_msgs/OperationModeState | operation mode state   |
+| `input/odometry`             | nav_msgs/msg/Odometry                     | vehicle odometry       |
 
 ### Publications
 


### PR DESCRIPTION
previously there was a mistake that odometry input was not included in README.md. Fixed that.

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
