### PR TITLE
ci(build-and-test-differential): set checkout fetch-depth to 1

### DIFF
--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Show disk space before the tasks
         run: df -h

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Show disk space before the tasks
         run: df -h


### PR DESCRIPTION
## Description

Right now this step takes about 2m22s.

![2024-06-10_12-04](https://github.com/autowarefoundation/autoware.universe/assets/10751153/fd7aeb02-c70f-4d22-94ed-c1e54e1403bc)

This happens for all jobs even before checking if any relevant files are changed.

**Before:** it downloaded the entire history and branches of the repository.
**After:** it only downloads the latest state of the repo (shallow copy).

## Tests performed

This PR CI, now it takes 5s (down from 2m22s).

![2024-06-10_12-10](https://github.com/autowarefoundation/autoware.universe/assets/10751153/5b2691e8-ef31-4e3b-8f89-34acadc1b91d)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
