### PR TITLE
fix(motion_planning.launch): fix input traj of obstacle_velocity_limiter

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -146,7 +146,7 @@
     <load_composable_node target="/planning/scenario_planning/lane_driving/motion_planning/motion_planning_container">
       <composable_node pkg="obstacle_velocity_limiter" plugin="obstacle_velocity_limiter::ObstacleVelocityLimiterNode" name="obstacle_velocity_limiter" namespace="">
         <!-- topic remap -->
-        <remap from="~/input/trajectory" to="path_optimizer/trajectory"/>
+        <remap from="~/input/trajectory" to="motion_velocity_planner/trajectory"/>
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
         <remap from="~/input/dynamic_obstacles" to="/perception/object_recognition/objects"/>
         <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
A previous PR changed the input topics of the `obstacle_velocity_limiter`, causing the `motion_velocity_planner` output to be ignored (see https://github.com/autowarefoundation/autoware.universe/commit/d2f41bc62e6a25bec56b767b0ef19987a6e4c0d6#diff-68856cde486208f016738f11d6bd8defc247a7f8c5c55b9d739d928d778f94c4L149).
The present PR fixes the issue.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Modules of the `motion_velocity_planner` (currently only the `out_of_lane` module) are working as expected.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->
None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
