### PR TITLE
refactor(gyro_odometer): apply static analysis

### DIFF
--- a/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp
+++ b/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp
@@ -30,14 +30,14 @@ class DiagnosticsModule
 public:
   DiagnosticsModule(rclcpp::Node * node, const std::string & diagnostic_name);
   void clear();
-  void addKeyValue(const diagnostic_msgs::msg::KeyValue & key_value_msg);
+  void add_key_value(const diagnostic_msgs::msg::KeyValue & key_value_msg);
   template <typename T>
-  void addKeyValue(const std::string & key, const T & value);
-  void updateLevelAndMessage(const int8_t level, const std::string & message);
+  void add_key_value(const std::string & key, const T & value);
+  void update_level_and_message(const int8_t level, const std::string & message);
   void publish(const rclcpp::Time & publish_time_stamp);
 
 private:
-  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray(
+  [[nodiscard]] diagnostic_msgs::msg::DiagnosticArray create_diagnostics_array(
     const rclcpp::Time & publish_time_stamp) const;
 
   rclcpp::Clock::SharedPtr clock_;
@@ -47,18 +47,18 @@ private:
 };
 
 template <typename T>
-void DiagnosticsModule::addKeyValue(const std::string & key, const T & value)
+void DiagnosticsModule::add_key_value(const std::string & key, const T & value)
 {
   diagnostic_msgs::msg::KeyValue key_value;
   key_value.key = key;
   key_value.value = std::to_string(value);
-  addKeyValue(key_value);
+  add_key_value(key_value);
 }
 
 template <>
-void DiagnosticsModule::addKeyValue(const std::string & key, const std::string & value);
+void DiagnosticsModule::add_key_value(const std::string & key, const std::string & value);
 template <>
-void DiagnosticsModule::addKeyValue(const std::string & key, const bool & value);
+void DiagnosticsModule::add_key_value(const std::string & key, const bool & value);
 
 }  // namespace autoware::gyro_odometer
 

--- a/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
+++ b/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
@@ -47,14 +47,13 @@ private:
 
 public:
   explicit GyroOdometerNode(const rclcpp::NodeOptions & node_options);
-  ~GyroOdometerNode();
 
 private:
-  void callbackVehicleTwist(
+  void callback_vehicle_twist(
     const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr vehicle_twist_msg_ptr);
-  void callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr);
-  void concatGyroAndOdometer();
-  void publishData(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
+  void callback_imu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr);
+  void concat_gyro_and_odometer();
+  void publish_data(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
   rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
     vehicle_twist_sub_;

--- a/localization/gyro_odometer/src/diagnostics_module.cpp
+++ b/localization/gyro_odometer/src/diagnostics_module.cpp
@@ -44,7 +44,7 @@ void DiagnosticsModule::clear()
   diagnostics_status_msg_.message = "";
 }
 
-void DiagnosticsModule::addKeyValue(const diagnostic_msgs::msg::KeyValue & key_value_msg)
+void DiagnosticsModule::add_key_value(const diagnostic_msgs::msg::KeyValue & key_value_msg)
 {
   auto it = std::find_if(
     std::begin(diagnostics_status_msg_.values), std::end(diagnostics_status_msg_.values),
@@ -58,24 +58,24 @@ void DiagnosticsModule::addKeyValue(const diagnostic_msgs::msg::KeyValue & key_v
 }
 
 template <>
-void DiagnosticsModule::addKeyValue(const std::string & key, const std::string & value)
+void DiagnosticsModule::add_key_value(const std::string & key, const std::string & value)
 {
   diagnostic_msgs::msg::KeyValue key_value;
   key_value.key = key;
   key_value.value = value;
-  addKeyValue(key_value);
+  add_key_value(key_value);
 }
 
 template <>
-void DiagnosticsModule::addKeyValue(const std::string & key, const bool & value)
+void DiagnosticsModule::add_key_value(const std::string & key, const bool & value)
 {
   diagnostic_msgs::msg::KeyValue key_value;
   key_value.key = key;
   key_value.value = value ? "True" : "False";
-  addKeyValue(key_value);
+  add_key_value(key_value);
 }
 
-void DiagnosticsModule::updateLevelAndMessage(const int8_t level, const std::string & message)
+void DiagnosticsModule::update_level_and_message(const int8_t level, const std::string & message)
 {
   if ((level > diagnostic_msgs::msg::DiagnosticStatus::OK)) {
     if (!diagnostics_status_msg_.message.empty()) {
@@ -90,10 +90,10 @@ void DiagnosticsModule::updateLevelAndMessage(const int8_t level, const std::str
 
 void DiagnosticsModule::publish(const rclcpp::Time & publish_time_stamp)
 {
-  diagnostics_pub_->publish(createDiagnosticsArray(publish_time_stamp));
+  diagnostics_pub_->publish(create_diagnostics_array(publish_time_stamp));
 }
 
-diagnostic_msgs::msg::DiagnosticArray DiagnosticsModule::createDiagnosticsArray(
+diagnostic_msgs::msg::DiagnosticArray DiagnosticsModule::create_diagnostics_array(
   const rclcpp::Time & publish_time_stamp) const
 {
   diagnostic_msgs::msg::DiagnosticArray diagnostics_msg;

--- a/localization/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/gyro_odometer/src/gyro_odometer_core.cpp
@@ -31,13 +31,13 @@
 namespace autoware::gyro_odometer
 {
 
-std::array<double, 9> transformCovariance(const std::array<double, 9> & cov)
+std::array<double, 9> transform_covariance(const std::array<double, 9> & cov)
 {
   using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
 
   double max_cov = std::max({cov[COV_IDX::X_X], cov[COV_IDX::Y_Y], cov[COV_IDX::Z_Z]});
 
-  std::array<double, 9> cov_transformed;
+  std::array<double, 9> cov_transformed = {};
   cov_transformed.fill(0.);
   cov_transformed[COV_IDX::X_X] = max_cov;
   cov_transformed[COV_IDX::Y_Y] = max_cov;
@@ -57,11 +57,11 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
 
   vehicle_twist_sub_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
     "vehicle/twist_with_covariance", rclcpp::QoS{100},
-    std::bind(&GyroOdometerNode::callbackVehicleTwist, this, std::placeholders::_1));
+    std::bind(&GyroOdometerNode::callback_vehicle_twist, this, std::placeholders::_1));
 
   imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
     "imu", rclcpp::QoS{100},
-    std::bind(&GyroOdometerNode::callbackImu, this, std::placeholders::_1));
+    std::bind(&GyroOdometerNode::callback_imu, this, std::placeholders::_1));
 
   twist_raw_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist_raw", rclcpp::QoS{10});
   twist_with_covariance_raw_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
@@ -76,49 +76,47 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
   // TODO(YamatoAndo) createTimer
 }
 
-GyroOdometerNode::~GyroOdometerNode()
-{
-}
-
-void GyroOdometerNode::callbackVehicleTwist(
-  const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr vehicle_twist_ptr)
+void GyroOdometerNode::callback_vehicle_twist(
+  const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr vehicle_twist_msg_ptr)
 {
   diagnostics_->clear();
-  diagnostics_->addKeyValue(
-    "topic_time_stamp", static_cast<rclcpp::Time>(vehicle_twist_ptr->header.stamp).nanoseconds());
+  diagnostics_->add_key_value(
+    "topic_time_stamp",
+    static_cast<rclcpp::Time>(vehicle_twist_msg_ptr->header.stamp).nanoseconds()
+  );
 
   vehicle_twist_arrived_ = true;
-  latest_vehicle_twist_ros_time_ = vehicle_twist_ptr->header.stamp;
-  vehicle_twist_queue_.push_back(*vehicle_twist_ptr);
-  concatGyroAndOdometer();
+  latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr->header.stamp;
+  vehicle_twist_queue_.push_back(*vehicle_twist_msg_ptr);
+  concat_gyro_and_odometer();
 
-  diagnostics_->publish(vehicle_twist_ptr->header.stamp);
+  diagnostics_->publish(vehicle_twist_msg_ptr->header.stamp);
 }
 
-void GyroOdometerNode::callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr)
+void GyroOdometerNode::callback_imu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr)
 {
   diagnostics_->clear();
-  diagnostics_->addKeyValue(
+  diagnostics_->add_key_value(
     "topic_time_stamp", static_cast<rclcpp::Time>(imu_msg_ptr->header.stamp).nanoseconds());
 
   imu_arrived_ = true;
   latest_imu_ros_time_ = imu_msg_ptr->header.stamp;
   gyro_queue_.push_back(*imu_msg_ptr);
-  concatGyroAndOdometer();
+  concat_gyro_and_odometer();
 
   diagnostics_->publish(imu_msg_ptr->header.stamp);
 }
 
-void GyroOdometerNode::concatGyroAndOdometer()
+void GyroOdometerNode::concat_gyro_and_odometer()
 {
   // check arrive first topic
-  diagnostics_->addKeyValue("is_arrived_first_vehicle_twist", vehicle_twist_arrived_);
-  diagnostics_->addKeyValue("is_arrived_first_imu", imu_arrived_);
+  diagnostics_->add_key_value("is_arrived_first_vehicle_twist", vehicle_twist_arrived_);
+  diagnostics_->add_key_value("is_arrived_first_imu", imu_arrived_);
   if (!vehicle_twist_arrived_) {
     std::stringstream message;
     message << "Twist msg is not subscribed";
     RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, message.str());
-    diagnostics_->updateLevelAndMessage(
+    diagnostics_->update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
 
     vehicle_twist_queue_.clear();
@@ -129,7 +127,7 @@ void GyroOdometerNode::concatGyroAndOdometer()
     std::stringstream message;
     message << "Imu msg is not subscribed";
     RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, message.str());
-    diagnostics_->updateLevelAndMessage(
+    diagnostics_->update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
 
     vehicle_twist_queue_.clear();
@@ -141,14 +139,14 @@ void GyroOdometerNode::concatGyroAndOdometer()
   const double vehicle_twist_dt =
     std::abs((this->now() - latest_vehicle_twist_ros_time_).seconds());
   const double imu_dt = std::abs((this->now() - latest_imu_ros_time_).seconds());
-  diagnostics_->addKeyValue("vehicle_twist_time_stamp_dt", vehicle_twist_dt);
-  diagnostics_->addKeyValue("imu_time_stamp_dt", imu_dt);
+  diagnostics_->add_key_value("vehicle_twist_time_stamp_dt", vehicle_twist_dt);
+  diagnostics_->add_key_value("imu_time_stamp_dt", imu_dt);
   if (vehicle_twist_dt > message_timeout_sec_) {
     const std::string message = fmt::format(
       "Vehicle twist msg is timeout. vehicle_twist_dt: {}[sec], tolerance {}[sec]",
       vehicle_twist_dt, message_timeout_sec_);
     RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, message);
-    diagnostics_->updateLevelAndMessage(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
+    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
 
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();
@@ -158,7 +156,7 @@ void GyroOdometerNode::concatGyroAndOdometer()
     const std::string message = fmt::format(
       "Imu msg is timeout. imu_dt: {}[sec], tolerance {}[sec]", imu_dt, message_timeout_sec_);
     RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, message);
-    diagnostics_->updateLevelAndMessage(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
+    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
 
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();
@@ -166,8 +164,8 @@ void GyroOdometerNode::concatGyroAndOdometer()
   }
 
   // check queue size
-  diagnostics_->addKeyValue("vehicle_twist_queue_size", vehicle_twist_queue_.size());
-  diagnostics_->addKeyValue("imu_queue_size", gyro_queue_.size());
+  diagnostics_->add_key_value("vehicle_twist_queue_size", vehicle_twist_queue_.size());
+  diagnostics_->add_key_value("imu_queue_size", gyro_queue_.size());
   if (vehicle_twist_queue_.empty()) {
     // not output error and clear queue
     return;
@@ -182,13 +180,13 @@ void GyroOdometerNode::concatGyroAndOdometer()
     transform_listener_->getLatestTransform(gyro_queue_.front().header.frame_id, output_frame_);
 
   const bool is_succeed_transform_imu = (tf_imu2base_ptr != nullptr);
-  diagnostics_->addKeyValue("is_succeed_transform_imu", is_succeed_transform_imu);
+  diagnostics_->add_key_value("is_succeed_transform_imu", is_succeed_transform_imu);
   if (!is_succeed_transform_imu) {
     std::stringstream message;
     message << "Please publish TF " << output_frame_ << " to "
             << gyro_queue_.front().header.frame_id;
     RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, message.str());
-    diagnostics_->updateLevelAndMessage(
+    diagnostics_->update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::ERROR, message.str());
 
     vehicle_twist_queue_.clear();
@@ -208,7 +206,7 @@ void GyroOdometerNode::concatGyroAndOdometer()
 
     gyro.header.frame_id = output_frame_;
     gyro.angular_velocity = transformed_angular_velocity.vector;
-    gyro.angular_velocity_covariance = transformCovariance(gyro.angular_velocity_covariance);
+    gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
   }
 
   using COV_IDX_XYZ = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
@@ -223,8 +221,8 @@ void GyroOdometerNode::concatGyroAndOdometer()
     vx_mean += vehicle_twist.twist.twist.linear.x;
     vx_covariance_original += vehicle_twist.twist.covariance[0 * 6 + 0];
   }
-  vx_mean /= vehicle_twist_queue_.size();
-  vx_covariance_original /= vehicle_twist_queue_.size();
+  vx_mean /= static_cast<double>(vehicle_twist_queue_.size());
+  vx_covariance_original /= static_cast<double>(vehicle_twist_queue_.size());
 
   for (const auto & gyro : gyro_queue_) {
     gyro_mean.x += gyro.angular_velocity.x;
@@ -234,12 +232,12 @@ void GyroOdometerNode::concatGyroAndOdometer()
     gyro_covariance_original.y += gyro.angular_velocity_covariance[COV_IDX_XYZ::Y_Y];
     gyro_covariance_original.z += gyro.angular_velocity_covariance[COV_IDX_XYZ::Z_Z];
   }
-  gyro_mean.x /= gyro_queue_.size();
-  gyro_mean.y /= gyro_queue_.size();
-  gyro_mean.z /= gyro_queue_.size();
-  gyro_covariance_original.x /= gyro_queue_.size();
-  gyro_covariance_original.y /= gyro_queue_.size();
-  gyro_covariance_original.z /= gyro_queue_.size();
+  gyro_mean.x /= static_cast<double>(gyro_queue_.size());
+  gyro_mean.y /= static_cast<double>(gyro_queue_.size());
+  gyro_mean.z /= static_cast<double>(gyro_queue_.size());
+  gyro_covariance_original.x /= static_cast<double>(gyro_queue_.size());
+  gyro_covariance_original.y /= static_cast<double>(gyro_queue_.size());
+  gyro_covariance_original.z /= static_cast<double>(gyro_queue_.size());
 
   // concat
   geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov;
@@ -257,23 +255,23 @@ void GyroOdometerNode::concatGyroAndOdometer()
   // From a statistical point of view, here we reduce the covariances according to the number of
   // observed data
   twist_with_cov.twist.covariance[COV_IDX_XYZRPY::X_X] =
-    vx_covariance_original / vehicle_twist_queue_.size();
+    vx_covariance_original / static_cast<double>(vehicle_twist_queue_.size());
   twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Y_Y] = 100000.0;
   twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Z_Z] = 100000.0;
   twist_with_cov.twist.covariance[COV_IDX_XYZRPY::ROLL_ROLL] =
-    gyro_covariance_original.x / gyro_queue_.size();
+    gyro_covariance_original.x / static_cast<double>(gyro_queue_.size());
   twist_with_cov.twist.covariance[COV_IDX_XYZRPY::PITCH_PITCH] =
-    gyro_covariance_original.y / gyro_queue_.size();
+    gyro_covariance_original.y / static_cast<double>(gyro_queue_.size());
   twist_with_cov.twist.covariance[COV_IDX_XYZRPY::YAW_YAW] =
-    gyro_covariance_original.z / gyro_queue_.size();
+    gyro_covariance_original.z / static_cast<double>(gyro_queue_.size());
 
-  publishData(twist_with_cov);
+  publish_data(twist_with_cov);
 
   vehicle_twist_queue_.clear();
   gyro_queue_.clear();
 }
 
-void GyroOdometerNode::publishData(
+void GyroOdometerNode::publish_data(
   const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw)
 {
   geometry_msgs::msg::TwistStamped twist_raw;

--- a/localization/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/gyro_odometer/src/gyro_odometer_core.cpp
@@ -82,8 +82,7 @@ void GyroOdometerNode::callback_vehicle_twist(
   diagnostics_->clear();
   diagnostics_->add_key_value(
     "topic_time_stamp",
-    static_cast<rclcpp::Time>(vehicle_twist_msg_ptr->header.stamp).nanoseconds()
-  );
+    static_cast<rclcpp::Time>(vehicle_twist_msg_ptr->header.stamp).nanoseconds());
 
   vehicle_twist_arrived_ = true;
   latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr->header.stamp;

--- a/localization/gyro_odometer/test/test_gyro_odometer_helper.cpp
+++ b/localization/gyro_odometer/test/test_gyro_odometer_helper.cpp
@@ -17,7 +17,7 @@
 using geometry_msgs::msg::TwistWithCovarianceStamped;
 using sensor_msgs::msg::Imu;
 
-Imu generateSampleImu()
+Imu generate_sample_imu()
 {
   Imu imu;
   imu.header.frame_id = "base_link";
@@ -27,7 +27,7 @@ Imu generateSampleImu()
   return imu;
 }
 
-TwistWithCovarianceStamped generateSampleVelocity()
+TwistWithCovarianceStamped generate_sample_velocity()
 {
   TwistWithCovarianceStamped twist;
   twist.header.frame_id = "base_link";
@@ -35,7 +35,7 @@ TwistWithCovarianceStamped generateSampleVelocity()
   return twist;
 }
 
-rclcpp::NodeOptions getNodeOptionsWithDefaultParams()
+rclcpp::NodeOptions get_node_options_with_default_params()
 {
   rclcpp::NodeOptions node_options;
 

--- a/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp
+++ b/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp
@@ -20,11 +20,8 @@
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
-using geometry_msgs::msg::TwistWithCovarianceStamped;
-using sensor_msgs::msg::Imu;
-
-Imu generateSampleImu();
-TwistWithCovarianceStamped generateSampleVelocity();
-rclcpp::NodeOptions getNodeOptionsWithDefaultParams();
+sensor_msgs::msg::Imu generate_sample_imu();
+geometry_msgs::msg::TwistWithCovarianceStamped generate_sample_velocity();
+rclcpp::NodeOptions get_node_options_with_default_params();
 
 #endif  // TEST_GYRO_ODOMETER_HELPER_HPP_

--- a/localization/gyro_odometer/test/test_gyro_odometer_pubsub.cpp
+++ b/localization/gyro_odometer/test/test_gyro_odometer_pubsub.cpp
@@ -50,12 +50,13 @@ public:
 class GyroOdometerValidator : public rclcpp::Node
 {
 public:
-  GyroOdometerValidator() : Node("gyro_odometer_validator"),
-    twist_sub(create_subscription<TwistWithCovarianceStamped>("/twist_with_covariance", 1,
+  GyroOdometerValidator()
+  : Node("gyro_odometer_validator"),
+    twist_sub(create_subscription<TwistWithCovarianceStamped>(
+      "/twist_with_covariance", 1,
       [this](const TwistWithCovarianceStamped::ConstSharedPtr msg) {
         received_latest_twist_ptr = msg;
-      })
-    ),
+      })),
     received_latest_twist_ptr(nullptr)
   {
   }
@@ -110,10 +111,8 @@ TEST(GyroOdometer, TestGyroOdometerWithImuAndVelocity)
   expected_output_twist.twist.twist.angular.y = input_imu.angular_velocity.y;
   expected_output_twist.twist.twist.angular.z = input_imu.angular_velocity.z;
 
-  auto gyro_odometer_node =
-    std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
-      get_node_options_with_default_params()
-    );
+  auto gyro_odometer_node = std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
+    get_node_options_with_default_params());
   auto imu_generator = std::make_shared<ImuGenerator>();
   auto velocity_generator = std::make_shared<VelocityGenerator>();
   auto gyro_odometer_validator_node = std::make_shared<GyroOdometerValidator>();
@@ -140,10 +139,8 @@ TEST(GyroOdometer, TestGyroOdometerImuOnly)
 {
   Imu input_imu = generate_sample_imu();
 
-  auto gyro_odometer_node =
-    std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
-      get_node_options_with_default_params()
-    );
+  auto gyro_odometer_node = std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
+    get_node_options_with_default_params());
   auto imu_generator = std::make_shared<ImuGenerator>();
   auto gyro_odometer_validator_node = std::make_shared<GyroOdometerValidator>();
 

--- a/localization/gyro_odometer/test/test_gyro_odometer_pubsub.cpp
+++ b/localization/gyro_odometer/test/test_gyro_odometer_pubsub.cpp
@@ -50,19 +50,21 @@ public:
 class GyroOdometerValidator : public rclcpp::Node
 {
 public:
-  GyroOdometerValidator() : Node("gyro_odometer_validator"), received_latest_twist_ptr(nullptr)
-  {
-    twist_sub = create_subscription<TwistWithCovarianceStamped>(
-      "/twist_with_covariance", 1, [this](const TwistWithCovarianceStamped::ConstSharedPtr msg) {
+  GyroOdometerValidator() : Node("gyro_odometer_validator"),
+    twist_sub(create_subscription<TwistWithCovarianceStamped>("/twist_with_covariance", 1,
+      [this](const TwistWithCovarianceStamped::ConstSharedPtr msg) {
         received_latest_twist_ptr = msg;
-      });
+      })
+    ),
+    received_latest_twist_ptr(nullptr)
+  {
   }
 
   rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr twist_sub;
   TwistWithCovarianceStamped::ConstSharedPtr received_latest_twist_ptr;
 };
 
-void spinSome(rclcpp::Node::SharedPtr node_ptr)
+void wait_spin_some(rclcpp::Node::SharedPtr node_ptr)
 {
   for (int i = 0; i < 50; ++i) {
     rclcpp::spin_some(node_ptr);
@@ -70,7 +72,7 @@ void spinSome(rclcpp::Node::SharedPtr node_ptr)
   }
 }
 
-bool isTwistValid(
+bool is_twist_valid(
   const TwistWithCovarianceStamped & twist, const TwistWithCovarianceStamped & twist_ground_truth)
 {
   if (twist.twist.twist.linear.x != twist_ground_truth.twist.twist.linear.x) {
@@ -99,8 +101,8 @@ bool isTwistValid(
 // velocity data are provided
 TEST(GyroOdometer, TestGyroOdometerWithImuAndVelocity)
 {
-  Imu input_imu = generateSampleImu();
-  TwistWithCovarianceStamped input_velocity = generateSampleVelocity();
+  Imu input_imu = generate_sample_imu();
+  TwistWithCovarianceStamped input_velocity = generate_sample_velocity();
 
   TwistWithCovarianceStamped expected_output_twist;
   expected_output_twist.twist.twist.linear.x = input_velocity.twist.twist.linear.x;
@@ -109,7 +111,9 @@ TEST(GyroOdometer, TestGyroOdometerWithImuAndVelocity)
   expected_output_twist.twist.twist.angular.z = input_imu.angular_velocity.z;
 
   auto gyro_odometer_node =
-    std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(getNodeOptionsWithDefaultParams());
+    std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
+      get_node_options_with_default_params()
+    );
   auto imu_generator = std::make_shared<ImuGenerator>();
   auto velocity_generator = std::make_shared<VelocityGenerator>();
   auto gyro_odometer_validator_node = std::make_shared<GyroOdometerValidator>();
@@ -120,13 +124,13 @@ TEST(GyroOdometer, TestGyroOdometerWithImuAndVelocity)
   velocity_generator->vehicle_velocity_pub->publish(input_velocity);
 
   // gyro_odometer receives IMU and velocity, and publishes the fused twist data.
-  spinSome(gyro_odometer_node);
+  wait_spin_some(gyro_odometer_node);
 
   // validator node receives the fused twist data and store in "received_latest_twist_ptr".
-  spinSome(gyro_odometer_validator_node);
+  wait_spin_some(gyro_odometer_validator_node);
 
   EXPECT_FALSE(gyro_odometer_validator_node->received_latest_twist_ptr == nullptr);
-  EXPECT_TRUE(isTwistValid(
+  EXPECT_TRUE(is_twist_valid(
     *(gyro_odometer_validator_node->received_latest_twist_ptr), expected_output_twist));
 }
 
@@ -134,20 +138,22 @@ TEST(GyroOdometer, TestGyroOdometerWithImuAndVelocity)
 // Verify that the gyro_odometer does NOT publish any outputs when only IMU is provided
 TEST(GyroOdometer, TestGyroOdometerImuOnly)
 {
-  Imu input_imu = generateSampleImu();
+  Imu input_imu = generate_sample_imu();
 
   auto gyro_odometer_node =
-    std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(getNodeOptionsWithDefaultParams());
+    std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
+      get_node_options_with_default_params()
+    );
   auto imu_generator = std::make_shared<ImuGenerator>();
   auto gyro_odometer_validator_node = std::make_shared<GyroOdometerValidator>();
 
   imu_generator->imu_pub->publish(input_imu);
 
   // gyro_odometer receives IMU
-  spinSome(gyro_odometer_node);
+  wait_spin_some(gyro_odometer_node);
 
   // validator node waits for the output fused twist from gyro_odometer
-  spinSome(gyro_odometer_validator_node);
+  wait_spin_some(gyro_odometer_validator_node);
 
   EXPECT_TRUE(gyro_odometer_validator_node->received_latest_twist_ptr == nullptr);
 }


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `localization/gyro_odometer`.

Fixed:
- camelCase to snake_case
- use explicit cast
- rename 
- use initialization list for some variable (in test)
- removed default destructor
- rename ambiguous function name (collide with some library)
- remove "using declaration" in header file

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

```Text
$ ./check_linter.sh gyro_odometer
...
13232 warnings generated.
Suppressed 13243 warnings (13232 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13229 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp:23:1: warning: using declarations in the global namespace in headers are prohibited [google-global-names-in-headers]
using geometry_msgs::msg::TwistWithCovarianceStamped;
^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp:24:1: warning: using declarations in the global namespace in headers are prohibited [google-global-names-in-headers]
using sensor_msgs::msg::Imu;
^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp:26:5: warning: invalid case style for function 'generateSampleImu' [readability-identifier-naming]
Imu generateSampleImu();
    ^~~~~~~~~~~~~~~~~
    generate_sample_imu
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp:27:28: warning: invalid case style for function 'generateSampleVelocity' [readability-identifier-naming]
TwistWithCovarianceStamped generateSampleVelocity();
                           ^~~~~~~~~~~~~~~~~~~~~~
                           generate_sample_velocity
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_helper.hpp:28:21: warning: invalid case style for function 'getNodeOptionsWithDefaultParams' [readability-identifier-naming]
rclcpp::NodeOptions getNodeOptionsWithDefaultParams();
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                    get_node_options_with_default_params
Suppressed 13235 warnings (13224 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13245 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp:33:8: warning: invalid case style for function 'addKeyValue' [readability-identifier-naming]
  void addKeyValue(const diagnostic_msgs::msg::KeyValue & key_value_msg);
       ^~~~~~~~~~~
       add_key_value
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp:35:8: warning: invalid case style for function 'addKeyValue' [readability-identifier-naming]
  void addKeyValue(const std::string & key, const T & value);
       ^~~~~~~~~~~
       add_key_value
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp:36:8: warning: invalid case style for function 'updateLevelAndMessage' [readability-identifier-naming]
  void updateLevelAndMessage(const int8_t level, const std::string & message);
       ^~~~~~~~~~~~~~~~~~~~~
       update_level_and_message
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp:40:3: warning: function 'createDiagnosticsArray' should be marked [[nodiscard]] [modernize-use-nodiscard]
  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray(
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/diagnostics_module.hpp:40:41: warning: invalid case style for function 'createDiagnosticsArray' [readability-identifier-naming]
  diagnostic_msgs::msg::DiagnosticArray createDiagnosticsArray(
                                        ^~~~~~~~~~~~~~~~~~~~~~
                                        create_diagnostics_array
Suppressed 13251 warnings (13240 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13799 warnings generated.
Suppressed 13810 warnings (13799 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14510 warnings generated.
Suppressed 14538 warnings (14510 in non-user code, 28 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
15508 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:43:7: warning: class 'GyroOdometerNode' defines a non-default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class GyroOdometerNode : public rclcpp::Node
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:50:3: error: annotate this function with 'override' or (rarely) 'final' [modernize-use-override,-warnings-as-errors]
  ~GyroOdometerNode();
  ^
                      override
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:53:8: warning: invalid case style for function 'callbackVehicleTwist' [readability-identifier-naming]
  void callbackVehicleTwist(
       ^~~~~~~~~~~~~~~~~~~~
       callback_vehicle_twist
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:55:8: warning: invalid case style for function 'callbackImu' [readability-identifier-naming]
  void callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr);
       ^~~~~~~~~~~
       callback_imu
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:56:8: warning: invalid case style for function 'concatGyroAndOdometer' [readability-identifier-naming]
  void concatGyroAndOdometer();
       ^~~~~~~~~~~~~~~~~~~~~
       concat_gyro_and_odometer
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:57:8: warning: invalid case style for function 'publishData' [readability-identifier-naming]
  void publishData(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
       ^~~~~~~~~~~
       publish_data
Suppressed 15513 warnings (15502 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
19912 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_pubsub.cpp:65:6: warning: invalid case style for function 'spinSome' [readability-identifier-naming]
void spinSome(rclcpp::Node::SharedPtr node_ptr)
     ^~~~~~~~
     spin_some
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/test/test_gyro_odometer_pubsub.cpp:73:6: warning: invalid case style for function 'isTwistValid' [readability-identifier-naming]
bool isTwistValid(
     ^~~~~~~~~~~~
     is_twist_valid
Suppressed 19938 warnings (19910 in non-user code, 28 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
20162 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:53:8: warning: function 'autoware::gyro_odometer::GyroOdometerNode::callbackVehicleTwist' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]
  void callbackVehicleTwist(
       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:83:24: note: the definition seen here
void GyroOdometerNode::callbackVehicleTwist(
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp:53:8: note: differing parameters are named here: ('vehicle_twist_msg_ptr'), in definition: ('vehicle_twist_ptr')
  void callbackVehicleTwist(
       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:34:23: warning: invalid case style for function 'transformCovariance' [readability-identifier-naming]
std::array<double, 9> transformCovariance(const std::array<double, 9> & cov)
                      ^~~~~~~~~~~~~~~~~~~
                      transform_covariance
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:40:3: warning: uninitialized record type: 'cov_transformed' [cppcoreguidelines-pro-type-member-init]
  std::array<double, 9> cov_transformed;
  ^
                                       {}
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:79:19: error: use '= default' to define a trivial destructor [modernize-use-equals-default,-warnings-as-errors]
GyroOdometerNode::~GyroOdometerNode()
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:226:14: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  vx_mean /= vehicle_twist_queue_.size();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:227:29: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  vx_covariance_original /= vehicle_twist_queue_.size();
                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:237:18: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  gyro_mean.x /= gyro_queue_.size();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:238:18: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  gyro_mean.y /= gyro_queue_.size();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:239:18: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  gyro_mean.z /= gyro_queue_.size();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:240:33: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  gyro_covariance_original.x /= gyro_queue_.size();
                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:241:33: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  gyro_covariance_original.y /= gyro_queue_.size();
                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:242:33: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
  gyro_covariance_original.z /= gyro_queue_.size();
                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:260:30: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    vx_covariance_original / vehicle_twist_queue_.size();
                             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:264:34: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    gyro_covariance_original.x / gyro_queue_.size();
                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:266:34: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    gyro_covariance_original.y / gyro_queue_.size();
                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/gyro_odometer/src/gyro_odometer_core.cpp:268:34: warning: narrowing conversion from 'std::deque::size_type' (aka 'unsigned long') to 'double' [cppcoreguidelines-narrowing-conversions]
    gyro_covariance_original.z / gyro_queue_.size();
                                 ^
Suppressed 20157 warnings (20146 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/diagnostics_module.cpp ...
1/5 files checked 15% done
Checking src/gyro_odometer_core.cpp ...
Checking src/gyro_odometer_core.cpp: ROS_DISTRO_GALACTIC...
2/5 files checked 67% done
Checking test/test_gyro_odometer_helper.cpp ...
3/5 files checked 73% done
Checking test/test_gyro_odometer_pubsub.cpp ...
test/test_gyro_odometer_pubsub.cpp:57:9: performance: Variable 'received_latest_twist_ptr' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
        received_latest_twist_ptr = msg;
        ^
4/5 files checked 96% done
Checking test/test_main.cpp ...
5/5 files checked 100% done

```
</details>

---

After this PR:

Check with check_linter.sh
```Text
$ ./check_linter.sh gyro_odometer
...
13240 warnings generated.
Suppressed 13251 warnings (13240 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13227 warnings generated.
Suppressed 13238 warnings (13227 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13224 warnings generated.
Suppressed 13235 warnings (13224 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14510 warnings generated.
Suppressed 14538 warnings (14510 in non-user code, 28 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13794 warnings generated.
Suppressed 13805 warnings (13794 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
15497 warnings generated.
Suppressed 15508 warnings (15497 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
19896 warnings generated.
Suppressed 19924 warnings (19896 in non-user code, 28 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
20134 warnings generated.
Suppressed 20145 warnings (20134 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

Check with cppcheck (no warnings):
```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

...
5/5 files checked 100% done
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
