### PR TITLE
refactor(pose2twist): apply static analysis

### DIFF
--- a/localization/pose2twist/include/pose2twist/pose2twist_core.hpp
+++ b/localization/pose2twist/include/pose2twist/pose2twist_core.hpp
@@ -25,10 +25,10 @@ class Pose2Twist : public rclcpp::Node
 {
 public:
   explicit Pose2Twist(const rclcpp::NodeOptions & options);
-  ~Pose2Twist() = default;
+  ~Pose2Twist() override = default;
 
 private:
-  void callbackPose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr);
+  void callback_pose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr);
 
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_sub_;
 

--- a/localization/pose2twist/src/pose2twist_core.cpp
+++ b/localization/pose2twist/src/pose2twist_core.cpp
@@ -38,10 +38,10 @@ Pose2Twist::Pose2Twist(const rclcpp::NodeOptions & options) : rclcpp::Node("pose
     create_publisher<tier4_debug_msgs::msg::Float32Stamped>("angular_z", durable_qos);
   // Note: this callback publishes topics above
   pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
-    "pose", queue_size, std::bind(&Pose2Twist::callbackPose, this, _1));
+    "pose", queue_size, std::bind(&Pose2Twist::callback_pose, this, _1));
 }
 
-double calcDiffForRadian(const double lhs_rad, const double rhs_rad)
+double calc_diff_for_radian(const double lhs_rad, const double rhs_rad)
 {
   double diff_rad = lhs_rad - rhs_rad;
   if (diff_rad > M_PI) {
@@ -53,7 +53,7 @@ double calcDiffForRadian(const double lhs_rad, const double rhs_rad)
 }
 
 // x: roll, y: pitch, z: yaw
-geometry_msgs::msg::Vector3 getRPY(const geometry_msgs::msg::Pose & pose)
+geometry_msgs::msg::Vector3 get_rpy(const geometry_msgs::msg::Pose & pose)
 {
   geometry_msgs::msg::Vector3 rpy;
   tf2::Quaternion q(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
@@ -61,12 +61,12 @@ geometry_msgs::msg::Vector3 getRPY(const geometry_msgs::msg::Pose & pose)
   return rpy;
 }
 
-geometry_msgs::msg::Vector3 getRPY(geometry_msgs::msg::PoseStamped::SharedPtr pose)
+geometry_msgs::msg::Vector3 get_rpy(geometry_msgs::msg::PoseStamped::SharedPtr pose)
 {
-  return getRPY(pose->pose);
+  return get_rpy(pose->pose);
 }
 
-geometry_msgs::msg::TwistStamped calcTwist(
+geometry_msgs::msg::TwistStamped calc_twist(
   geometry_msgs::msg::PoseStamped::SharedPtr pose_a,
   geometry_msgs::msg::PoseStamped::SharedPtr pose_b)
 {
@@ -79,8 +79,8 @@ geometry_msgs::msg::TwistStamped calcTwist(
     return twist;
   }
 
-  const auto pose_a_rpy = getRPY(pose_a);
-  const auto pose_b_rpy = getRPY(pose_b);
+  const auto pose_a_rpy = get_rpy(pose_a);
+  const auto pose_b_rpy = get_rpy(pose_b);
 
   geometry_msgs::msg::Vector3 diff_xyz;
   geometry_msgs::msg::Vector3 diff_rpy;
@@ -88,9 +88,9 @@ geometry_msgs::msg::TwistStamped calcTwist(
   diff_xyz.x = pose_b->pose.position.x - pose_a->pose.position.x;
   diff_xyz.y = pose_b->pose.position.y - pose_a->pose.position.y;
   diff_xyz.z = pose_b->pose.position.z - pose_a->pose.position.z;
-  diff_rpy.x = calcDiffForRadian(pose_b_rpy.x, pose_a_rpy.x);
-  diff_rpy.y = calcDiffForRadian(pose_b_rpy.y, pose_a_rpy.y);
-  diff_rpy.z = calcDiffForRadian(pose_b_rpy.z, pose_a_rpy.z);
+  diff_rpy.x = calc_diff_for_radian(pose_b_rpy.x, pose_a_rpy.x);
+  diff_rpy.y = calc_diff_for_radian(pose_b_rpy.y, pose_a_rpy.y);
+  diff_rpy.z = calc_diff_for_radian(pose_b_rpy.z, pose_a_rpy.z);
 
   geometry_msgs::msg::TwistStamped twist;
   twist.header = pose_b->header;
@@ -106,15 +106,15 @@ geometry_msgs::msg::TwistStamped calcTwist(
   return twist;
 }
 
-void Pose2Twist::callbackPose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr)
+void Pose2Twist::callback_pose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr)
 {
   // TODO(YamatoAndo) check time stamp diff
   // TODO(YamatoAndo) check suddenly move
   // TODO(YamatoAndo) apply low pass filter
 
-  geometry_msgs::msg::PoseStamped::SharedPtr current_pose_msg = pose_msg_ptr;
+  const geometry_msgs::msg::PoseStamped::SharedPtr & current_pose_msg = pose_msg_ptr;
   static geometry_msgs::msg::PoseStamped::SharedPtr prev_pose_msg = current_pose_msg;
-  geometry_msgs::msg::TwistStamped twist_msg = calcTwist(prev_pose_msg, current_pose_msg);
+  geometry_msgs::msg::TwistStamped twist_msg = calc_twist(prev_pose_msg, current_pose_msg);
   prev_pose_msg = current_pose_msg;
   twist_msg.header.frame_id = "base_link";
   twist_pub_->publish(twist_msg);


### PR DESCRIPTION
## Description

This PR is to apply some of the suggestions from linter.

Fixed:
- camelCase to snake_case
  - `getRPY` -> `get_rpy` while tf2::Matrix3x3 remains getRPY...
- some types

not Fixed:
- warnings for copy constructor and so on
- narrow conversion of double to float which is not the scope in these files

## Tests performed
```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```

Before fixing the code:
```Text
...
13362 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/include/pose2twist/pose2twist_core.hpp:24:7: warning: class 'Pose2Twist' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class Pose2Twist : public rclcpp::Node
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/include/pose2twist/pose2twist_core.hpp:28:3: error: annotate this function with 'override' or (rarely) 'final' [modernize-use-override,-warnings-as-errors]
  ~Pose2Twist() = default;
  ^
                override 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/include/pose2twist/pose2twist_core.hpp:31:8: warning: invalid case style for function 'callbackPose' [readability-identifier-naming]
  void callbackPose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr);
       ^~~~~~~~~~~~
       callback_pose
Suppressed 13370 warnings (13359 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
17462 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:44:8: warning: invalid case style for function 'calcDiffForRadian' [readability-identifier-naming]
double calcDiffForRadian(const double lhs_rad, const double rhs_rad)
       ^~~~~~~~~~~~~~~~~
       calc_diff_for_radian
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:56:29: warning: invalid case style for function 'getRPY' [readability-identifier-naming]
geometry_msgs::msg::Vector3 getRPY(const geometry_msgs::msg::Pose & pose)
                            ^~~~~~
                            get_rpy
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:64:29: warning: invalid case style for function 'getRPY' [readability-identifier-naming]
geometry_msgs::msg::Vector3 getRPY(geometry_msgs::msg::PoseStamped::SharedPtr pose)
                            ^~~~~~
                            get_rpy
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:69:34: warning: invalid case style for function 'calcTwist' [readability-identifier-naming]
geometry_msgs::msg::TwistStamped calcTwist(
                                 ^~~~~~~~~
                                 calc_twist
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:115:46: warning: local copy 'current_pose_msg' of the variable 'pose_msg_ptr' is never modified; consider avoiding the copy [performance-unnecessary-copy-initialization]
  geometry_msgs::msg::PoseStamped::SharedPtr current_pose_msg = pose_msg_ptr;
                                             ^
  const                                     &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:124:23: warning: narrowing conversion from 'geometry_msgs::msg::Vector3_::_x_type' (aka 'double') to 'tier4_debug_msgs::msg::Float32Stamped_::_data_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  linear_x_msg.data = twist_msg.twist.linear.x;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:129:24: warning: narrowing conversion from 'geometry_msgs::msg::Vector3_::_z_type' (aka 'double') to 'tier4_debug_msgs::msg::Float32Stamped_::_data_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  angular_z_msg.data = twist_msg.twist.angular.z;
                       ^
Suppressed 17466 warnings (17455 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

Check with cppcheck: (nothing specific)

----

After this PR:
```Text
...
13360 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/include/pose2twist/pose2twist_core.hpp:24:7: warning: class 'Pose2Twist' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class Pose2Twist : public rclcpp::Node
      ^
Suppressed 13370 warnings (13359 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
17455 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:124:23: warning: narrowing conversion from 'geometry_msgs::msg::Vector3_::_x_type' (aka 'double') to 'tier4_debug_msgs::msg::Float32Stamped_::_data_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  linear_x_msg.data = twist_msg.twist.linear.x;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose2twist/src/pose2twist_core.cpp:129:24: warning: narrowing conversion from 'geometry_msgs::msg::Vector3_::_z_type' (aka 'double') to 'tier4_debug_msgs::msg::Float32Stamped_::_data_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  angular_z_msg.data = twist_msg.twist.angular.z;
                       ^
Suppressed 17464 warnings (17453 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
