### PR TITLE
refactor(pose_estimator_arbiter): apply static analysis

### DIFF
--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp
@@ -30,7 +30,7 @@ struct GridKey
   GridKey() : x(0), y(0) {}
   GridKey(float x, float y) : x(std::floor(x / unit_length)), y(std::floor(y / unit_length)) {}
 
-  pcl::PointXYZ get_center_point() const
+  [[nodiscard]] pcl::PointXYZ get_center_point() const
   {
     pcl::PointXYZ xyz;
     xyz.x = unit_length * (static_cast<float>(x) + 0.5f);

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp
@@ -16,6 +16,11 @@
 
 #include "pose_estimator_arbiter/rule_helper/grid_key.hpp"
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <boost/functional/hash.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp
@@ -16,14 +16,14 @@
 
 #include "pose_estimator_arbiter/rule_helper/grid_key.hpp"
 
+#include <boost/functional/hash.hpp>
+
+#include <pcl_conversions/pcl_conversions.h>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <boost/functional/hash.hpp>
-
-#include <pcl_conversions/pcl_conversions.h>
 
 namespace pose_estimator_arbiter::rule_helper
 {

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.hpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.hpp
@@ -15,6 +15,8 @@
 #ifndef POSE_ESTIMATOR_ARBITER__RULE_HELPER__PCD_OCCUPANCY_HPP_
 #define POSE_ESTIMATOR_ARBITER__RULE_HELPER__PCD_OCCUPANCY_HPP_
 
+#include <string>
+
 #include <rclcpp/node.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -34,7 +36,7 @@ class PcdOccupancy
 public:
   explicit PcdOccupancy(int pcd_density_upper_threshold, int pcd_density_lower_threshold);
 
-  MarkerArray debug_marker_array() const;
+  [[nodiscard]] MarkerArray debug_marker_array() const;
   void init(PointCloud2::ConstSharedPtr msg);
   bool ndt_can_operate(
     const geometry_msgs::msg::Point & position, std::string * optional_message = nullptr) const;

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.hpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.hpp
@@ -15,8 +15,6 @@
 #ifndef POSE_ESTIMATOR_ARBITER__RULE_HELPER__PCD_OCCUPANCY_HPP_
 #define POSE_ESTIMATOR_ARBITER__RULE_HELPER__PCD_OCCUPANCY_HPP_
 
-#include <string>
-
 #include <rclcpp/node.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -25,6 +23,8 @@
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+
+#include <string>
 
 namespace pose_estimator_arbiter::rule_helper
 {

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.cpp
@@ -33,14 +33,14 @@ using BoostPolygon = boost::geometry::model::polygon<BoostPoint>;
 
 struct PoseEstimatorArea::Impl
 {
-  explicit Impl(rclcpp::Logger logger) : logger_(logger) {}
+  explicit Impl(const rclcpp::Logger& logger) : logger_(logger) {}
   std::multimap<std::string, BoostPolygon> bounding_boxes_;
 
   void init(HADMapBin::ConstSharedPtr msg);
-  bool within(
+  [[nodiscard]] bool within(
     const geometry_msgs::msg::Point & point, const std::string & pose_estimator_name) const;
 
-  MarkerArray debug_marker_array() const { return marker_array_; }
+  [[nodiscard]] MarkerArray debug_marker_array() const { return marker_array_; }
 
 private:
   rclcpp::Logger logger_;
@@ -105,7 +105,7 @@ void PoseEstimatorArea::Impl::init(HADMapBin::ConstSharedPtr msg)
     marker.color.set__r(1.0f).set__g(1.0f).set__b(0.0f).set__a(1.0f);
     marker.ns = subtype;
     marker.header.frame_id = "map";
-    marker.id = marker_array_.markers.size();
+    marker.id = static_cast<int>(marker_array_.markers.size());
 
     // Enqueue the vertices of the polygon to bounding box and visualization marker
     BoostPolygon poly;

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.cpp
@@ -33,7 +33,7 @@ using BoostPolygon = boost::geometry::model::polygon<BoostPoint>;
 
 struct PoseEstimatorArea::Impl
 {
-  explicit Impl(const rclcpp::Logger& logger) : logger_(logger) {}
+  explicit Impl(const rclcpp::Logger & logger) : logger_(logger) {}
   std::multimap<std::string, BoostPolygon> bounding_boxes_;
 
   void init(HADMapBin::ConstSharedPtr msg);

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.hpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.hpp
@@ -40,10 +40,10 @@ public:
   // This is assumed to be called only once in the vector map callback.
   void init(const HADMapBin::ConstSharedPtr msg);
 
-  bool within(
+  [[nodiscard]] bool within(
     const geometry_msgs::msg::Point & point, const std::string & pose_estimator_name) const;
 
-  MarkerArray debug_marker_array() const;
+  [[nodiscard]] MarkerArray debug_marker_array() const;
 
 private:
   struct Impl;

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp
@@ -23,7 +23,8 @@ namespace pose_estimator_arbiter::switch_rule
 PcdMapBasedRule::PcdMapBasedRule(
   rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
   std::shared_ptr<const SharedData> shared_data)
-: BaseSwitchRule(node), running_estimator_list_(std::move(running_estimator_list)),
+: BaseSwitchRule(node),
+  running_estimator_list_(std::move(running_estimator_list)),
   shared_data_(std::move(shared_data))
 {
   const int pcd_density_upper_threshold =

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp
@@ -16,12 +16,15 @@
 
 #include <tier4_autoware_utils/ros/parameter.hpp>
 
+#include <utility>
+
 namespace pose_estimator_arbiter::switch_rule
 {
 PcdMapBasedRule::PcdMapBasedRule(
-  rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
-  const std::shared_ptr<const SharedData> shared_data)
-: BaseSwitchRule(node), running_estimator_list_(running_estimator_list), shared_data_(shared_data)
+  rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
+  std::shared_ptr<const SharedData> shared_data)
+: BaseSwitchRule(node), running_estimator_list_(std::move(running_estimator_list)),
+  shared_data_(std::move(shared_data))
 {
   const int pcd_density_upper_threshold =
     tier4_autoware_utils::getOrDeclareParameter<int>(node, "pcd_density_upper_threshold");
@@ -63,14 +66,14 @@ std::unordered_map<PoseEstimatorType, bool> PcdMapBasedRule::update()
       {PoseEstimatorType::eagleye, false},
       {PoseEstimatorType::artag, false},
     };
-  } else {
-    debug_string_ = "Enable yabloc: ";
-    return {
-      {PoseEstimatorType::ndt, false},
-      {PoseEstimatorType::yabloc, true},
-      {PoseEstimatorType::eagleye, false},
-      {PoseEstimatorType::artag, false}};
   }
+
+  debug_string_ = "Enable yabloc: ";
+  return {
+    {PoseEstimatorType::ndt, false},
+    {PoseEstimatorType::yabloc, true},
+    {PoseEstimatorType::eagleye, false},
+    {PoseEstimatorType::artag, false}};
 }
 
 }  // namespace pose_estimator_arbiter::switch_rule

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.hpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.hpp
@@ -31,7 +31,7 @@ class PcdMapBasedRule : public BaseSwitchRule
 {
 public:
   PcdMapBasedRule(
-    rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
+    rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
     const std::shared_ptr<const SharedData> shared_data);
 
   std::unordered_map<PoseEstimatorType, bool> update() override;

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp
@@ -16,12 +16,15 @@
 
 #include <magic_enum.hpp>
 
+#include <utility>
+
 namespace pose_estimator_arbiter::switch_rule
 {
 VectorMapBasedRule::VectorMapBasedRule(
-  rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
-  const std::shared_ptr<const SharedData> shared_data)
-: BaseSwitchRule(node), running_estimator_list_(running_estimator_list), shared_data_(shared_data)
+  rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
+  std::shared_ptr<const SharedData> shared_data)
+: BaseSwitchRule(node), running_estimator_list_(std::move(running_estimator_list)),
+  shared_data_(std::move(shared_data))
 {
   pose_estimator_area_ = std::make_unique<rule_helper::PoseEstimatorArea>(node.get_logger());
 

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp
@@ -23,7 +23,8 @@ namespace pose_estimator_arbiter::switch_rule
 VectorMapBasedRule::VectorMapBasedRule(
   rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
   std::shared_ptr<const SharedData> shared_data)
-: BaseSwitchRule(node), running_estimator_list_(std::move(running_estimator_list)),
+: BaseSwitchRule(node),
+  running_estimator_list_(std::move(running_estimator_list)),
   shared_data_(std::move(shared_data))
 {
   pose_estimator_area_ = std::make_unique<rule_helper::PoseEstimatorArea>(node.get_logger());

--- a/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.hpp
+++ b/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.hpp
@@ -32,8 +32,8 @@ class VectorMapBasedRule : public BaseSwitchRule
 {
 public:
   VectorMapBasedRule(
-    rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
-    const std::shared_ptr<const SharedData> shared_data);
+    rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
+    std::shared_ptr<const SharedData> shared_data);
 
   std::unordered_map<PoseEstimatorType, bool> update() override;
 

--- a/localization/pose_estimator_arbiter/example_rule/test/test_pcd_map_based_rule.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/test/test_pcd_map_based_rule.cpp
@@ -19,10 +19,10 @@
 
 #include <unordered_set>
 
-class MockNode : public ::testing::Test
+class PcdMapBasedRuleMockNode : public ::testing::Test
 {
 protected:
-  virtual void SetUp()
+  void SetUp() override
   {
     rclcpp::init(0, nullptr);
     node = std::make_shared<rclcpp::Node>("test_node");
@@ -46,10 +46,10 @@ protected:
   std::shared_ptr<pose_estimator_arbiter::SharedData> shared_data_;
   std::shared_ptr<pose_estimator_arbiter::switch_rule::PcdMapBasedRule> rule_;
 
-  virtual void TearDown() { rclcpp::shutdown(); }
+  void TearDown() override { rclcpp::shutdown(); }
 };
 
-TEST_F(MockNode, pcdMapBasedRule)
+TEST_F(PcdMapBasedRuleMockNode, pcdMapBasedRule)
 {
   // Create dummy pcd and set
   {

--- a/localization/pose_estimator_arbiter/example_rule/test/test_rule_helper.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/test/test_rule_helper.cpp
@@ -28,10 +28,10 @@
 
 #include <unordered_set>
 
-class MockNode : public ::testing::Test
+class RuleHelperMockNode : public ::testing::Test
 {
 protected:
-  virtual void SetUp()
+  void SetUp() override
   {
     rclcpp::init(0, nullptr);
     node = std::make_shared<rclcpp::Node>("test_node");
@@ -39,10 +39,10 @@ protected:
 
   std::shared_ptr<rclcpp::Node> node{nullptr};
 
-  virtual void TearDown() { rclcpp::shutdown(); }
+  void TearDown() override { rclcpp::shutdown(); }
 };
 
-TEST_F(MockNode, poseEstimatorArea)
+TEST_F(RuleHelperMockNode, poseEstimatorArea)
 {
   auto create_polygon3d = []() -> lanelet::Polygon3d {
     lanelet::Polygon3d polygon;
@@ -73,7 +73,7 @@ TEST_F(MockNode, poseEstimatorArea)
   EXPECT_FALSE(pose_estimator_area.within(Point().set__x(-5).set__y(-5).set__z(0), "yabloc"));
 }
 
-TEST_F(MockNode, pcdOccupancy)
+TEST_F(RuleHelperMockNode, pcdOccupancy)
 {
   using pose_estimator_arbiter::rule_helper::PcdOccupancy;
   const int pcd_density_upper_threshold = 20;
@@ -89,7 +89,7 @@ TEST_F(MockNode, pcdOccupancy)
   EXPECT_FALSE(pcd_occupancy.ndt_can_operate(point, &message));
 }
 
-TEST_F(MockNode, gridKey)
+TEST_F(RuleHelperMockNode, gridKey)
 {
   using pose_estimator_arbiter::rule_helper::GridKey;
   EXPECT_TRUE(GridKey(10., -5.) == GridKey(10., -10.));

--- a/localization/pose_estimator_arbiter/example_rule/test/test_vector_map_based_rule.cpp
+++ b/localization/pose_estimator_arbiter/example_rule/test/test_vector_map_based_rule.cpp
@@ -24,10 +24,10 @@
 
 #include <unordered_set>
 
-class MockNode : public ::testing::Test
+class VectorMapBasedRuleMockNode : public ::testing::Test
 {
 protected:
-  virtual void SetUp()
+  void SetUp() override
   {
     rclcpp::init(0, nullptr);
     node = std::make_shared<rclcpp::Node>("test_node");
@@ -49,10 +49,10 @@ protected:
   std::shared_ptr<pose_estimator_arbiter::SharedData> shared_data_;
   std::shared_ptr<pose_estimator_arbiter::switch_rule::VectorMapBasedRule> rule_;
 
-  virtual void TearDown() { rclcpp::shutdown(); }
+  void TearDown() override { rclcpp::shutdown(); }
 };
 
-TEST_F(MockNode, vectorMapBasedRule)
+TEST_F(VectorMapBasedRuleMockNode, vectorMapBasedRule)
 {
   // Create dummy lanelet2 and set
   {

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/pose_estimator_type.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/pose_estimator_type.hpp
@@ -18,6 +18,6 @@
 namespace pose_estimator_arbiter
 {
 enum class PoseEstimatorType : int { ndt = 1, yabloc = 2, eagleye = 4, artag = 8 };
-}
+}  // namespace pose_estimator_arbiter
 
 #endif  // POSE_ESTIMATOR_ARBITER__POSE_ESTIMATOR_TYPE_HPP_

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp
@@ -30,29 +30,29 @@ namespace pose_estimator_arbiter
 template <typename T>
 struct CallbackInvokingVariable
 {
-  CallbackInvokingVariable() {}
+  CallbackInvokingVariable() = default;
 
-  explicit CallbackInvokingVariable(T initial_data) : value(initial_data) {}
+  explicit CallbackInvokingVariable(T initial_data) : value_(initial_data) {}
 
   // Set data and invoke all callbacks
   void set_and_invoke(T new_value)
   {
-    value = new_value;
+    value_ = new_value;
 
     // Call all callbacks with the new value
-    for (const auto & callback : callbacks) {
-      callback(value.value());
+    for (const auto & callback : callbacks_) {
+      callback(value_.value());
     }
   }
 
   // Same as std::optional::has_value()
-  bool has_value() const { return value.has_value(); }
+  bool has_value() const { return value_.has_value(); }
 
   // Same as std::optional::value()
-  const T operator()() const { return value.value(); }
+  T operator()() const { return value_.value(); }
 
   // Register callback function which is invoked when set_and_invoke() is called
-  void register_callback(std::function<void(T)> callback) const { callbacks.push_back(callback); }
+  void register_callback(std::function<void(T)> callback) const { callbacks_.push_back(callback); }
 
   // Create subscription callback function which is used as below:
   //   auto subscriber = create_subscription<T>("topic_name", 10,
@@ -64,10 +64,10 @@ struct CallbackInvokingVariable
 
 private:
   // The latest data
-  std::optional<T> value{std::nullopt};
+  std::optional<T> value_{std::nullopt};
 
   // These functions are expected not to change the value variable
-  mutable std::vector<std::function<void(T)>> callbacks;
+  mutable std::vector<std::function<void(T)>> callbacks_;
 };
 
 // This structure is handed to several modules as shared_ptr so that all modules can access data.
@@ -80,7 +80,7 @@ public:
   using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using InitializationState = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
 
-  SharedData() {}
+  SharedData() = default;
 
   // Used for stoppers
   CallbackInvokingVariable<PoseCovStamped::ConstSharedPtr> eagleye_output_pose_cov;

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/base_stopper.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/base_stopper.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
+#include <utility>
 
 namespace pose_estimator_arbiter::stopper
 {
@@ -28,11 +29,16 @@ class BaseStopper
 public:
   using SharedPtr = std::shared_ptr<BaseStopper>;
 
-  explicit BaseStopper(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
-  : logger_(node->get_logger()), shared_data_(shared_data)
+  explicit BaseStopper(rclcpp::Node * node, std::shared_ptr<const SharedData> shared_data)
+  : logger_(node->get_logger()), shared_data_(std::move(shared_data))
   {
   }
 
+  virtual ~BaseStopper() = default;
+  BaseStopper(const BaseStopper& other) = default;
+  BaseStopper(BaseStopper&& other) noexcept = default;
+  BaseStopper& operator=(const BaseStopper& other) = default;
+  BaseStopper& operator=(BaseStopper&& other) noexcept = default;
   void enable() { set_enable(true); }
   void disable() { set_enable(false); }
 

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/base_stopper.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/base_stopper.hpp
@@ -35,10 +35,10 @@ public:
   }
 
   virtual ~BaseStopper() = default;
-  BaseStopper(const BaseStopper& other) = default;
-  BaseStopper(BaseStopper&& other) noexcept = default;
-  BaseStopper& operator=(const BaseStopper& other) = default;
-  BaseStopper& operator=(BaseStopper&& other) noexcept = default;
+  BaseStopper(const BaseStopper & other) = default;
+  BaseStopper(BaseStopper && other) noexcept = default;
+  BaseStopper & operator=(const BaseStopper & other) = default;
+  BaseStopper & operator=(BaseStopper && other) noexcept = default;
   void enable() { set_enable(true); }
   void disable() { set_enable(false); }
 

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_artag.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_artag.hpp
@@ -29,8 +29,8 @@ class StopperArTag : public BaseStopper
   using SetBool = std_srvs::srv::SetBool;
 
 public:
-  explicit StopperArTag(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
-  : BaseStopper(node, shared_data)
+  explicit StopperArTag(rclcpp::Node * node,
+    const std::shared_ptr<const SharedData> & shared_data) : BaseStopper(node, shared_data)
   {
     ar_tag_is_enabled_ = true;
     pub_image_ = node->create_publisher<Image>("~/output/artag/image", rclcpp::SensorDataQoS());

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_artag.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_artag.hpp
@@ -29,8 +29,8 @@ class StopperArTag : public BaseStopper
   using SetBool = std_srvs::srv::SetBool;
 
 public:
-  explicit StopperArTag(rclcpp::Node * node,
-    const std::shared_ptr<const SharedData> & shared_data) : BaseStopper(node, shared_data)
+  explicit StopperArTag(rclcpp::Node * node, const std::shared_ptr<const SharedData> & shared_data)
+  : BaseStopper(node, shared_data)
   {
     ar_tag_is_enabled_ = true;
     pub_image_ = node->create_publisher<Image>("~/output/artag/image", rclcpp::SensorDataQoS());

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_eagleye.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_eagleye.hpp
@@ -27,8 +27,9 @@ class StopperEagleye : public BaseStopper
   using PoseCovStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
 public:
-  explicit StopperEagleye(rclcpp::Node * node,
-    const std::shared_ptr<const SharedData> & shared_data) : BaseStopper(node, shared_data)
+  explicit StopperEagleye(
+    rclcpp::Node * node, const std::shared_ptr<const SharedData> & shared_data)
+  : BaseStopper(node, shared_data)
   {
     eagleye_is_enabled_ = true;
     pub_pose_ = node->create_publisher<PoseCovStamped>("~/output/eagleye/pose_with_covariance", 5);

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_eagleye.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_eagleye.hpp
@@ -27,8 +27,8 @@ class StopperEagleye : public BaseStopper
   using PoseCovStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
 public:
-  explicit StopperEagleye(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
-  : BaseStopper(node, shared_data)
+  explicit StopperEagleye(rclcpp::Node * node,
+    const std::shared_ptr<const SharedData> & shared_data) : BaseStopper(node, shared_data)
   {
     eagleye_is_enabled_ = true;
     pub_pose_ = node->create_publisher<PoseCovStamped>("~/output/eagleye/pose_with_covariance", 5);

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_ndt.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_ndt.hpp
@@ -27,7 +27,7 @@ class StopperNdt : public BaseStopper
   using PointCloud2 = sensor_msgs::msg::PointCloud2;
 
 public:
-  explicit StopperNdt(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
+  explicit StopperNdt(rclcpp::Node * node, const std::shared_ptr<const SharedData> & shared_data)
   : BaseStopper(node, shared_data)
   {
     ndt_is_enabled_ = true;

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_yabloc.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_yabloc.hpp
@@ -29,7 +29,7 @@ class StopperYabLoc : public BaseStopper
   using SetBool = std_srvs::srv::SetBool;
 
 public:
-  explicit StopperYabLoc(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
+  explicit StopperYabLoc(rclcpp::Node * node, const std::shared_ptr<const SharedData> & shared_data)
   : BaseStopper(node, shared_data)
   {
     yabloc_is_enabled_ = true;

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/base_switch_rule.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/base_switch_rule.hpp
@@ -40,12 +40,16 @@ public:
   }
 
   virtual ~BaseSwitchRule() = default;
+  BaseSwitchRule(const BaseSwitchRule& other) = default;
+  BaseSwitchRule(BaseSwitchRule&& other) noexcept = default;
+  BaseSwitchRule& operator=(const BaseSwitchRule& other) = default;
+  BaseSwitchRule& operator=(BaseSwitchRule&& other) noexcept = default;
   virtual std::unordered_map<PoseEstimatorType, bool> update() = 0;
   virtual std::string debug_string() { return std::string{}; }
   virtual MarkerArray debug_marker_array() { return MarkerArray{}; }
 
 protected:
-  rclcpp::Logger get_logger() const { return *logger_ptr_; }
+  [[nodiscard]] rclcpp::Logger get_logger() const { return *logger_ptr_; }
   std::shared_ptr<rclcpp::Logger> logger_ptr_{nullptr};
 };
 

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/base_switch_rule.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/base_switch_rule.hpp
@@ -40,10 +40,10 @@ public:
   }
 
   virtual ~BaseSwitchRule() = default;
-  BaseSwitchRule(const BaseSwitchRule& other) = default;
-  BaseSwitchRule(BaseSwitchRule&& other) noexcept = default;
-  BaseSwitchRule& operator=(const BaseSwitchRule& other) = default;
-  BaseSwitchRule& operator=(BaseSwitchRule&& other) noexcept = default;
+  BaseSwitchRule(const BaseSwitchRule & other) = default;
+  BaseSwitchRule(BaseSwitchRule && other) noexcept = default;
+  BaseSwitchRule & operator=(const BaseSwitchRule & other) = default;
+  BaseSwitchRule & operator=(BaseSwitchRule && other) noexcept = default;
   virtual std::unordered_map<PoseEstimatorType, bool> update() = 0;
   virtual std::string debug_string() { return std::string{}; }
   virtual MarkerArray debug_marker_array() { return MarkerArray{}; }

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.cpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.cpp
@@ -19,14 +19,15 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace pose_estimator_arbiter::switch_rule
 {
 EnableAllRule::EnableAllRule(
-  rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
-  const std::shared_ptr<const SharedData>)
-: BaseSwitchRule(node), running_estimator_list_(running_estimator_list)
+  rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
+  const std::shared_ptr<const SharedData> &)
+: BaseSwitchRule(node), running_estimator_list_(std::move(running_estimator_list))
 {
 }
 

--- a/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.hpp
+++ b/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.hpp
@@ -29,10 +29,8 @@ class EnableAllRule : public BaseSwitchRule
 {
 public:
   EnableAllRule(
-    rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
-    const std::shared_ptr<const SharedData> shared_data);
-
-  virtual ~EnableAllRule() = default;
+    rclcpp::Node & node, std::unordered_set<PoseEstimatorType> running_estimator_list,
+    const std::shared_ptr<const SharedData> & shared_data);
 
   std::unordered_map<PoseEstimatorType, bool> update() override;
 


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `localization/pose_estimator_arbiter`.

Fixed:
- use explicit cast
- add missing includes
- add explicit constructor definition (e.g. copy constructor)
- [modernize-pass-by-value](https://clang.llvm.org/extra/clang-tidy/checks/modernize/pass-by-value.html)
  - instead of using const-reference, pass value and then move
- change class name in tests to avoid name collision
- change private variable name (adding `_`)

not Fixed:
- safe access to members of unions by `boost::variant`
  - speed concern

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

After fixing the includes,

```Text
$ ./check_linter.sh pose_estimator_arbiter
...
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/pose_estimator_type.hpp:21:1: error: namespace 'pose_estimator_arbiter' not terminated with a closing comment [llvm-namespace-comment,-warnings-as-errors]
}
^
  // namespace pose_estimator_arbiter
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/pose_estimator_type.hpp:18:11: note: namespace 'pose_estimator_arbiter' starts here
namespace pose_estimator_arbiter
          ^
1 warning treated as error
5489 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp:33:3: error: use '= default' to define a trivial default constructor [modernize-use-equals-default,-warnings-as-errors]
  CallbackInvokingVariable() {}
  ^                          ~~
                             = default;
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp:52:3: warning: return type 'const T' is 'const'-qualified at the top level, which may reduce code readability without improving const correctness [readability-const-return-type]
  const T operator()() const { return value.value(); }
  ^~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp:67:20: warning: invalid case style for private member 'value' [readability-identifier-naming]
  std::optional<T> value{std::nullopt};
                   ^~~~~
                   value_
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp:70:47: warning: invalid case style for private member 'callbacks' [readability-identifier-naming]
  mutable std::vector<std::function<void(T)>> callbacks;
                                              ^~~~~~~~~
                                              callbacks_
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/shared_data.hpp:83:3: error: use '= default' to define a trivial default constructor [modernize-use-equals-default,-warnings-as-errors]
  SharedData() {}
  ^            ~~
               = default;
Suppressed 5484 warnings (5484 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
2 warnings treated as errors
10231 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.hpp:43:3: warning: function 'within' should be marked [[nodiscard]] [modernize-use-nodiscard]
  bool within(
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.hpp:46:3: warning: function 'debug_marker_array' should be marked [[nodiscard]] [modernize-use-nodiscard]
  MarkerArray debug_marker_array() const;
  ^
  [[nodiscard]] 
Suppressed 10240 warnings (10229 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
24876 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:33:3: warning: function 'get_center_point' should be marked [[nodiscard]] [modernize-use-nodiscard]
  pcl::PointXYZ get_center_point() const
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:36:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.x = unit_length * (static_cast<float>(x) + 0.5f);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:37:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.y = unit_length * (static_cast<float>(y) + 0.5f);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:38:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.z = 0.f;
        ^
Suppressed 24874 warnings (24872 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13603 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/base_stopper.hpp:31:85: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  explicit BaseStopper(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
                                                                                    ^
                                                                                   &
Suppressed 13613 warnings (13602 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13886 warnings generated.
Suppressed 13897 warnings (13886 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
32636 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.hpp:39:3: warning: function 'debug_marker_array' should be marked [[nodiscard]] [modernize-use-nodiscard]
  MarkerArray debug_marker_array() const;
  ^
  [[nodiscard]] 
Suppressed 32648 warnings (32635 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14193 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_artag.hpp:32:86: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  explicit StopperArTag(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
                                                                                     ^
                                                                                    &
Suppressed 14203 warnings (14192 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14172 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_ndt.hpp:30:84: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  explicit StopperNdt(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
                                                                                   ^
                                                                                  &
Suppressed 14182 warnings (14171 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14172 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_eagleye.hpp:30:88: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  explicit StopperEagleye(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
                                                                                       ^
                                                                                      &
Suppressed 14182 warnings (14171 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14774 warnings generated.
Suppressed 14785 warnings (14774 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13400 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/base_switch_rule.hpp:31:7: warning: class 'BaseSwitchRule' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class BaseSwitchRule
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/base_switch_rule.hpp:48:3: warning: function 'get_logger' should be marked [[nodiscard]] [modernize-use-nodiscard]
  rclcpp::Logger get_logger() const { return *logger_ptr_; }
  ^
  [[nodiscard]] 
Suppressed 13409 warnings (13398 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
17446 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp:22:24: warning: pass by value and use std::move [modernize-pass-by-value]
  rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       std::unordered_set<PoseEstimatorType> 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp:23:43: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  const std::shared_ptr<const SharedData> shared_data)
                                          ^
                                         &
Suppressed 17455 warnings (17444 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14476 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/stopper/stopper_yabloc.hpp:32:87: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  explicit StopperYabLoc(rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data)
                                                                                      ^
                                                                                     &
Suppressed 14486 warnings (14475 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
7645 warnings generated.
Suppressed 7663 warnings (7645 in non-user code, 18 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13897 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.cpp:27:24: warning: pass by value and use std::move [modernize-pass-by-value]
  rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       std::unordered_set<PoseEstimatorType> 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.cpp:28:42: warning: the const qualified parameter #3 is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  const std::shared_ptr<const SharedData>)
                                         ^
                                         &
Suppressed 13906 warnings (13895 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13836 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.hpp:28:7: warning: class 'EnableAllRule' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class EnableAllRule : public BaseSwitchRule
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/src/pose_estimator_arbiter/switch_rule/enable_all_rule.hpp:35:11: error: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override,-warnings-as-errors]
  virtual ~EnableAllRule() = default;
  ~~~~~~~~^
                           override 
Suppressed 13845 warnings (13834 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
36145 warnings generated.
Suppressed 36158 warnings (36145 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
36226 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp:22:24: warning: pass by value and use std::move [modernize-pass-by-value]
  rclcpp::Node & node, const std::unordered_set<PoseEstimatorType> & running_estimator_list,
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       std::unordered_set<PoseEstimatorType> 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp:23:43: warning: the const qualified parameter 'shared_data' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  const std::shared_ptr<const SharedData> shared_data)
                                          ^
                                         &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp:66:5: warning: do not use 'else' after 'return' [readability-else-after-return]
  } else {
    ^~~~~~
... (omitted)

```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp ...
1/10 files checked 9% done
Checking example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.cpp ...
2/10 files checked 22% done
Checking example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp ...
3/10 files checked 29% done
Checking example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp ...
4/10 files checked 37% done
Checking example_rule/test/test_pcd_map_based_rule.cpp ...
5/10 files checked 47% done
Checking example_rule/test/test_rule_helper.cpp ...
6/10 files checked 57% done
Checking example_rule/test/test_vector_map_based_rule.cpp ...
7/10 files checked 68% done
Checking src/pose_estimator_arbiter/pose_estimator_arbiter_core.cpp ...
8/10 files checked 90% done
Checking src/pose_estimator_arbiter/switch_rule/enable_all_rule.cpp ...
9/10 files checked 94% done
Checking test/test_shared_data.cpp ...
10/10 files checked 100% done
example_rule/test/test_pcd_map_based_rule.cpp:22:1: error: The one definition rule is violated, different classes/structs have the same name 'MockNode' [ctuOneDefinitionRuleViolation]
class MockNode : public ::testing::Test
^
example_rule/test/test_rule_helper.cpp:31:1: note: The one definition rule is violated, different classes/structs have the same name 'MockNode'
class MockNode : public ::testing::Test
^
example_rule/test/test_pcd_map_based_rule.cpp:22:1: note: The one definition rule is violated, different classes/structs have the same name 'MockNode'
class MockNode : public ::testing::Test
^
example_rule/test/test_pcd_map_based_rule.cpp:22:1: error: The one definition rule is violated, different classes/structs have the same name 'MockNode' [ctuOneDefinitionRuleViolation]
class MockNode : public ::testing::Test
^
example_rule/test/test_vector_map_based_rule.cpp:27:1: note: The one definition rule is violated, different classes/structs have the same name 'MockNode'
class MockNode : public ::testing::Test
^
example_rule/test/test_pcd_map_based_rule.cpp:22:1: note: The one definition rule is violated, different classes/structs have the same name 'MockNode'
class MockNode : public ::testing::Test
^
example_rule/test/test_pcd_map_based_rule.cpp:25:0: style: The function 'SetUp' is never used. [unusedFunction]
  virtual void SetUp()
^
example_rule/test/test_pcd_map_based_rule.cpp:49:0: style: The function 'TearDown' is never used. [unusedFunction]
  virtual void TearDown() { rclcpp::shutdown(); }
```
</details>

---

After this PR:

Check with check_linter.sh
```Text
$ ./check_linter.sh pose_estimator_arbiter
...
5472 warnings generated.
Suppressed 5472 warnings (5472 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
10229 warnings generated.
Suppressed 10240 warnings (10229 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
24875 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:36:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.x = unit_length * (static_cast<float>(x) + 0.5f);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:37:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.y = unit_length * (static_cast<float>(y) + 0.5f);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/grid_key.hpp:38:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.z = 0.f;
        ^
Suppressed 24874 warnings (24872 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13585 warnings generated.
Suppressed 13596 warnings (13585 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13864 warnings generated.
Suppressed 13875 warnings (13864 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14155 warnings generated.
Suppressed 14166 warnings (14155 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14176 warnings generated.
Suppressed 14187 warnings (14176 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
32635 warnings generated.
14155 warnings generated.
Suppressed 14166 warnings (14155 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Suppressed 32648 warnings (32635 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14761 warnings generated.
Suppressed 14772 warnings (14761 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
17421 warnings generated.
Suppressed 17432 warnings (17421 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14459 warnings generated.
Suppressed 14470 warnings (14459 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13397 warnings generated.
Suppressed 13408 warnings (13397 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
7627 warnings generated.
Suppressed 7645 warnings (7627 in non-user code, 18 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13814 warnings generated.
Suppressed 13825 warnings (13814 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13858 warnings generated.
Suppressed 13869 warnings (13858 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
36124 warnings generated.
Suppressed 36137 warnings (36124 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
36201 warnings generated.
Suppressed 36214 warnings (36201 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
40381 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp:80:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      geometry_point.set__x(p.x).set__y(p.y).set__z(p.z);
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp:80:43: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      geometry_point.set__x(p.x).set__y(p.y).set__z(p.z);
                                          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp:80:55: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      geometry_point.set__x(p.x).set__y(p.y).set__z(p.z);
                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp:103:34: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    grid_point_count[GridKey(xyz.x, xyz.y)] += 1;
                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp:103:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    grid_point_count[GridKey(xyz.x, xyz.y)] += 1;
                                        ^
Suppressed 40389 warnings (40376 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
35887 warnings generated.
Suppressed 35980 warnings (35887 in non-user code, 93 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
41910 warnings generated.
Suppressed 41940 warnings (41910 in non-user code, 30 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
50885 warnings generated.
Suppressed 50984 warnings (50885 in non-user code, 99 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
60172 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/test/test_rule_helper.cpp:98:52: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  EXPECT_TRUE(GridKey(10., -5.).get_center_point().x == 15.f);
                                                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/test/test_rule_helper.cpp:99:52: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  EXPECT_TRUE(GridKey(10., -5.).get_center_point().y == -5.f);
                                                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_estimator_arbiter/example_rule/test/test_rule_helper.cpp:100:52: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  EXPECT_TRUE(GridKey(10., -5.).get_center_point().z == 0.f);
                                                   ^
Suppressed 60263 warnings (60169 in non-user code, 94 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27950 warnings generated.
Suppressed 27961 warnings (27950 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

Check with cppcheck (`SetUp` and `TearDown` is used in the test):
```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking example_rule/src/pose_estimator_arbiter/rule_helper/pcd_occupancy.cpp ...
1/10 files checked 9% done
Checking example_rule/src/pose_estimator_arbiter/rule_helper/pose_estimator_area.cpp ...
2/10 files checked 22% done
Checking example_rule/src/pose_estimator_arbiter/switch_rule/pcd_map_based_rule.cpp ...
3/10 files checked 29% done
Checking example_rule/src/pose_estimator_arbiter/switch_rule/vector_map_based_rule.cpp ...
4/10 files checked 37% done
Checking example_rule/test/test_pcd_map_based_rule.cpp ...
5/10 files checked 47% done
Checking example_rule/test/test_rule_helper.cpp ...
6/10 files checked 57% done
Checking example_rule/test/test_vector_map_based_rule.cpp ...
7/10 files checked 68% done
Checking src/pose_estimator_arbiter/pose_estimator_arbiter_core.cpp ...
8/10 files checked 90% done
Checking src/pose_estimator_arbiter/switch_rule/enable_all_rule.cpp ...
9/10 files checked 94% done
Checking test/test_shared_data.cpp ...
10/10 files checked 100% done
example_rule/test/test_pcd_map_based_rule.cpp:25:0: style: The function 'SetUp' is never used. [unusedFunction]
  void SetUp() override
^
example_rule/test/test_pcd_map_based_rule.cpp:49:0: style: The function 'TearDown' is never used. [unusedFunction]
  void TearDown() override { rclcpp::shutdown(); }
^
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
