### PR TITLE
feat(planning_evaluator): caluculate lateral/yaw deviation of ego pose from trajectory

### DIFF
--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/deviation_metrics.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/deviation_metrics.hpp
@@ -38,12 +38,28 @@ using geometry_msgs::msg::Pose;
 Stat<double> calcLateralDeviation(const Trajectory & ref, const Trajectory & traj);
 
 /**
+ * @brief calculate lateral deviation of the given trajectory from the reference trajectory
+ * @param [in] ref reference trajectory
+ * @param [in] point input point
+ * @return calculated statistics
+ */
+Stat<double> calcLateralDeviation(const Trajectory & traj, const Point & point);
+
+/**
  * @brief calculate yaw deviation of the given trajectory from the reference trajectory
  * @param [in] ref reference trajectory
  * @param [in] traj input trajectory
  * @return calculated statistics
  */
 Stat<double> calcYawDeviation(const Trajectory & ref, const Trajectory & traj);
+
+/**
+ * @brief calculate yaw deviation of the given trajectory from the reference trajectory
+ * @param [in] traj input trajectory
+ * @param [in] pose input pose
+ * @return calculated statistics
+ */
+Stat<double> calcYawDeviation(const Trajectory & traj, const Pose & pose);
 
 /**
  * @brief calculate velocity deviation of the given trajectory from the reference trajectory

--- a/evaluator/planning_evaluator/include/planning_evaluator/metrics/metric.hpp
+++ b/evaluator/planning_evaluator/include/planning_evaluator/metrics/metric.hpp
@@ -44,6 +44,8 @@ enum class Metric {
   modified_goal_longitudinal_deviation,
   modified_goal_lateral_deviation,
   modified_goal_yaw_deviation,
+  ego_pose_lateral_deviation,
+  ego_pose_yaw_deviation,
   SIZE,
 };
 
@@ -68,7 +70,9 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"obstacle_ttc", Metric::obstacle_ttc},
   {"modified_goal_longitudinal_deviation", Metric::modified_goal_longitudinal_deviation},
   {"modified_goal_lateral_deviation", Metric::modified_goal_lateral_deviation},
-  {"modified_goal_yaw_deviation", Metric::modified_goal_yaw_deviation}};
+  {"modified_goal_yaw_deviation", Metric::modified_goal_yaw_deviation},
+  {"ego_pose_lateral_deviation", Metric::ego_pose_lateral_deviation},
+  {"ego_pose_yaw_deviation", Metric::ego_pose_yaw_deviation}};
 
 static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::curvature, "curvature"},
@@ -88,7 +92,9 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::obstacle_ttc, "obstacle_ttc"},
   {Metric::modified_goal_longitudinal_deviation, "modified_goal_longitudinal_deviation"},
   {Metric::modified_goal_lateral_deviation, "modified_goal_lateral_deviation"},
-  {Metric::modified_goal_yaw_deviation, "modified_goal_yaw_deviation"}};
+  {Metric::modified_goal_yaw_deviation, "modified_goal_yaw_deviation"},
+  {Metric::ego_pose_lateral_deviation, "ego_pose_lateral_deviation"},
+  {Metric::ego_pose_yaw_deviation, "ego_pose_yaw_deviation"}};
 
 // Metrics descriptions
 static const std::unordered_map<Metric, std::string> metric_descriptions = {
@@ -109,7 +115,9 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
   {Metric::obstacle_ttc, "Obstacle_time_to_collision[s]"},
   {Metric::modified_goal_longitudinal_deviation, "Modified_goal_longitudinal_deviation[m]"},
   {Metric::modified_goal_lateral_deviation, "Modified_goal_lateral_deviation[m]"},
-  {Metric::modified_goal_yaw_deviation, "Modified_goal_yaw_deviation[rad]"}};
+  {Metric::modified_goal_yaw_deviation, "Modified_goal_yaw_deviation[rad]"},
+  {Metric::ego_pose_lateral_deviation, "Ego_pose_lateral_deviation[m]"},
+  {Metric::ego_pose_yaw_deviation, "Ego_pose_yaw_deviation[rad]"}};
 
 namespace details
 {

--- a/evaluator/planning_evaluator/param/planning_evaluator.defaults.yaml
+++ b/evaluator/planning_evaluator/param/planning_evaluator.defaults.yaml
@@ -22,6 +22,8 @@
       - modified_goal_longitudinal_deviation
       - modified_goal_lateral_deviation
       - modified_goal_yaw_deviation
+      - ego_pose_lateral_deviation
+      - ego_pose_yaw_deviation
 
     trajectory:
       min_point_dist_m: 0.1 # [m] minimum distance between two successive points to use for angle calculation

--- a/evaluator/planning_evaluator/src/metrics/deviation_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/deviation_metrics.cpp
@@ -44,6 +44,20 @@ Stat<double> calcLateralDeviation(const Trajectory & ref, const Trajectory & tra
   return stat;
 }
 
+Stat<double> calcLateralDeviation(const Trajectory & traj, const Point & point)
+{
+  Stat<double> stat;
+
+  if (traj.points.empty()) {
+    return stat;
+  }
+
+  const size_t nearest_index = motion_utils::findNearestIndex(traj.points, point);
+  stat.add(
+    std::abs(tier4_autoware_utils::calcLateralDeviation(traj.points[nearest_index].pose, point)));
+  return stat;
+}
+
 Stat<double> calcYawDeviation(const Trajectory & ref, const Trajectory & traj)
 {
   Stat<double> stat;
@@ -59,6 +73,19 @@ Stat<double> calcYawDeviation(const Trajectory & ref, const Trajectory & traj)
     const size_t nearest_index = motion_utils::findNearestIndex(ref.points, p.pose.position);
     stat.add(tier4_autoware_utils::calcYawDeviation(ref.points[nearest_index].pose, p.pose));
   }
+  return stat;
+}
+
+Stat<double> calcYawDeviation(const Trajectory & traj, const Pose & pose)
+{
+  Stat<double> stat;
+
+  if (traj.points.empty()) {
+    return stat;
+  }
+
+  const size_t nearest_index = motion_utils::findNearestIndex(traj.points, pose.position);
+  stat.add(std::abs(tier4_autoware_utils::calcYawDeviation(traj.points[nearest_index].pose, pose)));
   return stat;
 }
 

--- a/evaluator/planning_evaluator/src/metrics_calculator.cpp
+++ b/evaluator/planning_evaluator/src/metrics_calculator.cpp
@@ -69,6 +69,10 @@ std::optional<Stat<double>> MetricsCalculator::calculate(
       return metrics::calcDistanceToObstacle(dynamic_objects_, traj);
     case Metric::obstacle_ttc:
       return metrics::calcTimeToCollision(dynamic_objects_, traj, parameters.obstacle.dist_thr_m);
+    case Metric::ego_pose_lateral_deviation:
+      return metrics::calcLateralDeviation(traj, ego_pose_.position);
+    case Metric::ego_pose_yaw_deviation:
+      return metrics::calcYawDeviation(traj, ego_pose_);
     default:
       return {};
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

caluculate lateral/yaw deviation of ego pose from trajectory 

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/33c63718-34a0-402b-b216-3bd37ac3277d)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/538729fd-c1b3-4a99-9ca7-78ddfd675d22)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/4f6fc3cd-327d-4c77-8eab-1cbbbbccd4b4)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
