### PR TITLE
fix(autoware_planning_validator): revert node name change

### DIFF
--- a/planning/planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/launch/planning_validator.launch.xml
@@ -3,7 +3,7 @@
   <arg name="input_trajectory" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
   <arg name="output_trajectory" default="/planning/scenario_planning/trajectory"/>
 
-  <node name="autoware_planning_validator" exec="planning_validator_node" pkg="autoware_planning_validator" output="screen">
+  <node name="planning_validator" exec="planning_validator_node" pkg="autoware_planning_validator" output="screen">
     <!-- load config a file -->
     <param from="$(var planning_validator_param_path)"/>
 


### PR DESCRIPTION
## Description

change node name in the [PR](https://github.com/autowarefoundation/autoware.universe/pull/7320) and it causes diag error.
As a result, autoware engage from RVIZ gui was not working.
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/0309cbac-3406-4005-8e41-7e2643692574)
The error was following by clicking the gui bottom
```
[service_log_checker_node-4] [ERROR 1717762673.010612554] [system.service_log_checker]: /api/operation_mode/change_to_autonomous: status code 1 'The mode change is blocked by the system.' (/default_ad_api/node/operation_mode) (set_error():84)
```

<!-- Write a brief description of this PR. -->

## Tests performed

confirmed engage works with psim

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
