### PR TITLE
fix(multi_object_tracker): fix segmentation fault bug of the debug object process 

### DIFF
--- a/perception/multi_object_tracker/src/debugger/debug_object.cpp
+++ b/perception/multi_object_tracker/src/debugger/debug_object.cpp
@@ -134,6 +134,9 @@ void TrackerObjectDebugger::process()
 {
   if (!is_initialized_) return;
 
+  // Check if object_data_list_ is empty
+  if (object_data_list_.empty()) return;
+
   // update uuid_int
   for (auto & object_data : object_data_list_) {
     current_ids_.insert(object_data.uuid_int);


### PR DESCRIPTION
## Description

In the planning simulator, the multi-object-tracker crash was reported.
https://github.com/autowarefoundation/autoware.universe/pull/7127#issuecomment-2139952978
```
[multi_object_tracker_node-49] *** Aborted at 1717082878 (unix time) try "date -d @1717082878" if you are using GNU date ***
[multi_object_tracker_node-49] PC: @                0x0 (unknown)
[multi_object_tracker_node-49] *** SIGSEGV (@0x20) received by PID 461172 (TID 0x7df1e7c2f8c0) from PID 32; stack trace: ***
[multi_object_tracker_node-49]     @     0x7df1e548a206 (unknown)
[multi_object_tracker_node-49]     @     0x7df1e7a45320 (unknown)
[multi_object_tracker_node-49]     @     0x7df1e4932f0f TrackerObjectDebugger::process()
[multi_object_tracker_node-49]     @     0x7df1e48f8e08 TrackerDebugger::publishObjectsMarkers()
[multi_object_tracker_node-49]     @     0x7df1e48881e6 multi_object_tracker::MultiObjectTracker::publish()
[multi_object_tracker_node-49]     @     0x7df1e4887e5e multi_object_tracker::MultiObjectTracker::checkAndPublish()
[multi_object_tracker_node-49]     @     0x7df1e48875cc multi_object_tracker::MultiObjectTracker::onTimer()
[multi_object_tracker_node-49]     @     0x7df1e48cf76d std::__invoke_impl<>()
[multi_object_tracker_node-49]     @     0x7df1e48c98e9 std::__invoke<>()
[multi_object_tracker_node-49]     @     0x7df1e48c449b _ZNSt5_BindIFMN20multi_object_tracker18MultiObjectTrackerEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
[multi_object_tracker_node-49]     @     0x7df1e48bdab5 std::_Bind<>::operator()<>()
[multi_object_tracker_node-49]     @     0x7df1e48edabc rclcpp::GenericTimer<>::execute_callback_delegate<>()
[multi_object_tracker_node-49]     @     0x7df1e48ea877 rclcpp::GenericTimer<>::execute_callback()
[multi_object_tracker_node-49]     @     0x7df1e8307a51 rclcpp::Executor::execute_any_executable()
[multi_object_tracker_node-49]     @     0x7df1e8319234 rclcpp::executors::SingleThreadedExecutor::spin()
[multi_object_tracker_node-49]     @     0x65224930e45c main
[multi_object_tracker_node-49]     @     0x7df1e7a2a1ca (unknown)
[multi_object_tracker_node-49]     @     0x7df1e7a2a28b __libc_start_main
[multi_object_tracker_node-49]     @     0x65224930dac5 _start
```
The code was reviewed and found a bug can cause segmentation fault.

## Tests performed
The symptom couldn't be reproduced in my environment.

## Effects on system behavior

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
