### PR TITLE
refactor(pose_initializer): apply static analysis

### DIFF
--- a/localization/pose_initializer/src/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/src/pose_initializer/copy_vector_to_array.hpp
@@ -40,7 +40,7 @@ template <class NodeT>
 std::array<double, 36> get_covariance_parameter(NodeT * node, const std::string & name)
 {
   const auto parameter = node->template declare_parameter<std::vector<double>>(name);
-  std::array<double, 36> covariance;
+  std::array<double, 36> covariance{};
   copy_vector_to_array(parameter, covariance);
   return covariance;
 }

--- a/localization/pose_initializer/src/pose_initializer/gnss_module.cpp
+++ b/localization/pose_initializer/src/pose_initializer/gnss_module.cpp
@@ -19,10 +19,10 @@
 
 #include <memory>
 
-GnssModule::GnssModule(rclcpp::Node * node) 
-  : fitter_(node)
-  , clock_(node->get_clock())
-  , timeout_(node->declare_parameter<double>("gnss_pose_timeout"))
+GnssModule::GnssModule(rclcpp::Node * node)
+: fitter_(node),
+  clock_(node->get_clock()),
+  timeout_(node->declare_parameter<double>("gnss_pose_timeout"))
 {
   sub_gnss_pose_ = node->create_subscription<PoseWithCovarianceStamped>(
     "gnss_pose_cov", 1, std::bind(&GnssModule::on_pose, this, std::placeholders::_1));

--- a/localization/pose_initializer/src/pose_initializer/gnss_module.cpp
+++ b/localization/pose_initializer/src/pose_initializer/gnss_module.cpp
@@ -19,13 +19,18 @@
 
 #include <memory>
 
-GnssModule::GnssModule(rclcpp::Node * node) : fitter_(node)
+GnssModule::GnssModule(rclcpp::Node * node) 
+  : fitter_(node)
+  , clock_(node->get_clock())
+  , timeout_(node->declare_parameter<double>("gnss_pose_timeout"))
 {
   sub_gnss_pose_ = node->create_subscription<PoseWithCovarianceStamped>(
-    "gnss_pose_cov", 1, [this](PoseWithCovarianceStamped::ConstSharedPtr msg) { pose_ = msg; });
+    "gnss_pose_cov", 1, std::bind(&GnssModule::on_pose, this, std::placeholders::_1));
+}
 
-  clock_ = node->get_clock();
-  timeout_ = node->declare_parameter<double>("gnss_pose_timeout");
+void GnssModule::on_pose(PoseWithCovarianceStamped::ConstSharedPtr msg)
+{
+  pose_ = msg;
 }
 
 geometry_msgs::msg::PoseWithCovarianceStamped GnssModule::get_pose()

--- a/localization/pose_initializer/src/pose_initializer/gnss_module.hpp
+++ b/localization/pose_initializer/src/pose_initializer/gnss_module.hpp
@@ -30,6 +30,8 @@ public:
   PoseWithCovarianceStamped get_pose();
 
 private:
+  void on_pose(PoseWithCovarianceStamped::ConstSharedPtr msg);
+
   map_height_fitter::MapHeightFitter fitter_;
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_gnss_pose_;

--- a/localization/pose_initializer/src/pose_initializer/ndt_module.cpp
+++ b/localization/pose_initializer/src/pose_initializer/ndt_module.cpp
@@ -24,8 +24,7 @@ using Initialize = localization_interface::Initialize;
 using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
 NdtModule::NdtModule(rclcpp::Node * node)
-  : logger_(node->get_logger())
-  , cli_align_(node->create_client<RequestPoseAlignment>("ndt_align"))
+: logger_(node->get_logger()), cli_align_(node->create_client<RequestPoseAlignment>("ndt_align"))
 {
 }
 

--- a/localization/pose_initializer/src/pose_initializer/ndt_module.cpp
+++ b/localization/pose_initializer/src/pose_initializer/ndt_module.cpp
@@ -23,9 +23,10 @@ using ServiceException = component_interface_utils::ServiceException;
 using Initialize = localization_interface::Initialize;
 using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-NdtModule::NdtModule(rclcpp::Node * node) : logger_(node->get_logger())
+NdtModule::NdtModule(rclcpp::Node * node)
+  : logger_(node->get_logger())
+  , cli_align_(node->create_client<RequestPoseAlignment>("ndt_align"))
 {
-  cli_align_ = node->create_client<RequestPoseAlignment>("ndt_align");
 }
 
 PoseWithCovarianceStamped NdtModule::align_pose(const PoseWithCovarianceStamped & pose)

--- a/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp
@@ -67,28 +67,24 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
       throw std::invalid_argument(
         "Could not set user defined initial pose. The size of initial_pose is " +
         std::to_string(initial_pose_array.size()) + ". It must be 7.");
-    } else if (
+    }
+    if (
       std::abs(initial_pose_array[3]) < 1e-6 && std::abs(initial_pose_array[4]) < 1e-6 &&
       std::abs(initial_pose_array[5]) < 1e-6 && std::abs(initial_pose_array[6]) < 1e-6) {
       throw std::invalid_argument("Input quaternion is invalid. All elements are close to zero.");
-    } else {
-      geometry_msgs::msg::Pose initial_pose;
-      initial_pose.position.x = initial_pose_array[0];
-      initial_pose.position.y = initial_pose_array[1];
-      initial_pose.position.z = initial_pose_array[2];
-      initial_pose.orientation.x = initial_pose_array[3];
-      initial_pose.orientation.y = initial_pose_array[4];
-      initial_pose.orientation.z = initial_pose_array[5];
-      initial_pose.orientation.w = initial_pose_array[6];
-
-      set_user_defined_initial_pose(initial_pose, true);
     }
-  }
-}
 
-PoseInitializer::~PoseInitializer()
-{
-  // to delete gnss module
+    geometry_msgs::msg::Pose initial_pose;
+    initial_pose.position.x = initial_pose_array[0];
+    initial_pose.position.y = initial_pose_array[1];
+    initial_pose.position.z = initial_pose_array[2];
+    initial_pose.orientation.x = initial_pose_array[3];
+    initial_pose.orientation.y = initial_pose_array[4];
+    initial_pose.orientation.z = initial_pose_array[5];
+    initial_pose.orientation.w = initial_pose_array[6];
+
+    set_user_defined_initial_pose(initial_pose, true);
+  }
 }
 
 void PoseInitializer::change_state(State::Message::_state_type state)
@@ -175,7 +171,7 @@ void PoseInitializer::on_initialize(
         std::stringstream message;
         message << "No input pose_with_covariance. If you want to use DIRECT method, please input "
                    "pose_with_covariance.";
-        RCLCPP_ERROR(get_logger(), message.str().c_str());
+        RCLCPP_ERROR_STREAM(get_logger(), message.str());
         throw ServiceException(
           autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR, message.str());
       }
@@ -186,7 +182,7 @@ void PoseInitializer::on_initialize(
     } else {
       std::stringstream message;
       message << "Unknown method type (=" << std::to_string(req->method) << ")";
-      RCLCPP_ERROR(get_logger(), message.str().c_str());
+      RCLCPP_ERROR_STREAM(get_logger(), message.str());
       throw ServiceException(
         autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR, message.str());
     }

--- a/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp
+++ b/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp
@@ -35,7 +35,6 @@ class PoseInitializer : public rclcpp::Node
 {
 public:
   explicit PoseInitializer(const rclcpp::NodeOptions & options);
-  ~PoseInitializer();
 
 private:
   using ServiceException = component_interface_utils::ServiceException;
@@ -48,8 +47,8 @@ private:
   component_interface_utils::Publisher<State>::SharedPtr pub_state_;
   component_interface_utils::Service<Initialize>::SharedPtr srv_initialize_;
   State::Message state_;
-  std::array<double, 36> output_pose_covariance_;
-  std::array<double, 36> gnss_particle_covariance_;
+  std::array<double, 36> output_pose_covariance_{};
+  std::array<double, 36> gnss_particle_covariance_{};
   std::unique_ptr<GnssModule> gnss_;
   std::unique_ptr<NdtModule> ndt_;
   std::unique_ptr<YabLocModule> yabloc_;

--- a/localization/pose_initializer/src/pose_initializer/yabloc_module.cpp
+++ b/localization/pose_initializer/src/pose_initializer/yabloc_module.cpp
@@ -24,8 +24,7 @@ using Initialize = localization_interface::Initialize;
 using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
 YabLocModule::YabLocModule(rclcpp::Node * node)
-  : logger_(node->get_logger())
-  , cli_align_(node->create_client<RequestPoseAlignment>("yabloc_align"))
+: logger_(node->get_logger()), cli_align_(node->create_client<RequestPoseAlignment>("yabloc_align"))
 {
 }
 

--- a/localization/pose_initializer/src/pose_initializer/yabloc_module.cpp
+++ b/localization/pose_initializer/src/pose_initializer/yabloc_module.cpp
@@ -23,9 +23,10 @@ using ServiceException = component_interface_utils::ServiceException;
 using Initialize = localization_interface::Initialize;
 using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-YabLocModule::YabLocModule(rclcpp::Node * node) : logger_(node->get_logger())
+YabLocModule::YabLocModule(rclcpp::Node * node)
+  : logger_(node->get_logger())
+  , cli_align_(node->create_client<RequestPoseAlignment>("yabloc_align"))
 {
-  cli_align_ = node->create_client<RequestPoseAlignment>("yabloc_align");
 }
 
 PoseWithCovarianceStamped YabLocModule::align_pose(const PoseWithCovarianceStamped & pose)

--- a/localization/pose_initializer/test/test_copy_vector_to_array.cpp
+++ b/localization/pose_initializer/test/test_copy_vector_to_array.cpp
@@ -19,7 +19,7 @@
 TEST(CopyVectorToArray, CopyAllElements)
 {
   const std::vector<int> vector{0, 1, 2, 3, 4};
-  std::array<int, 5> array;
+  std::array<int, 5> array{};
   copy_vector_to_array<int, 5>(vector, array);
   EXPECT_THAT(array, testing::ElementsAre(0, 1, 2, 3, 4));
 }
@@ -28,7 +28,7 @@ TEST(CopyVectorToArray, CopyZeroElements)
 {
   const std::vector<int> vector{};
   // just confirm that this works
-  std::array<int, 0> array;
+  std::array<int, 0> array{};
   copy_vector_to_array<int, 0>(vector, array);
 }
 
@@ -36,7 +36,7 @@ TEST(CopyVectorToArray, ThrowsInvalidArgumentIfMoreElementsExpected)
 {
   auto f = [] {
     const std::vector<int> vector{0, 1, 2, 3, 4};
-    std::array<int, 6> array;
+    std::array<int, 6> array{};
     copy_vector_to_array<int, 6>(vector, array);
   };
 


### PR DESCRIPTION
## Description

Fixed all of the points raised by clang-tidy, cpplint and cppcheck.

<!-- Write a brief description of this PR. -->

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

before PR

<details>
<summary>output from above commands</summary>

```
$ ./check_linter.sh localization/pose_initializer
+ TARGET_DIR=localization/pose_initializer
+++ pwd
++ basename /home/yamato_ando/autoware
+ current_dir=autoware
+ [[ ! autoware =~ ^(autoware|pilot-auto) ]]
+ set +eux
+ fdfind -e cpp -e hpp --full-path localization/pose_initializer
++ nproc
+ xargs -P 20 '-I{}' cpplint '{}'
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/gnss_module.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/ndt_localization_trigger_module.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/ndt_localization_trigger_module.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/gnss_module.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/stop_check_module.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/ekf_localization_trigger_module.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/ndt_module.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/ekf_localization_trigger_module.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/test/test_copy_vector_to_array.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/yabloc_module.cpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/ndt_module.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/stop_check_module.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/yabloc_module.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/copy_vector_to_array.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp
Done processing ./src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp
+ fdfind -e cpp -e hpp --full-path localization/pose_initializer
++ nproc
+ xargs -P 20 '-I{}' clang-tidy -p build/ '{}'
3778 warnings generated.
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/copy_vector_to_array.hpp:43:3: warning: uninitialized record type: 'covariance' [cppcoreguidelines-pro-type-member-init]
  std::array<double, 36> covariance;
  ^
                                   {}
Suppressed 3777 warnings (3777 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8854 warnings generated.
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/test/test_copy_vector_to_array.cpp:22:3: warning: uninitialized record type: 'array' [cppcoreguidelines-pro-type-member-init]
  std::array<int, 5> array;
  ^
                          {}
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/test/test_copy_vector_to_array.cpp:31:3: warning: uninitialized record type: 'array' [cppcoreguidelines-pro-type-member-init]
  std::array<int, 0> array;
  ^
                          {}
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/test/test_copy_vector_to_array.cpp:39:5: warning: uninitialized record type: 'array' [cppcoreguidelines-pro-type-member-init]
    std::array<int, 6> array;
    ^
                            {}
Suppressed 8881 warnings (8851 in non-user code, 30 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13352 warnings generated.
Suppressed 13363 warnings (13352 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13657 warnings generated.
Suppressed 13668 warnings (13657 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13657 warnings generated.
Suppressed 13668 warnings (13657 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13352 warnings generated.
Suppressed 13363 warnings (13352 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13668 warnings generated.
Suppressed 13679 warnings (13668 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13349 warnings generated.
Suppressed 13360 warnings (13349 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13668 warnings generated.
Suppressed 13679 warnings (13668 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13297 warnings generated.
Suppressed 13308 warnings (13297 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13297 warnings generated.
Suppressed 13308 warnings (13297 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13821 warnings generated.
Suppressed 13832 warnings (13821 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14338 warnings generated.
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp:34:7: warning: class 'PoseInitializer' defines a non-default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class PoseInitializer : public rclcpp::Node
      ^
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.hpp:38:3: error: annotate this function with 'override' or (rarely) 'final' [modernize-use-override,-warnings-as-errors]
  ~PoseInitializer();
  ^
                     override
Suppressed 14347 warnings (14336 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
16591 warnings and 2 errors generated.
Error while processing /home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp.
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:29:1: warning: constructor does not initialize these fields: output_pose_covariance_, gnss_particle_covariance_ [cppcoreguidelines-pro-type-member-init]
PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
^
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:70:7: warning: do not use 'else' after 'throw' [readability-else-after-return]
    } else if (
      ^~~~~~~~~
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:89:18: error: use '= default' to define a trivial destructor [modernize-use-equals-default,-warnings-as-errors]
PoseInitializer::~PoseInitializer()
                 ^
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:178:36: error: format string is not a string literal (potentially insecure) [clang-diagnostic-format-security]
        RCLCPP_ERROR(get_logger(), message.str().c_str());
                                   ^
/home/yamato_ando/autoware/install/rclcpp/include/rclcpp/rclcpp/logging.hpp:1407:7: note: expanded from macro 'RCLCPP_ERROR'
      __VA_ARGS__); \
      ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:997:5: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
    __VA_ARGS__)
    ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:72:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^~~~~~~~~~~
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:178:36: note: treat the string as an argument to avoid this
        RCLCPP_ERROR(get_logger(), message.str().c_str());
                                   ^
                                   "%s", 
/home/yamato_ando/autoware/install/rclcpp/include/rclcpp/rclcpp/logging.hpp:1407:7: note: expanded from macro 'RCLCPP_ERROR'
      __VA_ARGS__); \
      ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:997:5: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
    __VA_ARGS__)
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:72:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:189:34: error: format string is not a string literal (potentially insecure) [clang-diagnostic-format-security]
      RCLCPP_ERROR(get_logger(), message.str().c_str());
                                 ^
/home/yamato_ando/autoware/install/rclcpp/include/rclcpp/rclcpp/logging.hpp:1407:7: note: expanded from macro 'RCLCPP_ERROR'
      __VA_ARGS__); \
      ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:997:5: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
    __VA_ARGS__)
    ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:72:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^~~~~~~~~~~
/home/yamato_ando/autoware/src/universe/autoware.universe/localization/pose_initializer/src/pose_initializer/pose_initializer_core.cpp:189:34: note: treat the string as an argument to avoid this
      RCLCPP_ERROR(get_logger(), message.str().c_str());
                                 ^
                                 "%s", 
/home/yamato_ando/autoware/install/rclcpp/include/rclcpp/rclcpp/logging.hpp:1407:7: note: expanded from macro 'RCLCPP_ERROR'
      __VA_ARGS__); \
      ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:997:5: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
    __VA_ARGS__)
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:72:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^
Suppressed 16599 warnings (16588 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
16019 warnings generated.
Suppressed 16030 warnings (16019 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
16343 warnings generated.
Suppressed 16354 warnings (16343 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>


<details>
<summary>output from cppcheck</summary>

```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .
Checking src/pose_initializer/ekf_localization_trigger_module.cpp ...
1/8 files checked 11% done
Checking src/pose_initializer/gnss_module.cpp ...
src/pose_initializer/gnss_module.cpp:25:81: performance: Variable 'pose_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
    "gnss_pose_cov", 1, [this](PoseWithCovarianceStamped::ConstSharedPtr msg) { pose_ = msg; });
                                                                                ^
src/pose_initializer/gnss_module.cpp:27:3: performance: Variable 'clock_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
  clock_ = node->get_clock();
  ^
2/8 files checked 19% done
Checking src/pose_initializer/ndt_localization_trigger_module.cpp ...
3/8 files checked 30% done
Checking src/pose_initializer/ndt_module.cpp ...
src/pose_initializer/ndt_module.cpp:28:3: performance: Variable 'cli_align_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
  cli_align_ = node->create_client<RequestPoseAlignment>("ndt_align");
  ^
4/8 files checked 39% done
Checking src/pose_initializer/pose_initializer_core.cpp ...
5/8 files checked 78% done
Checking src/pose_initializer/stop_check_module.cpp ...
6/8 files checked 83% done
Checking src/pose_initializer/yabloc_module.cpp ...
src/pose_initializer/yabloc_module.cpp:28:3: performance: Variable 'cli_align_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
  cli_align_ = node->create_client<RequestPoseAlignment>("yabloc_align");
  ^
7/8 files checked 92% done
Checking test/test_copy_vector_to_array.cpp ...
8/8 files checked 100% done

```

</details>


---

after PR

clear all warnings

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
