### PR TITLE
fix(start_planner): redefine the necessary parameters

### DIFF
--- a/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
+++ b/planning/autoware_behavior_path_planner_common/include/autoware_behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
@@ -60,7 +60,7 @@ struct ParallelParkingParameters
   // pull_out
   double pull_out_velocity{0.0};
   double pull_out_lane_departure_margin{0.0};
-  double pull_out_path_interval{0.0};
+  double pull_out_arc_path_interval{0.0};
   double pull_out_max_steer_angle{0.0};
 };
 

--- a/planning/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
+++ b/planning/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
@@ -244,7 +244,7 @@ bool GeometricParallelParking::planPullOut(
     auto arc_paths = planOneTrial(
       *end_pose, start_pose, R_E_min_, road_lanes, shoulder_lanes, is_forward, left_side_start,
       start_pose_offset, parameters_.pull_out_lane_departure_margin,
-      parameters_.pull_out_path_interval, lane_departure_checker);
+      parameters_.pull_out_arc_path_interval, lane_departure_checker);
     if (arc_paths.empty()) {
       // not found path
       continue;

--- a/planning/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -35,6 +35,7 @@
       # geometric pull out
       enable_geometric_pull_out: true
       geometric_collision_check_distance_from_end: 0.0
+      arc_path_interval: 1.0
       divide_pull_out_path: true
       geometric_pull_out_velocity: 1.0
       lane_departure_margin: 0.2

--- a/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -91,6 +91,8 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   p.divide_pull_out_path = node->declare_parameter<bool>(ns + "divide_pull_out_path");
   p.parallel_parking_parameters.pull_out_velocity =
     node->declare_parameter<double>(ns + "geometric_pull_out_velocity");
+  p.parallel_parking_parameters.pull_out_path_interval =
+    node->declare_parameter<double>(ns + "arc_path_interval");
   p.parallel_parking_parameters.pull_out_lane_departure_margin =
     node->declare_parameter<double>(ns + "lane_departure_margin");
   p.lane_departure_check_expansion_margin =
@@ -416,6 +418,8 @@ void StartPlannerModuleManager::updateModuleParams(
       parameters, ns + "maximum_longitudinal_deviation", p->maximum_longitudinal_deviation);
     updateParam<bool>(parameters, ns + "enable_geometric_pull_out", p->enable_geometric_pull_out);
     updateParam<bool>(parameters, ns + "divide_pull_out_path", p->divide_pull_out_path);
+    updateParam<double>(
+      parameters, ns + "arc_path_interval", p->parallel_parking_parameters.pull_out_path_interval);
     updateParam<double>(
       parameters, ns + "lane_departure_margin",
       p->parallel_parking_parameters.pull_out_lane_departure_margin);

--- a/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -419,7 +419,8 @@ void StartPlannerModuleManager::updateModuleParams(
     updateParam<bool>(parameters, ns + "enable_geometric_pull_out", p->enable_geometric_pull_out);
     updateParam<bool>(parameters, ns + "divide_pull_out_path", p->divide_pull_out_path);
     updateParam<double>(
-      parameters, ns + "arc_path_interval", p->parallel_parking_parameters.pull_out_arc_path_interval);
+      parameters, ns + "arc_path_interval",
+      p->parallel_parking_parameters.pull_out_arc_path_interval);
     updateParam<double>(
       parameters, ns + "lane_departure_margin",
       p->parallel_parking_parameters.pull_out_lane_departure_margin);

--- a/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -91,7 +91,7 @@ void StartPlannerModuleManager::init(rclcpp::Node * node)
   p.divide_pull_out_path = node->declare_parameter<bool>(ns + "divide_pull_out_path");
   p.parallel_parking_parameters.pull_out_velocity =
     node->declare_parameter<double>(ns + "geometric_pull_out_velocity");
-  p.parallel_parking_parameters.pull_out_path_interval =
+  p.parallel_parking_parameters.pull_out_arc_path_interval =
     node->declare_parameter<double>(ns + "arc_path_interval");
   p.parallel_parking_parameters.pull_out_lane_departure_margin =
     node->declare_parameter<double>(ns + "lane_departure_margin");
@@ -419,7 +419,7 @@ void StartPlannerModuleManager::updateModuleParams(
     updateParam<bool>(parameters, ns + "enable_geometric_pull_out", p->enable_geometric_pull_out);
     updateParam<bool>(parameters, ns + "divide_pull_out_path", p->divide_pull_out_path);
     updateParam<double>(
-      parameters, ns + "arc_path_interval", p->parallel_parking_parameters.pull_out_path_interval);
+      parameters, ns + "arc_path_interval", p->parallel_parking_parameters.pull_out_arc_path_interval);
     updateParam<double>(
       parameters, ns + "lane_departure_margin",
       p->parallel_parking_parameters.pull_out_lane_departure_margin);


### PR DESCRIPTION
## Description

Because of removing necessary parameter in this [PR](https://github.com/autowarefoundation/autoware_launch/pull/1022), geometric path(path includs dry steering) can't be generated.
In this PR, 
- restore the param. 
- change the variable name from `pull_out_path_interval` to `pull_out_arc_path_interval`

parameter change is in this [PR](https://github.com/autowarefoundation/autoware_launch/pull/1027)

<!-- Write a brief description of this PR. -->

## Tests performed

run psim and confirmed geometric path can be generated.
![image](https://github.com/autowarefoundation/autoware.universe/assets/32741405/4448e561-841a-4dc1-bedb-5911ef477bd5)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
