### PR TITLE
ci(build-and-test): run on self hosted

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
### **User description**
## Description

Since this job is triggered once the PR is merged to main, we will run it on self hosted instances to not burden the github hosted runners.

This way, more urgent `build-and-test-differential` jobs can keep running on the github hosted instances.

### Example worst case without this PR:

If we merge 5 PRs in a short amount of time, we will have 10 `build-and-test` (cuda and non-cuda) jobs start, each taking about 2 hours. And these are not even urgent since they are already merged.

But they will occupy 10/20 of the GitHub Hosted Runners for the next 2 hours.

The `build-and-test-differential` jobs will occupy the rest and most of the very small jobs will be unable to run for a long while.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the GitHub Actions workflow for the `build-and-test` job to run on self-hosted runners instead of GitHub-hosted runners.
- This change aims to reduce the load on GitHub-hosted runners, allowing more urgent jobs to run without delay.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-test.yaml</strong><dd><code>Configure build-and-test job to run on self-hosted runners.</code></dd></summary>
<hr>

.github/workflows/build-and-test.yaml
<li>Changed the runner from <code>ubuntu-latest</code> to <code>[self-hosted, linux, X64]</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/autowarefoundation/autoware.universe/pull/7336/files#diff-a551b322da0f9fe92abd1ec41e43c58dc5d138c0000430395e66f0c581387cd2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

