### PR TITLE
feat(operation_mode_transition_manager): use polling subscriber

### DIFF
--- a/control/operation_mode_transition_manager/src/node.cpp
+++ b/control/operation_mode_transition_manager/src/node.cpp
@@ -22,14 +22,6 @@ namespace operation_mode_transition_manager
 OperationModeTransitionManager::OperationModeTransitionManager(const rclcpp::NodeOptions & options)
 : Node("operation_mode_transition_manager", options), compatibility_(this)
 {
-  sub_control_mode_report_ = create_subscription<ControlModeReport>(
-    "control_mode_report", 1,
-    [this](const ControlModeReport::SharedPtr msg) { control_mode_report_ = *msg; });
-
-  sub_gate_operation_mode_ = create_subscription<OperationModeState>(
-    "gate_operation_mode", 1,
-    [this](const OperationModeState::SharedPtr msg) { gate_operation_mode_ = *msg; });
-
   cli_control_mode_ = create_client<ControlModeCommand>("control_mode_request");
   pub_debug_info_ = create_publisher<ModeChangeBase::DebugInfo>("~/debug_info", 1);
 
@@ -214,6 +206,9 @@ void OperationModeTransitionManager::processTransition()
 
 void OperationModeTransitionManager::onTimer()
 {
+  control_mode_report_ = *sub_control_mode_report_.takeData();
+  gate_operation_mode_ = *sub_gate_operation_mode_.takeData();
+
   for (const auto & [type, mode] : modes_) {
     mode->update(current_mode_ == type && transition_);
   }

--- a/control/operation_mode_transition_manager/src/node.hpp
+++ b/control/operation_mode_transition_manager/src/node.hpp
@@ -21,10 +21,10 @@
 #include <component_interface_specs/system.hpp>
 #include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/polling_subscriber.hpp>
 
 #include <memory>
 #include <unordered_map>
-#include <utility>
 
 namespace operation_mode_transition_manager
 {
@@ -49,8 +49,10 @@ private:
     const ChangeOperationModeAPI::Service::Response::SharedPtr response);
 
   using ControlModeCommandType = ControlModeCommand::Request::_mode_type;
-  rclcpp::Subscription<ControlModeReport>::SharedPtr sub_control_mode_report_;
-  rclcpp::Subscription<OperationModeState>::SharedPtr sub_gate_operation_mode_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<ControlModeReport> sub_control_mode_report_{
+    this, "control_mode_report"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_gate_operation_mode_{
+    this, "gate_operation_mode"};
   rclcpp::Client<ControlModeCommand>::SharedPtr cli_control_mode_;
   rclcpp::Publisher<ModeChangeBase::DebugInfo>::SharedPtr pub_debug_info_;
   rclcpp::TimerBase::SharedPtr timer_;


### PR DESCRIPTION
## Description

Applying polling subscriber based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612).

## Tests performed

Run PSIM and ensure that vehicle is engaged.

## Effects on system behavior

Nothing but more efficient CPU usage

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
