### PR TITLE
refactor(map_tf_generator): apply static analysis

### DIFF
--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -18,7 +18,7 @@
 #include <random>
 #include <vector>
 
-std::vector<size_t> UniformRandom(const size_t max_exclusive, const size_t n)
+std::vector<size_t> inline uniform_random(const size_t max_exclusive, const size_t n)
 {
   std::default_random_engine generator;
   std::uniform_int_distribution<size_t> distribution(0, max_exclusive - 1);

--- a/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp
@@ -35,7 +35,8 @@ class PcdMapTFGeneratorNode : public rclcpp::Node
 public:
   using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
   explicit PcdMapTFGeneratorNode(const rclcpp::NodeOptions & options)
-  : Node("pcd_map_tf_generator", options), map_frame_(declare_parameter<std::string>("map_frame")),
+  : Node("pcd_map_tf_generator", options),
+    map_frame_(declare_parameter<std::string>("map_frame")),
     viewer_frame_(declare_parameter<std::string>("viewer_frame"))
   {
     sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(

--- a/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp
@@ -26,22 +26,21 @@
 
 #include <memory>
 #include <string>
+#include <variant>
 
-constexpr size_t N_SAMPLES = 20;
+constexpr size_t n_samples = 20;
 
 class PcdMapTFGeneratorNode : public rclcpp::Node
 {
 public:
   using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
   explicit PcdMapTFGeneratorNode(const rclcpp::NodeOptions & options)
-  : Node("pcd_map_tf_generator", options)
+  : Node("pcd_map_tf_generator", options), map_frame_(declare_parameter<std::string>("map_frame")),
+    viewer_frame_(declare_parameter<std::string>("viewer_frame"))
   {
-    map_frame_ = declare_parameter<std::string>("map_frame");
-    viewer_frame_ = declare_parameter<std::string>("viewer_frame");
-
     sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
       "pointcloud_map", rclcpp::QoS{1}.transient_local(),
-      std::bind(&PcdMapTFGeneratorNode::onPointCloud, this, std::placeholders::_1));
+      std::bind(&PcdMapTFGeneratorNode::on_point_cloud, this, std::placeholders::_1));
 
     static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
   }
@@ -53,7 +52,7 @@ private:
 
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_broadcaster_;
 
-  void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
+  void on_point_cloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
   {
     // fix random seed to produce the same viewer position every time
     // 3939 is just the author's favorite number
@@ -62,32 +61,32 @@ private:
     PointCloud clouds;
     pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, clouds);
 
-    const std::vector<size_t> indices = UniformRandom(clouds.size(), N_SAMPLES);
+    const std::vector<size_t> indices = uniform_random(clouds.size(), n_samples);
     double coordinate[3] = {0, 0, 0};
     for (const auto i : indices) {
       coordinate[0] += clouds.points[i].x;
       coordinate[1] += clouds.points[i].y;
       coordinate[2] += clouds.points[i].z;
     }
-    coordinate[0] = coordinate[0] / indices.size();
-    coordinate[1] = coordinate[1] / indices.size();
-    coordinate[2] = coordinate[2] / indices.size();
+    coordinate[0] = coordinate[0] / static_cast<double>(indices.size());
+    coordinate[1] = coordinate[1] / static_cast<double>(indices.size());
+    coordinate[2] = coordinate[2] / static_cast<double>(indices.size());
 
-    geometry_msgs::msg::TransformStamped static_transformStamped;
-    static_transformStamped.header.stamp = this->now();
-    static_transformStamped.header.frame_id = map_frame_;
-    static_transformStamped.child_frame_id = viewer_frame_;
-    static_transformStamped.transform.translation.x = coordinate[0];
-    static_transformStamped.transform.translation.y = coordinate[1];
-    static_transformStamped.transform.translation.z = coordinate[2];
+    geometry_msgs::msg::TransformStamped static_transform_stamped;
+    static_transform_stamped.header.stamp = this->now();
+    static_transform_stamped.header.frame_id = map_frame_;
+    static_transform_stamped.child_frame_id = viewer_frame_;
+    static_transform_stamped.transform.translation.x = coordinate[0];
+    static_transform_stamped.transform.translation.y = coordinate[1];
+    static_transform_stamped.transform.translation.z = coordinate[2];
     tf2::Quaternion quat;
     quat.setRPY(0, 0, 0);
-    static_transformStamped.transform.rotation.x = quat.x();
-    static_transformStamped.transform.rotation.y = quat.y();
-    static_transformStamped.transform.rotation.z = quat.z();
-    static_transformStamped.transform.rotation.w = quat.w();
+    static_transform_stamped.transform.rotation.x = quat.x();
+    static_transform_stamped.transform.rotation.y = quat.y();
+    static_transform_stamped.transform.rotation.z = quat.z();
+    static_transform_stamped.transform.rotation.w = quat.w();
 
-    static_broadcaster_->sendTransform(static_transformStamped);
+    static_broadcaster_->sendTransform(static_transform_stamped);
 
     RCLCPP_INFO_STREAM(
       get_logger(), "broadcast static tf. map_frame:"

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -21,10 +21,10 @@ using testing::Each;
 using testing::Ge;
 using testing::Lt;
 
-TEST(UniformRandom, UniformRandom)
+TEST(uniform_random, uniform_random)
 {
   {
-    const std::vector<size_t> random = UniformRandom(4, 0);
+    const std::vector<size_t> random = uniform_random(4, 0);
     ASSERT_EQ(random.size(), static_cast<size_t>(0));
   }
 
@@ -35,7 +35,7 @@ TEST(UniformRandom, UniformRandom)
     const size_t max_exclusive = 4;
 
     for (int i = 0; i < 50; i++) {
-      const std::vector<size_t> random = UniformRandom(4, 10);
+      const std::vector<size_t> random = uniform_random(4, 10);
       ASSERT_EQ(random.size(), 10U);
       ASSERT_THAT(random, Each(AllOf(Ge(min_inclusive), Lt(max_exclusive))));  // in range [0, 4)
     }


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `map/map_tf_generator`.

Fixed:
- camelCase to snake_case
- variable name changed from VAR_NAME to var_name
- use explicit cast
- use initialization list for some variable

Not fixed:
- using [std, boost]::variant for safe access
  - for speed concern

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

```Text
./check_linter.sh map_tf_generator
...
3453 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp:21:21: warning: function 'UniformRandom' defined in a header file; function definitions in header files can lead to ODR violations [misc-definitions-in-headers]
std::vector<size_t> UniformRandom(const size_t max_exclusive, const size_t n)
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp:21:21: note: make as 'inline'
std::vector<size_t> UniformRandom(const size_t max_exclusive, const size_t n)
                    ^
inline 
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp:21:21: warning: invalid case style for function 'UniformRandom' [readability-identifier-naming]
std::vector<size_t> UniformRandom(const size_t max_exclusive, const size_t n)
                    ^~~~~~~~~~~~~
                    uniform_random
Suppressed 3451 warnings (3451 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8967 warnings generated.
Suppressed 8998 warnings (8967 in non-user code, 31 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43025 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:30:18: warning: invalid case style for constexpr variable 'N_SAMPLES' [readability-identifier-naming]
constexpr size_t N_SAMPLES = 20;
                 ^~~~~~~~~
                 n_samples
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:56:8: warning: invalid case style for function 'onPointCloud' [readability-identifier-naming]
  void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
       ^~~~~~~~~~~~
       on_point_cloud
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:68:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      coordinate[0] += clouds.points[i].x;
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:69:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      coordinate[1] += clouds.points[i].y;
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:70:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      coordinate[2] += clouds.points[i].z;
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:72:37: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    coordinate[0] = coordinate[0] / indices.size();
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:73:37: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    coordinate[1] = coordinate[1] / indices.size();
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:74:37: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    coordinate[2] = coordinate[2] / indices.size();
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:76:42: warning: invalid case style for variable 'static_transformStamped' [readability-identifier-naming]
    geometry_msgs::msg::TransformStamped static_transformStamped;
                                         ^~~~~~~~~~~~~~~~~~~~~~~
                                         static_transform_stamped
Suppressed 43029 warnings (43016 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
54629 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/vector_map_tf_generator_node.cpp:52:8: warning: invalid case style for function 'onVectorMap' [readability-identifier-naming]
  void onVectorMap(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg)
       ^~~~~~~~~~~
       on_vector_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/vector_map_tf_generator_node.cpp:69:64: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
      std::accumulate(points_x.begin(), points_x.end(), 0.0) / points_x.size();
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/vector_map_tf_generator_node.cpp:71:64: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
      std::accumulate(points_y.begin(), points_y.end(), 0.0) / points_y.size();
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/vector_map_tf_generator_node.cpp:73:64: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
      std::accumulate(points_z.begin(), points_z.end(), 0.0) / points_z.size();
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/vector_map_tf_generator_node.cpp:75:42: warning: invalid case style for variable 'static_transformStamped' [readability-identifier-naming]
    geometry_msgs::msg::TransformStamped static_transformStamped;
                                         ^~~~~~~~~~~~~~~~~~~~~~~
                                         static_transform_stamped
Suppressed 54700 warnings (54624 in non-user code, 76 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/pcd_map_tf_generator_node.cpp ...
src/pcd_map_tf_generator_node.cpp:39:5: performance: Variable 'map_frame_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
    map_frame_ = declare_parameter<std::string>("map_frame");
    ^
src/pcd_map_tf_generator_node.cpp:40:5: performance: Variable 'viewer_frame_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
    viewer_frame_ = declare_parameter<std::string>("viewer_frame");
    ^
1/3 files checked 41% done
Checking src/vector_map_tf_generator_node.cpp ...
src/vector_map_tf_generator_node.cpp:34:5: performance: Variable 'map_frame_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
    map_frame_ = declare_parameter<std::string>("map_frame");
    ^
src/vector_map_tf_generator_node.cpp:35:5: performance: Variable 'viewer_frame_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
    viewer_frame_ = declare_parameter<std::string>("viewer_frame");
    ^
2/3 files checked 85% done
Checking test/test_uniform_random.cpp ...
3/3 files checked 100% done
test/test_uniform_random.cpp:24:0: style: The function 'TEST' is never used. [unusedFunction]
TEST(UniformRandom, UniformRandom)
```
</details>

---

After this PR:

Check with check_linter.sh
```Text
$ ./check_linter.sh map_tf_generator
...
3451 warnings generated.
Suppressed 3451 warnings (3451 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8965 warnings generated.
Suppressed 8996 warnings (8965 in non-user code, 31 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43017 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:67:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      coordinate[0] += clouds.points[i].x;
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:68:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      coordinate[1] += clouds.points[i].y;
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp:69:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      coordinate[2] += clouds.points[i].z;
                                        ^
Suppressed 43027 warnings (43014 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
54624 warnings generated.
Suppressed 54700 warnings (54624 in non-user code, 76 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

Check with cppcheck (not changed):
```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/pcd_map_tf_generator_node.cpp ...
1/3 files checked 41% done
Checking src/vector_map_tf_generator_node.cpp ...
2/3 files checked 85% done
Checking test/test_uniform_random.cpp ...
3/3 files checked 100% done
test/test_uniform_random.cpp:24:0: style: The function 'TEST' is never used. [unusedFunction]
TEST(uniform_random, uniform_random)
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
