### PR TITLE
fix(behavior_velocity_planner): fix test_depend

### DIFF
--- a/planning/autoware_behavior_velocity_planner/package.xml
+++ b/planning/autoware_behavior_velocity_planner/package.xml
@@ -68,6 +68,7 @@
   <test_depend>autoware_behavior_velocity_blind_spot_module</test_depend>
   <test_depend>autoware_behavior_velocity_crosswalk_module</test_depend>
   <test_depend>autoware_behavior_velocity_intersection_module</test_depend>
+  <test_depend>autoware_behavior_velocity_no_stopping_area_module</test_depend>
   <test_depend>autoware_behavior_velocity_occlusion_spot_module</test_depend>
   <test_depend>autoware_behavior_velocity_run_out_module</test_depend>
   <test_depend>autoware_behavior_velocity_stop_line_module</test_depend>
@@ -78,7 +79,6 @@
   <test_depend>behavior_velocity_blind_spot_module</test_depend>
   <test_depend>behavior_velocity_detection_area_module</test_depend>
   <test_depend>behavior_velocity_no_drivable_lane_module</test_depend>
-  <test_depend>behavior_velocity_no_stopping_area_module</test_depend>
   <test_depend>behavior_velocity_speed_bump_module</test_depend>
   <!--<test_depend>autoware_behavior_velocity_template_module</test_depend>-->
 

--- a/planning/autoware_behavior_velocity_planner/package.xml
+++ b/planning/autoware_behavior_velocity_planner/package.xml
@@ -66,6 +66,7 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_behavior_velocity_blind_spot_module</test_depend>
+  <test_depend>autoware_behavior_velocity_blind_spot_module</test_depend>
   <test_depend>autoware_behavior_velocity_crosswalk_module</test_depend>
   <test_depend>autoware_behavior_velocity_intersection_module</test_depend>
   <test_depend>autoware_behavior_velocity_no_stopping_area_module</test_depend>
@@ -76,7 +77,6 @@
   <test_depend>autoware_behavior_velocity_virtual_traffic_light_module</test_depend>
   <test_depend>autoware_behavior_velocity_walkway_module</test_depend>
   <test_depend>autoware_lint_common</test_depend>
-  <test_depend>behavior_velocity_blind_spot_module</test_depend>
   <test_depend>behavior_velocity_detection_area_module</test_depend>
   <test_depend>behavior_velocity_no_drivable_lane_module</test_depend>
   <test_depend>behavior_velocity_speed_bump_module</test_depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix 
```
+ rosdep install -y --from-paths src --ignore-src --rosdistro humble
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
autoware_behavior_velocity_planner: Cannot locate rosdep definition for [behavior_velocity_no_stopping_area_module]
```
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

rosdep install
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
