### PR TITLE
feat(tier4_autoware_utils): add the API to check if taken data is stale

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -64,6 +64,12 @@ public:
         "serialization while updateLatestData()");
     }
   };
+  /*
+   * @brief take and return the latest data from DDS queue if such data existed, otherwise return
+   * previous taken data("stale" data)
+   * @note if you want to ignore "stale" data, you should use takeNewData()
+   * instead
+   */
   typename T::ConstSharedPtr takeData()
   {
     auto new_data = std::make_shared<T>();
@@ -75,6 +81,25 @@ public:
 
     return data_;
   };
+
+  /*
+   * @brief take and return the latest data from DDS queue if such data existed, otherwise return
+   * nullptr instead
+   * @note this API allows you to avoid redundant computation on the taken data which is unchanged
+   * since the previous cycle
+   */
+  typename T::ConstSharedPtr takeNewData()
+  {
+    auto new_data = std::make_shared<T>();
+    rclcpp::MessageInfo message_info;
+    const bool success = subscriber_->take(*new_data, message_info);
+    if (success) {
+      data_ = new_data;
+      return data_;
+    } else {
+      return nullptr;
+    }
+  }
 };
 
 template <typename T, int N>

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -259,7 +259,7 @@ void LaneDepartureCheckerNode::onTimer()
   reference_trajectory_ = sub_reference_trajectory_.takeData();
   predicted_trajectory_ = sub_predicted_trajectory_.takeData();
 
-  const auto lanelet_map_bin_msg = sub_lanelet_map_bin_.takeData();
+  const auto lanelet_map_bin_msg = sub_lanelet_map_bin_.takeNewData();
   if (lanelet_map_bin_msg) {
     lanelet_map_ = std::make_shared<lanelet::LaneletMap>();
     lanelet::utils::conversion::fromBinMsg(


### PR DESCRIPTION
## Description

add `takeNewData` to polling subscriber

use case: current PollingSubscriber::takeData() returns the previously-taken data if popping from dds queue failed. But sometimes we want to know if the taken-data is "stale". For example we want to process lanelet_map message only when the process is called initially or the map has changed by differential loading.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

lane_departure_checker becomes lightweight.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
