### PR TITLE
fix(pose2twist): compute angular velocity through quaternion

### DIFF
--- a/localization/pose2twist/CMakeLists.txt
+++ b/localization/pose2twist/CMakeLists.txt
@@ -14,6 +14,13 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTOR SingleThreadedExecutor
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_auto_add_gtest(test_angular_velocity
+    test/test_angular_velocity.cpp
+  )
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   launch

--- a/localization/pose2twist/README.md
+++ b/localization/pose2twist/README.md
@@ -5,7 +5,7 @@
 This `pose2twist` calculates the velocity from the input pose history. In addition to the computed twist, this node outputs the linear-x and angular-z components as a float message to simplify debugging.
 
 The `twist.linear.x` is calculated as `sqrt(dx * dx + dy * dy + dz * dz) / dt`, and the values in the `y` and `z` fields are zero.
-The `twist.angular` is calculated as `d_roll / dt`, `d_pitch / dt` and `d_yaw / dt` for each field.
+The `twist.angular` is calculated as `relative_rotation_vector / dt` for each field.
 
 ## Inputs / Outputs
 

--- a/localization/pose2twist/include/pose2twist/pose2twist_core.hpp
+++ b/localization/pose2twist/include/pose2twist/pose2twist_core.hpp
@@ -27,8 +27,10 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-geometry_msgs::msg::Vector3 rotation_vector_from_quaternion(
+// Compute the relative rotation of q2 from q1 as a rotation vector
+geometry_msgs::msg::Vector3 compute_relative_rotation_vector(
   const tf2::Quaternion & q1, const tf2::Quaternion & q2);
+
 class Pose2Twist : public rclcpp::Node
 {
 public:

--- a/localization/pose2twist/include/pose2twist/pose2twist_core.hpp
+++ b/localization/pose2twist/include/pose2twist/pose2twist_core.hpp
@@ -21,6 +21,14 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
+geometry_msgs::msg::Vector3 rotation_vector_from_quaternion(
+  const tf2::Quaternion & q1, const tf2::Quaternion & q2);
 class Pose2Twist : public rclcpp::Node
 {
 public:

--- a/localization/pose2twist/src/pose2twist_core.cpp
+++ b/localization/pose2twist/src/pose2twist_core.cpp
@@ -69,7 +69,7 @@ geometry_msgs::msg::TwistStamped calc_twist(
   const auto pose_b_quaternion = get_quaternion(pose_b);
 
   geometry_msgs::msg::Vector3 diff_xyz;
-  const geometry_msgs::msg::Vector3 diff_rpy =
+  const geometry_msgs::msg::Vector3 relative_rotation_vector =
     compute_relative_rotation_vector(pose_a_quaternion, pose_b_quaternion);
 
   diff_xyz.x = pose_b->pose.position.x - pose_a->pose.position.x;
@@ -83,9 +83,9 @@ geometry_msgs::msg::TwistStamped calc_twist(
     dt;
   twist.twist.linear.y = 0;
   twist.twist.linear.z = 0;
-  twist.twist.angular.x = diff_rpy.x / dt;
-  twist.twist.angular.y = diff_rpy.y / dt;
-  twist.twist.angular.z = diff_rpy.z / dt;
+  twist.twist.angular.x = relative_rotation_vector.x / dt;
+  twist.twist.angular.y = relative_rotation_vector.y / dt;
+  twist.twist.angular.z = relative_rotation_vector.z / dt;
 
   return twist;
 }

--- a/localization/pose2twist/src/pose2twist_core.cpp
+++ b/localization/pose2twist/src/pose2twist_core.cpp
@@ -14,12 +14,6 @@
 
 #include "pose2twist/pose2twist_core.hpp"
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
-
 #include <cmath>
 #include <cstddef>
 #include <functional>

--- a/localization/pose2twist/src/pose2twist_core.cpp
+++ b/localization/pose2twist/src/pose2twist_core.cpp
@@ -41,29 +41,18 @@ Pose2Twist::Pose2Twist(const rclcpp::NodeOptions & options) : rclcpp::Node("pose
     "pose", queue_size, std::bind(&Pose2Twist::callback_pose, this, _1));
 }
 
-double calc_diff_for_radian(const double lhs_rad, const double rhs_rad)
+tf2::Quaternion get_quaternion(const geometry_msgs::msg::PoseStamped::SharedPtr & pose_stamped_ptr)
 {
-  double diff_rad = lhs_rad - rhs_rad;
-  if (diff_rad > M_PI) {
-    diff_rad = diff_rad - 2 * M_PI;
-  } else if (diff_rad < -M_PI) {
-    diff_rad = diff_rad + 2 * M_PI;
-  }
-  return diff_rad;
+  const auto & orientation = pose_stamped_ptr->pose.orientation;
+  return tf2::Quaternion{orientation.x, orientation.y, orientation.z, orientation.w};
 }
 
-// x: roll, y: pitch, z: yaw
-geometry_msgs::msg::Vector3 get_rpy(const geometry_msgs::msg::Pose & pose)
+geometry_msgs::msg::Vector3 rotation_vector_from_quaternion(
+  const tf2::Quaternion & q1, const tf2::Quaternion & q2)
 {
-  geometry_msgs::msg::Vector3 rpy;
-  tf2::Quaternion q(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
-  tf2::Matrix3x3(q).getRPY(rpy.x, rpy.y, rpy.z);
-  return rpy;
-}
-
-geometry_msgs::msg::Vector3 get_rpy(geometry_msgs::msg::PoseStamped::SharedPtr pose)
-{
-  return get_rpy(pose->pose);
+  const tf2::Quaternion diff_quaternion = q1.inverse() * q2;
+  const tf2::Vector3 axis = diff_quaternion.getAxis() * diff_quaternion.getAngle();
+  return geometry_msgs::msg::Vector3{}.set__x(axis.x()).set__y(axis.y()).set__z(axis.z());
 }
 
 geometry_msgs::msg::TwistStamped calc_twist(
@@ -79,18 +68,16 @@ geometry_msgs::msg::TwistStamped calc_twist(
     return twist;
   }
 
-  const auto pose_a_rpy = get_rpy(pose_a);
-  const auto pose_b_rpy = get_rpy(pose_b);
+  const auto pose_a_quaternion = get_quaternion(pose_a);
+  const auto pose_b_quaternion = get_quaternion(pose_b);
 
   geometry_msgs::msg::Vector3 diff_xyz;
-  geometry_msgs::msg::Vector3 diff_rpy;
+  const geometry_msgs::msg::Vector3 diff_rpy =
+    rotation_vector_from_quaternion(pose_a_quaternion, pose_b_quaternion);
 
   diff_xyz.x = pose_b->pose.position.x - pose_a->pose.position.x;
   diff_xyz.y = pose_b->pose.position.y - pose_a->pose.position.y;
   diff_xyz.z = pose_b->pose.position.z - pose_a->pose.position.z;
-  diff_rpy.x = calc_diff_for_radian(pose_b_rpy.x, pose_a_rpy.x);
-  diff_rpy.y = calc_diff_for_radian(pose_b_rpy.y, pose_a_rpy.y);
-  diff_rpy.z = calc_diff_for_radian(pose_b_rpy.z, pose_a_rpy.z);
 
   geometry_msgs::msg::TwistStamped twist;
   twist.header = pose_b->header;

--- a/localization/pose2twist/src/pose2twist_core.cpp
+++ b/localization/pose2twist/src/pose2twist_core.cpp
@@ -41,9 +41,12 @@ tf2::Quaternion get_quaternion(const geometry_msgs::msg::PoseStamped::SharedPtr 
   return tf2::Quaternion{orientation.x, orientation.y, orientation.z, orientation.w};
 }
 
-geometry_msgs::msg::Vector3 rotation_vector_from_quaternion(
+geometry_msgs::msg::Vector3 compute_relative_rotation_vector(
   const tf2::Quaternion & q1, const tf2::Quaternion & q2)
 {
+  // If we define q2 as the rotation obntained by applying dq after applying q1,
+  // then q2 = q1 * dq .
+  // Therefore, dq = q1.inverse() * q2 .
   const tf2::Quaternion diff_quaternion = q1.inverse() * q2;
   const tf2::Vector3 axis = diff_quaternion.getAxis() * diff_quaternion.getAngle();
   return geometry_msgs::msg::Vector3{}.set__x(axis.x()).set__y(axis.y()).set__z(axis.z());
@@ -67,7 +70,7 @@ geometry_msgs::msg::TwistStamped calc_twist(
 
   geometry_msgs::msg::Vector3 diff_xyz;
   const geometry_msgs::msg::Vector3 diff_rpy =
-    rotation_vector_from_quaternion(pose_a_quaternion, pose_b_quaternion);
+    compute_relative_rotation_vector(pose_a_quaternion, pose_b_quaternion);
 
   diff_xyz.x = pose_b->pose.position.x - pose_a->pose.position.x;
   diff_xyz.y = pose_b->pose.position.y - pose_a->pose.position.y;

--- a/localization/pose2twist/src/pose2twist_core.cpp
+++ b/localization/pose2twist/src/pose2twist_core.cpp
@@ -44,7 +44,7 @@ tf2::Quaternion get_quaternion(const geometry_msgs::msg::PoseStamped::SharedPtr 
 geometry_msgs::msg::Vector3 compute_relative_rotation_vector(
   const tf2::Quaternion & q1, const tf2::Quaternion & q2)
 {
-  // If we define q2 as the rotation obntained by applying dq after applying q1,
+  // If we define q2 as the rotation obtained by applying dq after applying q1,
   // then q2 = q1 * dq .
   // Therefore, dq = q1.inverse() * q2 .
   const tf2::Quaternion diff_quaternion = q1.inverse() * q2;

--- a/localization/pose2twist/test/test_angular_velocity.cpp
+++ b/localization/pose2twist/test/test_angular_velocity.cpp
@@ -1,0 +1,41 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pose2twist/pose2twist_core.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(AngularVelocityFromQuaternion, CheckNumericalValidity)
+{
+  tf2::Quaternion initial_q;
+  initial_q.setRPY(0.2, 0.3, 0.4);
+
+  const tf2::Vector3 expected_axis = tf2::Vector3(0.1, 0.2, 0.3).normalized();
+  const double expected_angle = 0.1;  // 0.1 radian = 5.7 degrees
+
+  tf2::Quaternion expected_q;
+  expected_q.setRotation(expected_axis, expected_angle);
+
+  const tf2::Quaternion final_q = initial_q * expected_q;
+
+  const geometry_msgs::msg::Vector3 rotation_vector =
+    rotation_vector_from_quaternion(initial_q, final_q);
+
+  // 1e-3 radian = 0.057 degrees
+  constexpr double ACCEPTABLE_ERROR = 1e-3;
+
+  EXPECT_NEAR(rotation_vector.x, expected_axis.x() * expected_angle, ACCEPTABLE_ERROR);
+  EXPECT_NEAR(rotation_vector.y, expected_axis.y() * expected_angle, ACCEPTABLE_ERROR);
+  EXPECT_NEAR(rotation_vector.z, expected_axis.z() * expected_angle, ACCEPTABLE_ERROR);
+}

--- a/localization/pose2twist/test/test_angular_velocity.cpp
+++ b/localization/pose2twist/test/test_angular_velocity.cpp
@@ -21,7 +21,7 @@ constexpr double ACCEPTABLE_ERROR = 1e-3;
 
 TEST(AngularVelocityFromQuaternion, CheckMultiplicationOrder)
 {
-  // If we define q2 as the rotation obntained by applying dq after applying q1, then q2 = q1 * dq .
+  // If we define q2 as the rotation obtained by applying dq after applying q1, then q2 = q1 * dq .
   //
   // IT IS NOT q2 = dq * q1 .
   //

--- a/localization/pose2twist/test/test_angular_velocity.cpp
+++ b/localization/pose2twist/test/test_angular_velocity.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 // 1e-3 radian = 0.057 degrees
-constexpr double ACCEPTABLE_ERROR = 1e-3;
+constexpr double acceptable_error = 1e-3;
 
 TEST(AngularVelocityFromQuaternion, CheckMultiplicationOrder)
 {
@@ -54,9 +54,9 @@ TEST(AngularVelocityFromQuaternion, CheckMultiplicationOrder)
   //
   //
   //
-  EXPECT_NEAR(initially_rotated_vector.x(), -2., ACCEPTABLE_ERROR);
-  EXPECT_NEAR(initially_rotated_vector.y(), 1., ACCEPTABLE_ERROR);
-  EXPECT_NEAR(initially_rotated_vector.z(), 3., ACCEPTABLE_ERROR);
+  EXPECT_NEAR(initially_rotated_vector.x(), -2., acceptable_error);
+  EXPECT_NEAR(initially_rotated_vector.y(), 1., acceptable_error);
+  EXPECT_NEAR(initially_rotated_vector.z(), 3., acceptable_error);
 
   tf2::Quaternion dq;
   dq.setRPY(0., M_PI / 2., 0.);  // pitch = 90 degrees
@@ -72,17 +72,17 @@ TEST(AngularVelocityFromQuaternion, CheckMultiplicationOrder)
   //         |
   //         v
   //
-  EXPECT_NEAR(finally_rotated_vector.x(), -2., ACCEPTABLE_ERROR);
-  EXPECT_NEAR(finally_rotated_vector.y(), 3., ACCEPTABLE_ERROR);
-  EXPECT_NEAR(finally_rotated_vector.z(), -1., ACCEPTABLE_ERROR);
+  EXPECT_NEAR(finally_rotated_vector.x(), -2., acceptable_error);
+  EXPECT_NEAR(finally_rotated_vector.y(), 3., acceptable_error);
+  EXPECT_NEAR(finally_rotated_vector.z(), -1., acceptable_error);
 
   // Failure case
   {
     const tf2::Vector3 false_rotated_vector = tf2::quatRotate(dq * q1, target_vector);
 
-    EXPECT_FALSE(std::abs(false_rotated_vector.x() - (-2)) < ACCEPTABLE_ERROR);
-    EXPECT_FALSE(std::abs(false_rotated_vector.y() - (3)) < ACCEPTABLE_ERROR);
-    EXPECT_FALSE(std::abs(false_rotated_vector.z() - (-1)) < ACCEPTABLE_ERROR);
+    EXPECT_FALSE(std::abs(false_rotated_vector.x() - (-2)) < acceptable_error);
+    EXPECT_FALSE(std::abs(false_rotated_vector.y() - (3)) < acceptable_error);
+    EXPECT_FALSE(std::abs(false_rotated_vector.z() - (-1)) < acceptable_error);
   }
 }
 
@@ -104,9 +104,9 @@ TEST(AngularVelocityFromQuaternion, CheckNumericalValidity)
     const geometry_msgs::msg::Vector3 rotation_vector =
       compute_relative_rotation_vector(initial_q, final_q);
 
-    EXPECT_NEAR(rotation_vector.x, expected_axis.x() * expected_angle, ACCEPTABLE_ERROR);
-    EXPECT_NEAR(rotation_vector.y, expected_axis.y() * expected_angle, ACCEPTABLE_ERROR);
-    EXPECT_NEAR(rotation_vector.z, expected_axis.z() * expected_angle, ACCEPTABLE_ERROR);
+    EXPECT_NEAR(rotation_vector.x, expected_axis.x() * expected_angle, acceptable_error);
+    EXPECT_NEAR(rotation_vector.y, expected_axis.y() * expected_angle, acceptable_error);
+    EXPECT_NEAR(rotation_vector.z, expected_axis.z() * expected_angle, acceptable_error);
   };
 
   test(tf2::Vector3(1.0, 0.0, 0.0).normalized(), 0.1);   // 0.1 radian =  5.7 degrees


### PR DESCRIPTION
## Description

I have modified the method for obtaining angular velocity from pose.
In the previous approach, incorrect values could be obtained when pitch or yaw were not zero.

Additionally, I have added tests to verify the correctness of my implementation.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

### logging_simualtor.launch.xml &  pose2twist.launch.xml

I have confirmed that twist is being output by launching logging_simulator and pose_twist.launch.

Furthermore, I have verified that the estimated angular velocity does not differ from the previous method.
(Since roll and pitch are sufficiently small in the sample rosbag, the previous method also estimate the correct angular velocity.)

![image](https://github.com/autowarefoundation/autoware.universe/assets/24854875/a68e4cf2-075f-4842-a745-69b5f359b51e)


### Execute gtest

gtest has been passed.

`colcon test --event-handlers console_cohesion+ summary+ --packages-select pose2twist`

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable. 

## Interface changes

Interface does not change.
<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
