### PR TITLE
refactor(localization_util): apply static analysis

### DIFF
--- a/localization/localization_util/src/util_func.cpp
+++ b/localization/localization_util/src/util_func.cpp
@@ -28,11 +28,11 @@ std_msgs::msg::ColorRGBA exchange_color_crc(double x)
     color.b = 1.0;
     color.g = static_cast<float>(std::sin(x * 2.0 * M_PI));
     color.r = 0;
-  } else if (x > 0.25 && x <= 0.5) {
+  } else if (x <= 0.5) {
     color.b = static_cast<float>(std::sin(x * 2 * M_PI));
     color.g = 1.0;
     color.r = 0;
-  } else if (x > 0.5 && x <= 0.75) {
+  } else if (x <= 0.75) {
     color.b = 0;
     color.g = 1.0;
     color.r = static_cast<float>(-std::sin(x * 2.0 * M_PI));

--- a/localization/localization_util/test/test_smart_pose_buffer.cpp
+++ b/localization/localization_util/test/test_smart_pose_buffer.cpp
@@ -43,7 +43,8 @@ bool compare_pose(
 }
 
 class TestSmartPoseBuffer : public ::testing::Test
-{};
+{
+};
 
 TEST_F(TestSmartPoseBuffer, interpolate_pose)  // NOLINT
 {

--- a/localization/localization_util/test/test_smart_pose_buffer.cpp
+++ b/localization/localization_util/test/test_smart_pose_buffer.cpp
@@ -43,12 +43,7 @@ bool compare_pose(
 }
 
 class TestSmartPoseBuffer : public ::testing::Test
-{
-protected:
-  void SetUp() override {}
-
-  void TearDown() override {}
-};
+{};
 
 TEST_F(TestSmartPoseBuffer, interpolate_pose)  // NOLINT
 {

--- a/localization/localization_util/test/test_smart_pose_buffer.cpp
+++ b/localization/localization_util/test/test_smart_pose_buffer.cpp
@@ -42,11 +42,7 @@ bool compare_pose(
          pose_a.pose.pose.orientation.w == pose_b.pose.pose.orientation.w;
 }
 
-class TestSmartPoseBuffer : public ::testing::Test
-{
-};
-
-TEST_F(TestSmartPoseBuffer, interpolate_pose)  // NOLINT
+TEST(TestSmartPoseBuffer, interpolate_pose)  // NOLINT
 {
   rclcpp::Logger logger = rclcpp::get_logger("test_logger");
   const double pose_timeout_sec = 10.0;


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `localization/localization_util`.

Fixed:
- remove meaningless conditions
- (removed unused codes in test)


the notion "style: Variable 'ex' can be..." from cppcheck is fixed in https://github.com/autowarefoundation/autoware.universe/pull/7278

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

```Text
$ ./check_linter.sh localization_util
...
9505 warnings generated.
Suppressed 9507 warnings (9505 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
30971 warnings generated.
30906 warnings generated.
Suppressed 30919 warnings (30906 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
31734 warnings generated.
Suppressed 31747 warnings (31734 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
30933 warnings generated.
Suppressed 30946 warnings (30933 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
32362 warnings generated.
Suppressed 32396 warnings (32362 in non-user code, 34 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
61942 warnings generated.
Suppressed 61968 warnings (61942 in non-user code, 26 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
$cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive . -I ../ndt_scan_matcher/src/*

Checking src/smart_pose_buffer.cpp ...
1/6 files checked 6% done
Checking src/util_func.cpp ...
src/util_func.cpp:31:16: style: Condition 'x>0.25' is always true [knownConditionTrueFalse]
  } else if (x > 0.25 && x <= 0.5) {
               ^
src/util_func.cpp:27:9: note: Assuming condition 'x<=0.25' is false
  if (x <= 0.25) {
        ^
src/util_func.cpp:31:16: note: Condition 'x>0.25' is always true
  } else if (x > 0.25 && x <= 0.5) {
               ^
2/6 files checked 17% done
Checking test/test_smart_pose_buffer.cpp ...
3/6 files checked 22% done
Checking ../ndt_scan_matcher/src/map_update_module.cpp ...
4/6 files checked 35% done
Checking ../ndt_scan_matcher/src/ndt_scan_matcher_core.cpp ...
../ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:647:38: style: Variable 'ex' can be declared as reference to const [constVariableReference]
  } catch (tf2::TransformException & ex) {
                                     ^
Checking ../ndt_scan_matcher/src/ndt_scan_matcher_core.cpp: ROS_DISTRO_GALACTIC...
5/6 files checked 96% done
Checking ../ndt_scan_matcher/src/particle.cpp ...
6/6 files checked 100% done
test/test_smart_pose_buffer.cpp:48:0: style: The function 'SetUp' is never used. [unusedFunction]
  void SetUp() override {}
^
test/test_smart_pose_buffer.cpp:50:0: style: The function 'TearDown' is never used. [unusedFunction]
  void TearDown() override {}
```
</details>

---

After this PR:

Check with check_linter.sh (no change)

Check with cppcheck:
```
cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive . -I ../ndt_scan_matcher/src/*

Checking src/smart_pose_buffer.cpp ...
1/6 files checked 6% done
Checking src/util_func.cpp ...
2/6 files checked 17% done
Checking test/test_smart_pose_buffer.cpp ...
3/6 files checked 22% done
Checking ../ndt_scan_matcher/src/map_update_module.cpp ...
4/6 files checked 34% done
Checking ../ndt_scan_matcher/src/ndt_scan_matcher_core.cpp ...
../ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:647:38: style: Variable 'ex' can be declared as reference to const [constVariableReference]
  } catch (tf2::TransformException & ex) {
                                     ^
Checking ../ndt_scan_matcher/src/ndt_scan_matcher_core.cpp: ROS_DISTRO_GALACTIC...
5/6 files checked 96% done
Checking ../ndt_scan_matcher/src/particle.cpp ...
6/6 files checked 100% done
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
