### PR TITLE
feat(joy_controller): use polling subscriber

### DIFF
--- a/control/joy_controller/include/joy_controller/joy_controller.hpp
+++ b/control/joy_controller/include/joy_controller/joy_controller.hpp
@@ -18,6 +18,7 @@
 #include "joy_controller/joy_converter/joy_converter_base.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/polling_subscriber.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_vehicle_msgs/msg/engage.hpp>
@@ -66,19 +67,20 @@ private:
   double backward_accel_ratio_;
 
   // CallbackGroups
-  rclcpp::CallbackGroup::SharedPtr callback_group_subscribers_;
   rclcpp::CallbackGroup::SharedPtr callback_group_services_;
 
   // Subscriber
-  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr sub_joy_;
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<sensor_msgs::msg::Joy> sub_joy_{
+    this, "input/joy"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry> sub_odom_{
+    this, "input/odometry"};
 
   rclcpp::Time last_joy_received_time_;
   std::shared_ptr<const JoyConverterBase> joy_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_;
 
-  void onJoy(const sensor_msgs::msg::Joy::ConstSharedPtr msg);
-  void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
+  void onJoy();
+  void onOdometry();
 
   // Publisher
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;

--- a/control/joy_controller/package.xml
+++ b/control/joy_controller/package.xml
@@ -26,6 +26,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tier4_api_utils</depend>
+  <depend>tier4_autoware_utils</depend>
   <depend>tier4_control_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The same as https://github.com/autowarefoundation/autoware.universe/pull/6997 based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612), the polling subscriber is used in the obstacle_avoidance_planner.
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Nothing

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing but more efficient CPU usage

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
