### PR TITLE
fix(start_planner): set minimum velocity to avoid high curvature in trajectroy  

### DIFF
--- a/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -325,7 +325,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     shift_line.end = *shift_end_pose_ptr;
     shift_line.end_shift_length = shift_length;
     path_shifter.addShiftLine(shift_line);
-    path_shifter.setVelocity(1.0);  // initial velocity is 0
+    path_shifter.setVelocity(1.0);  // initial velocity is 1.0
     path_shifter.setLongitudinalAcceleration(longitudinal_acc);
     path_shifter.setLateralAccelerationLimit(lateral_acc);
 

--- a/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -325,6 +325,9 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     shift_line.end = *shift_end_pose_ptr;
     shift_line.end_shift_length = shift_length;
     path_shifter.addShiftLine(shift_line);
+    // Setting 0.0 for initial velocity causes discontinuous curvature around shift start pose.
+    // Although the direct cause is not entirely clear, setting the initial velocity to 1.0 resolved
+    // the issue, so this change will be applied for now.
     path_shifter.setVelocity(1.0);  // initial velocity is 1.0
     path_shifter.setLongitudinalAcceleration(longitudinal_acc);
     path_shifter.setLateralAccelerationLimit(lateral_acc);

--- a/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -325,10 +325,14 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     shift_line.end = *shift_end_pose_ptr;
     shift_line.end_shift_length = shift_length;
     path_shifter.addShiftLine(shift_line);
-    // Setting 0.0 for initial velocity causes discontinuous curvature around shift start pose.
-    // Although the direct cause is not entirely clear, setting the initial velocity to 1.0 resolved
-    // the issue, so this change will be applied for now.
-    path_shifter.setVelocity(1.0);  // initial velocity is 1.0
+    // In the current path generation logic:
+    // - Considering the maximum curvature of the path results in a smaller shift distance.
+    // - Setting the allowable maximum lateral acceleration to a value smaller than the one
+    // calculated by the constant lateral jerk trajectory generation.
+    // - Setting the initial velocity to a very small value, such as 0.0.
+    // These conditions cause the curvature around the shift start pose to become larger than
+    // expected. To address this issue, an initial velocity 1.0 is provided.
+    path_shifter.setVelocity(1.0);
     path_shifter.setLongitudinalAcceleration(longitudinal_acc);
     path_shifter.setLateralAccelerationLimit(lateral_acc);
 

--- a/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -325,7 +325,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     shift_line.end = *shift_end_pose_ptr;
     shift_line.end_shift_length = shift_length;
     path_shifter.addShiftLine(shift_line);
-    path_shifter.setVelocity(0.0);  // initial velocity is 0
+    path_shifter.setVelocity(1.0);  // initial velocity is 0
     path_shifter.setLongitudinalAcceleration(longitudinal_acc);
     path_shifter.setLateralAccelerationLimit(lateral_acc);
 


### PR DESCRIPTION
## Description

The issue is unexpected high curvature was observed when high lateral acceleration is applied for the path generation in the start planner.

**lateral_acc = 0.4**  (maximum curvature is 0.07)
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/a79218b4-4d6b-49a4-9106-7f55bc4e370c)


but curvature calculated in the `planning_evaluator` exceeds the expected curvature 
```
--
  name: curvature
  message: ''
  hardware_id: ''
  values:
  - key: min
    value: '-0.077920683269826679'
  - key: max
    value: '0.029597384047832055'
  - key: mean
    value: '-0.00717520342333883057143'
--
```

After applying this PR

**lateral_acc = 0.4**  (maximum curvature is 0.07)
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/dba743f3-9ccd-420f-a905-6bd37afa3e22)

```
--
  name: curvature
  message: ''
  hardware_id: ''
  values:
  - key: min
    value: '-0.047812135579225153'
  - key: max
    value: '0.039412954283098052'
  - key: mean
    value: '-0.0140280992746446812733'
- level: "\0"
--
```


## Notes for reviewer

The issue seems to be that the path points around the shift start point are not generated as intended, resulting in discontinuous curvature. 
This is likely caused by providing an initial velocity of 0.0 when generating the constant jerk path.

Although the direct cause is not entirely clear, setting the initial velocity to 1.0 during shift path generation resolved the issue, so this change will be applied in this PR.
Initially, I suspected inconsistencies in the path generation method described in the [documentation](https://autowarefoundation.github.io/autoware.universe/latest/planning/autoware_behavior_path_planner_common/docs/behavior_path_planner_path_generation_design/). However, I confirmed that the implementation follows the documentation and that there are no issues with the method itself.



<!-- Write a brief description of this PR. -->

## Tests performed
The measured curvature is under configured maximum curvature with lateral_acc from 0.4 to 0.5 



<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/7bef95e2-f70e-597f-a524-26f25c5ac613?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
