### PR TITLE
feat(tier4_autoware_utils): add InterProcessPollingSubscriber helper factory

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -27,6 +27,14 @@ namespace tier4_autoware_utils
 template <typename T>
 class InterProcessPollingSubscriber
 {
+public:
+  using SharedPtr = std::shared_ptr<InterProcessPollingSubscriber<T>>;
+  static SharedPtr create_subscription(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
+  {
+    return std::make_shared<InterProcessPollingSubscriber<T>>(node, topic_name, qos);
+  }
+
 private:
   typename rclcpp::Subscription<T>::SharedPtr subscriber_;
   typename T::SharedPtr data_;


### PR DESCRIPTION
## Description

enable rclcpp-like usage

```
  auto sub_autoware_state_ptr =
    tier4_autoware_utils::InterProcessPollingSubscriber<AutowareState>::create_subscription(
      this, "/autoware/state");
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

I replaced a subscriber in AEB module 
```
auto sub_autoware_state_ptr =
    tier4_autoware_utils::InterProcessPollingSubscriber<AutowareState>::create_subscription(
      this, "/autoware/state");
```
and checked it works

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
