### PR TITLE
feat(default_ad_api_helpers): use polling subscriber

### DIFF
--- a/system/default_ad_api_helpers/ad_api_adaptors/package.xml
+++ b/system/default_ad_api_helpers/ad_api_adaptors/package.xml
@@ -18,6 +18,7 @@
   <depend>map_height_fitter</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_autoware_utils</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.cpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.cpp
@@ -54,29 +54,17 @@ void RoutingAdaptor::on_timer()
     rclcpp::Time(rough_goal_msg->header.stamp) > last_time) {
     if (rclcpp::Time(fixed_goal_msg->header.stamp) > rclcpp::Time(rough_goal_msg->header.stamp)) {
       request_timing_control_ = 1;
-      route_->header = fixed_goal_msg->header;
-      route_->goal = fixed_goal_msg->pose;
-      route_->waypoints.clear();
-      route_->option.allow_goal_modification = false;
+      set_route_from_goal(fixed_goal_msg, false);
     } else {
       request_timing_control_ = 1;
-      route_->header = rough_goal_msg->header;
-      route_->goal = rough_goal_msg->pose;
-      route_->waypoints.clear();
-      route_->option.allow_goal_modification = true;
+      set_route_from_goal(rough_goal_msg, true);
     }
   } else if (fixed_goal_msg && rclcpp::Time(fixed_goal_msg->header.stamp) > last_time) {
     request_timing_control_ = 1;
-    route_->header = fixed_goal_msg->header;
-    route_->goal = fixed_goal_msg->pose;
-    route_->waypoints.clear();
-    route_->option.allow_goal_modification = false;
+    set_route_from_goal(fixed_goal_msg, false);
   } else if (rough_goal_msg && rclcpp::Time(rough_goal_msg->header.stamp) > last_time) {
     request_timing_control_ = 1;
-    route_->header = rough_goal_msg->header;
-    route_->goal = rough_goal_msg->pose;
-    route_->waypoints.clear();
-    route_->option.allow_goal_modification = true;
+    set_route_from_goal(rough_goal_msg, true);
   }
   if (waypoint_msg && rclcpp::Time(waypoint_msg->header.stamp) > last_time) {
     if (route_->header.frame_id != waypoint_msg->header.frame_id) {
@@ -108,6 +96,15 @@ void RoutingAdaptor::on_timer()
       cli_route_->async_send_request(route_, [this](auto) { calling_service_ = false; });
     }
   }
+}
+
+void RoutingAdaptor::set_route_from_goal(
+  const PoseStamped::ConstSharedPtr msg, const bool allow_goal_modification)
+{
+  route_->header = msg->header;
+  route_->goal = msg->pose;
+  route_->waypoints.clear();
+  route_->option.allow_goal_modification = allow_goal_modification;
 }
 
 void RoutingAdaptor::on_reroute(const PoseStamped::ConstSharedPtr pose)

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
@@ -61,8 +61,6 @@ private:
   void on_timer();
   void set_route_from_goal(
     const PoseStamped::ConstSharedPtr pose, const bool allow_goal_modification);
-  void on_rough_goal(const PoseStamped::ConstSharedPtr pose);
-  void on_waypoint(const PoseStamped::ConstSharedPtr pose);
   void on_reroute(const PoseStamped::ConstSharedPtr pose);
 };
 

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
@@ -18,6 +18,7 @@
 #include <autoware_ad_api_specs/routing.hpp>
 #include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/polling_subscriber.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
@@ -41,10 +42,14 @@ private:
   component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
   component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
   component_interface_utils::Subscription<RouteState>::SharedPtr sub_state_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_fixed_goal_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_rough_goal_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_waypoint_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_reroute_;
+  // Subscriber without callback
+  tier4_autoware_utils::InterProcessPollingSubscriber<PoseStamped> sub_fixed_goal_{
+    this, "~/input/fixed_goal"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<PoseStamped> sub_rough_goal_{
+    this, "~/input/rough_goal"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<PoseStamped> sub_waypoint_{
+    this, "~/input/waypoint"};
   rclcpp::TimerBase::SharedPtr timer_;
 
   bool calling_service_ = false;

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
@@ -58,7 +58,8 @@ private:
   RouteState::Message::_state_type state_;
 
   void on_timer();
-  void on_fixed_goal(const PoseStamped::ConstSharedPtr pose);
+  void set_route_from_goal(
+    const PoseStamped::ConstSharedPtr pose, const bool allow_goal_modification);
   void on_rough_goal(const PoseStamped::ConstSharedPtr pose);
   void on_waypoint(const PoseStamped::ConstSharedPtr pose);
   void on_reroute(const PoseStamped::ConstSharedPtr pose);

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
@@ -51,6 +51,7 @@ private:
   tier4_autoware_utils::InterProcessPollingSubscriber<PoseStamped> sub_waypoint_{
     this, "~/input/waypoint"};
   rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Time previous_timer_time_ = rclcpp::Time(0);
 
   bool calling_service_ = false;
   int request_timing_control_ = 0;


### PR DESCRIPTION
## Description

The same as https://github.com/autowarefoundation/autoware.universe/pull/6997 based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612), the polling subscriber is used in the default_ad_api_helpers.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim test were performed

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing but more efficient CPU usage

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
