### PR TITLE
refactor(behavior_path_planner_common): fix namespace of drivable_area_expansion

### DIFF
--- a/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
-    ament_index_cpp::get_package_share_directory("behavior_path_planner");
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner");
 
   std::vector<std::string> module_names;
   module_names.emplace_back("autoware::behavior_path_planner::DynamicAvoidanceModuleManager");

--- a/planning/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
-    ament_index_cpp::get_package_share_directory("behavior_path_planner");
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner");
   const auto behavior_path_lane_change_module_dir =
     ament_index_cpp::get_package_share_directory("autoware_behavior_path_lane_change_module");
 

--- a/planning/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
-    ament_index_cpp::get_package_share_directory("behavior_path_planner");
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner");
   const auto behavior_path_lane_change_module_dir =
     ament_index_cpp::get_package_share_directory("autoware_behavior_path_lane_change_module");
 

--- a/planning/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
-    ament_index_cpp::get_package_share_directory("behavior_path_planner");
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner");
 
   std::vector<std::string> module_names;
 

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/data_manager.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/data_manager.hpp
@@ -162,7 +162,8 @@ struct PlannerData
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   std::map<int64_t, TrafficSignalStamped> traffic_light_id_map;
   BehaviorPathPlannerParameters parameters{};
-  drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
+  autoware::behavior_path_planner::drivable_area_expansion::DrivableAreaExpansionParameters
+    drivable_area_expansion_parameters{};
   VelocityLimit::ConstSharedPtr external_limit_max_velocity{};
 
   mutable std::vector<geometry_msgs::msg::Pose> drivable_area_expansion_prev_path_poses{};

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/drivable_area_expansion.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/drivable_area_expansion.hpp
@@ -26,7 +26,7 @@
 #include <memory>
 #include <vector>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 /// @brief Expand the drivable area based on the path curvature and the vehicle dimensions
 /// @param[inout] path path whose drivable area will be expanded
@@ -131,7 +131,7 @@ void calculate_expansion_distances(
 std::vector<double> calculate_smoothed_curvatures(
   const std::vector<Pose> & poses, const size_t smoothing_window_size);
 
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion
 
 // clang-format off
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__DRIVABLE_AREA_EXPANSION_HPP_  // NOLINT

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/footprints.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/footprints.hpp
@@ -23,7 +23,7 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 /// @brief translate a polygon by some (x,y) vector
 /// @param[in] polygon input polygon
@@ -45,5 +45,5 @@ Polygon2d create_footprint(const geometry_msgs::msg::Pose & pose, const Polygon2
 MultiPolygon2d create_object_footprints(
   const autoware_perception_msgs::msg::PredictedObjects & objects,
   const DrivableAreaExpansionParameters & params);
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__FOOTPRINTS_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/map_utils.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/map_utils.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 /// @brief Extract uncrossable segments from the lanelet map that are in range of ego
 /// @param[in] lanelet_map lanelet map
@@ -39,6 +39,6 @@ SegmentRtree extract_uncrossable_segments(
 /// @param[in] types type strings to check
 /// @return true if the linestring has one of the given types
 bool has_types(const lanelet::ConstLineString3d & ls, const std::vector<std::string> & types);
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion
 
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__MAP_UTILS_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 
 struct DrivableAreaExpansionParameters
@@ -125,5 +125,5 @@ struct DrivableAreaExpansionParameters
   }
 };
 
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__PARAMETERS_HPP_

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/path_projection.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/path_projection.hpp
@@ -23,7 +23,7 @@
 
 #include <limits>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 /// @brief project a point to a segment
 /// @param p point to project on the segment
@@ -178,7 +178,7 @@ inline LineString2d sub_linestring(
   sub_ls.push_back(to_point);
   return sub_ls;
 }
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion
 
 // clang-format off
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__PATH_PROJECTION_HPP_  // NOLINT

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp
@@ -23,7 +23,7 @@
 #include <vector>
 namespace autoware::behavior_path_planner::utils
 {
-using drivable_area_expansion::DrivableAreaExpansionParameters;
+using autoware::behavior_path_planner::drivable_area_expansion::DrivableAreaExpansionParameters;
 
 std::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
 

--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/types.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/drivable_area_expansion/types.hpp
@@ -27,7 +27,7 @@
 #include <optional>
 #include <vector>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::PathPoint;
@@ -70,5 +70,5 @@ struct Expansion
   std::vector<PointDistance> right_projections;
   std::vector<double> min_lane_widths;
 };
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion
 #endif  // AUTOWARE_BEHAVIOR_PATH_PLANNER_COMMON__UTILS__DRIVABLE_AREA_EXPANSION__TYPES_HPP_

--- a/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -30,7 +30,7 @@
 
 #include <limits>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 
 namespace
@@ -435,4 +435,4 @@ void expand_drivable_area(
   planner_data->drivable_area_expansion_prev_path_poses = path_poses;
   planner_data->drivable_area_expansion_prev_curvatures = curvatures;
 }
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion

--- a/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
@@ -23,7 +23,7 @@
 
 #include <tf2/utils.h>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 Polygon2d translate_polygon(const Polygon2d & polygon, const double x, const double y)
 {
@@ -62,4 +62,4 @@ MultiPolygon2d create_object_footprints(
   }
   return footprints;
 }
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion

--- a/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/map_utils.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/map_utils.cpp
@@ -21,7 +21,7 @@
 
 #include <algorithm>
 
-namespace drivable_area_expansion
+namespace autoware::behavior_path_planner::drivable_area_expansion
 {
 SegmentRtree extract_uncrossable_segments(
   const lanelet::LaneletMap & lanelet_map, const Point & ego_point,
@@ -51,4 +51,4 @@ bool has_types(const lanelet::ConstLineString3d & ls, const std::vector<std::str
   const auto type = ls.attributeOr(lanelet::AttributeName::Type, no_type);
   return (type != no_type && std::find(types.begin(), types.end(), type) != types.end());
 }
-}  // namespace drivable_area_expansion
+}  // namespace autoware::behavior_path_planner::drivable_area_expansion

--- a/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -843,7 +843,8 @@ void generateDrivableArea(
 
   const auto & expansion_params = planner_data->drivable_area_expansion_parameters;
   if (expansion_params.enabled) {
-    drivable_area_expansion::expand_drivable_area(path, planner_data);
+    autoware::behavior_path_planner::drivable_area_expansion::expand_drivable_area(
+      path, planner_data);
   }
 }
 

--- a/planning/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
+++ b/planning/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
@@ -21,14 +21,14 @@
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
 
-using drivable_area_expansion::LineString2d;
-using drivable_area_expansion::Point2d;
-using drivable_area_expansion::Segment2d;
+using autoware::behavior_path_planner::drivable_area_expansion::LineString2d;
+using autoware::behavior_path_planner::drivable_area_expansion::Point2d;
+using autoware::behavior_path_planner::drivable_area_expansion::Segment2d;
 constexpr auto eps = 1e-9;
 
 TEST(DrivableAreaExpansionProjection, PointToSegment)
 {
-  using drivable_area_expansion::point_to_segment_projection;
+  using autoware::behavior_path_planner::drivable_area_expansion::point_to_segment_projection;
 
   {
     Point2d query(1.0, 1.0);
@@ -90,7 +90,7 @@ TEST(DrivableAreaExpansionProjection, PointToSegment)
 
 TEST(DrivableAreaExpansionProjection, PointToLinestring)
 {
-  using drivable_area_expansion::point_to_linestring_projection;
+  using autoware::behavior_path_planner::drivable_area_expansion::point_to_linestring_projection;
 
   LineString2d ls = {
     Point2d(0.0, 0.0), Point2d(10.0, 0.0), Point2d(10.0, 10.0), Point2d(0.0, 10.0),
@@ -123,7 +123,7 @@ TEST(DrivableAreaExpansionProjection, PointToLinestring)
 
 TEST(DrivableAreaExpansionProjection, LinestringToPoint)
 {
-  using drivable_area_expansion::linestring_to_point_projection;
+  using autoware::behavior_path_planner::drivable_area_expansion::linestring_to_point_projection;
 
   LineString2d ls = {
     Point2d(0.0, 0.0), Point2d(10.0, 0.0), Point2d(10.0, 10.0), Point2d(0.0, 10.0),
@@ -153,8 +153,8 @@ TEST(DrivableAreaExpansionProjection, LinestringToPoint)
 
 TEST(DrivableAreaExpansionProjection, InverseProjection)
 {
-  using drivable_area_expansion::linestring_to_point_projection;
-  using drivable_area_expansion::point_to_linestring_projection;
+  using autoware::behavior_path_planner::drivable_area_expansion::linestring_to_point_projection;
+  using autoware::behavior_path_planner::drivable_area_expansion::point_to_linestring_projection;
 
   LineString2d ls = {
     Point2d(0.0, 0.0), Point2d(10.0, 0.0), Point2d(10.0, 10.0), Point2d(0.0, 10.0),
@@ -174,16 +174,17 @@ TEST(DrivableAreaExpansionProjection, InverseProjection)
 
 TEST(DrivableAreaExpansionProjection, expand_drivable_area)
 {
-  drivable_area_expansion::DrivableAreaExpansionParameters params;
-  drivable_area_expansion::PredictedObjects dynamic_objects;
+  autoware::behavior_path_planner::drivable_area_expansion::DrivableAreaExpansionParameters params;
+  autoware::behavior_path_planner::drivable_area_expansion::PredictedObjects dynamic_objects;
   autoware_map_msgs::msg::LaneletMapBin map;
   lanelet::LaneletMapPtr empty_lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::toBinMsg(empty_lanelet_map_ptr, &map);
   autoware::route_handler::RouteHandler route_handler(map);
   lanelet::ConstLanelets path_lanes = {};
-  drivable_area_expansion::PathWithLaneId path;
+  autoware::behavior_path_planner::drivable_area_expansion::PathWithLaneId path;
   {  // Simple path with Y=0 and X = 0, 1, 2
-    drivable_area_expansion::PathWithLaneId::_points_type::value_type p;
+    autoware::behavior_path_planner::drivable_area_expansion::PathWithLaneId::_points_type::
+      value_type p;
     p.point.pose.position.x = 0.0;
     p.point.pose.position.y = 0.0;
     path.points.push_back(p);
@@ -193,8 +194,8 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
     path.points.push_back(p);
   }
   {  // Left bound at Y = 1, Right bound at Y = -1
-    drivable_area_expansion::Point pl;
-    drivable_area_expansion::Point pr;
+    autoware::behavior_path_planner::drivable_area_expansion::Point pl;
+    autoware::behavior_path_planner::drivable_area_expansion::Point pr;
     pl.y = 1.0;
     pr.y = -1.0;
     pl.x = 0.0;
@@ -226,11 +227,12 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
   autoware::behavior_path_planner::PlannerData planner_data;
   planner_data.drivable_area_expansion_parameters = params;
   planner_data.dynamic_object =
-    std::make_shared<drivable_area_expansion::PredictedObjects>(dynamic_objects);
+    std::make_shared<autoware::behavior_path_planner::drivable_area_expansion::PredictedObjects>(
+      dynamic_objects);
   planner_data.self_odometry = std::make_shared<nav_msgs::msg::Odometry>();
   planner_data.route_handler =
     std::make_shared<autoware::route_handler::RouteHandler>(route_handler);
-  drivable_area_expansion::expand_drivable_area(
+  autoware::behavior_path_planner::drivable_area_expansion::expand_drivable_area(
     path, std::make_shared<autoware::behavior_path_planner::PlannerData>(planner_data));
   // unchanged path points
   ASSERT_EQ(path.points.size(), 3ul);
@@ -259,7 +261,7 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
   // add some curvature
   path.points[1].point.pose.position.y = 0.5;
 
-  drivable_area_expansion::expand_drivable_area(
+  autoware::behavior_path_planner::drivable_area_expansion::expand_drivable_area(
     path, std::make_shared<autoware::behavior_path_planner::PlannerData>(planner_data));
   // expanded left bound
   ASSERT_EQ(path.left_bound.size(), 3ul);

--- a/planning/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
-    ament_index_cpp::get_package_share_directory("behavior_path_planner");
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner");
 
   std::vector<std::string> module_names;
   module_names.emplace_back("autoware::behavior_path_planner::SideShiftModuleManager");

--- a/planning/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
-    ament_index_cpp::get_package_share_directory("behavior_path_planner");
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner");
 
   std::vector<std::string> module_names;
   module_names.emplace_back(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Change namespace from `drivable_area_expansion`  to `autoware::behavior_path_planner::drivable_area_expansion`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
