### PR TITLE
feat(polling_subscriber): polling srbscriber for multiple data

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -20,19 +20,25 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 namespace tier4_autoware_utils
 {
 
-template <typename T>
-class InterProcessPollingSubscriber
+template <typename T, int N = 1, typename Enable = void>
+class InterProcessPollingSubscriber;
+
+template <typename T, int N>
+class InterProcessPollingSubscriber<T, N, typename std::enable_if<N == 1>::type>
 {
 public:
-  using SharedPtr = std::shared_ptr<InterProcessPollingSubscriber<T>>;
+  using SharedPtr =
+    std::shared_ptr<InterProcessPollingSubscriber<T, N, typename std::enable_if<N == 1>::type>>;
   static SharedPtr create_subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
-    return std::make_shared<InterProcessPollingSubscriber<T>>(node, topic_name, qos);
+    return std::make_shared<InterProcessPollingSubscriber<T, N>>(node, topic_name, qos);
   }
 
 private:
@@ -68,6 +74,56 @@ public:
     }
 
     return data_;
+  };
+};
+
+template <typename T, int N>
+class InterProcessPollingSubscriber<T, N, typename std::enable_if<(N >= 2)>::type>
+{
+public:
+  using SharedPtr =
+    std::shared_ptr<InterProcessPollingSubscriber<T, N, typename std::enable_if<(N >= 2)>::type>>;
+  static SharedPtr create_subscription(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{N})
+  {
+    return std::make_shared<InterProcessPollingSubscriber<T, N>>(node, topic_name, qos);
+  }
+
+private:
+  typename rclcpp::Subscription<T>::SharedPtr subscriber_;
+
+public:
+  explicit InterProcessPollingSubscriber(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{N})
+  {
+    auto noexec_callback_group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    auto noexec_subscription_options = rclcpp::SubscriptionOptions();
+    noexec_subscription_options.callback_group = noexec_callback_group;
+
+    subscriber_ = node->create_subscription<T>(
+      topic_name, qos,
+      [node]([[maybe_unused]] const typename T::ConstSharedPtr msg) { assert(false); },
+      noexec_subscription_options);
+    if (qos.get_rmw_qos_profile().depth != N) {
+      throw std::invalid_argument(
+        "InterProcessPollingSubscriber will be used with depth == " + std::to_string(N) +
+        ", which may cause inefficient serialization while updateLatestData()");
+    }
+  };
+  std::vector<typename T::ConstSharedPtr> takeData()
+  {
+    std::vector<typename T::ConstSharedPtr> data;
+    rclcpp::MessageInfo message_info;
+    for (int i = 0; i < N; ++i) {
+      auto datum = std::make_shared<T>();
+      if (subscriber_->take(*datum, message_info)) {
+        data.push_back(datum);
+      } else {
+        break;
+      }
+    }
+    return data;
   };
 };
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -105,7 +105,7 @@ public:
       topic_name, qos,
       [node]([[maybe_unused]] const typename T::ConstSharedPtr msg) { assert(false); },
       noexec_subscription_options);
-    if (qos.get_rmw_qos_profile().depth != N) {
+    if (qos.get_rmw_qos_profile().depth < N) {
       throw std::invalid_argument(
         "InterProcessPollingSubscriber will be used with depth == " + std::to_string(N) +
         ", which may cause inefficient serialization while updateLatestData()");


### PR DESCRIPTION
## Description

Enable accumulation of past data with a polling subscriber.
If you want to accumulate 100 pieces of past data, declare the polling subscriber as follows.

```cpp
tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry, 100>::SharedPtr sub_odom_;
```
By doing so, takeData returns a history as a std::vector.

```cpp
std::vector<std::shared_ptr<const nav_msgs::msg::Odometry>> msgs = sub_odom_->takeData();
```

It has been confirmed that it works correctly in [this branch](https://github.com/yhisaki/autoware.universe/tree/polling_subscriber-scenario_selector).

This feature is implemented using [template specialization](https://en.cppreference.com/w/cpp/language/partial_specialization) and [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae).

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
