### PR TITLE
refactor(pose_instability_detector): apply static analysis

### DIFF
--- a/localization/pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp
+++ b/localization/pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp
@@ -50,8 +50,8 @@ public:
   };
 
   explicit PoseInstabilityDetector(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
-  ThresholdValues calculate_threshold(double interval_sec);
-  void dead_reckon(
+  ThresholdValues calculate_threshold(double interval_sec) const;
+  static void dead_reckon(
     PoseStamped::SharedPtr & initial_pose, const rclcpp::Time & end_time,
     const std::deque<TwistWithCovarianceStamped> & twist_deque, Pose::SharedPtr & estimated_pose);
 
@@ -60,7 +60,7 @@ private:
   void callback_twist(TwistWithCovarianceStamped::ConstSharedPtr twist_msg_ptr);
   void callback_timer();
 
-  std::deque<TwistWithCovarianceStamped> clip_out_necessary_twist(
+  static std::deque<TwistWithCovarianceStamped> clip_out_necessary_twist(
     const std::deque<TwistWithCovarianceStamped> & twist_buffer, const rclcpp::Time & start_time,
     const rclcpp::Time & end_time);
 
@@ -75,8 +75,6 @@ private:
 
   // parameters
   const double timer_period_;  // [sec]
-
-  ThresholdValues threshold_values_;
 
   const double heading_velocity_maximum_;                 // [m/s]
   const double heading_velocity_scale_factor_tolerance_;  // [%]


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `localization/pose_instability_detector`.

Fixed:
- removed unused private variable
- change camelCase to snake_case
- add initialization to uninitialized variable
- add `const` or `static` to method which can be it

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

After fixing the includes,

```Text
$ ./check_linter.sh pose_instability_detector
...
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp:79:19: error: private field 'threshold_values_' is not used [clang-diagnostic-unused-private-field]
  ThresholdValues threshold_values_;
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp:28:1: warning: constructor does not initialize these fields: threshold_values_ [cppcoreguidelines-pro-type-member-init]
PoseInstabilityDetector::PoseInstabilityDetector(const rclcpp::NodeOptions & options)
^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp:121:19: warning: invalid case style for variable 'DR_pose' [readability-identifier-naming]
  Pose::SharedPtr DR_pose = std::make_shared<Pose>();
                  ^~~~~~~
                  dr_pose
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp:126:14: warning: invalid case style for variable 'ekf_to_DR' [readability-identifier-naming]
  const Pose ekf_to_DR = tier4_autoware_utils::inverseTransformPose(*DR_pose, latest_ekf_pose);
             ^~~~~~~~~
             ekf_to_dr
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp:180:67: error: method 'calculate_threshold' can be made const [readability-make-member-function-const,-warnings-as-errors]
PoseInstabilityDetector::ThresholdValues PoseInstabilityDetector::calculate_threshold(
                                                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp:232:3: warning: uninitialized record type: 'result_values' [cppcoreguidelines-pro-type-member-init]
  ThresholdValues result_values;
  ^
                               {}
/home/masakibaba/autoware/src/universe/autoware.universe/localization/pose_instability_detector/src/pose_instability_detector.cpp:306:26: warning: method 'clip_out_necessary_twist' can be made static [readability-convert-member-functions-to-static]
PoseInstabilityDetector::clip_out_necessary_twist(
                         ^
Suppressed 71314 warnings (71288 in non-user code, 26 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler errors, but -fix-errors was not specified.
Fixes have NOT been applied.

1 warning treated as error

```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/pose_instability_detector.cpp ...
1/2 files checked 74% done
Checking test/test.cpp ...
2/2 files checked 100% done
test/test.cpp:36:0: style: The function 'SetUp' is never used. [unusedFunction]
  void SetUp() override
^
test/test.cpp:65:0: style: The function 'TearDown' is never used. [unusedFunction]
  void TearDown() override
^
```
</details>

---

After this PR:

Check with check_linter.sh
```Text
$ ./check_linter.sh pose_instability_detector
...
13733 warnings generated.
Suppressed 13744 warnings (13733 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
16438 warnings generated.
Suppressed 16449 warnings (16438 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
18354 warnings generated.
Suppressed 18384 warnings (18354 in non-user code, 30 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
35644 warnings generated.
71288 warnings generated.
Suppressed 71314 warnings (71288 in non-user code, 26 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

Check with cppcheck: no change

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
