### PR TITLE
fix(tier4_control_launch, crosswalk_traffic_light_estimator): fix a mistake when adding prefixes

### DIFF
--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -16,7 +16,6 @@
   <exec_depend>autoware_lane_departure_checker</exec_depend>
   <exec_depend>autoware_vehicle_cmd_gate</exec_depend>
   <exec_depend>control_evaluator</exec_depend>
-  <exec_depend>external_cmd_selector</exec_depend>
   <exec_depend>shift_decider</exec_depend>
   <exec_depend>trajectory_follower_node</exec_depend>
 

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "crosswalk_traffic_light_estimator/node.hpp"
+#include "autoware_crosswalk_traffic_light_estimator/node.hpp"
 
 #include <lanelet2_extension/regulatory_elements/Forward.hpp>
 #include <lanelet2_extension/utility/message_conversion.hpp>


### PR DESCRIPTION
## Description

I encountered the following error:

```
/home/shintarosakoda/autoware/src/universe/autoware.universe/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp:14:10: fatal error: crosswalk_traffic_light_estimator/node.hpp: そのようなファイルやディレクトリはありません
   14 | #include "crosswalk_traffic_light_estimator/node.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and

```
+ rosdep install -y --from-paths src --ignore-src --rosdistro humble
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
tier4_control_launch: Cannot locate rosdep definition for [external_cmd_selector]
```


Related PR

* https://github.com/autowarefoundation/autoware.universe/pull/7384
* https://github.com/autowarefoundation/autoware.universe/pull/7365

## Tests performed

I have confirmed that the build is successful on the local machine and that logging_simulator works properly.

## Effects on system behavior

There are no effects on system behavior.

## Interface changes

There are no interface changes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
