### PR TITLE
feat(autoware_control_validator): add polling subcribers

### DIFF
--- a/control/autoware_control_validator/include/autoware_control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware_control_validator/control_validator.hpp
@@ -73,7 +73,6 @@ private:
     this, "~/input/kinematics"};
   tier4_autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_reference_traj_{
     this, "~/input/reference_trajectory"};
-
   rclcpp::Publisher<ControlValidatorStatus>::SharedPtr pub_status_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_markers_;
 

--- a/control/autoware_control_validator/include/autoware_control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware_control_validator/control_validator.hpp
@@ -18,6 +18,7 @@
 #include "autoware_control_validator/debug_marker.hpp"
 #include "autoware_control_validator/msg/control_validator_status.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
+#include "tier4_autoware_utils/ros/polling_subscriber.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -48,7 +49,6 @@ class ControlValidator : public rclcpp::Node
 public:
   explicit ControlValidator(const rclcpp::NodeOptions & options);
 
-  void onReferenceTrajectory(const Trajectory::ConstSharedPtr msg);
   void onPredictedTrajectory(const Trajectory::ConstSharedPtr msg);
 
   bool checkValidMaxDistanceDeviation(const Trajectory & predicted_trajectory);
@@ -68,9 +68,12 @@ private:
 
   void setStatus(DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg);
 
-  rclcpp::Subscription<Odometry>::SharedPtr sub_kinematics_;
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_reference_traj_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_predicted_traj_;
+  tier4_autoware_utils::InterProcessPollingSubscriber<Odometry> sub_kinematics_{
+    this, "~/input/kinematics"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_reference_traj_{
+    this, "~/input/reference_trajectory"};
+
   rclcpp::Publisher<ControlValidatorStatus>::SharedPtr pub_status_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_markers_;
 


### PR DESCRIPTION
## Description

Add polling subscriber to control validator

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSIM
![image](https://github.com/autowarefoundation/autoware.universe/assets/25967964/6cc1e2df-aec7-48bd-b3cb-4791acc3e3d0)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
