### PR TITLE
refactor(bpp): add namespace `autoware::`

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -41,22 +41,22 @@
   <arg name="behavior_path_planner_launch_modules" default="["/>
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::StaticObstacleAvoidanceModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::StaticObstacleAvoidanceModuleManager, '&quot;)"
     if="$(var launch_static_obstacle_avoidance)"
   />
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::DynamicObstacleAvoidanceModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::DynamicObstacleAvoidanceModuleManager, '&quot;)"
     if="$(var launch_dynamic_obstacle_avoidance)"
   />
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::SideShiftModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::SideShiftModuleManager, '&quot;)"
     if="$(var launch_side_shift_module)"
   />
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::StartPlannerModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::StartPlannerModuleManager, '&quot;)"
     if="$(var launch_start_planner_module)"
   />
   <let
@@ -66,17 +66,17 @@
   />
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::GoalPlannerModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::GoalPlannerModuleManager, '&quot;)"
     if="$(var launch_goal_planner_module)"
   />
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::LaneChangeRightModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::LaneChangeRightModuleManager, '&quot;)"
     if="$(var launch_lane_change_right_module)"
   />
   <let
     name="behavior_path_planner_launch_modules"
-    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'behavior_path_planner::LaneChangeLeftModuleManager, '&quot;)"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::LaneChangeLeftModuleManager, '&quot;)"
     if="$(var launch_lane_change_left_module)"
   />
   <let
@@ -176,7 +176,7 @@
   <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="both">
-    <composable_node pkg="autoware_behavior_path_planner" plugin="behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
+    <composable_node pkg="autoware_behavior_path_planner" plugin="autoware::behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
       <!-- topic remap -->
       <remap from="~/input/route" to="$(var input_route_topic_name)"/>
       <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -57,6 +57,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <exec_depend>autoware_behavior_path_planner</exec_depend>
   <exec_depend>autoware_behavior_velocity_planner</exec_depend>
   <exec_depend>autoware_costmap_generator</exec_depend>
   <exec_depend>autoware_external_cmd_selector</exec_depend>
@@ -71,7 +72,6 @@
   <exec_depend>autoware_scenario_selector</exec_depend>
   <exec_depend>autoware_surround_obstacle_checker</exec_depend>
   <exec_depend>autoware_velocity_smoother</exec_depend>
-  <exec_depend>behavior_path_planner</exec_depend>
   <exec_depend>glog_component</exec_depend>
   <exec_depend>obstacle_stop_planner</exec_depend>
   <exec_depend>planning_evaluator</exec_depend>

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/plugins.xml
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_avoidance_by_lane_change_module">
-  <class type="autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/data_structs.hpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/data_structs.hpp
@@ -18,7 +18,7 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::AvoidanceParameters;
+using autoware::behavior_path_planner::AvoidanceParameters;
 
 struct AvoidanceByLCParameters : public AvoidanceParameters
 {

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.cpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.cpp
@@ -22,8 +22,8 @@
 
 namespace autoware::behavior_path_planner
 {
+using autoware::behavior_path_planner::State;
 using autoware::route_handler::Direction;
-using ::behavior_path_planner::State;
 
 AvoidanceByLaneChangeInterface::AvoidanceByLaneChangeInterface(
   const std::string & name, rclcpp::Node & node,

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.hpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.hpp
@@ -27,9 +27,9 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::LaneChangeInterface;
-using ::behavior_path_planner::ObjectsOfInterestMarkerInterface;
-using ::behavior_path_planner::RTCInterface;
+using autoware::behavior_path_planner::LaneChangeInterface;
+using autoware::behavior_path_planner::ObjectsOfInterestMarkerInterface;
+using autoware::behavior_path_planner::RTCInterface;
 
 class AvoidanceByLaneChangeInterface : public LaneChangeInterface
 {

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.cpp
@@ -27,8 +27,8 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::getParameter;
-using ::behavior_path_planner::ObjectParameter;
+using autoware::behavior_path_planner::getParameter;
+using autoware::behavior_path_planner::ObjectParameter;
 
 void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
 {
@@ -198,4 +198,4 @@ AvoidanceByLaneChangeModuleManager::createNewSceneModuleInstance()
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
   autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager,
-  ::behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.hpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.hpp
@@ -28,9 +28,9 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::LaneChangeModuleManager;
-using ::behavior_path_planner::LaneChangeModuleType;
-using ::behavior_path_planner::SceneModuleInterface;
+using autoware::behavior_path_planner::LaneChangeModuleManager;
+using autoware::behavior_path_planner::LaneChangeModuleType;
+using autoware::behavior_path_planner::SceneModuleInterface;
 
 class AvoidanceByLaneChangeModuleManager : public LaneChangeModuleManager
 {

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -35,12 +35,12 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::Direction;
-using ::behavior_path_planner::LaneChangeModuleType;
-using ::behavior_path_planner::ObjectInfo;
-using ::behavior_path_planner::Point2d;
-using ::behavior_path_planner::utils::lane_change::debug::createExecutionArea;
-namespace utils = ::behavior_path_planner::utils;
+using autoware::behavior_path_planner::Direction;
+using autoware::behavior_path_planner::LaneChangeModuleType;
+using autoware::behavior_path_planner::ObjectInfo;
+using autoware::behavior_path_planner::Point2d;
+using autoware::behavior_path_planner::utils::lane_change::debug::createExecutionArea;
+namespace utils = autoware::behavior_path_planner::utils;
 
 AvoidanceByLaneChange::AvoidanceByLaneChange(
   const std::shared_ptr<LaneChangeParameters> & parameters,

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.hpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.hpp
@@ -23,15 +23,15 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::DebugData;
+using autoware::behavior_path_planner::DebugData;
 using AvoidanceDebugData = DebugData;
-using ::behavior_path_planner::AvoidancePlanningData;
-using ::behavior_path_planner::LaneChangeParameters;
-using ::behavior_path_planner::NormalLaneChange;
-using ::behavior_path_planner::ObjectData;
-using ::behavior_path_planner::ObjectDataArray;
-using ::behavior_path_planner::PredictedObject;
-using ::behavior_path_planner::helper::static_obstacle_avoidance::AvoidanceHelper;
+using autoware::behavior_path_planner::AvoidancePlanningData;
+using autoware::behavior_path_planner::LaneChangeParameters;
+using autoware::behavior_path_planner::NormalLaneChange;
+using autoware::behavior_path_planner::ObjectData;
+using autoware::behavior_path_planner::ObjectDataArray;
+using autoware::behavior_path_planner::PredictedObject;
+using autoware::behavior_path_planner::helper::static_obstacle_avoidance::AvoidanceHelper;
 
 class AvoidanceByLaneChange : public NormalLaneChange
 {

--- a/planning/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <vector>
 
-using ::behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()

--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware_behavior_path_dynamic_obstacle_avoidance_module/manager.hpp
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware_behavior_path_dynamic_obstacle_avoidance_module/manager.hpp
@@ -25,7 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class DynamicObstacleAvoidanceModuleManager : public SceneModuleManagerInterface
@@ -53,6 +53,6 @@ private:
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_DYNAMIC_OBSTACLE_AVOIDANCE_MODULE__MANAGER_HPP_

--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware_behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware_behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
@@ -55,7 +55,7 @@ std::vector<T> getAllKeys(const std::unordered_map<T, S> & map)
 }
 }  // namespace
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware_perception_msgs::msg::PredictedPath;
 using tier4_autoware_utils::Polygon2d;
@@ -459,6 +459,6 @@ private:
     std::chrono::milliseconds, std::chrono::microseconds, std::chrono::steady_clock>
     stop_watch_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_DYNAMIC_OBSTACLE_AVOIDANCE_MODULE__SCENE_HPP_

--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/plugins.xml
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_dynamic_obstacle_avoidance_module">
-  <class type="behavior_path_planner::DynamicObstacleAvoidanceModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::DynamicObstacleAvoidanceModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 namespace
 {
@@ -291,9 +291,9 @@ bool DynamicObstacleAvoidanceModuleManager::isAlwaysExecutableModule() const
 {
   return true;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::DynamicObstacleAvoidanceModuleManager,
-  behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::DynamicObstacleAvoidanceModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -37,7 +37,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 namespace
 {
@@ -1861,4 +1861,4 @@ DynamicObstacleAvoidanceModule::calcEgoPathReservePoly(const PathWithLaneId & eg
   return {left_avoid_poly, right_avoid_poly};
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -20,7 +20,7 @@
 
 #include <vector>
 
-using behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
@@ -47,7 +47,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
     ament_index_cpp::get_package_share_directory("behavior_path_planner");
 
   std::vector<std::string> module_names;
-  module_names.emplace_back("behavior_path_planner::DynamicAvoidanceModuleManager");
+  module_names.emplace_back("autoware::behavior_path_planner::DynamicAvoidanceModuleManager");
 
   std::vector<rclcpp::Parameter> params;
   params.emplace_back("launch_modules", module_names);

--- a/planning/autoware_behavior_path_external_request_lane_change_module/plugins.xml
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/plugins.xml
@@ -1,4 +1,4 @@
 <library path="autoware_behavior_path_external_request_lane_change_module">
-  <class type="autoware::behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
-  <class type="autoware::behavior_path_planner::ExternalRequestLaneChangeRightModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::ExternalRequestLaneChangeRightModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_external_request_lane_change_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/src/manager.cpp
@@ -19,7 +19,7 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::LaneChangeInterface;
+using autoware::behavior_path_planner::LaneChangeInterface;
 
 std::unique_ptr<SceneModuleInterface>
 ExternalRequestLaneChangeRightModuleManager::createNewSceneModuleInstance()
@@ -44,7 +44,7 @@ ExternalRequestLaneChangeLeftModuleManager::createNewSceneModuleInstance()
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
   autoware::behavior_path_planner::ExternalRequestLaneChangeRightModuleManager,
-  ::behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::SceneModuleManagerInterface)
 PLUGINLIB_EXPORT_CLASS(
   autoware::behavior_path_planner::ExternalRequestLaneChangeLeftModuleManager,
-  ::behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_external_request_lane_change_module/src/manager.hpp
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/src/manager.hpp
@@ -25,9 +25,9 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::LaneChangeModuleManager;
-using ::behavior_path_planner::LaneChangeModuleType;
-using ::behavior_path_planner::SceneModuleInterface;
+using autoware::behavior_path_planner::LaneChangeModuleManager;
+using autoware::behavior_path_planner::LaneChangeModuleType;
+using autoware::behavior_path_planner::SceneModuleInterface;
 
 class ExternalRequestLaneChangeRightModuleManager : public LaneChangeModuleManager
 {

--- a/planning/autoware_behavior_path_external_request_lane_change_module/src/scene.cpp
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/src/scene.cpp
@@ -20,7 +20,7 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::LaneChangeModuleType;
+using autoware::behavior_path_planner::LaneChangeModuleType;
 
 ExternalRequestLaneChange::ExternalRequestLaneChange(
   const std::shared_ptr<LaneChangeParameters> & parameters, Direction direction)

--- a/planning/autoware_behavior_path_external_request_lane_change_module/src/scene.hpp
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/src/scene.hpp
@@ -21,9 +21,9 @@
 
 namespace autoware::behavior_path_planner
 {
-using ::behavior_path_planner::Direction;
-using ::behavior_path_planner::LaneChangeParameters;
-using ::behavior_path_planner::NormalLaneChange;
+using autoware::behavior_path_planner::Direction;
+using autoware::behavior_path_planner::LaneChangeParameters;
+using autoware::behavior_path_planner::NormalLaneChange;
 
 class ExternalRequestLaneChange : public NormalLaneChange
 {

--- a/planning/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -22,7 +22,7 @@
 #include <cmath>
 #include <vector>
 
-using ::behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/default_fixed_goal_planner.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/default_fixed_goal_planner.hpp
@@ -21,7 +21,7 @@
 
 #include <memory>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class DefaultFixedGoalPlanner : public FixedGoalPlannerBase
@@ -40,6 +40,6 @@ protected:
     const PathWithLaneId & refined_path,
     const std::shared_ptr<const PlannerData> & planner_data) const;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__DEFAULT_FIXED_GOAL_PLANNER_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/fixed_goal_planner_base.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/fixed_goal_planner_base.hpp
@@ -26,7 +26,7 @@ using geometry_msgs::msg::Pose;
 using tier4_autoware_utils::LinearRing2d;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class FixedGoalPlannerBase
@@ -48,6 +48,6 @@ public:
 protected:
   BehaviorModuleOutput previous_module_output_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__FIXED_GOAL_PLANNER_BASE_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/freespace_pull_over.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/freespace_pull_over.hpp
@@ -26,7 +26,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::freespace_planning_algorithms::AbstractPlanningAlgorithm;
 using autoware::freespace_planning_algorithms::AstarSearch;
@@ -49,6 +49,6 @@ protected:
   bool use_back_;
   bool left_side_parking_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__FREESPACE_PULL_OVER_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/geometric_pull_over.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/geometric_pull_over.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::lane_departure_checker::LaneDepartureChecker;
 class GeometricPullOver : public PullOverPlannerBase
@@ -63,6 +63,6 @@ protected:
 
   GeometricParallelParking planner_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GEOMETRIC_PULL_OVER_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -48,7 +48,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::lane_departure_checker::LaneDepartureChecker;
 using autoware_vehicle_msgs::msg::HazardLightsCommand;
@@ -64,11 +64,11 @@ using autoware::freespace_planning_algorithms::PlannerCommonParam;
 using autoware::freespace_planning_algorithms::RRTStar;
 using autoware::freespace_planning_algorithms::RRTStarParam;
 
-using behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
-using behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
-using behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
+using autoware::behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 using tier4_autoware_utils::Polygon2d;
 
 #define DEFINE_SETTER_WITH_MUTEX(TYPE, NAME)                  \
@@ -666,6 +666,6 @@ private:
   void setDebugData();
   void printParkingPositionError() const;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GOAL_PLANNER_MODULE_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_planner_parameters.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_planner_parameters.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 using autoware::freespace_planning_algorithms::AstarParam;
@@ -126,6 +126,6 @@ struct GoalPlannerParameters
   // debug
   bool print_debug_info{false};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GOAL_PLANNER_PARAMETERS_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_searcher.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_searcher.hpp
@@ -21,7 +21,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using tier4_autoware_utils::LinearRing2d;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
@@ -70,6 +70,6 @@ private:
   LinearRing2d vehicle_footprint_{};
   bool left_side_parking_{true};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GOAL_SEARCHER_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_searcher_base.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/goal_searcher_base.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Pose;
 using tier4_autoware_utils::MultiPolygon2d;
@@ -76,6 +76,6 @@ protected:
   Pose reference_goal_pose_{};
   MultiPolygon2d area_polygons_{};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GOAL_SEARCHER_BASE_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/manager.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/manager.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class GoalPlannerModuleManager : public SceneModuleManagerInterface
@@ -53,6 +53,6 @@ private:
   std::shared_ptr<GoalPlannerParameters> parameters_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__MANAGER_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/pull_over_planner_base.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/pull_over_planner_base.hpp
@@ -29,7 +29,7 @@ using geometry_msgs::msg::Pose;
 using tier4_autoware_utils::LinearRing2d;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 enum class PullOverPlannerType {
   NONE = 0,
@@ -139,6 +139,6 @@ protected:
 
   BehaviorModuleOutput previous_module_output_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__PULL_OVER_PLANNER_BASE_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/shift_pull_over.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/shift_pull_over.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::lane_departure_checker::LaneDepartureChecker;
 
@@ -57,6 +57,6 @@ protected:
 
   bool left_side_parking_{true};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__SHIFT_PULL_OVER_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/util.hpp
+++ b/planning/autoware_behavior_path_goal_planner_module/include/autoware_behavior_path_goal_planner_module/util.hpp
@@ -33,7 +33,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::goal_planner_utils
+namespace autoware::behavior_path_planner::goal_planner_utils
 {
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
@@ -108,6 +108,6 @@ MarkerArray createLaneletPolygonMarkerArray(
 MarkerArray createNumObjectsToAvoidTextsMarkerArray(
   const GoalCandidates & goal_candidates, std::string && ns,
   const std_msgs::msg::ColorRGBA & color);
-}  // namespace behavior_path_planner::goal_planner_utils
+}  // namespace autoware::behavior_path_planner::goal_planner_utils
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_GOAL_PLANNER_MODULE__UTIL_HPP_

--- a/planning/autoware_behavior_path_goal_planner_module/plugins.xml
+++ b/planning/autoware_behavior_path_goal_planner_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_goal_planner_module">
-  <class type="behavior_path_planner::GoalPlannerModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::GoalPlannerModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
@@ -23,7 +23,7 @@
 
 #include <memory>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using Point2d = tier4_autoware_utils::Point2d;
 using tier4_planning_msgs::msg::PathWithLaneId;
@@ -105,4 +105,4 @@ PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection(
   return refined_path;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp
@@ -23,7 +23,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 FreespacePullOver::FreespacePullOver(
   rclcpp::Node & node, const GoalPlannerParameters & parameters,
@@ -137,4 +137,4 @@ std::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
 
   return pull_over_path;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_goal_planner_module/src/geometric_pull_over.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/geometric_pull_over.cpp
@@ -23,7 +23,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 GeometricPullOver::GeometricPullOver(
   rclcpp::Node & node, const GoalPlannerParameters & parameters,
@@ -79,4 +79,4 @@ std::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
 
   return pull_over_path;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -39,7 +39,7 @@
 #include <utility>
 #include <vector>
 
-using behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance;
+using autoware::behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance;
 using motion_utils::calcLongitudinalOffsetPose;
 using motion_utils::calcSignedArcLength;
 using motion_utils::findFirstNearestSegmentIndexWithSoftConstraints;
@@ -50,7 +50,7 @@ using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::inverseTransformPose;
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 GoalPlannerModule::GoalPlannerModule(
   const std::string & name, rclcpp::Node & node,
@@ -2152,8 +2152,8 @@ void GoalPlannerModule::updateSafetyCheckTargetObjectsData(
 static std::vector<utils::path_safety_checker::ExtendedPredictedObject> filterObjectsByWithinPolicy(
   const std::shared_ptr<const PredictedObjects> & objects,
   const lanelet::ConstLanelets & target_lanes,
-  const std::shared_ptr<behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams> &
-    params)
+  const std::shared_ptr<
+    autoware::behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams> & params)
 {
   // implanted part of behavior_path_planner::utils::path_safety_checker::filterObjects() and
   // createTargetObjectsOnLane()
@@ -2229,7 +2229,7 @@ std::pair<bool, bool> GoalPlannerModule::isSafePath(
   const bool is_object_front = true;
   const bool limit_to_max_velocity = true;
   const auto ego_predicted_path =
-    behavior_path_planner::utils::path_safety_checker::createPredictedPath(
+    autoware::behavior_path_planner::utils::path_safety_checker::createPredictedPath(
       ego_predicted_path_params, pull_over_path.points, current_pose, current_velocity, ego_seg_idx,
       is_object_front, limit_to_max_velocity);
 
@@ -2289,7 +2289,7 @@ std::pair<bool, bool> GoalPlannerModule::isSafePath(
   CollisionCheckDebugMap collision_check{};
   const bool current_is_safe = std::invoke([&]() {
     if (parameters.safety_check_params.method == "RSS") {
-      return behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS(
+      return autoware::behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS(
         pull_over_path, ego_predicted_path, filtered_objects, collision_check,
         planner_data->parameters, safety_check_params->rss_params,
         objects_filtering_params->use_all_predicted_path, hysteresis_factor);
@@ -2627,4 +2627,4 @@ void GoalPlannerModule::GoalPlannerData::update(
   goal_searcher->setReferenceGoal(goal_searcher_->getReferenceGoal());
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -30,7 +30,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::lane_departure_checker::LaneDepartureChecker;
 using lanelet::autoware::NoParkingArea;
@@ -545,4 +545,4 @@ GoalCandidate GoalSearcher::getClosetGoalCandidateAlongLanes(
   return *closest_goal_candidate;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 void GoalPlannerModuleManager::init(rclcpp::Node * node)
 {
@@ -878,9 +878,9 @@ bool GoalPlannerModuleManager::isSimultaneousExecutableAsCandidateModule() const
   return config_.enable_simultaneous_execution_as_candidate_module;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::GoalPlannerModuleManager,
-  behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::GoalPlannerModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_goal_planner_module/src/shift_pull_over.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/shift_pull_over.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 ShiftPullOver::ShiftPullOver(
   rclcpp::Node & node, const GoalPlannerParameters & parameters,
@@ -324,4 +324,4 @@ double ShiftPullOver::calcBeforeShiftedArcLength(
 
   return before_arc_length;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::goal_planner_utils
+namespace autoware::behavior_path_planner::goal_planner_utils
 {
 
 using tier4_autoware_utils::calcOffsetPose;
@@ -447,4 +447,4 @@ std::vector<Polygon2d> createPathFootPrints(
   return footprints;
 }
 
-}  // namespace behavior_path_planner::goal_planner_utils
+}  // namespace autoware::behavior_path_planner::goal_planner_utils

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/interface.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/interface.hpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::objects_of_interest_marker_interface::ColorName;
 using autoware::objects_of_interest_marker_interface::ObjectsOfInterestMarkerInterface;
@@ -154,6 +154,6 @@ protected:
 
   bool is_abort_approval_requested_{false};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__INTERFACE_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/manager.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/manager.hpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::route_handler::Direction;
 
@@ -71,6 +71,6 @@ public:
   {
   }
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__MANAGER_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/scene.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/scene.hpp
@@ -21,15 +21,16 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
+using autoware::behavior_path_planner::utils::path_safety_checker::
+  PoseWithVelocityAndPolygonStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
 using autoware::route_handler::Direction;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityAndPolygonStamped;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
 using data::lane_change::LanesPolygon;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
@@ -204,5 +205,5 @@ protected:
 
   double stop_time_{0.0};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__SCENE_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/base_class.hpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <utility>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::route_handler::Direction;
 using data::lane_change::PathSafetyStatus;
@@ -238,5 +238,5 @@ protected:
   rclcpp::Logger logger_ = utils::lane_change::getLogger(getModuleTypeStr());
   mutable rclcpp::Clock clock_{RCL_ROS_TIME};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__BASE_CLASS_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/data_structs.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 struct LateralAccelerationMap
 {
@@ -208,9 +208,9 @@ enum class LaneChangeModuleType {
   EXTERNAL_REQUEST,
   AVOIDANCE_BY_LANE_CHANGE,
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
-namespace behavior_path_planner::data::lane_change
+namespace autoware::behavior_path_planner::data::lane_change
 {
 struct PathSafetyStatus
 {
@@ -224,6 +224,6 @@ struct LanesPolygon
   std::optional<lanelet::BasicPolygon2d> target;
   std::vector<lanelet::BasicPolygon2d> target_backward;
 };
-}  // namespace behavior_path_planner::data::lane_change
+}  // namespace autoware::behavior_path_planner::data::lane_change
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__DATA_STRUCTS_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/debug_structs.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/debug_structs.hpp
@@ -26,7 +26,7 @@
 #include <limits>
 #include <string>
 
-namespace behavior_path_planner::data::lane_change
+namespace autoware::behavior_path_planner::data::lane_change
 {
 using utils::path_safety_checker::CollisionCheckDebugMap;
 struct Debug
@@ -71,6 +71,6 @@ struct Debug
     is_abort = false;
   }
 };
-}  // namespace behavior_path_planner::data::lane_change
+}  // namespace autoware::behavior_path_planner::data::lane_change
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__DEBUG_STRUCTS_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/markers.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/markers.hpp
@@ -29,9 +29,9 @@
 
 namespace marker_utils::lane_change_markers
 {
-using behavior_path_planner::LaneChangePath;
-using behavior_path_planner::data::lane_change::Debug;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObjects;
+using autoware::behavior_path_planner::LaneChangePath;
+using autoware::behavior_path_planner::data::lane_change::Debug;
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObjects;
 using visualization_msgs::msg::MarkerArray;
 MarkerArray showAllValidLaneChangePath(
   const std::vector<LaneChangePath> & lanes, std::string && ns);

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/path.hpp
@@ -23,9 +23,9 @@
 
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
-using behavior_path_planner::TurnSignalInfo;
+using autoware::behavior_path_planner::TurnSignalInfo;
 using tier4_planning_msgs::msg::PathWithLaneId;
 struct LaneChangePath
 {
@@ -49,5 +49,5 @@ struct LaneChangeStatus
   double start_distance{0.0};
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__PATH_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/autoware_behavior_path_lane_change_module/include/autoware_behavior_path_lane_change_module/utils/utils.hpp
@@ -36,16 +36,17 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::utils::lane_change
+namespace autoware::behavior_path_planner::utils::lane_change
 {
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
+using autoware::behavior_path_planner::utils::path_safety_checker::
+  PoseWithVelocityAndPolygonStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
 using autoware::route_handler::Direction;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityAndPolygonStamped;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
 using data::lane_change::LanesPolygon;
 using data::lane_change::PathSafetyStatus;
 using geometry_msgs::msg::Point;
@@ -297,15 +298,15 @@ double calcPhaseLength(
 LanesPolygon createLanesPolygon(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
   const std::vector<lanelet::ConstLanelets> & target_backward_lanes);
-}  // namespace behavior_path_planner::utils::lane_change
+}  // namespace autoware::behavior_path_planner::utils::lane_change
 
-namespace behavior_path_planner::utils::lane_change::debug
+namespace autoware::behavior_path_planner::utils::lane_change::debug
 {
 geometry_msgs::msg::Point32 create_point32(const geometry_msgs::msg::Pose & pose);
 
 geometry_msgs::msg::Polygon createExecutionArea(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const Pose & pose,
   double additional_lon_offset, double additional_lat_offset);
-}  // namespace behavior_path_planner::utils::lane_change::debug
+}  // namespace autoware::behavior_path_planner::utils::lane_change::debug
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/autoware_behavior_path_lane_change_module/plugins.xml
+++ b/planning/autoware_behavior_path_lane_change_module/plugins.xml
@@ -1,4 +1,4 @@
 <library path="autoware_behavior_path_lane_change_module">
-  <class type="behavior_path_planner::LaneChangeLeftModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
-  <class type="behavior_path_planner::LaneChangeRightModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::LaneChangeLeftModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::LaneChangeRightModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <utility>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using tier4_autoware_utils::appendMarkerArray;
 using utils::lane_change::assignToCandidate;
@@ -380,4 +380,4 @@ void LaneChangeInterface::updateSteeringFactorPtr(
     {output.start_distance_to_path_change, output.finish_distance_to_path_change},
     PlanningBehavior::LANE_CHANGE, steering_factor_direction, SteeringFactor::APPROACHING, "");
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 void LaneChangeModuleManager::init(rclcpp::Node * node)
@@ -390,12 +390,12 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
   });
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::LaneChangeRightModuleManager,
-  behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::LaneChangeRightModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::LaneChangeLeftModuleManager,
-  behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::LaneChangeLeftModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -35,7 +35,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using motion_utils::calcSignedArcLength;
 using utils::lane_change::calcMinimumLaneChangeLength;
@@ -1953,8 +1953,9 @@ bool NormalLaneChange::calcAbortPath()
   PathShifter path_shifter;
   path_shifter.setPath(lane_changing_path);
   path_shifter.addShiftLine(shift_line);
-  const auto lateral_jerk = behavior_path_planner::PathShifter::calcJerkFromLatLonDistance(
-    shift_line.end_shift_length, abort_start_dist, current_velocity);
+  const auto lateral_jerk =
+    autoware::behavior_path_planner::PathShifter::calcJerkFromLatLonDistance(
+      shift_line.end_shift_length, abort_start_dist, current_velocity);
   path_shifter.setVelocity(current_velocity);
   const auto lateral_acc_range =
     lane_change_parameters_->lane_change_lat_acc_map.find(current_velocity);
@@ -2248,4 +2249,4 @@ bool NormalLaneChange::check_prepare_phase() const
 
   return check_in_intersection || check_in_turns || check_in_general_lanes;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -55,7 +55,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::utils::lane_change
+namespace autoware::behavior_path_planner::utils::lane_change
 {
 using autoware::route_handler::RouteHandler;
 using autoware_perception_msgs::msg::ObjectClassification;
@@ -1226,9 +1226,9 @@ LanesPolygon createLanesPolygon(
   }
   return lanes_polygon;
 }
-}  // namespace behavior_path_planner::utils::lane_change
+}  // namespace autoware::behavior_path_planner::utils::lane_change
 
-namespace behavior_path_planner::utils::lane_change::debug
+namespace autoware::behavior_path_planner::utils::lane_change::debug
 {
 geometry_msgs::msg::Point32 create_point32(const geometry_msgs::msg::Pose & pose)
 {
@@ -1266,4 +1266,4 @@ geometry_msgs::msg::Polygon createExecutionArea(
   return polygon;
 }
 
-}  // namespace behavior_path_planner::utils::lane_change::debug
+}  // namespace autoware::behavior_path_planner::utils::lane_change::debug

--- a/planning/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -22,7 +22,7 @@
 #include <cmath>
 #include <vector>
 
-using behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
@@ -51,8 +51,8 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
     ament_index_cpp::get_package_share_directory("autoware_behavior_path_lane_change_module");
 
   std::vector<std::string> module_names;
-  module_names.emplace_back("behavior_path_planner::LaneChangeRightModuleManager");
-  module_names.emplace_back("behavior_path_planner::LaneChangeLeftModuleManager");
+  module_names.emplace_back("autoware::behavior_path_planner::LaneChangeRightModuleManager");
+  module_names.emplace_back("autoware::behavior_path_planner::LaneChangeLeftModuleManager");
 
   std::vector<rclcpp::Parameter> params;
   params.emplace_back("launch_modules", module_names);

--- a/planning/autoware_behavior_path_lane_change_module/test/test_lane_change_utils.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/test/test_lane_change_utils.cpp
@@ -41,7 +41,7 @@ TEST(BehaviorPathPlanningLaneChangeUtilsTest, projectCurrentPoseToTarget)
 
 TEST(BehaviorPathPlanningLaneChangeUtilsTest, TESTLateralAccelerationMap)
 {
-  behavior_path_planner::LateralAccelerationMap lat_acc_map;
+  autoware::behavior_path_planner::LateralAccelerationMap lat_acc_map;
   lat_acc_map.add(0.0, 0.2, 0.315);
   lat_acc_map.add(3.0, 0.2, 0.315);
   lat_acc_map.add(5.0, 0.2, 0.315);

--- a/planning/autoware_behavior_path_planner/CMakeLists.txt
+++ b/planning/autoware_behavior_path_planner/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(${PROJECT_NAME}_lib
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}_lib
-  PLUGIN "behavior_path_planner::BehaviorPathPlannerNode"
+  PLUGIN "autoware::behavior_path_planner::BehaviorPathPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 

--- a/planning/autoware_behavior_path_planner/include/autoware_behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/autoware_behavior_path_planner/include/autoware_behavior_path_planner/behavior_path_planner_node.hpp
@@ -49,7 +49,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_map_msgs::msg::LaneletMapBin;
@@ -226,6 +226,6 @@ private:
 
   std::unique_ptr<tier4_autoware_utils::PublishedTimePublisher> published_time_publisher_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER__BEHAVIOR_PATH_PLANNER_NODE_HPP_

--- a/planning/autoware_behavior_path_planner/include/autoware_behavior_path_planner/planner_manager.hpp
+++ b/planning/autoware_behavior_path_planner/include/autoware_behavior_path_planner/planner_manager.hpp
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 using tier4_autoware_utils::StopWatch;
@@ -469,6 +469,6 @@ private:
 
   size_t max_iteration_num_{100};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER__PLANNER_MANAGER_HPP_

--- a/planning/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -42,7 +42,7 @@ rclcpp::SubscriptionOptions createSubscriptionOptions(rclcpp::Node * node_ptr)
 }
 }  // namespace
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::vehicle_info_utils::VehicleInfoUtils;
 using tier4_planning_msgs::msg::PathChangeModuleId;
@@ -949,7 +949,7 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
 
   return result;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(behavior_path_planner::BehaviorPathPlannerNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::behavior_path_planner::BehaviorPathPlannerNode)

--- a/planning/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -28,11 +28,12 @@
 #include <memory>
 #include <string>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 PlannerManager::PlannerManager(rclcpp::Node & node, const size_t max_iteration_num)
 : plugin_loader_(
-    "autoware_behavior_path_planner", "behavior_path_planner::SceneModuleManagerInterface"),
+    "autoware_behavior_path_planner",
+    "autoware::behavior_path_planner::SceneModuleManagerInterface"),
   logger_(node.get_logger().get_child("planner_manager")),
   clock_(*node.get_clock()),
   max_iteration_num_{max_iteration_num}
@@ -980,4 +981,4 @@ std::string PlannerManager::getNames(const std::vector<SceneModulePtr> & modules
   return ss.str();
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner/test/input.cpp
+++ b/planning/autoware_behavior_path_planner/test/input.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "input.hpp"
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware_planning_msgs::msg::PathPoint;
 using geometry_msgs::msg::Twist;
@@ -87,4 +87,4 @@ Pose generateEgoSamplePose(float && p_x, float && p_y, float && p_z)
   pose.position.z = p_z;
   return pose;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner/test/input.hpp
+++ b/planning/autoware_behavior_path_planner/test/input.hpp
@@ -25,7 +25,7 @@
 
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware_planning_msgs::msg::PathPoint;
 using geometry_msgs::msg::Pose;
@@ -41,4 +41,4 @@ PathWithLaneId generateDiagonalSamplePathWithLaneId(
 Twist generateSampleEgoTwist(float && l_x, float && l_y, float && l_z);
 
 Pose generateEgoSamplePose(float && p_x, float && p_y, float && p_z);
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <vector>
 
-using behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()

--- a/planning/autoware_behavior_path_planner/test/test_utils.cpp
+++ b/planning/autoware_behavior_path_planner/test/test_utils.cpp
@@ -23,20 +23,20 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using behavior_path_planner::PathWithLaneId;
-using behavior_path_planner::Pose;
-using behavior_path_planner::utils::FrenetPoint;
+using autoware::behavior_path_planner::PathWithLaneId;
+using autoware::behavior_path_planner::Pose;
+using autoware::behavior_path_planner::utils::FrenetPoint;
 using geometry_msgs::msg::Point;
 
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnStraightLine)
 {
   PathWithLaneId path =
-    behavior_path_planner::generateStraightSamplePathWithLaneId(0.0f, 1.0f, 10u);
-  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(10.7f, -1.7f, 0.0);
+    autoware::behavior_path_planner::generateStraightSamplePathWithLaneId(0.0f, 1.0f, 10u);
+  Pose vehicle_pose = autoware::behavior_path_planner::generateEgoSamplePose(10.7f, -1.7f, 0.0);
 
   const size_t vehicle_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     path.points, vehicle_pose, 3.0, 1.0);
-  const auto vehicle_pose_frenet = behavior_path_planner::utils::convertToFrenetPoint(
+  const auto vehicle_pose_frenet = autoware::behavior_path_planner::utils::convertToFrenetPoint(
     path.points, vehicle_pose.position, vehicle_seg_idx);
 
   EXPECT_NEAR(vehicle_pose_frenet.distance, -1.7f, 1e-3);
@@ -46,12 +46,12 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnStraightLin
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnDiagonalLine)
 {
   PathWithLaneId path =
-    behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
-  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(0.1f, 0.1f, 0.0);
+    autoware::behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
+  Pose vehicle_pose = autoware::behavior_path_planner::generateEgoSamplePose(0.1f, 0.1f, 0.0);
 
   const size_t vehicle_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     path.points, vehicle_pose, 3.0, 1.0);
-  const auto vehicle_pose_frenet = behavior_path_planner::utils::convertToFrenetPoint(
+  const auto vehicle_pose_frenet = autoware::behavior_path_planner::utils::convertToFrenetPoint(
     path.points, vehicle_pose.position, vehicle_seg_idx);
 
   EXPECT_NEAR(vehicle_pose_frenet.distance, 0, 1e-2);
@@ -60,7 +60,8 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnDiagonalLin
 
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
 {
-  PathWithLaneId path = behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 5u);
+  PathWithLaneId path =
+    autoware::behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 5u);
   path.points.at(0).lane_ids.push_back(0);
   path.points.at(1).lane_ids.push_back(1);
   path.points.at(2).lane_ids.push_back(2);
@@ -70,7 +71,7 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
   path.points.at(4).lane_ids.push_back(5);
 
   PathWithLaneId path_with_goal;
-  behavior_path_planner::utils::setGoal(
+  autoware::behavior_path_planner::utils::setGoal(
     3.5, M_PI * 0.5, path, path.points.back().point.pose, 5, &path_with_goal);
 
   // Check if skipped lane ids by smooth skip connection are filled in output path.
@@ -83,8 +84,8 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
 
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, expandLanelets)
 {
-  using behavior_path_planner::DrivableLanes;
-  using behavior_path_planner::utils::expandLanelets;
+  using autoware::behavior_path_planner::DrivableLanes;
+  using autoware::behavior_path_planner::utils::expandLanelets;
   std::vector<DrivableLanes> original_lanelets;
   {  // empty list of lanelets, empty output
     const auto expanded_lanelets = expandLanelets(original_lanelets, 0.0, 0.0);

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/data_manager.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/data_manager.hpp
@@ -48,7 +48,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::route_handler::RouteHandler;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
@@ -267,6 +267,6 @@ struct PlannerData
   }
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__DATA_MANAGER_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -54,7 +54,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::objects_of_interest_marker_interface::ColorName;
 using autoware::objects_of_interest_marker_interface::ObjectsOfInterestMarkerInterface;
@@ -643,6 +643,6 @@ protected:
   mutable MarkerArray drivable_lanes_marker_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_INTERFACE_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/interface/scene_module_manager_interface.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/interface/scene_module_manager_interface.hpp
@@ -33,7 +33,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 using motion_utils::createDeadLineVirtualWallMarker;
@@ -346,6 +346,6 @@ protected:
   ModuleConfigParameters config_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_MANAGER_INTERFACE_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/interface/scene_module_visitor.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/interface/scene_module_visitor.hpp
@@ -18,7 +18,7 @@
 #include "tier4_planning_msgs/msg/detail/avoidance_debug_msg_array__struct.hpp"
 
 #include <memory>
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 // Forward Declaration
 class StaticObstacleAvoidanceModule;
@@ -42,6 +42,6 @@ public:
 protected:
   mutable std::shared_ptr<AvoidanceDebugMsgArray> avoidance_visitor_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__INTERFACE__SCENE_MODULE_VISITOR_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/marker_utils/utils.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/marker_utils/utils.hpp
@@ -34,14 +34,14 @@
 
 namespace marker_utils
 {
+using autoware::behavior_path_planner::DrivableLanes;
+using autoware::behavior_path_planner::ShiftLineArray;
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugPair;
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObjects;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
-using behavior_path_planner::DrivableLanes;
-using behavior_path_planner::ShiftLineArray;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugPair;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObjects;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/turn_signal_decider.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/turn_signal_decider.hpp
@@ -40,7 +40,7 @@
 #include <string>
 #include <utility>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::route_handler::RouteHandler;
 using autoware_vehicle_msgs::msg::HazardLightsCommand;
@@ -296,6 +296,6 @@ private:
   mutable double intersection_distance_ = std::numeric_limits<double>::max();
   mutable Pose intersection_pose_point_ = Pose();
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__TURN_SIGNAL_DECIDER_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/drivable_area_expansion.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/drivable_area_expansion.hpp
@@ -33,7 +33,7 @@ namespace drivable_area_expansion
 /// @param[inout] planner_data planning data (params, dynamic objects, vehicle info, ...)
 void expand_drivable_area(
   PathWithLaneId & path,
-  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data);
+  const std::shared_ptr<const autoware::behavior_path_planner::PlannerData> planner_data);
 
 /// @brief try to reuse the previous path poses and their previously calculated curvatures
 /// @details poses are reused if they do not deviate too much from the current path

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-namespace behavior_path_planner::utils
+namespace autoware::behavior_path_planner::utils
 {
 using drivable_area_expansion::DrivableAreaExpansionParameters;
 
@@ -100,7 +100,7 @@ std::vector<DrivableLanes> combineDrivableLanes(
   const std::vector<DrivableLanes> & original_drivable_lanes_vec,
   const std::vector<DrivableLanes> & new_drivable_lanes_vec);
 
-}  // namespace behavior_path_planner::utils
+}  // namespace autoware::behavior_path_planner::utils
 
 // clang-format off
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__STATIC_DRIVABLE_AREA_HPP_  // NOLINT

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.hpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 int discretizeAngle(const double theta, const int theta_size);
 
@@ -143,6 +143,6 @@ protected:
   PlannerWaypoints waypoints_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__OCCUPANCY_GRID_BASED_COLLISION_DETECTOR__OCCUPANCY_GRID_BASED_COLLISION_DETECTOR_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/common_module_data.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/common_module_data.hpp
@@ -21,12 +21,12 @@
 
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 using autoware_perception_msgs::msg::PredictedObjects;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 /*
  * Common data for start/goal_planner module
  */
@@ -40,6 +40,6 @@ struct StartGoalPlannerData
   CollisionCheckDebugMap collision_check;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PARKING_DEPARTURE__COMMON_MODULE_DATA_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
@@ -31,7 +31,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
@@ -148,7 +148,7 @@ private:
   Pose start_pose_{};
   Pose arc_end_pose_{};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 // clang-format off
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PARKING_DEPARTURE__GEOMETRIC_PARALLEL_PARKING_HPP_  // NOLINT

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/utils.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/utils.hpp
@@ -23,13 +23,13 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::utils::parking_departure
+namespace autoware::behavior_path_planner::utils::parking_departure
 {
 
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
-using behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
-using behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
-using behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
+using autoware::behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
 
 std::optional<double> calcFeasibleDecelDistance(
   std::shared_ptr<const PlannerData> planner_data, const double acc_lim, const double jerk_lim,
@@ -81,6 +81,6 @@ std::pair<double, bool> calcEndArcLength(
   const double s_start, const double forward_path_length, const lanelet::ConstLanelets & road_lanes,
   const Pose & goal_pose);
 
-}  // namespace behavior_path_planner::utils::parking_departure
+}  // namespace autoware::behavior_path_planner::utils::parking_departure
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PARKING_DEPARTURE__UTILS_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::utils::path_safety_checker::filter
+namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 {
 
 using autoware_perception_msgs::msg::PredictedObject;
@@ -42,9 +42,9 @@ bool position_filter(
   const geometry_msgs::msg::Point & current_pose, const double forward_distance,
   const double backward_distance);
 
-}  // namespace behavior_path_planner::utils::path_safety_checker::filter
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 
-namespace behavior_path_planner::utils::path_safety_checker
+namespace autoware::behavior_path_planner::utils::path_safety_checker
 {
 
 using autoware_perception_msgs::msg::PredictedObject;
@@ -318,6 +318,6 @@ void filterObjects(std::vector<PredictedObject> & objects, Func filter)
   [[maybe_unused]] std::vector<PredictedObject> removed_objects{};
   filterObjects(objects, removed_objects, filter);
 }
-}  // namespace behavior_path_planner::utils::path_safety_checker
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PATH_SAFETY_CHECKER__OBJECTS_FILTERING_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::utils::path_safety_checker
+namespace autoware::behavior_path_planner::utils::path_safety_checker
 {
 
 using autoware_perception_msgs::msg::PredictedObject;
@@ -236,7 +236,7 @@ using CollisionCheckDebugPair = std::pair<boost::uuids::uuid, CollisionCheckDebu
 using CollisionCheckDebugMap =
   std::unordered_map<CollisionCheckDebugPair::first_type, CollisionCheckDebugPair::second_type>;
 
-}  // namespace behavior_path_planner::utils::path_safety_checker
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker
 
 // clang-format off
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PATH_SAFETY_CHECKER__PATH_SAFETY_CHECKER_PARAMETERS_HPP_  // NOLINT

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -28,14 +28,14 @@
 
 #include <vector>
 
-namespace behavior_path_planner::utils::path_safety_checker
+namespace autoware::behavior_path_planner::utils::path_safety_checker
 {
 
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedPath;
 using autoware_perception_msgs::msg::Shape;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using tier4_autoware_utils::calcYawDeviation;
@@ -155,6 +155,6 @@ bool checkSafetyWithIntegralPredictedPolygon(
 CollisionCheckDebugPair createObjectDebug(const ExtendedPredictedObject & obj);
 void updateCollisionCheckDebugMap(
   CollisionCheckDebugMap & debug_map, CollisionCheckDebugPair & object_debug, bool is_safe);
-}  // namespace behavior_path_planner::utils::path_safety_checker
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PATH_SAFETY_CHECKER__SAFETY_CHECK_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
@@ -246,6 +246,6 @@ private:
   }
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PATH_SHIFTER__PATH_SHIFTER_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/path_utils.hpp
@@ -33,7 +33,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::utils
+namespace autoware::behavior_path_planner::utils
 {
 using autoware_planning_msgs::msg::Path;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
@@ -111,6 +111,6 @@ BehaviorModuleOutput getReferencePath(
 
 BehaviorModuleOutput createGoalAroundPath(const std::shared_ptr<const PlannerData> & planner_data);
 
-}  // namespace behavior_path_planner::utils
+}  // namespace autoware::behavior_path_planner::utils
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PATH_UTILS_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/traffic_light_utils.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/traffic_light_utils.hpp
@@ -30,7 +30,7 @@
 #include <limits>
 #include <memory>
 
-namespace behavior_path_planner::utils::traffic_light
+namespace autoware::behavior_path_planner::utils::traffic_light
 {
 
 using autoware_perception_msgs::msg::TrafficLightElement;
@@ -107,6 +107,6 @@ bool isStoppedAtRedTrafficLightWithinDistance(
  */
 bool isTrafficSignalStop(
   const lanelet::ConstLanelets & lanelets, const std::shared_ptr<const PlannerData> & planner_data);
-}  // namespace behavior_path_planner::utils::traffic_light
+}  // namespace autoware::behavior_path_planner::utils::traffic_light
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__TRAFFIC_LIGHT_UTILS_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/utils.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/utils.hpp
@@ -39,7 +39,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::utils
+namespace autoware::behavior_path_planner::utils
 {
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
@@ -348,6 +348,6 @@ size_t findNearestSegmentIndex(
 
   return motion_utils::findNearestSegmentIndex(points, pose.position);
 }
-}  // namespace behavior_path_planner::utils
+}  // namespace autoware::behavior_path_planner::utils
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__UTILS_HPP_

--- a/planning/autoware_behavior_path_planner_common/src/interface/scene_module_visitor.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/interface/scene_module_visitor.cpp
@@ -16,10 +16,10 @@
 
 #include "autoware_behavior_path_planner_common/interface/scene_module_interface.hpp"
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 std::shared_ptr<AvoidanceDebugMsgArray> SceneModuleVisitor::getAvoidanceModuleDebugMsg() const
 {
   return avoidance_visitor_;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
@@ -30,7 +30,7 @@
 
 namespace marker_utils
 {
-using behavior_path_planner::utils::calcPathArcLengthArray;
+using autoware::behavior_path_planner::utils::calcPathArcLengthArray;
 using std_msgs::msg::ColorRGBA;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
@@ -582,7 +582,7 @@ MarkerArray showFilteredObjects(
   const ExtendedPredictedObjects & predicted_objects, const std::string & ns,
   const ColorRGBA & color, int32_t id)
 {
-  using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
+  using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
   if (predicted_objects.empty()) {
     return MarkerArray{};
   }

--- a/planning/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <utility>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using motion_utils::calcSignedArcLength;
 
@@ -790,4 +790,4 @@ std::pair<TurnSignalInfo, bool> TurnSignalDecider::getBehaviorTurnSignalInfo(
   return std::make_pair(turn_signal_info, false);
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -359,7 +359,7 @@ void calculate_expansion_distances(
 
 void expand_drivable_area(
   PathWithLaneId & path,
-  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data)
+  const std::shared_ptr<const autoware::behavior_path_planner::PlannerData> planner_data)
 {
   // skip if no bounds or not enough points to calculate path curvature
   if (path.points.size() < 3 || path.left_bound.empty() || path.right_bound.empty()) return;

--- a/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -232,7 +232,7 @@ std::vector<lanelet::ConstPoint3d> extractBoundFromPolygon(
 }
 }  // namespace
 
-namespace behavior_path_planner::utils::drivable_area_processing
+namespace autoware::behavior_path_planner::utils::drivable_area_processing
 {
 std::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectBound(
   const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2,
@@ -636,9 +636,9 @@ std::vector<Point> updateBoundary(
 
   return center_pos;
 }
-}  // namespace behavior_path_planner::utils::drivable_area_processing
+}  // namespace autoware::behavior_path_planner::utils::drivable_area_processing
 
-namespace behavior_path_planner::utils
+namespace autoware::behavior_path_planner::utils
 {
 using tier4_autoware_utils::Point2d;
 
@@ -1822,4 +1822,4 @@ lanelet::ConstLanelets combineLanelets(
 
   return combined_lanes;
 }
-}  // namespace behavior_path_planner::utils
+}  // namespace autoware::behavior_path_planner::utils

--- a/planning/autoware_behavior_path_planner_common/src/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
@@ -19,7 +19,7 @@
 
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using tier4_autoware_utils::createQuaternionFromYaw;
 using tier4_autoware_utils::normalizeRadian;
@@ -214,4 +214,4 @@ bool OccupancyGridBasedCollisionDetector::hasObstacleOnPath(
   return false;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
@@ -41,7 +41,7 @@ using tier4_autoware_utils::normalizeRadian;
 using tier4_autoware_utils::transformPose;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 void GeometricParallelParking::incrementPathIndex()
 {
@@ -612,4 +612,4 @@ void GeometricParallelParking::setTurningRadius(
     common_params.wheel_base + common_params.front_overhang);
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
@@ -19,7 +19,7 @@
 #include <lanelet2_extension/utility/utilities.hpp>
 #include <motion_utils/distance/distance.hpp>
 
-namespace behavior_path_planner::utils::parking_departure
+namespace autoware::behavior_path_planner::utils::parking_departure
 {
 
 using motion_utils::calcDecelDistWithJerkAndAccConstraints;
@@ -136,7 +136,7 @@ std::optional<PathWithLaneId> generateFeasibleStopPath(
   // try to insert stop point in current_path after approval
   // but if can't stop with constraints(maximum deceleration, maximum jerk), don't insert stop point
   const auto min_stop_distance =
-    behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
+    autoware::behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
       planner_data, maximum_deceleration, maximum_jerk, 0.0);
 
   if (!min_stop_distance) {
@@ -177,4 +177,4 @@ std::pair<double, bool> calcEndArcLength(
   return {s_goal, true};
 }
 
-}  // namespace behavior_path_planner::utils::parking_departure
+}  // namespace autoware::behavior_path_planner::utils::parking_departure

--- a/planning/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -24,7 +24,7 @@
 
 #include <algorithm>
 
-namespace behavior_path_planner::utils::path_safety_checker::filter
+namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 {
 bool velocity_filter(const PredictedObject & object, double velocity_threshold, double max_velocity)
 {
@@ -53,9 +53,9 @@ bool is_within_circle(
     std::hypot(reference_point.x - object_pos.x, reference_point.y - object_pos.y);
   return dist < search_radius;
 }
-}  // namespace behavior_path_planner::utils::path_safety_checker::filter
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 
-namespace behavior_path_planner::utils::path_safety_checker
+namespace autoware::behavior_path_planner::utils::path_safety_checker
 {
 bool isCentroidWithinLanelet(const PredictedObject & object, const lanelet::ConstLanelet & lanelet)
 {
@@ -410,4 +410,4 @@ bool isTargetObjectType(
     (t == ObjectClassification::MOTORCYCLE && target_object_types.check_motorcycle) ||
     (t == ObjectClassification::PEDESTRIAN && target_object_types.check_pedestrian));
 }
-}  // namespace behavior_path_planner::utils::path_safety_checker
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker

--- a/planning/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -28,7 +28,7 @@
 
 #include <limits>
 
-namespace behavior_path_planner::utils::path_safety_checker
+namespace autoware::behavior_path_planner::utils::path_safety_checker
 {
 
 namespace bg = boost::geometry;
@@ -710,4 +710,4 @@ void updateCollisionCheckDebugMap(
   debug_map.insert(object_debug);
 }
 
-}  // namespace behavior_path_planner::utils::path_safety_checker
+}  // namespace autoware::behavior_path_planner::utils::path_safety_checker

--- a/planning/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
@@ -31,7 +31,7 @@ std::string toStr(const geometry_msgs::msg::Point & p)
 {
   return "(" + std::to_string(p.x) + ", " + std::to_string(p.y) + ", " + std::to_string(p.z) + ")";
 }
-std::string toStr(const behavior_path_planner::ShiftLine & p)
+std::string toStr(const autoware::behavior_path_planner::ShiftLine & p)
 {
   return "start point = " + toStr(p.start.position) + ", end point = " + toStr(p.end.position) +
          ", start idx = " + std::to_string(p.start_idx) +
@@ -48,7 +48,7 @@ std::string toStr(const std::vector<double> & v)
 }
 }  // namespace
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 using motion_utils::findNearestIndex;
@@ -648,4 +648,4 @@ std::optional<ShiftLine> PathShifter::getLastShiftLine() const
   return *furthest;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -32,7 +32,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::utils
+namespace autoware::behavior_path_planner::utils
 {
 /**
  * @brief calc path arclength on each points from start point to end point.
@@ -684,4 +684,4 @@ BehaviorModuleOutput createGoalAroundPath(const std::shared_ptr<const PlannerDat
   return output;
 }
 
-}  // namespace behavior_path_planner::utils
+}  // namespace autoware::behavior_path_planner::utils

--- a/planning/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -16,7 +16,7 @@
 #include <motion_utils/trajectory/trajectory.hpp>
 #include <traffic_light_utils/traffic_light_utils.hpp>
 
-namespace behavior_path_planner::utils::traffic_light
+namespace autoware::behavior_path_planner::utils::traffic_light
 {
 using motion_utils::calcSignedArcLength;
 
@@ -147,4 +147,4 @@ bool isTrafficSignalStop(
   return false;
 }
 
-}  // namespace behavior_path_planner::utils::traffic_light
+}  // namespace autoware::behavior_path_planner::utils::traffic_light

--- a/planning/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -69,7 +69,7 @@ double calcInterpolatedVelocity(
 }
 }  // namespace
 
-namespace behavior_path_planner::utils
+namespace autoware::behavior_path_planner::utils
 {
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::Shape;
@@ -1653,4 +1653,4 @@ bool checkOriginalGoalIsInShoulder(const std::shared_ptr<RouteHandler> & route_h
   const Pose & goal_pose = route_handler->getOriginalGoalPose();
   return !route_handler->getShoulderLaneletsAtPose(goal_pose).empty();
 }
-}  // namespace behavior_path_planner::utils
+}  // namespace autoware::behavior_path_planner::utils

--- a/planning/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
+++ b/planning/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
@@ -223,7 +223,7 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
     params.vehicle_info.wheel_base_m = 2.0;
     params.vehicle_info.vehicle_width_m = 2.0;
   }
-  behavior_path_planner::PlannerData planner_data;
+  autoware::behavior_path_planner::PlannerData planner_data;
   planner_data.drivable_area_expansion_parameters = params;
   planner_data.dynamic_object =
     std::make_shared<drivable_area_expansion::PredictedObjects>(dynamic_objects);
@@ -231,7 +231,7 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
   planner_data.route_handler =
     std::make_shared<autoware::route_handler::RouteHandler>(route_handler);
   drivable_area_expansion::expand_drivable_area(
-    path, std::make_shared<behavior_path_planner::PlannerData>(planner_data));
+    path, std::make_shared<autoware::behavior_path_planner::PlannerData>(planner_data));
   // unchanged path points
   ASSERT_EQ(path.points.size(), 3ul);
   for (auto i = 0.0; i < path.points.size(); ++i) {
@@ -260,7 +260,7 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
   path.points[1].point.pose.position.y = 0.5;
 
   drivable_area_expansion::expand_drivable_area(
-    path, std::make_shared<behavior_path_planner::PlannerData>(planner_data));
+    path, std::make_shared<autoware::behavior_path_planner::PlannerData>(planner_data));
   // expanded left bound
   ASSERT_EQ(path.left_bound.size(), 3ul);
   EXPECT_GT(path.left_bound[0].y, 1.0);

--- a/planning/autoware_behavior_path_planner_common/test/test_safety_check.cpp
+++ b/planning/autoware_behavior_path_planner_common/test/test_safety_check.cpp
@@ -27,8 +27,8 @@
 
 constexpr double epsilon = 1e-6;
 
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 using autoware_perception_msgs::msg::Shape;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
@@ -37,7 +37,7 @@ using tier4_autoware_utils::Polygon2d;
 
 TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
 {
-  using behavior_path_planner::utils::path_safety_checker::createExtendedPolygon;
+  using autoware::behavior_path_planner::utils::path_safety_checker::createExtendedPolygon;
 
   autoware::vehicle_info_utils::VehicleInfo vehicle_info;
   vehicle_info.max_longitudinal_offset_m = 4.0;
@@ -133,7 +133,7 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
 
 TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedObjPolygon)
 {
-  using behavior_path_planner::utils::path_safety_checker::createExtendedPolygon;
+  using autoware::behavior_path_planner::utils::path_safety_checker::createExtendedPolygon;
   using tier4_autoware_utils::createPoint;
   using tier4_autoware_utils::createQuaternionFromYaw;
 
@@ -183,8 +183,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedObjPolygon)
 
 TEST(BehaviorPathPlanningSafetyUtilsTest, calcRssDistance)
 {
-  using behavior_path_planner::utils::path_safety_checker::calcRssDistance;
-  using behavior_path_planner::utils::path_safety_checker::RSSparams;
+  using autoware::behavior_path_planner::utils::path_safety_checker::calcRssDistance;
+  using autoware::behavior_path_planner::utils::path_safety_checker::RSSparams;
 
   {
     const double front_vel = 5.0;

--- a/planning/autoware_behavior_path_planner_common/test/test_turn_signal.cpp
+++ b/planning/autoware_behavior_path_planner_common/test/test_turn_signal.cpp
@@ -22,13 +22,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+using autoware::behavior_path_planner::PathWithLaneId;
+using autoware::behavior_path_planner::Pose;
+using autoware::behavior_path_planner::TurnSignalDecider;
+using autoware::behavior_path_planner::TurnSignalInfo;
 using autoware_planning_msgs::msg::PathPoint;
 using autoware_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
-using behavior_path_planner::PathWithLaneId;
-using behavior_path_planner::Pose;
-using behavior_path_planner::TurnSignalDecider;
-using behavior_path_planner::TurnSignalInfo;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Twist;
 using tier4_autoware_utils::createPoint;

--- a/planning/autoware_behavior_path_sampling_planner_module/include/autoware_behavior_path_sampling_planner_module/manager.hpp
+++ b/planning/autoware_behavior_path_sampling_planner_module/include/autoware_behavior_path_sampling_planner_module/manager.hpp
@@ -28,8 +28,6 @@
 
 namespace autoware::behavior_path_planner
 {
-using namespace ::behavior_path_planner;  // NOLINT TODO(Maxime): remove once moved to autoware
-                                          // namespace
 class SamplingPlannerModuleManager : public SceneModuleManagerInterface
 {
 public:

--- a/planning/autoware_behavior_path_sampling_planner_module/include/autoware_behavior_path_sampling_planner_module/sampling_planner_module.hpp
+++ b/planning/autoware_behavior_path_sampling_planner_module/include/autoware_behavior_path_sampling_planner_module/sampling_planner_module.hpp
@@ -58,9 +58,6 @@
 #include <vector>
 namespace autoware::behavior_path_planner
 {
-// NOLINT
-using namespace ::behavior_path_planner;  // NOLINT TODO(Maxime): remove once moved to autoware
-                                          // namespace
 using autoware_planning_msgs::msg::TrajectoryPoint;
 struct SamplingPlannerData
 {

--- a/planning/autoware_behavior_path_sampling_planner_module/include/autoware_behavior_path_sampling_planner_module/util.hpp
+++ b/planning/autoware_behavior_path_sampling_planner_module/include/autoware_behavior_path_sampling_planner_module/util.hpp
@@ -28,8 +28,6 @@
 #include <vector>
 namespace autoware::behavior_path_planner
 {
-using namespace ::behavior_path_planner;  // NOLINT TODO(Maxime): remove once moved to autoware
-                                          // namespace
 using geometry_msgs::msg::Pose;
 
 struct SoftConstraintsInputs

--- a/planning/autoware_behavior_path_sampling_planner_module/plugins.xml
+++ b/planning/autoware_behavior_path_sampling_planner_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_sampling_planner_module">
-  <class type="autoware::behavior_path_planner::SamplingPlannerModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::SamplingPlannerModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_sampling_planner_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_sampling_planner_module/src/manager.cpp
@@ -139,4 +139,4 @@ void SamplingPlannerModuleManager::updateModuleParams(
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
   autoware::behavior_path_planner::SamplingPlannerModuleManager,
-  ::behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/data_structs.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using tier4_planning_msgs::msg::LateralOffset;
 
@@ -50,5 +50,5 @@ struct SideShiftDebugData
   double current_request{0.0};
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE_BEHAVIOR_PATH_SIDE_SHIFT_MODULE__DATA_STRUCTS_HPP_

--- a/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/manager.hpp
+++ b/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/manager.hpp
@@ -25,7 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class SideShiftModuleManager : public SceneModuleManagerInterface
@@ -48,6 +48,6 @@ private:
   std::shared_ptr<SideShiftParameters> parameters_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_SIDE_SHIFT_MODULE__MANAGER_HPP_

--- a/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/scene.hpp
+++ b/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/scene.hpp
@@ -30,7 +30,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::OccupancyGrid;
@@ -129,6 +129,6 @@ private:
   void setDebugMarkersVisualization() const;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_SIDE_SHIFT_MODULE__SCENE_HPP_

--- a/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/utils.hpp
+++ b/planning/autoware_behavior_path_side_shift_module/include/autoware_behavior_path_side_shift_module/utils.hpp
@@ -20,7 +20,7 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
@@ -39,6 +39,6 @@ Point transformToGrid(
   const Point & pt, const double longitudinal_offset, const double lateral_offset, const double yaw,
   const TransformStamped & geom_tf);
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_SIDE_SHIFT_MODULE__UTILS_HPP_

--- a/planning/autoware_behavior_path_side_shift_module/plugins.xml
+++ b/planning/autoware_behavior_path_side_shift_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_side_shift_module">
-  <class type="behavior_path_planner::SideShiftModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::SideShiftModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 void SideShiftModuleManager::init(rclcpp::Node * node)
@@ -60,8 +60,9 @@ void SideShiftModuleManager::updateModuleParams(
   });
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::SideShiftModuleManager, behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::SideShiftModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -26,7 +26,7 @@
 #include <memory>
 #include <string>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Point;
 using motion_utils::calcSignedArcLength;
@@ -160,10 +160,11 @@ bool SideShiftModule::canTransitSuccessState()
   const auto & inserted_shift_line_start_pose = inserted_shift_line_.start;
   const auto & inserted_shift_line_end_pose = inserted_shift_line_.end;
   const double self_to_shift_line_start_arc_length =
-    behavior_path_planner::utils::getSignedDistance(
+    autoware::behavior_path_planner::utils::getSignedDistance(
       current_pose, inserted_shift_line_start_pose, current_lanes);
-  const double self_to_shift_line_end_arc_length = behavior_path_planner::utils::getSignedDistance(
-    current_pose, inserted_shift_line_end_pose, current_lanes);
+  const double self_to_shift_line_end_arc_length =
+    autoware::behavior_path_planner::utils::getSignedDistance(
+      current_pose, inserted_shift_line_end_pose, current_lanes);
   if (self_to_shift_line_start_arc_length >= 0) {
     shift_status_ = SideShiftStatus::BEFORE_SHIFT;
   } else if (self_to_shift_line_start_arc_length < 0 && self_to_shift_line_end_arc_length > 0) {
@@ -480,4 +481,4 @@ void SideShiftModule::setDebugMarkersVisualization() const
     add_shift_line_marker("side_shift_shift_points", 0.7, 0.7, 0.7, 0.4);
   }
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_side_shift_module/src/utils.cpp
+++ b/planning/autoware_behavior_path_side_shift_module/src/utils.cpp
@@ -22,7 +22,7 @@
 
 #include <cmath>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 void setOrientation(PathWithLaneId * path)
 {
@@ -98,4 +98,4 @@ Point transformToGrid(
   return grid_pt;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <vector>
 
-using behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
@@ -50,7 +50,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
     ament_index_cpp::get_package_share_directory("behavior_path_planner");
 
   std::vector<std::string> module_names;
-  module_names.emplace_back("behavior_path_planner::SideShiftModuleManager");
+  module_names.emplace_back("autoware::behavior_path_planner::SideShiftModuleManager");
 
   std::vector<rclcpp::Parameter> params;
   params.emplace_back("launch_modules", module_names);

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/data_structs.hpp
@@ -26,13 +26,13 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 using autoware_perception_msgs::msg::PredictedObjects;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebugMap;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 
 using autoware::freespace_planning_algorithms::AstarParam;
 using autoware::freespace_planning_algorithms::PlannerCommonParam;
@@ -68,7 +68,7 @@ struct StartPlannerParameters
   std::vector<double> collision_check_margins{};
   double collision_check_margin_from_front_object{0.0};
   double th_moving_object_velocity{0.0};
-  behavior_path_planner::utils::path_safety_checker::ObjectTypesToCheck
+  autoware::behavior_path_planner::utils::path_safety_checker::ObjectTypesToCheck
     object_types_to_check_for_path_generation{};
   double center_line_path_interval{0.0};
   double lane_departure_check_expansion_margin{0.0};
@@ -126,12 +126,12 @@ struct StartPlannerParameters
   // surround moving obstacle check
   double search_radius{0.0};
   double th_moving_obstacle_velocity{0.0};
-  behavior_path_planner::utils::path_safety_checker::ObjectTypesToCheck
+  autoware::behavior_path_planner::utils::path_safety_checker::ObjectTypesToCheck
     surround_moving_obstacles_type_to_check{};
 
   bool print_debug_info{false};
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__DATA_STRUCTS_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/debug.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/debug.hpp
@@ -20,9 +20,9 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
-using behavior_path_planner::StartPlannerDebugData;
+using autoware::behavior_path_planner::StartPlannerDebugData;
 
 void updateSafetyCheckDebugData(
   StartPlannerDebugData & data, const PredictedObjects & filtered_objects,
@@ -34,6 +34,6 @@ void updateSafetyCheckDebugData(
   data.ego_predicted_path = ego_predicted_path;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__DEBUG_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/freespace_pull_out.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/freespace_pull_out.hpp
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::freespace_planning_algorithms::AbstractPlanningAlgorithm;
 using autoware::freespace_planning_algorithms::AstarSearch;
@@ -47,6 +47,6 @@ protected:
   double velocity_;
   bool use_back_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__FREESPACE_PULL_OUT_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 class GeometricPullOut : public PullOutPlannerBase
 {
@@ -42,6 +42,6 @@ public:
   ParallelParkingParameters parallel_parking_parameters_;
   std::shared_ptr<autoware::lane_departure_checker::LaneDepartureChecker> lane_departure_checker_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__GEOMETRIC_PULL_OUT_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/manager.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/manager.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class StartPlannerModuleManager : public SceneModuleManagerInterface
@@ -51,6 +51,6 @@ private:
   std::shared_ptr<StartPlannerParameters> parameters_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__MANAGER_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/pull_out_path.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/pull_out_path.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using tier4_planning_msgs::msg::PathWithLaneId;
 struct PullOutPath
@@ -33,5 +33,5 @@ struct PullOutPath
   Pose start_pose{};
   Pose end_pose{};
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__PULL_OUT_PATH_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -26,7 +26,7 @@
 
 #include <memory>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using geometry_msgs::msg::Pose;
 using tier4_autoware_utils::LinearRing2d;
@@ -65,7 +65,7 @@ public:
 
 protected:
   bool isPullOutPathCollided(
-    behavior_path_planner::PullOutPath & pull_out_path,
+    autoware::behavior_path_planner::PullOutPath & pull_out_path,
     double collision_check_distance_from_end) const
   {
     // check for collisions
@@ -86,7 +86,7 @@ protected:
       pull_out_lane_stop_objects, parameters_.object_types_to_check_for_path_generation);
 
     const auto collision_check_section_path =
-      behavior_path_planner::start_planner_utils::extractCollisionCheckSection(
+      autoware::behavior_path_planner::start_planner_utils::extractCollisionCheckSection(
         pull_out_path, collision_check_distance_from_end);
     if (!collision_check_section_path) return true;
 
@@ -100,6 +100,6 @@ protected:
   StartPlannerParameters parameters_;
   double collision_check_margin_;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__PULL_OUT_PLANNER_BASE_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/shift_pull_out.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware::lane_departure_checker::LaneDepartureChecker;
 
@@ -59,6 +59,6 @@ private:
     const double lon_acc, const double shift_time, const double shift_length,
     const double max_curvature, const double min_distance) const;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__SHIFT_PULL_OUT_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/start_planner_module.hpp
@@ -44,14 +44,14 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
+using autoware::behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
+using autoware::behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 using autoware::lane_departure_checker::LaneDepartureChecker;
-using behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
-using behavior_path_planner::utils::path_safety_checker::ObjectsFilteringParams;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::SafetyCheckParams;
-using behavior_path_planner::utils::path_safety_checker::TargetObjectsOnLane;
 using geometry_msgs::msg::PoseArray;
 using PriorityOrder = std::vector<std::pair<size_t, std::shared_ptr<PullOutPlannerBase>>>;
 
@@ -201,7 +201,7 @@ private:
   bool requiresDynamicObjectsCollisionDetection() const;
 
   uint16_t getSteeringFactorDirection(
-    const behavior_path_planner::BehaviorModuleOutput & output) const
+    const autoware::behavior_path_planner::BehaviorModuleOutput & output) const
   {
     switch (output.turn_signal_info.turn_signal.command) {
       case TurnIndicatorsCommand::ENABLE_LEFT:
@@ -242,13 +242,13 @@ private:
     const Pose & refined_start_pose, const Pose & goal_pose, const double collision_check_margin);
 
   PathWithLaneId extractCollisionCheckSection(
-    const PullOutPath & path, const behavior_path_planner::PlannerType & planner_type);
+    const PullOutPath & path, const autoware::behavior_path_planner::PlannerType & planner_type);
   void updateStatusWithCurrentPath(
-    const behavior_path_planner::PullOutPath & path, const Pose & start_pose,
-    const behavior_path_planner::PlannerType & planner_type);
+    const autoware::behavior_path_planner::PullOutPath & path, const Pose & start_pose,
+    const autoware::behavior_path_planner::PlannerType & planner_type);
   void updateStatusWithNextPath(
-    const behavior_path_planner::PullOutPath & path, const Pose & start_pose,
-    const behavior_path_planner::PlannerType & planner_type);
+    const autoware::behavior_path_planner::PullOutPath & path, const Pose & start_pose,
+    const autoware::behavior_path_planner::PlannerType & planner_type);
   void updateStatusIfNoSafePathFound();
 
   std::shared_ptr<StartPlannerParameters> parameters_;
@@ -334,6 +334,6 @@ private:
   void setDebugData();
   void logPullOutStatus(rclcpp::Logger::Level log_level = rclcpp::Logger::Level::Info) const;
 };
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__START_PLANNER_MODULE_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/util.hpp
+++ b/planning/autoware_behavior_path_start_planner_module/include/autoware_behavior_path_start_planner_module/util.hpp
@@ -34,12 +34,12 @@
 #include <memory>
 #include <utility>
 
-namespace behavior_path_planner::start_planner_utils
+namespace autoware::behavior_path_planner::start_planner_utils
 {
+using autoware::behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
 using autoware::route_handler::RouteHandler;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
-using behavior_path_planner::utils::path_safety_checker::EgoPredictedPathParams;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using tier4_planning_msgs::msg::PathWithLaneId;
@@ -53,6 +53,6 @@ Pose getBackedPose(
   const Pose & current_pose, const double & yaw_shoulder_lane, const double & back_distance);
 std::optional<PathWithLaneId> extractCollisionCheckSection(
   const PullOutPath & path, const double collision_check_distance_from_end);
-}  // namespace behavior_path_planner::start_planner_utils
+}  // namespace autoware::behavior_path_planner::start_planner_utils
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_START_PLANNER_MODULE__UTIL_HPP_

--- a/planning/autoware_behavior_path_start_planner_module/plugins.xml
+++ b/planning/autoware_behavior_path_start_planner_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_start_planner_module">
-  <class type="behavior_path_planner::StartPlannerModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::StartPlannerModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_start_planner_module/src/debug.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/debug.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware_behavior_path_start_planner_module/debug.hpp"
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 void updateSafetyCheckDebugData(
@@ -27,4 +27,4 @@ void updateSafetyCheckDebugData(
   data.ego_predicted_path = ego_predicted_path;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 FreespacePullOut::FreespacePullOut(
   rclcpp::Node & node, const StartPlannerParameters & parameters,
@@ -91,8 +91,9 @@ std::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const
   constexpr double offset_from_end_pose = 1.0;
   const auto arc_position_end = lanelet::utils::getArcCoordinates(road_lanes, end_pose);
   const double s_start = std::max(arc_position_end.length + offset_from_end_pose, 0.0);
-  const auto path_end_info = behavior_path_planner::utils::parking_departure::calcEndArcLength(
-    s_start, forward_path_length, road_lanes, goal_pose);
+  const auto path_end_info =
+    autoware::behavior_path_planner::utils::parking_departure::calcEndArcLength(
+      s_start, forward_path_length, road_lanes, goal_pose);
   const double s_end = path_end_info.first;
   const bool path_terminal_is_goal = path_end_info.second;
 
@@ -114,4 +115,4 @@ std::optional<PullOutPath> FreespacePullOut::plan(const Pose & start_pose, const
 
   return pull_out_path;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -26,7 +26,7 @@ using lanelet::utils::getArcCoordinates;
 using motion_utils::findNearestIndex;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcOffsetPose;
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using start_planner_utils::getPullOutLanes;
 
@@ -121,4 +121,4 @@ std::optional<PullOutPath> GeometricPullOut::plan(const Pose & start_pose, const
 
   return output;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 void StartPlannerModuleManager::init(rclcpp::Node * node)
 {
@@ -795,9 +795,9 @@ bool StartPlannerModuleManager::isSimultaneousExecutableAsCandidateModule() cons
 
   return std::all_of(observers_.begin(), observers_.end(), checker);
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::StartPlannerModuleManager,
-  behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::StartPlannerModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -31,7 +31,7 @@ using lanelet::utils::getArcCoordinates;
 using motion_utils::findNearestIndex;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcOffsetPose;
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using start_planner_utils::getPullOutLanes;
 
@@ -225,8 +225,9 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   // generate road lane reference path
   const auto arc_position_start = getArcCoordinates(road_lanes, start_pose);
   const double s_start = std::max(arc_position_start.length - backward_path_length, 0.0);
-  const auto path_end_info = behavior_path_planner::utils::parking_departure::calcEndArcLength(
-    s_start, forward_path_length, road_lanes, goal_pose);
+  const auto path_end_info =
+    autoware::behavior_path_planner::utils::parking_departure::calcEndArcLength(
+      s_start, forward_path_length, road_lanes, goal_pose);
   const double s_end = path_end_info.first;
   const bool path_terminal_is_goal = path_end_info.second;
 
@@ -416,4 +417,4 @@ double ShiftPullOut::calcBeforeShiftedArcLength(
   return before_arc_length;
 }
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -39,8 +39,8 @@
 #include <utility>
 #include <vector>
 
-using behavior_path_planner::utils::parking_departure::initializeCollisionCheckDebugMap;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
+using autoware::behavior_path_planner::utils::parking_departure::initializeCollisionCheckDebugMap;
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
 using motion_utils::calcLateralOffset;
 using motion_utils::calcLongitudinalOffsetPose;
 using tier4_autoware_utils::calcOffsetPose;
@@ -50,7 +50,7 @@ using tier4_autoware_utils::calcOffsetPose;
 #define DEBUG_PRINT(...) \
   RCLCPP_DEBUG_EXPRESSION(getLogger(), parameters_->print_debug_info, __VA_ARGS__)
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 StartPlannerModule::StartPlannerModule(
   const std::string & name, rclcpp::Node & node,
@@ -478,7 +478,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
     lanelet::ConstLanelet closest_lanelet_const(closest_lanelet.constData());
     // Check backwards just in case the Vehicle behind ego is in a different lanelet
     constexpr double backwards_length = 200.0;
-    const auto prev_lanes = behavior_path_planner::utils::getBackwardLanelets(
+    const auto prev_lanes = autoware::behavior_path_planner::utils::getBackwardLanelets(
       *route_handler, target_lanes, current_pose, backwards_length);
     // return all the relevant lanelets
     lanelet::ConstLanelets relevant_lanelets{closest_lanelet_const};
@@ -658,7 +658,7 @@ BehaviorModuleOutput StartPlannerModule::plan()
     if (!status_.is_safe_dynamic_objects) {
       auto current_path = getCurrentPath();
       const auto stop_path =
-        behavior_path_planner::utils::parking_departure::generateFeasibleStopPath(
+        autoware::behavior_path_planner::utils::parking_departure::generateFeasibleStopPath(
           current_path, planner_data_, stop_pose_, parameters_->maximum_deceleration_for_stop,
           parameters_->maximum_jerk_for_stop);
 
@@ -915,8 +915,8 @@ bool StartPlannerModule::findPullOutPath(
 }
 
 void StartPlannerModule::updateStatusWithCurrentPath(
-  const behavior_path_planner::PullOutPath & path, const Pose & start_pose,
-  const behavior_path_planner::PlannerType & planner_type)
+  const autoware::behavior_path_planner::PullOutPath & path, const Pose & start_pose,
+  const autoware::behavior_path_planner::PlannerType & planner_type)
 {
   const std::lock_guard<std::mutex> lock(mutex_);
   status_.driving_forward = true;
@@ -927,8 +927,8 @@ void StartPlannerModule::updateStatusWithCurrentPath(
 }
 
 void StartPlannerModule::updateStatusWithNextPath(
-  const behavior_path_planner::PullOutPath & path, const Pose & start_pose,
-  const behavior_path_planner::PlannerType & planner_type)
+  const autoware::behavior_path_planner::PullOutPath & path, const Pose & start_pose,
+  const autoware::behavior_path_planner::PlannerType & planner_type)
 {
   const std::lock_guard<std::mutex> lock(mutex_);
   status_.driving_forward = false;
@@ -1371,7 +1371,7 @@ bool StartPlannerModule::isSafePath() const
   const bool is_object_front = true;
   const bool limit_to_max_velocity = true;
   const auto ego_predicted_path =
-    behavior_path_planner::utils::path_safety_checker::createPredictedPath(
+    autoware::behavior_path_planner::utils::path_safety_checker::createPredictedPath(
       ego_predicted_path_params_, pull_out_path.points, current_pose, current_velocity, ego_seg_idx,
       is_object_front, limit_to_max_velocity);
 
@@ -1401,7 +1401,7 @@ bool StartPlannerModule::isSafePath() const
   merged_target_object.insert(
     merged_target_object.end(), target_objects_on_lane.on_shoulder_lane.begin(),
     target_objects_on_lane.on_shoulder_lane.end());
-  return behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS(
+  return autoware::behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS(
     pull_out_path, ego_predicted_path, merged_target_object, debug_data_.collision_check,
     planner_data_->parameters, safety_check_params_->rss_params,
     objects_filtering_params_->use_all_predicted_path, hysteresis_factor);
@@ -1831,4 +1831,4 @@ void StartPlannerModule::StartPlannerData::update(
   main_thread_pull_out_status = pull_out_status_;
   is_stopped = is_stopped_;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::start_planner_utils
+namespace autoware::behavior_path_planner::start_planner_utils
 {
 PathWithLaneId getBackwardPath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & shoulder_lanes,
@@ -139,4 +139,4 @@ std::optional<PathWithLaneId> extractCollisionCheckSection(
   return collision_check_section;
 }
 
-}  // namespace behavior_path_planner::start_planner_utils
+}  // namespace autoware::behavior_path_planner::start_planner_utils

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -32,11 +32,11 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
+using autoware::behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 using autoware::route_handler::Direction;
-using behavior_path_planner::utils::path_safety_checker::CollisionCheckDebug;
 
 enum class ObjectInfo {
   NONE = 0,
@@ -671,6 +671,6 @@ struct DebugData
   AvoidanceDebugMsgArray avoidance_debug_msg_array;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__DATA_STRUCTS_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/debug.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/debug.hpp
@@ -21,17 +21,17 @@
 #include <memory>
 #include <string>
 
-namespace behavior_path_planner::utils::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 
-using behavior_path_planner::AvoidanceParameters;
-using behavior_path_planner::AvoidancePlanningData;
-using behavior_path_planner::AvoidLineArray;
-using behavior_path_planner::DebugData;
-using behavior_path_planner::ObjectDataArray;
-using behavior_path_planner::ObjectInfo;
-using behavior_path_planner::PathShifter;
-using behavior_path_planner::ShiftLineArray;
+using autoware::behavior_path_planner::AvoidanceParameters;
+using autoware::behavior_path_planner::AvoidancePlanningData;
+using autoware::behavior_path_planner::AvoidLineArray;
+using autoware::behavior_path_planner::DebugData;
+using autoware::behavior_path_planner::ObjectDataArray;
+using autoware::behavior_path_planner::ObjectInfo;
+using autoware::behavior_path_planner::PathShifter;
+using autoware::behavior_path_planner::ShiftLineArray;
 
 MarkerArray createEgoStatusMarkerArray(
   const AvoidancePlanningData & data, const Pose & p_ego, std::string && ns);
@@ -50,14 +50,14 @@ MarkerArray createOtherObjectsMarkerArray(
 MarkerArray createDebugMarkerArray(
   const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug,
   const std::shared_ptr<AvoidanceParameters> & parameters);
-}  // namespace behavior_path_planner::utils::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 
-std::string toStrInfo(const behavior_path_planner::ShiftLineArray & sl_arr);
+std::string toStrInfo(const autoware::behavior_path_planner::ShiftLineArray & sl_arr);
 
-std::string toStrInfo(const behavior_path_planner::AvoidLineArray & ap_arr);
+std::string toStrInfo(const autoware::behavior_path_planner::AvoidLineArray & ap_arr);
 
-std::string toStrInfo(const behavior_path_planner::ShiftLine & sl);
+std::string toStrInfo(const autoware::behavior_path_planner::ShiftLine & sl);
 
-std::string toStrInfo(const behavior_path_planner::AvoidLine & ap);
+std::string toStrInfo(const autoware::behavior_path_planner::AvoidLine & ap);
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__DEBUG_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/helper.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/helper.hpp
@@ -26,11 +26,11 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::helper::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::helper::static_obstacle_avoidance
 {
 
-using behavior_path_planner::PathShifter;
-using behavior_path_planner::PlannerData;
+using autoware::behavior_path_planner::PathShifter;
+using autoware::behavior_path_planner::PlannerData;
 
 class AvoidanceHelper
 {
@@ -518,6 +518,6 @@ private:
 
   std::optional<std::pair<Pose, double>> max_v_point_;
 };
-}  // namespace behavior_path_planner::helper::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::helper::static_obstacle_avoidance
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__HELPER_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/manager.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/manager.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 class StaticObstacleAvoidanceModuleManager : public SceneModuleManagerInterface
@@ -50,6 +50,6 @@ private:
   std::shared_ptr<AvoidanceParameters> parameters_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__MANAGER_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 using autoware_perception_msgs::msg::ObjectClassification;
 using tier4_autoware_utils::getOrDeclareParameter;
@@ -401,6 +401,6 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
 
   return p;
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__PARAMETER_HELPER_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -33,7 +33,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 
 using helper::static_obstacle_avoidance::AvoidanceHelper;
@@ -456,6 +456,6 @@ private:
   mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
 };
 
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__SCENE_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/shift_line_generator.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/shift_line_generator.hpp
@@ -22,11 +22,11 @@
 
 #include <memory>
 
-namespace behavior_path_planner::utils::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 
-using behavior_path_planner::PathShifter;
-using behavior_path_planner::helper::static_obstacle_avoidance::AvoidanceHelper;
+using autoware::behavior_path_planner::PathShifter;
+using autoware::behavior_path_planner::helper::static_obstacle_avoidance::AvoidanceHelper;
 
 class ShiftLineGenerator
 {
@@ -242,6 +242,6 @@ private:
   double base_offset_{0.0};
 };
 
-}  // namespace behavior_path_planner::utils::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__SHIFT_LINE_GENERATOR_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/type_alias.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/type_alias.hpp
@@ -31,7 +31,7 @@
 #include <tier4_rtc_msgs/msg/state.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 // auto msgs
 using autoware_perception_msgs::msg::PredictedObject;
@@ -69,6 +69,6 @@ using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 using tier4_autoware_utils::pose2transform;
 using tier4_autoware_utils::toHexString;
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__TYPE_ALIAS_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/utils.hpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware_behavior_path_static_obstacle_avoidance_module/utils.hpp
@@ -23,14 +23,15 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::utils::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 
-using behavior_path_planner::PlannerData;
-using behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityAndPolygonStamped;
-using behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
-using behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
+using autoware::behavior_path_planner::PlannerData;
+using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObject;
+using autoware::behavior_path_planner::utils::path_safety_checker::
+  PoseWithVelocityAndPolygonStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVelocityStamped;
+using autoware::behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
 
 static constexpr const char * logger_namespace =
   "planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance.utils";
@@ -174,6 +175,6 @@ double calcDistanceToAvoidStartLine(
   const std::shared_ptr<const PlannerData> & planner_data,
   const std::shared_ptr<AvoidanceParameters> & parameters);
 
-}  // namespace behavior_path_planner::utils::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_STATIC_OBSTACLE_AVOIDANCE_MODULE__UTILS_HPP_

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/plugins.xml
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/plugins.xml
@@ -1,3 +1,3 @@
 <library path="autoware_behavior_path_static_obstacle_avoidance_module">
-  <class type="behavior_path_planner::StaticObstacleAvoidanceModuleManager" base_class_type="behavior_path_planner::SceneModuleManagerInterface"/>
+  <class type="autoware::behavior_path_planner::StaticObstacleAvoidanceModuleManager" base_class_type="autoware::behavior_path_planner::SceneModuleManagerInterface"/>
 </library>

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::utils::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 namespace
 {
@@ -49,7 +49,7 @@ MarkerArray createObjectsCubeMarkerArray(
   MarkerArray msg;
 
   const auto is_small_object = [](const auto & o) {
-    const auto t = behavior_path_planner::utils::getHighestProbLabel(o.classification);
+    const auto t = autoware::behavior_path_planner::utils::getHighestProbLabel(o.classification);
     return t == ObjectClassification::PEDESTRIAN || t == ObjectClassification::BICYCLE ||
            t == ObjectClassification::MOTORCYCLE || t == ObjectClassification::UNKNOWN;
   };
@@ -507,7 +507,7 @@ MarkerArray createDebugMarkerArray(
   const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug,
   const std::shared_ptr<AvoidanceParameters> & parameters)
 {
-  using behavior_path_planner::utils::transformToLanelets;
+  using autoware::behavior_path_planner::utils::transformToLanelets;
   using lanelet::visualization::laneletsAsTriangleMarkerArray;
   using marker_utils::createLaneletsAreaMarkerArray;
   using marker_utils::createObjectsMarkerArray;
@@ -653,9 +653,9 @@ MarkerArray createDebugMarkerArray(
 
   return msg;
 }
-}  // namespace behavior_path_planner::utils::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 
-std::string toStrInfo(const behavior_path_planner::ShiftLineArray & sl_arr)
+std::string toStrInfo(const autoware::behavior_path_planner::ShiftLineArray & sl_arr)
 {
   if (sl_arr.empty()) {
     return "point is empty";
@@ -667,7 +667,7 @@ std::string toStrInfo(const behavior_path_planner::ShiftLineArray & sl_arr)
   return ss.str();
 }
 
-std::string toStrInfo(const behavior_path_planner::ShiftLine & sl)
+std::string toStrInfo(const autoware::behavior_path_planner::ShiftLine & sl)
 {
   const auto & ps = sl.start.position;
   const auto & pe = sl.end.position;
@@ -678,7 +678,7 @@ std::string toStrInfo(const behavior_path_planner::ShiftLine & sl)
   return ss.str();
 }
 
-std::string toStrInfo(const behavior_path_planner::AvoidLineArray & ap_arr)
+std::string toStrInfo(const autoware::behavior_path_planner::AvoidLineArray & ap_arr)
 {
   if (ap_arr.empty()) {
     return "point is empty";
@@ -689,7 +689,7 @@ std::string toStrInfo(const behavior_path_planner::AvoidLineArray & ap_arr)
   }
   return ss.str();
 }
-std::string toStrInfo(const behavior_path_planner::AvoidLine & ap)
+std::string toStrInfo(const autoware::behavior_path_planner::AvoidLine & ap)
 {
   using tier4_autoware_utils::toHexString;
 

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 void StaticObstacleAvoidanceModuleManager::init(rclcpp::Node * node)
 {
@@ -279,9 +279,9 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
     if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(
-  behavior_path_planner::StaticObstacleAvoidanceModuleManager,
-  behavior_path_planner::SceneModuleManagerInterface)
+  autoware::behavior_path_planner::StaticObstacleAvoidanceModuleManager,
+  autoware::behavior_path_planner::SceneModuleManagerInterface)

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner
+namespace autoware::behavior_path_planner
 {
 namespace
 {
@@ -1801,4 +1801,4 @@ void SceneModuleVisitor::visitAvoidanceModule(const StaticObstacleAvoidanceModul
 {
   avoidance_visitor_ = module->get_debug_msg_array();
 }
-}  // namespace behavior_path_planner
+}  // namespace autoware::behavior_path_planner

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -17,7 +17,7 @@
 #include "autoware_behavior_path_planner_common/utils/utils.hpp"
 #include "autoware_behavior_path_static_obstacle_avoidance_module/utils.hpp"
 
-namespace behavior_path_planner::utils::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 
 namespace
@@ -1418,4 +1418,4 @@ void ShiftLineGenerator::setRawRegisteredShiftLine(
     }
   }
 }
-}  // namespace behavior_path_planner::utils::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -37,12 +37,12 @@
 #include <string>
 #include <vector>
 
-namespace behavior_path_planner::utils::static_obstacle_avoidance
+namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 
+using autoware::behavior_path_planner::utils::traffic_light::calcDistanceToRedTrafficLight;
+using autoware::behavior_path_planner::utils::traffic_light::getDistanceToNextTrafficLight;
 using autoware_perception_msgs::msg::TrafficLightElement;
-using behavior_path_planner::utils::traffic_light::calcDistanceToRedTrafficLight;
-using behavior_path_planner::utils::traffic_light::getDistanceToNextTrafficLight;
 
 namespace
 {
@@ -2369,4 +2369,4 @@ double calcDistanceToReturnDeadLine(
 
   return distance_to_return_dead_line;
 }
-}  // namespace behavior_path_planner::utils::static_obstacle_avoidance
+}  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -20,7 +20,7 @@
 
 #include <vector>
 
-using behavior_path_planner::BehaviorPathPlannerNode;
+using autoware::behavior_path_planner::BehaviorPathPlannerNode;
 using planning_test_utils::PlanningInterfaceTestManager;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
@@ -47,7 +47,8 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
     ament_index_cpp::get_package_share_directory("behavior_path_planner");
 
   std::vector<std::string> module_names;
-  module_names.emplace_back("behavior_path_planner::StaticObstacleAvoidanceModuleManager");
+  module_names.emplace_back(
+    "autoware::behavior_path_planner::StaticObstacleAvoidanceModuleManager");
 
   std::vector<rclcpp::Parameter> params;
   params.emplace_back("launch_modules", module_names);

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -18,11 +18,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+using autoware::behavior_path_planner::ObjectData;
+using autoware::behavior_path_planner::utils::static_obstacle_avoidance::isOnRight;
+using autoware::behavior_path_planner::utils::static_obstacle_avoidance::isSameDirectionShift;
+using autoware::behavior_path_planner::utils::static_obstacle_avoidance::isShiftNecessary;
 using autoware::route_handler::Direction;
-using behavior_path_planner::ObjectData;
-using behavior_path_planner::utils::static_obstacle_avoidance::isOnRight;
-using behavior_path_planner::utils::static_obstacle_avoidance::isSameDirectionShift;
-using behavior_path_planner::utils::static_obstacle_avoidance::isShiftNecessary;
 
 TEST(BehaviorPathPlanningAvoidanceUtilsTest, shiftLengthDirectionTest)
 {


### PR DESCRIPTION
## Description

add namespace `autoware::` to all bpp modules.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

```
[component_container_mt-32] ***********************************************************                                                   
[component_container_mt-32]                   planner manager status                                                                      
[component_container_mt-32] -----------------------------------------------------------                                                   
[component_container_mt-32] registered modules: [static_obstacle_avoidance][dynamic_obstacle_avoidance][side_shift][start_planner][sampling_planner][goal_planner][lane_change_right][lane_change_left][external_request_lane_change_right][external_request_lane_change_left][avoidance_by_lane_change]
[component_container_mt-32] approved modules  : [external_request_lane_change_right(RUNNING)]->[goal_planner(RUNNING)]->                  
[component_container_mt-32] candidate module  :                                                                                           
[component_container_mt-32] update module info:                                                                                           
[component_container_mt-32] processing time   : [external_request_lane_change_left  : 0.0ms]                                              
[component_container_mt-32]                     [external_request_lane_change_right : 5.0ms]                                              
[component_container_mt-32]                     [lane_change_left                   : 0.0ms]                                              
[component_container_mt-32]                     [lane_change_right                  : 0.0ms]                                              
[component_container_mt-32]                     [sampling_planner                   : 0.0ms]                                              
[component_container_mt-32]                     [start_planner                      : 0.0ms]                                              
[component_container_mt-32]                     [side_shift                         : 0.1ms]                                              
[component_container_mt-32]                     [goal_planner                       : 1.9ms]                                              
[component_container_mt-32]                     [dynamic_obstacle_avoidance         : 0.2ms]                                              
[component_container_mt-32]                     [avoidance_by_lane_change           : 0.0ms]                                              
[component_container_mt-32]                     [static_obstacle_avoidance          : 0.1ms]                                              
[component_container_mt-32]                     [total_time                         : 8.1ms]     
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
