### PR TITLE
refactor(object_merger): rework parameters

### DIFF
--- a/perception/object_merger/README.md
+++ b/perception/object_merger/README.md
@@ -25,16 +25,9 @@ The successive shortest path algorithm is used to solve the data association pro
 
 ## Parameters
 
-| Name                        | Type                  | Description                                                                                                                                                                                                                        |
-| --------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `can_assign_matrix`         | double                | Assignment table for data association                                                                                                                                                                                              |
-| `max_dist_matrix`           | double                | Maximum distance table for data association                                                                                                                                                                                        |
-| `max_area_matrix`           | double                | Maximum area table for data association                                                                                                                                                                                            |
-| `min_area_matrix`           | double                | Minimum area table for data association                                                                                                                                                                                            |
-| `max_rad_matrix`            | double                | Maximum angle table for data association                                                                                                                                                                                           |
-| `base_link_frame_id`        | double                | association frame                                                                                                                                                                                                                  |
-| `distance_threshold_list`   | `std::vector<double>` | Distance threshold for each class used in judging overlap. The class order depends on [ObjectClassification](https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_perception_msgs/msg/ObjectClassification.msg). |
-| `generalized_iou_threshold` | `std::vector<double>` | Generalized IoU threshold for each class                                                                                                                                                                                           |
+{{ json_to_markdown("perception/object_merger/schema/object_association_merger.schema.json") }}
+{{ json_to_markdown("perception/object_merger/schema/data_association_matrix.schema.json") }}
+{{ json_to_markdown("perception/object_merger/schema/overlapped_judge.schema.json") }}
 
 ## Tips
 

--- a/perception/object_merger/config/object_association_merger.param.yaml
+++ b/perception/object_merger/config/object_association_merger.param.yaml
@@ -2,4 +2,7 @@
   ros__parameters:
     sync_queue_size: 20
     precision_threshold_to_judge_overlapped: 0.4
+    recall_threshold_to_judge_overlapped: 0.5
     remove_overlapped_unknown_objects: true
+    base_link_frame_id: base_link
+    priority_mode: 3  # PriorityMode::Confidence

--- a/perception/object_merger/schema/data_association_matrix.schema.json
+++ b/perception/object_merger/schema/data_association_matrix.schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Data Association Matrix Parameters",
+    "type": "object",
+    "properties": {
+      "ros__parameters": {
+        "type": "object",
+        "properties": {
+          "can_assign_matrix": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Assignment table for data association"
+          },
+          "max_dist_matrix": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Maximum distance table for data association"
+          },
+          "max_rad_matrix": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Maximum angle table for data association. If value is greater than pi, it will be ignored."
+          },
+          "min_iou_matrix": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Minimum IoU threshold matrix for data association. If value is negative, it will be ignored."
+          }
+        },
+        "required": [
+          "can_assign_matrix",
+          "max_dist_matrix",
+          "max_rad_matrix",
+          "min_iou_matrix"
+        ]
+      }
+    }
+  }
+  

--- a/perception/object_merger/schema/data_association_matrix.schema.json
+++ b/perception/object_merger/schema/data_association_matrix.schema.json
@@ -1,47 +1,41 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Data Association Matrix Parameters",
-    "type": "object",
-    "properties": {
-      "ros__parameters": {
-        "type": "object",
-        "properties": {
-          "can_assign_matrix": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "description": "Assignment table for data association"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Data Association Matrix Parameters",
+  "type": "object",
+  "properties": {
+    "ros__parameters": {
+      "type": "object",
+      "properties": {
+        "can_assign_matrix": {
+          "type": "array",
+          "items": {
+            "type": "number"
           },
-          "max_dist_matrix": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "description": "Maximum distance table for data association"
-          },
-          "max_rad_matrix": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "description": "Maximum angle table for data association. If value is greater than pi, it will be ignored."
-          },
-          "min_iou_matrix": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "description": "Minimum IoU threshold matrix for data association. If value is negative, it will be ignored."
-          }
+          "description": "Assignment table for data association"
         },
-        "required": [
-          "can_assign_matrix",
-          "max_dist_matrix",
-          "max_rad_matrix",
-          "min_iou_matrix"
-        ]
-      }
+        "max_dist_matrix": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Maximum distance table for data association"
+        },
+        "max_rad_matrix": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Maximum angle table for data association. If value is greater than pi, it will be ignored."
+        },
+        "min_iou_matrix": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Minimum IoU threshold matrix for data association. If value is negative, it will be ignored."
+        }
+      },
+      "required": ["can_assign_matrix", "max_dist_matrix", "max_rad_matrix", "min_iou_matrix"]
     }
   }
-  
+}

--- a/perception/object_merger/schema/object_association_merger.schema.json
+++ b/perception/object_merger/schema/object_association_merger.schema.json
@@ -1,64 +1,63 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Parameters for Object Association Merger Node",
-    "type": "object",
-    "definitions": {
-      "object_association_merger": {
-        "type": "object",
-        "properties": {
-          "sync_queue_size": {
-            "type": "integer",
-            "description": "The size of the synchronization queue.",
-            "default": 20
-          },
-          "precision_threshold_to_judge_overlapped": {
-            "type": "number",
-            "description": "The precision threshold to judge if objects are overlapped.",
-            "default": 0.4
-          },
-          "recall_threshold_to_judge_overlapped": {
-            "type": "number",
-            "description": "The recall threshold to judge if objects are overlapped.",
-            "default": 0.5
-          },
-          "remove_overlapped_unknown_objects": {
-            "type": "boolean",
-            "description": "Flag to remove overlapped unknown objects.",
-            "default": true
-          },
-          "base_link_frame_id": {
-            "type": "string",
-            "description": "The frame ID of the association frame.",
-            "default": "base_link"
-          },
-          "priority_mode": {
-            "type": "integer",
-            "description": "Index for the priority_mode.",
-            "default": 3,
-            "enum": [0, 1, 2, 3]
-          }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Object Association Merger Node",
+  "type": "object",
+  "definitions": {
+    "object_association_merger": {
+      "type": "object",
+      "properties": {
+        "sync_queue_size": {
+          "type": "integer",
+          "description": "The size of the synchronization queue.",
+          "default": 20
         },
-        "required": [
-          "sync_queue_size",
-          "precision_threshold_to_judge_overlapped",
-          "recall_threshold_to_judge_overlapped",
-          "remove_overlapped_unknown_objects",
-          "base_link_frame_id",
-          "priority_mode"
-        ]
-      }
-    },
-    "properties": {
-      "/**": {
-        "type": "object",
-        "properties": {
-          "ros__parameters": {
-            "$ref": "#/definitions/object_association_merger"
-          }
+        "precision_threshold_to_judge_overlapped": {
+          "type": "number",
+          "description": "The precision threshold to judge if objects are overlapped.",
+          "default": 0.4
         },
-        "required": ["ros__parameters"]
-      }
-    },
-    "required": ["/**"]
-  }
-  
+        "recall_threshold_to_judge_overlapped": {
+          "type": "number",
+          "description": "The recall threshold to judge if objects are overlapped.",
+          "default": 0.5
+        },
+        "remove_overlapped_unknown_objects": {
+          "type": "boolean",
+          "description": "Flag to remove overlapped unknown objects.",
+          "default": true
+        },
+        "base_link_frame_id": {
+          "type": "string",
+          "description": "The frame ID of the association frame.",
+          "default": "base_link"
+        },
+        "priority_mode": {
+          "type": "integer",
+          "description": "Index for the priority_mode.",
+          "default": 3,
+          "enum": [0, 1, 2, 3]
+        }
+      },
+      "required": [
+        "sync_queue_size",
+        "precision_threshold_to_judge_overlapped",
+        "recall_threshold_to_judge_overlapped",
+        "remove_overlapped_unknown_objects",
+        "base_link_frame_id",
+        "priority_mode"
+      ]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/object_association_merger"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}

--- a/perception/object_merger/schema/object_association_merger.schema.json
+++ b/perception/object_merger/schema/object_association_merger.schema.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Parameters for Object Association Merger Node",
+    "type": "object",
+    "definitions": {
+      "object_association_merger": {
+        "type": "object",
+        "properties": {
+          "sync_queue_size": {
+            "type": "integer",
+            "description": "The size of the synchronization queue.",
+            "default": 20
+          },
+          "precision_threshold_to_judge_overlapped": {
+            "type": "number",
+            "description": "The precision threshold to judge if objects are overlapped.",
+            "default": 0.4
+          },
+          "recall_threshold_to_judge_overlapped": {
+            "type": "number",
+            "description": "The recall threshold to judge if objects are overlapped.",
+            "default": 0.5
+          },
+          "remove_overlapped_unknown_objects": {
+            "type": "boolean",
+            "description": "Flag to remove overlapped unknown objects.",
+            "default": true
+          },
+          "base_link_frame_id": {
+            "type": "string",
+            "description": "The frame ID of the association frame.",
+            "default": "base_link"
+          },
+          "priority_mode": {
+            "type": "integer",
+            "description": "Index for the priority_mode.",
+            "default": 3,
+            "enum": [0, 1, 2, 3]
+          }
+        },
+        "required": [
+          "sync_queue_size",
+          "precision_threshold_to_judge_overlapped",
+          "recall_threshold_to_judge_overlapped",
+          "remove_overlapped_unknown_objects",
+          "base_link_frame_id",
+          "priority_mode"
+        ]
+      }
+    },
+    "properties": {
+      "/**": {
+        "type": "object",
+        "properties": {
+          "ros__parameters": {
+            "$ref": "#/definitions/object_association_merger"
+          }
+        },
+        "required": ["ros__parameters"]
+      }
+    },
+    "required": ["/**"]
+  }
+  

--- a/perception/object_merger/schema/overlapped_judge.schema.json
+++ b/perception/object_merger/schema/overlapped_judge.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Overlapped Judge Parameters",
+    "type": "object",
+    "properties": {
+      "ros__parameters": {
+        "type": "object",
+        "properties": {
+          "distance_threshold_list": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Distance threshold for each class used in judging overlap."
+          },
+          "generalized_iou_threshold": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Generalized IoU threshold for each class."
+          }
+        },
+        "required": [
+          "distance_threshold_list",
+          "generalized_iou_threshold"
+        ]
+      }
+    }
+  }
+  

--- a/perception/object_merger/schema/overlapped_judge.schema.json
+++ b/perception/object_merger/schema/overlapped_judge.schema.json
@@ -1,31 +1,27 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Overlapped Judge Parameters",
-    "type": "object",
-    "properties": {
-      "ros__parameters": {
-        "type": "object",
-        "properties": {
-          "distance_threshold_list": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "description": "Distance threshold for each class used in judging overlap."
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Overlapped Judge Parameters",
+  "type": "object",
+  "properties": {
+    "ros__parameters": {
+      "type": "object",
+      "properties": {
+        "distance_threshold_list": {
+          "type": "array",
+          "items": {
+            "type": "number"
           },
-          "generalized_iou_threshold": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "description": "Generalized IoU threshold for each class."
-          }
+          "description": "Distance threshold for each class used in judging overlap."
         },
-        "required": [
-          "distance_threshold_list",
-          "generalized_iou_threshold"
-        ]
-      }
+        "generalized_iou_threshold": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Generalized IoU threshold for each class."
+        }
+      },
+      "required": ["distance_threshold_list", "generalized_iou_threshold"]
     }
   }
-  
+}

--- a/perception/object_merger/src/object_association_merger/node.cpp
+++ b/perception/object_merger/src/object_association_merger/node.cpp
@@ -80,16 +80,16 @@ ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptio
   object1_sub_(this, "input/object1", rclcpp::QoS{1}.get_rmw_qos_profile())
 {
   // Parameters
-  base_link_frame_id_ = declare_parameter<std::string>("base_link_frame_id", "base_link");
+  base_link_frame_id_ = declare_parameter<std::string>("base_link_frame_id");
   priority_mode_ = static_cast<PriorityMode>(
-    declare_parameter<int>("priority_mode", static_cast<int>(PriorityMode::Confidence)));
-  sync_queue_size_ = declare_parameter<int>("sync_queue_size", 20);
+    declare_parameter<int>("priority_mode"));
+  sync_queue_size_ = declare_parameter<int>("sync_queue_size");
   remove_overlapped_unknown_objects_ =
-    declare_parameter<bool>("remove_overlapped_unknown_objects", true);
+    declare_parameter<bool>("remove_overlapped_unknown_objects");
   overlapped_judge_param_.precision_threshold =
     declare_parameter<double>("precision_threshold_to_judge_overlapped");
   overlapped_judge_param_.recall_threshold =
-    declare_parameter<double>("recall_threshold_to_judge_overlapped", 0.5);
+    declare_parameter<double>("recall_threshold_to_judge_overlapped");
   overlapped_judge_param_.generalized_iou_threshold =
     convertListToClassMap(declare_parameter<std::vector<double>>("generalized_iou_threshold"));
 

--- a/perception/object_merger/src/object_association_merger/node.cpp
+++ b/perception/object_merger/src/object_association_merger/node.cpp
@@ -81,11 +81,9 @@ ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptio
 {
   // Parameters
   base_link_frame_id_ = declare_parameter<std::string>("base_link_frame_id");
-  priority_mode_ = static_cast<PriorityMode>(
-    declare_parameter<int>("priority_mode"));
+  priority_mode_ = static_cast<PriorityMode>(declare_parameter<int>("priority_mode"));
   sync_queue_size_ = declare_parameter<int>("sync_queue_size");
-  remove_overlapped_unknown_objects_ =
-    declare_parameter<bool>("remove_overlapped_unknown_objects");
+  remove_overlapped_unknown_objects_ = declare_parameter<bool>("remove_overlapped_unknown_objects");
   overlapped_judge_param_.precision_threshold =
     declare_parameter<double>("precision_threshold_to_judge_overlapped");
   overlapped_judge_param_.recall_threshold =


### PR DESCRIPTION
## Description
Implement the ROS Node configuration layout described in https://github.com/orgs/autowarefoundation/discussions/3371 for the `object_merger` package.

 * Remove the default value from the source code in order to ensure all parameter values are passed from the parameter files.
 * Use types that match the ones returned from declare_parameter() in order to prevent confusion and potential coding errors.
 * Move the default parameter file to a standardized location. Use the JSON Schema for that.
 * Updated readme file.

## Tests performed
Package built and launched locally.

## Notes for reviewers
 Nothing inside the src code part was changed, only taking the parameters out.

## Interface changes
Parameter values are now required to be passed to the node when launched.

## Effects on system behavior
None

## Pre-review checklist for the PR author
The PR author **must** check the checkboxes below when creating the PR.

 * [x]  I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
 * [x]  The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

 ## In-review checklist for the PR reviewers
 The PR reviewers **must** check the checkboxes below before approval.

 * [ ]  The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).
 * [ ]  The PR has been properly tested.
 * [ ]  The PR has been reviewed by the code owners.
 
 ## Post-review checklist for the PR author
 The PR author **must** check the checkboxes below before merging.
 
 * [ ]  There are no open discussions or they are tracked via tickets.
 * [ ]  The PR is ready for merge.
 
 After all checkboxes are checked, anyone who has write access can merge the PR.

