### PR TITLE
feat(planning_validator): use polling subscriber

### DIFF
--- a/planning/planning_validator/include/autoware_planning_validator/planning_validator.hpp
+++ b/planning/planning_validator/include/autoware_planning_validator/planning_validator.hpp
@@ -18,6 +18,7 @@
 #include "autoware_planning_validator/debug_marker.hpp"
 #include "autoware_planning_validator/msg/planning_validator_status.hpp"
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
+#include "tier4_autoware_utils/ros/polling_subscriber.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
@@ -102,7 +103,8 @@ private:
 
   void setStatus(DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg);
 
-  rclcpp::Subscription<Odometry>::SharedPtr sub_kinematics_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<Odometry> sub_kinematics_{
+    this, "~/input/kinematics"};
   rclcpp::Subscription<Trajectory>::SharedPtr sub_traj_;
   rclcpp::Publisher<Trajectory>::SharedPtr pub_traj_;
   rclcpp::Publisher<PlanningValidatorStatus>::SharedPtr pub_status_;

--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -32,9 +32,6 @@ PlanningValidator::PlanningValidator(const rclcpp::NodeOptions & options)
 {
   using std::placeholders::_1;
 
-  sub_kinematics_ = create_subscription<Odometry>(
-    "~/input/kinematics", 1,
-    [this](const Odometry::ConstSharedPtr msg) { current_kinematics_ = msg; });
   sub_traj_ = create_subscription<Trajectory>(
     "~/input/trajectory", 1, std::bind(&PlanningValidator::onTrajectory, this, _1));
 
@@ -194,6 +191,9 @@ void PlanningValidator::onTrajectory(const Trajectory::ConstSharedPtr msg)
   stop_watch_.tic(__func__);
 
   current_trajectory_ = msg;
+
+  // receive data
+  current_kinematics_ = sub_kinematics_.takeData();
 
   if (!isDataReady()) return;
 

--- a/planning/planning_validator/test/src/test_planning_validator_pubsub.cpp
+++ b/planning/planning_validator/test/src/test_planning_validator_pubsub.cpp
@@ -182,7 +182,7 @@ TEST(PlanningValidator, DiagCheckForTooLongIntervalTrajectory)
 
 TEST(PlanningValidator, DiagCheckSize)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_size";
+  const auto diag_name = "planning_validator: trajectory_validation_size";
   const auto odom = generateDefaultOdometry();
   runWithBadTrajectory(generateTrajectory(1.0, 1.0, 0.0, 0), odom, diag_name);
   runWithBadTrajectory(generateTrajectory(1.0, 1.0, 0.0, 1), odom, diag_name);
@@ -192,7 +192,7 @@ TEST(PlanningValidator, DiagCheckSize)
 
 TEST(PlanningValidator, DiagCheckInterval)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_interval";
+  const auto diag_name = "planning_validator: trajectory_validation_interval";
   const auto odom = generateDefaultOdometry();
 
   // Larger interval than threshold -> must be NG
@@ -216,7 +216,7 @@ TEST(PlanningValidator, DiagCheckInterval)
 
 TEST(PlanningValidator, DiagCheckRelativeAngle)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_relative_angle";
+  const auto diag_name = "planning_validator: trajectory_validation_relative_angle";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -246,7 +246,7 @@ TEST(PlanningValidator, DiagCheckRelativeAngle)
 
 TEST(PlanningValidator, DiagCheckCurvature)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_curvature";
+  const auto diag_name = "planning_validator: trajectory_validation_curvature";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -279,7 +279,7 @@ TEST(PlanningValidator, DiagCheckCurvature)
 
 TEST(PlanningValidator, DiagCheckLateralAcceleration)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_lateral_acceleration";
+  const auto diag_name = "planning_validator: trajectory_validation_lateral_acceleration";
   constexpr double speed = 10.0;
 
   // Note: lateral_acceleration is speed^2 * curvature;
@@ -303,7 +303,7 @@ TEST(PlanningValidator, DiagCheckLateralAcceleration)
 
 TEST(PlanningValidator, DiagCheckLongitudinalMaxAcc)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_acceleration";
+  const auto diag_name = "planning_validator: trajectory_validation_acceleration";
   constexpr double speed = 1.0;
 
   // Larger acceleration than threshold -> must be NG
@@ -325,7 +325,7 @@ TEST(PlanningValidator, DiagCheckLongitudinalMaxAcc)
 
 TEST(PlanningValidator, DiagCheckLongitudinalMinAcc)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_deceleration";
+  const auto diag_name = "planning_validator: trajectory_validation_deceleration";
   constexpr double speed = 20.0;
 
   const auto test = [&](const auto acceleration, const bool expect_ok) {
@@ -346,7 +346,7 @@ TEST(PlanningValidator, DiagCheckLongitudinalMinAcc)
 
 TEST(PlanningValidator, DiagCheckSteering)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_steering";
+  const auto diag_name = "planning_validator: trajectory_validation_steering";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -370,7 +370,7 @@ TEST(PlanningValidator, DiagCheckSteering)
 
 TEST(PlanningValidator, DiagCheckSteeringRate)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_steering_rate";
+  const auto diag_name = "planning_validator: trajectory_validation_steering_rate";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -394,7 +394,7 @@ TEST(PlanningValidator, DiagCheckSteeringRate)
 
 TEST(PlanningValidator, DiagCheckVelocityDeviation)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_velocity_deviation";
+  const auto diag_name = "planning_validator: trajectory_validation_velocity_deviation";
   const auto test = [&](const auto trajectory_speed, const auto ego_speed, const bool expect_ok) {
     const auto trajectory = generateTrajectory(1.0, trajectory_speed, 0.0, 10);
     const auto ego_odom = generateDefaultOdometry(0.0, 0.0, ego_speed);
@@ -412,7 +412,7 @@ TEST(PlanningValidator, DiagCheckVelocityDeviation)
 
 TEST(PlanningValidator, DiagCheckDistanceDeviation)
 {
-  const auto diag_name = "autoware_planning_validator: trajectory_validation_distance_deviation";
+  const auto diag_name = "planning_validator: trajectory_validation_distance_deviation";
   const auto test = [&](const auto ego_x, const auto ego_y, const bool expect_ok) {
     const auto trajectory = generateTrajectory(1.0, 3.0, 0.0, 10);
     const auto last_p = trajectory.points.back().pose.position;
@@ -439,7 +439,7 @@ TEST(PlanningValidator, DiagCheckDistanceDeviation)
 TEST(PlanningValidator, DiagCheckLongitudinalDistanceDeviation)
 {
   const auto diag_name =
-    "autoware_planning_validator: trajectory_validation_longitudinal_distance_deviation";
+    "planning_validator: trajectory_validation_longitudinal_distance_deviation";
   const auto trajectory = generateTrajectory(1.0, 3.0, 0.0, 10);
   const auto test = [&](const auto ego_x, const auto ego_y, const bool expect_ok) {
     const auto ego_odom = generateDefaultOdometry(ego_x, ego_y, 0.0);
@@ -470,7 +470,7 @@ TEST(PlanningValidator, DiagCheckLongitudinalDistanceDeviation)
 TEST(PlanningValidator, DiagCheckForwardTrajectoryLength)
 {
   const auto diag_name =
-    "autoware_planning_validator: trajectory_validation_forward_trajectory_length";
+    "planning_validator: trajectory_validation_forward_trajectory_length";
   constexpr auto trajectory_v = 10.0;
   constexpr size_t trajectory_size = 10;
   constexpr auto ego_v = 10.0;

--- a/planning/planning_validator/test/src/test_planning_validator_pubsub.cpp
+++ b/planning/planning_validator/test/src/test_planning_validator_pubsub.cpp
@@ -469,8 +469,7 @@ TEST(PlanningValidator, DiagCheckLongitudinalDistanceDeviation)
 
 TEST(PlanningValidator, DiagCheckForwardTrajectoryLength)
 {
-  const auto diag_name =
-    "planning_validator: trajectory_validation_forward_trajectory_length";
+  const auto diag_name = "planning_validator: trajectory_validation_forward_trajectory_length";
   constexpr auto trajectory_v = 10.0;
   constexpr size_t trajectory_size = 10;
   constexpr auto ego_v = 10.0;

--- a/planning/planning_validator/test/src/test_planning_validator_pubsub.cpp
+++ b/planning/planning_validator/test/src/test_planning_validator_pubsub.cpp
@@ -182,7 +182,7 @@ TEST(PlanningValidator, DiagCheckForTooLongIntervalTrajectory)
 
 TEST(PlanningValidator, DiagCheckSize)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_size";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_size";
   const auto odom = generateDefaultOdometry();
   runWithBadTrajectory(generateTrajectory(1.0, 1.0, 0.0, 0), odom, diag_name);
   runWithBadTrajectory(generateTrajectory(1.0, 1.0, 0.0, 1), odom, diag_name);
@@ -192,7 +192,7 @@ TEST(PlanningValidator, DiagCheckSize)
 
 TEST(PlanningValidator, DiagCheckInterval)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_interval";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_interval";
   const auto odom = generateDefaultOdometry();
 
   // Larger interval than threshold -> must be NG
@@ -216,7 +216,7 @@ TEST(PlanningValidator, DiagCheckInterval)
 
 TEST(PlanningValidator, DiagCheckRelativeAngle)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_relative_angle";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_relative_angle";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -246,7 +246,7 @@ TEST(PlanningValidator, DiagCheckRelativeAngle)
 
 TEST(PlanningValidator, DiagCheckCurvature)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_curvature";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_curvature";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -279,7 +279,7 @@ TEST(PlanningValidator, DiagCheckCurvature)
 
 TEST(PlanningValidator, DiagCheckLateralAcceleration)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_lateral_acceleration";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_lateral_acceleration";
   constexpr double speed = 10.0;
 
   // Note: lateral_acceleration is speed^2 * curvature;
@@ -303,7 +303,7 @@ TEST(PlanningValidator, DiagCheckLateralAcceleration)
 
 TEST(PlanningValidator, DiagCheckLongitudinalMaxAcc)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_acceleration";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_acceleration";
   constexpr double speed = 1.0;
 
   // Larger acceleration than threshold -> must be NG
@@ -325,7 +325,7 @@ TEST(PlanningValidator, DiagCheckLongitudinalMaxAcc)
 
 TEST(PlanningValidator, DiagCheckLongitudinalMinAcc)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_deceleration";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_deceleration";
   constexpr double speed = 20.0;
 
   const auto test = [&](const auto acceleration, const bool expect_ok) {
@@ -346,7 +346,7 @@ TEST(PlanningValidator, DiagCheckLongitudinalMinAcc)
 
 TEST(PlanningValidator, DiagCheckSteering)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_steering";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_steering";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -370,7 +370,7 @@ TEST(PlanningValidator, DiagCheckSteering)
 
 TEST(PlanningValidator, DiagCheckSteeringRate)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_steering_rate";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_steering_rate";
 
   // TODO(Horibe): interval must be larger than min_interval used in planning_validator.cpp
   constexpr auto interval = 1.1;
@@ -394,7 +394,7 @@ TEST(PlanningValidator, DiagCheckSteeringRate)
 
 TEST(PlanningValidator, DiagCheckVelocityDeviation)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_velocity_deviation";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_velocity_deviation";
   const auto test = [&](const auto trajectory_speed, const auto ego_speed, const bool expect_ok) {
     const auto trajectory = generateTrajectory(1.0, trajectory_speed, 0.0, 10);
     const auto ego_odom = generateDefaultOdometry(0.0, 0.0, ego_speed);
@@ -412,7 +412,7 @@ TEST(PlanningValidator, DiagCheckVelocityDeviation)
 
 TEST(PlanningValidator, DiagCheckDistanceDeviation)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_distance_deviation";
+  const auto diag_name = "autoware_planning_validator: trajectory_validation_distance_deviation";
   const auto test = [&](const auto ego_x, const auto ego_y, const bool expect_ok) {
     const auto trajectory = generateTrajectory(1.0, 3.0, 0.0, 10);
     const auto last_p = trajectory.points.back().pose.position;
@@ -439,7 +439,7 @@ TEST(PlanningValidator, DiagCheckDistanceDeviation)
 TEST(PlanningValidator, DiagCheckLongitudinalDistanceDeviation)
 {
   const auto diag_name =
-    "planning_validator: trajectory_validation_longitudinal_distance_deviation";
+    "autoware_planning_validator: trajectory_validation_longitudinal_distance_deviation";
   const auto trajectory = generateTrajectory(1.0, 3.0, 0.0, 10);
   const auto test = [&](const auto ego_x, const auto ego_y, const bool expect_ok) {
     const auto ego_odom = generateDefaultOdometry(ego_x, ego_y, 0.0);
@@ -469,7 +469,8 @@ TEST(PlanningValidator, DiagCheckLongitudinalDistanceDeviation)
 
 TEST(PlanningValidator, DiagCheckForwardTrajectoryLength)
 {
-  const auto diag_name = "planning_validator: trajectory_validation_forward_trajectory_length";
+  const auto diag_name =
+    "autoware_planning_validator: trajectory_validation_forward_trajectory_length";
   constexpr auto trajectory_v = 10.0;
   constexpr size_t trajectory_size = 10;
   constexpr auto ego_v = 10.0;


### PR DESCRIPTION
## Description

The same as [this PR](https://github.com/autowarefoundation/autoware.universe/pull/6997) based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612), the polling subscriber is used in the obstacle_avoidance_planner.

after the [PR](https://github.com/autowarefoundation/autoware.universe/pull/7320) is merged

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

check psim and echo topic with following command

```
ros2 topic echo /planning/autoware_planning_validator/validation_status
```
get the following output
```
---
stamp:
  sec: 1717738132
  nanosec: 36705836
is_valid_size: true
is_valid_finite_value: true
is_valid_interval: true
is_valid_relative_angle: true
is_valid_curvature: true
is_valid_lateral_acc: true
is_valid_longitudinal_max_acc: true
is_valid_longitudinal_min_acc: true
is_valid_steering: true
is_valid_steering_rate: true
is_valid_velocity_deviation: true
is_valid_distance_deviation: true
is_valid_longitudinal_distance_deviation: true
is_valid_forward_trajectory_length: true
trajectory_size: 162
max_interval_distance: 1.0000000358459422
max_relative_angle: 0.00020640208742839228
max_curvature: 0.0001376013912444474
max_lateral_acc: 0.004167162866877597
max_longitudinal_acc: 1.0023255348205566
min_longitudinal_acc: 0.0
max_steering: 0.0003839078627112221
max_steering_rate: 0.001138575508739542
velocity_deviation: 0.2500005066394806
distance_deviation: 0.16999918825570942
longitudinal_distance_deviation: 0.0
forward_trajectory_length_required: 0.0
forward_trajectory_length_measured: 0.0
invalid_count: 0
---

```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
