### PR TITLE
feat(autoware_lane_departure_checker): use polling subscriber

### DIFF
--- a/control/lane_departure_checker/include/autoware_lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/lane_departure_checker/include/autoware_lane_departure_checker/lane_departure_checker_node.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE_LANE_DEPARTURE_CHECKER__LANE_DEPARTURE_CHECKER_NODE_HPP_
 
 #include "autoware_lane_departure_checker/lane_departure_checker.hpp"
+#include "tier4_autoware_utils/ros/polling_subscriber.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -66,11 +67,16 @@ public:
 
 private:
   // Subscriber
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_lanelet_map_bin_;
-  rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_reference_trajectory_;
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_predicted_trajectory_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry> sub_odom_{
+    this, "~/input/odometry"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<LaneletMapBin> sub_lanelet_map_bin_{
+    this, "~/input/lanelet_map_bin", rclcpp::QoS{1}.transient_local()};
+  tier4_autoware_utils::InterProcessPollingSubscriber<LaneletRoute> sub_route_{
+    this, "~/input/route"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_reference_trajectory_{
+    this, "~/input/reference_trajectory"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_predicted_trajectory_{
+    this, "~/input/predicted_trajectory"};
 
   // Data Buffer
   nav_msgs::msg::Odometry::ConstSharedPtr current_odom_;

--- a/control/lane_departure_checker/include/autoware_lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/lane_departure_checker/include/autoware_lane_departure_checker/lane_departure_checker_node.hpp
@@ -117,7 +117,7 @@ private:
   // Core
   Input input_{};
   Output output_{};
-  std::unique_ptr<LaneDepartureChecker> autoware_lane_departure_checker_;
+  std::unique_ptr<LaneDepartureChecker> lane_departure_checker_;
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_{this};

--- a/control/lane_departure_checker/include/autoware_lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/lane_departure_checker/include/autoware_lane_departure_checker/lane_departure_checker_node.hpp
@@ -117,7 +117,7 @@ private:
   // Core
   Input input_{};
   Output output_{};
-  std::unique_ptr<LaneDepartureChecker> lane_departure_checker_;
+  std::unique_ptr<LaneDepartureChecker> autoware_lane_departure_checker_;
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_{this};

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -169,22 +169,6 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   lane_departure_checker_ = std::make_unique<LaneDepartureChecker>();
   lane_departure_checker_->setParam(param_, vehicle_info);
 
-  // Subscriber
-  sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "~/input/odometry", 1, std::bind(&LaneDepartureCheckerNode::onOdometry, this, _1));
-  sub_lanelet_map_bin_ = this->create_subscription<LaneletMapBin>(
-    "~/input/lanelet_map_bin", rclcpp::QoS{1}.transient_local(),
-    std::bind(&LaneDepartureCheckerNode::onLaneletMapBin, this, _1));
-  sub_route_ = this->create_subscription<LaneletRoute>(
-    "~/input/route", rclcpp::QoS{1}.transient_local(),
-    std::bind(&LaneDepartureCheckerNode::onRoute, this, _1));
-  sub_reference_trajectory_ = this->create_subscription<Trajectory>(
-    "~/input/reference_trajectory", 1,
-    std::bind(&LaneDepartureCheckerNode::onReferenceTrajectory, this, _1));
-  sub_predicted_trajectory_ = this->create_subscription<Trajectory>(
-    "~/input/predicted_trajectory", 1,
-    std::bind(&LaneDepartureCheckerNode::onPredictedTrajectory, this, _1));
-
   // Publisher
   // Nothing
 
@@ -199,36 +183,6 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   const auto period_ns = rclcpp::Rate(node_param_.update_rate).period();
   timer_ = rclcpp::create_timer(
     this, get_clock(), period_ns, std::bind(&LaneDepartureCheckerNode::onTimer, this));
-}
-
-void LaneDepartureCheckerNode::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
-{
-  current_odom_ = msg;
-}
-
-void LaneDepartureCheckerNode::onLaneletMapBin(const LaneletMapBin::ConstSharedPtr msg)
-{
-  lanelet_map_ = std::make_shared<lanelet::LaneletMap>();
-  lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_, &traffic_rules_, &routing_graph_);
-
-  // get all shoulder lanes
-  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_);
-  shoulder_lanelets_ = lanelet::utils::query::shoulderLanelets(all_lanelets);
-}
-
-void LaneDepartureCheckerNode::onRoute(const LaneletRoute::ConstSharedPtr msg)
-{
-  route_ = msg;
-}
-
-void LaneDepartureCheckerNode::onReferenceTrajectory(const Trajectory::ConstSharedPtr msg)
-{
-  reference_trajectory_ = msg;
-}
-
-void LaneDepartureCheckerNode::onPredictedTrajectory(const Trajectory::ConstSharedPtr msg)
-{
-  predicted_trajectory_ = msg;
 }
 
 bool LaneDepartureCheckerNode::isDataReady()
@@ -299,6 +253,22 @@ void LaneDepartureCheckerNode::onTimer()
   std::map<std::string, double> processing_time_map;
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
   stop_watch.tic("Total");
+
+  current_odom_ = sub_odom_.takeData();
+  route_ = sub_route_.takeData();
+  reference_trajectory_ = sub_reference_trajectory_.takeData();
+  predicted_trajectory_ = sub_predicted_trajectory_.takeData();
+
+  const auto lanelet_map_bin_msg = sub_lanelet_map_bin_.takeData();
+  if (lanelet_map_bin_msg) {
+    lanelet_map_ = std::make_shared<lanelet::LaneletMap>();
+    lanelet::utils::conversion::fromBinMsg(
+      *lanelet_map_bin_msg, lanelet_map_, &traffic_rules_, &routing_graph_);
+
+    // get all shoulder lanes
+    lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_);
+    shoulder_lanelets_ = lanelet::utils::query::shoulderLanelets(all_lanelets);
+  }
 
   if (!isDataReady()) {
     return;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -166,8 +166,8 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
     add_on_set_parameters_callback(std::bind(&LaneDepartureCheckerNode::onParameter, this, _1));
 
   // Core
-  lane_departure_checker_ = std::make_unique<LaneDepartureChecker>();
-  lane_departure_checker_->setParam(param_, vehicle_info);
+  autoware_lane_departure_checker_ = std::make_unique<LaneDepartureChecker>();
+  autoware_lane_departure_checker_->setParam(param_, vehicle_info);
 
   // Subscriber
   sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
@@ -351,7 +351,7 @@ void LaneDepartureCheckerNode::onTimer()
   input_.boundary_types_to_detect = node_param_.boundary_types_to_detect;
   processing_time_map["Node: setInputData"] = stop_watch.toc(true);
 
-  output_ = lane_departure_checker_->update(input_);
+  output_ = autoware_lane_departure_checker_->update(input_);
   processing_time_map["Node: update"] = stop_watch.toc(true);
 
   updater_.force_update();
@@ -410,8 +410,8 @@ rcl_interfaces::msg::SetParametersResult LaneDepartureCheckerNode::onParameter(
     update_param(parameters, "delay_time", param_.delay_time);
     update_param(parameters, "min_braking_distance", param_.min_braking_distance);
 
-    if (lane_departure_checker_) {
-      lane_departure_checker_->setParam(param_);
+    if (autoware_lane_departure_checker_) {
+      autoware_lane_departure_checker_->setParam(param_);
     }
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -166,8 +166,8 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
     add_on_set_parameters_callback(std::bind(&LaneDepartureCheckerNode::onParameter, this, _1));
 
   // Core
-  autoware_lane_departure_checker_ = std::make_unique<LaneDepartureChecker>();
-  autoware_lane_departure_checker_->setParam(param_, vehicle_info);
+  lane_departure_checker_ = std::make_unique<LaneDepartureChecker>();
+  lane_departure_checker_->setParam(param_, vehicle_info);
 
   // Subscriber
   sub_odom_ = this->create_subscription<nav_msgs::msg::Odometry>(
@@ -351,7 +351,7 @@ void LaneDepartureCheckerNode::onTimer()
   input_.boundary_types_to_detect = node_param_.boundary_types_to_detect;
   processing_time_map["Node: setInputData"] = stop_watch.toc(true);
 
-  output_ = autoware_lane_departure_checker_->update(input_);
+  output_ = lane_departure_checker_->update(input_);
   processing_time_map["Node: update"] = stop_watch.toc(true);
 
   updater_.force_update();
@@ -410,8 +410,8 @@ rcl_interfaces::msg::SetParametersResult LaneDepartureCheckerNode::onParameter(
     update_param(parameters, "delay_time", param_.delay_time);
     update_param(parameters, "min_braking_distance", param_.min_braking_distance);
 
-    if (autoware_lane_departure_checker_) {
-      autoware_lane_departure_checker_->setParam(param_);
+    if (lane_departure_checker_) {
+      lane_departure_checker_->setParam(param_);
     }
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -41,8 +41,6 @@
   <depend>autoware_frenet_planner</depend>
   <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_path_sampler</depend>
-  <depend>autoware_lane_departure_checker</depend>
-  <depend>autoware_path_sampler</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -42,6 +42,7 @@
   <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_path_sampler</depend>
   <depend>autoware_lane_departure_checker</depend>
+  <depend>autoware_path_sampler</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -41,6 +41,7 @@
   <depend>autoware_frenet_planner</depend>
   <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_path_sampler</depend>
+  <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>


### PR DESCRIPTION
## Description


The same as [this PR](https://github.com/autowarefoundation/autoware.universe/pull/6997) based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612), the polling subscriber is used in the obstacle_avoidance_planner.

after the [PR](https://github.com/autowarefoundation/autoware.universe/pull/7325) is merged
<!-- Write a brief description of this PR. -->

## Tests performed

run psim

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
