### PR TITLE
refactor(yabloc_common): apply static analysis

### DIFF
--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -29,7 +29,7 @@
   <arg name="use_emergency_handler" default="true" description="use emergency handler packages"/>
   <arg name="mrm_handler_param_path"/>
   <arg name="diagnostic_graph_aggregator_param_path"/>
-  <arg name="diagnostic_graph_aggregator_graph_path"/>
+  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml" />
 
   <let name="sensor_launch_pkg" value="$(find-pkg-share $(var sensor_model)_launch)"/>
 

--- a/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp
@@ -31,17 +31,17 @@ public:
 
   explicit CameraInfoSubscriber(rclcpp::Node * node);
 
-  bool is_camera_info_ready() const;
+  [[nodiscard]] bool is_camera_info_ready() const;
 
-  bool is_camera_info_nullopt() const;
+  [[nodiscard]] bool is_camera_info_nullopt() const;
 
-  Eigen::Vector2i size() const;
+  [[nodiscard]] Eigen::Vector2i size() const;
 
-  Eigen::Matrix3f intrinsic() const;
+  [[nodiscard]] Eigen::Matrix3f intrinsic() const;
 
   // This member function DOES NOT check isCameraInfoReady()
   // If it it not ready, throw bad optional access
-  std::string get_frame_id() const;
+  [[nodiscard]] std::string get_frame_id() const;
 
 private:
   rclcpp::Subscription<CameraInfo>::SharedPtr sub_info_;

--- a/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp
@@ -31,25 +31,26 @@ struct Color
   }
 
   explicit Color(const cv::Scalar & rgb, float a = 1.0f)
-  : r(rgb[2] / 255.f), g(rgb[1] / 255.f), b(rgb[0] / 255.f), a(a)
+  : r(static_cast<float>(rgb[2]) / 255.f), g(static_cast<float>(rgb[1]) / 255.f),
+    b(static_cast<float>(rgb[0]) / 255.f), a(a)
   {
   }
 
-  operator uint32_t() const
+  explicit operator uint32_t() const
   {
     union uchar4_uint32 {
       uint8_t rgba[4];
       uint32_t u32;
     };
-    uchar4_uint32 tmp;
+    uchar4_uint32 tmp{};
     tmp.rgba[0] = static_cast<uint8_t>(r * 255);
     tmp.rgba[1] = static_cast<uint8_t>(g * 255);
     tmp.rgba[2] = static_cast<uint8_t>(b * 255);
     tmp.rgba[3] = static_cast<uint8_t>(a * 255);
     return tmp.u32;
   }
-  operator const cv::Scalar() const { return cv::Scalar(255 * b, 255 * g, 255 * r); }
-  operator const std_msgs::msg::ColorRGBA() const
+  explicit operator cv::Scalar() const { return {255 * b, 255 * g, 255 * r}; }
+  explicit operator std_msgs::msg::ColorRGBA() const
   {
     std_msgs::msg::ColorRGBA rgba;
     rgba.a = a;

--- a/localization/yabloc/yabloc_common/include/yabloc_common/gamma_converter.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/gamma_converter.hpp
@@ -27,7 +27,8 @@ public:
   {
     lut_ = cv::Mat(1, 256, CV_8UC1);
     for (int i = 0; i < 256; i++) {
-      lut_.at<uchar>(0, i) = 256 * std::pow(i / 256.f, gamma);
+      lut_.at<uchar>(0, i) =
+        static_cast<unsigned char>(256 * std::pow(static_cast<float>(i) / 256.f, gamma));
     }
   }
 

--- a/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp
@@ -46,39 +46,39 @@ struct GroundPlane
     }
   }
 
-  float height() const { return xyz.z(); }
+  [[nodiscard]] float height() const { return xyz.z(); }
 
-  Eigen::Quaternionf align_with_slope(const Eigen::Quaternionf & q) const
+  [[nodiscard]] Eigen::Quaternionf align_with_slope(const Eigen::Quaternionf & q) const
   {
     return Eigen::Quaternionf{align_with_slope(q.toRotationMatrix())};
   }
 
-  Eigen::Matrix3f align_with_slope(const Eigen::Matrix3f & R) const
+  [[nodiscard]] Eigen::Matrix3f align_with_slope(const Eigen::Matrix3f & R) const
   {
-    Eigen::Matrix3f R_;
+    Eigen::Matrix3f r;
     Eigen::Vector3f rz = this->normal;
     Eigen::Vector3f azimuth = R * Eigen::Vector3f::UnitX();
     Eigen::Vector3f ry = (rz.cross(azimuth)).normalized();
     Eigen::Vector3f rx = ry.cross(rz);
-    R_.col(0) = rx;
-    R_.col(1) = ry;
-    R_.col(2) = rz;
-    return R_;
+    r.col(0) = rx;
+    r.col(1) = ry;
+    r.col(2) = rz;
+    return r;
   }
 
-  Sophus::SE3f align_with_slope(const Sophus::SE3f & pose) const
+  [[nodiscard]] Sophus::SE3f align_with_slope(const Sophus::SE3f & pose) const
   {
     return {align_with_slope(pose.rotationMatrix()), pose.translation()};
   }
 
-  Eigen::Affine3f align_with_slope(const Eigen::Affine3f & pose) const
+  [[nodiscard]] Eigen::Affine3f align_with_slope(const Eigen::Affine3f & pose) const
   {
-    Eigen::Matrix3f R = pose.rotation();
+    Eigen::Matrix3f r = pose.rotation();
     Eigen::Vector3f t = pose.translation();
-    return Eigen::Translation3f(t) * align_with_slope(R);
+    return Eigen::Translation3f(t) * align_with_slope(r);
   }
 
-  Float32Array msg() const
+  [[nodiscard]] Float32Array msg() const
   {
     Float32Array array;
     for (int i = 0; i < 3; i++) array.data.push_back(xyz(i));

--- a/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/filter/moving_averaging.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/filter/moving_averaging.hpp
@@ -32,7 +32,7 @@ public:
 
     Eigen::Vector3f mean = Eigen::Vector3f::Zero();
     for (const Eigen::Vector3f & v : buffer_) mean += v;
-    mean /= buffer_.size();
+    mean /= static_cast<float>(buffer_.size());
 
     return mean.normalized();
   }

--- a/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/ground_server.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/ground_server.hpp
@@ -61,8 +61,8 @@ public:
 
 private:
   const bool force_zero_tilt_;
-  const float R;
-  const int K;
+  const float R_;
+  const int K_;
 
   // Subscriber
   rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;

--- a/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp
@@ -26,12 +26,14 @@
 
 namespace yabloc::ground_server
 {
-void upsample_line_string(
+void inline upsample_line_string(
   const lanelet::ConstPoint3d & from, const lanelet::ConstPoint3d & to,
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud)
 {
-  Eigen::Vector3f f(from.x(), from.y(), from.z());
-  Eigen::Vector3f t(to.x(), to.y(), to.z());
+  Eigen::Vector3f f(static_cast<float>(from.x()), static_cast<float>(from.y()),
+    static_cast<float>(from.z()));
+  Eigen::Vector3f t(static_cast<float>(to.x()), static_cast<float>(to.y()),
+    static_cast<float>(to.z()));
   float length = (t - f).norm();
   Eigen::Vector3f d = (t - f).normalized();
   for (float l = 0; l < length; l += 0.5f) {
@@ -41,7 +43,9 @@ void upsample_line_string(
   }
 };
 
-std::vector<int> merge_indices(const std::vector<int> & indices1, const std::vector<int> & indices2)
+std::vector<int> inline merge_indices(
+  const std::vector<int> & indices1, const std::vector<int> & indices2
+)
 {
   std::unordered_set<int> set;
   for (int i : indices1) set.insert(i);

--- a/localization/yabloc/yabloc_common/include/yabloc_common/ll2_decomposer/ll2_decomposer.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/ll2_decomposer/ll2_decomposer.hpp
@@ -54,17 +54,18 @@ private:
 
   void on_map(const LaneletMapBin & msg);
 
-  pcl::PointNormal to_point_normal(
-    const lanelet::ConstPoint3d & from, const lanelet::ConstPoint3d & to) const;
+  static pcl::PointNormal to_point_normal(
+    const lanelet::ConstPoint3d & from, const lanelet::ConstPoint3d & to) ;
 
-  pcl::PointCloud<pcl::PointNormal> split_line_strings(
+  static pcl::PointCloud<pcl::PointNormal> split_line_strings(
     const lanelet::ConstLineStrings3d & line_strings);
 
   pcl::PointCloud<pcl::PointXYZL> load_bounding_boxes(const lanelet::PolygonLayer & polygons) const;
 
-  lanelet::ConstLineStrings3d extract_specified_line_string(
-    const lanelet::LineStringLayer & line_strings, const std::set<std::string> & visible_labels);
-  lanelet::ConstPolygons3d extract_specified_polygon(
+  static lanelet::ConstLineStrings3d extract_specified_line_string(
+    const lanelet::LineStringLayer & line_string_layer,
+    const std::set<std::string> & visible_labels);
+  static lanelet::ConstPolygons3d extract_specified_polygon(
     const lanelet::PolygonLayer & polygon_layer, const std::set<std::string> & visible_labels);
 
   MarkerArray make_sign_marker_msg(

--- a/localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp
+++ b/localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp
@@ -51,8 +51,8 @@ Eigen::Matrix3f CameraInfoSubscriber::intrinsic() const
   if (!opt_info_.has_value()) {
     throw std::runtime_error("camera_info is not ready but it's accessed");
   }
-  const Eigen::Matrix3d Kd_t = Eigen::Map<const Eigen::Matrix<double, 3, 3>>(opt_info_->k.data());
-  return Kd_t.cast<float>().transpose();
+  const Eigen::Matrix3d kd_t = Eigen::Map<const Eigen::Matrix<double, 3, 3>>(opt_info_->k.data());
+  return kd_t.cast<float>().transpose();
 }
 
 }  // namespace yabloc::common

--- a/localization/yabloc/yabloc_common/src/color.cpp
+++ b/localization/yabloc/yabloc_common/src/color.cpp
@@ -19,7 +19,9 @@ namespace yabloc::common::color_scale
 Color rainbow(float value)
 {
   // clang-format off
-  float r = 1.0f, g = 1.0f, b = 1.0f;
+  float r = 1.0f;
+  float g = 1.0f;
+  float b = 1.0f;
   value = std::clamp(value, 0.0f, 1.0f);
   if (value < 0.25f) {
     r = 0; g = 4 * (value);
@@ -42,16 +44,15 @@ Color hsv_to_rgb(float h_, float s_, float v_)
 
   if (h < 60)
     return {max, h / 60 * (max - min) + min, min};
-  else if (h < 120)
+  if (h < 120)
     return {(120 - h) / 60 * (max - min) + min, max, min};
-  else if (h < 180)
+  if (h < 180)
     return {min, max, (h - 120) / 60 * (max - min) + min};
-  else if (h < 240)
+  if (h < 240)
     return {min, (240 - h) / 60 * (max - min) + min, max};
-  else if (h < 300)
+  if (h < 300)
     return {(h - 240) / 60 * (max - min) + min, min, max};
-  else
-    return {max, min, (360 - h) / 60 * (max - min) + min};
+  return {max, min, (360 - h) / 60 * (max - min) + min};
 }
 
 Color blue_red(float value)

--- a/localization/yabloc/yabloc_common/src/cv_decompress.cpp
+++ b/localization/yabloc/yabloc_common/src/cv_decompress.cpp
@@ -28,16 +28,16 @@ cv::Mat decompress_image(const sensor_msgs::msg::CompressedImage & compressed_im
   cv::Mat raw_image;
 
   const std::string & format = compressed_img.format;
-  const std::string encoding = format.substr(0, format.find(";"));
+  const std::string encoding = format.substr(0, format.find(';'));
 
-  constexpr int DECODE_GRAY = 0;
-  constexpr int DECODE_RGB = 1;
+  constexpr int decode_gray = 0;
+  constexpr int decode_rgb = 1;
 
   bool encoding_is_bayer = encoding.find("bayer") != std::string::npos;
   if (!encoding_is_bayer) {
-    return cv::imdecode(cv::Mat(compressed_img.data), DECODE_RGB);
+    return cv::imdecode(cv::Mat(compressed_img.data), decode_rgb);
   }
-  raw_image = cv::imdecode(cv::Mat(compressed_img.data), DECODE_GRAY);
+  raw_image = cv::imdecode(cv::Mat(compressed_img.data), decode_gray);
 
   // TODO(KYabuuchi) integrate with implementation in the sensing/perception component
   if (encoding == "bayer_rggb8") {

--- a/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
+++ b/localization/yabloc/yabloc_common/src/extract_line_segments.cpp
@@ -21,11 +21,11 @@ pcl::PointCloud<pcl::PointNormal> extract_near_line_segments(
   const float max_range)
 {
   constexpr double sqrt_two = 1.41421356237309504880;
-  const Eigen::Vector3f pose_vector = transform.translation();
+  const Eigen::Vector3f & pose_vector = transform.translation();
 
   // All line segments contained in a square with max_range on one side must be taken out,
   // so pick up those that are closer than the **diagonals** of the square.
-  auto check_intersection = [sqrt_two, max_range,
+  auto check_intersection = [max_range,
                              pose_vector](const pcl::PointNormal & pn) -> bool {
     const Eigen::Vector3f from = pn.getVector3fMap() - pose_vector;
     const Eigen::Vector3f to = pn.getNormalVector3fMap() - pose_vector;
@@ -42,11 +42,8 @@ pcl::PointCloud<pcl::PointNormal> extract_near_line_segments(
   };
 
   pcl::PointCloud<pcl::PointNormal> dst;
-  for (const pcl::PointNormal & pn : line_segments) {
-    if (check_intersection(pn)) {
-      dst.push_back(pn);
-    }
-  }
+  std::copy_if(line_segments.begin(), line_segments.end(), std::back_inserter(dst),
+    [check_intersection](const auto& pn) { return check_intersection(pn); });
   return dst;
 }
 

--- a/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp
+++ b/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp
@@ -21,6 +21,7 @@
 #include <yabloc_common/color.hpp>
 #include <yabloc_common/pub_sub.hpp>
 
+#include <cmath>
 #include <pcl/ModelCoefficients.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/voxel_grid.h>
@@ -33,8 +34,8 @@ namespace yabloc::ground_server
 GroundServer::GroundServer(const rclcpp::NodeOptions & options)
 : Node("ground_server", options),
   force_zero_tilt_(declare_parameter<bool>("force_zero_tilt")),
-  R(declare_parameter<int>("R")),
-  K(declare_parameter<int>("K"))
+  R_(static_cast<float>(declare_parameter<int>("R"))),
+  K_(static_cast<int>(declare_parameter<int>("K")))
 {
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -147,8 +148,8 @@ float GroundServer::estimate_height_simply(const geometry_msgs::msg::Point & poi
 {
   // NOTE: Sometimes it might give not-accurate height
   constexpr float sq_radius = 3.0 * 3.0;
-  const float x = point.x;
-  const float y = point.y;
+  const auto x = static_cast<float>(point.x);
+  const auto y = static_cast<float>(point.y);
 
   float height = std::numeric_limits<float>::infinity();
   for (const auto & p : cloud_->points) {
@@ -186,12 +187,12 @@ std::vector<int> GroundServer::estimate_inliers_by_ransac(const std::vector<int>
 GroundServer::GroundPlane GroundServer::estimate_ground(const Point & point)
 {
   // Because height_filter_ is always initialized, getValue does not return nullopt
-  const float predicted_z = height_filter_.getValue().value();
-  const pcl::PointXYZ xyz(point.x, point.y, predicted_z);
+  const float predicted_z = static_cast<float>(height_filter_.getValue().value());
+  const pcl::PointXYZ xyz(static_cast<float>(point.x), static_cast<float>(point.y), predicted_z);
 
   std::vector<int> raw_indices;
   std::vector<float> distances;
-  kdtree_->nearestKSearch(xyz, K, raw_indices, distances);
+  kdtree_->nearestKSearch(xyz, K_, raw_indices, distances);
 
   std::vector<int> indices = estimate_inliers_by_ransac(raw_indices);
 
@@ -206,7 +207,7 @@ GroundServer::GroundPlane GroundServer::estimate_ground(const Point & point)
 
   // NOTE: I forgot why I don't use coefficients computed by SACSegmentation
   Eigen::Vector4f plane_parameter;
-  float curvature;
+  float curvature = NAN;
   pcl::solvePlaneParameters(covariance, centroid, plane_parameter, curvature);
   Eigen::Vector3f normal = plane_parameter.topRows(3).normalized();
 
@@ -229,15 +230,16 @@ GroundServer::GroundPlane GroundServer::estimate_ground(const Point & point)
   const Eigen::Vector3f filt_normal = normal_filter_.update(normal);
 
   GroundPlane plane;
-  plane.xyz = Eigen::Vector3f(point.x, point.y, predicted_z);
+  plane.xyz = Eigen::Vector3f(static_cast<float>(point.x), static_cast<float>(point.y),
+    predicted_z);
   plane.normal = filt_normal;
 
   // Compute z value by intersection of estimated plane and orthogonal line
   {
     Eigen::Vector3f center = centroid.topRows(3);
     float inner = center.dot(plane.normal);
-    float px_nx = point.x * plane.normal.x();
-    float py_ny = point.y * plane.normal.y();
+    float px_nx = static_cast<float>(point.x) * plane.normal.x();
+    float py_ny = static_cast<float>(point.y) * plane.normal.y();
     plane.xyz.z() = (inner - px_nx - py_ny) / plane.normal.z();
   }
 

--- a/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp
+++ b/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp
@@ -31,9 +31,9 @@ pcl::PointCloud<pcl::PointXYZ> sample_from_polygons(const lanelet::PolygonLayer 
   for (const lanelet::ConstPolygon3d & polygon : polygons) {
     for (const lanelet::ConstPoint3d & p : polygon) {
       pcl::PointXYZ xyz;
-      xyz.x = p.x();
-      xyz.y = p.y();
-      xyz.z = p.z();
+      xyz.x = static_cast<float>(p.x());
+      xyz.y = static_cast<float>(p.y());
+      xyz.z = static_cast<float>(p.z());
       raw_cloud.push_back(xyz);
     }
   }
@@ -45,9 +45,9 @@ void push_back_line(
 {
   Eigen::Vector3f f = from.getVector3fMap();
   Eigen::Vector3f t = to.getVector3fMap();
-  const float L = (f - t).norm();
+  const float vec_len = (f - t).norm();
 
-  for (float l = 0.f; l < L; l += 0.25f) {
+  for (float l = 0.f; l < vec_len; l += 0.25f) {
     Eigen::Vector3f xyz = f + (t - f) * l;
     dst_cloud.emplace_back(xyz.x(), xyz.y(), xyz.z());
   }
@@ -56,19 +56,23 @@ void push_back_line(
 void push_back_contour(
   pcl::PointCloud<pcl::PointXYZ> & dst_cloud, const pcl::PointCloud<pcl::PointXYZ> & vertices)
 {
-  const int N = vertices.size();
-  for (int i = 0; i < N - 1; ++i) {
+  const int n = static_cast<int>(vertices.size());
+  for (int i = 0; i < n - 1; ++i) {
     push_back_line(dst_cloud, vertices.at(i), vertices.at(i + 1));
   }
-  push_back_line(dst_cloud, vertices.at(0), vertices.at(N - 1));
+  push_back_line(dst_cloud, vertices.at(0), vertices.at(n - 1));
 }
 
 pcl::PointCloud<pcl::PointXYZ> shrink_vertices(
   const pcl::PointCloud<pcl::PointXYZ> & vertices, float rate)
 {
-  Eigen::Vector3f center = Eigen::Vector3f::Zero();
-  for (const pcl::PointXYZ p : vertices) center += p.getVector3fMap();
-  center /= vertices.size();
+  // Eigen::Vector3f center = Eigen::Vector3f::Zero();
+  // for (const pcl::PointXYZ p : vertices) center += p.getVector3fMap();
+  Eigen::Vector3f center = std::accumulate(
+    vertices.begin(), vertices.end(), Eigen::Vector3f::Zero().eval(),
+    [](const Eigen::Vector3f& acc, const pcl::PointXYZ& p) { return acc + p.getVector3fMap(); }
+  );
+  center /= static_cast<float>(vertices.size());
 
   pcl::PointCloud<pcl::PointXYZ> dst_cloud;
   for (const pcl::PointXYZ p : vertices) {

--- a/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp
+++ b/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp
@@ -44,7 +44,7 @@ Ll2Decomposer::Ll2Decomposer(const rclcpp::NodeOptions & options) : Node("ll2_to
     [this](const std::string & param_name, std::set<std::string> & labels) -> void {
     this->template declare_parameter<std::vector<std::string>>(param_name);
     auto label_array = get_parameter(param_name).as_string_array();
-    for (auto l : label_array) labels.insert(l);
+    for (const auto& l : label_array) labels.insert(l);
   };
 
   load_lanelet2_labels("road_marking_labels", road_marking_labels_);
@@ -86,14 +86,14 @@ pcl::PointCloud<pcl::PointXYZL> Ll2Decomposer::load_bounding_boxes(
 
   for (const lanelet::ConstPolygon3d & polygon : polygons) {
     if (!polygon.hasAttribute(lanelet::AttributeName::Type)) continue;
-    lanelet::Attribute attr = polygon.attribute(lanelet::AttributeName::Type);
+    const lanelet::Attribute& attr = polygon.attribute(lanelet::AttributeName::Type);
     if (bounding_box_labels_.count(attr.value()) == 0) continue;
 
     for (const lanelet::ConstPoint3d & p : polygon) {
       pcl::PointXYZL xyzl;
-      xyzl.x = p.x();
-      xyzl.y = p.y();
-      xyzl.z = p.z();
+      xyzl.x = static_cast<float>(p.x());
+      xyzl.y = static_cast<float>(p.y());
+      xyzl.z = static_cast<float>(p.z());
       xyzl.label = index;
       cloud.push_back(xyzl);
     }
@@ -151,7 +151,7 @@ lanelet::ConstLineStrings3d Ll2Decomposer::extract_specified_line_string(
   lanelet::ConstLineStrings3d line_strings;
   for (const lanelet::ConstLineString3d & line : line_string_layer) {
     if (!line.hasAttribute(lanelet::AttributeName::Type)) continue;
-    lanelet::Attribute attr = line.attribute(lanelet::AttributeName::Type);
+    const lanelet::Attribute& attr = line.attribute(lanelet::AttributeName::Type);
     if (visible_labels.count(attr.value()) == 0) continue;
     line_strings.push_back(line);
   }
@@ -164,7 +164,7 @@ lanelet::ConstPolygons3d Ll2Decomposer::extract_specified_polygon(
   lanelet::ConstPolygons3d polygons;
   for (const lanelet::ConstPolygon3d & polygon : polygon_layer) {
     if (!polygon.hasAttribute(lanelet::AttributeName::Type)) continue;
-    lanelet::Attribute attr = polygon.attribute(lanelet::AttributeName::Type);
+    const lanelet::Attribute& attr = polygon.attribute(lanelet::AttributeName::Type);
     if (visible_labels.count(attr.value()) == 0) continue;
     polygons.push_back(polygon);
   }
@@ -172,15 +172,15 @@ lanelet::ConstPolygons3d Ll2Decomposer::extract_specified_polygon(
 }
 
 pcl::PointNormal Ll2Decomposer::to_point_normal(
-  const lanelet::ConstPoint3d & from, const lanelet::ConstPoint3d & to) const
+  const lanelet::ConstPoint3d & from, const lanelet::ConstPoint3d & to)
 {
   pcl::PointNormal pn;
-  pn.x = from.x();
-  pn.y = from.y();
-  pn.z = from.z();
-  pn.normal_x = to.x();
-  pn.normal_y = to.y();
-  pn.normal_z = to.z();
+  pn.x = static_cast<float>(from.x());
+  pn.y = static_cast<float>(from.y());
+  pn.z = static_cast<float>(from.z());
+  pn.normal_x = static_cast<float>(to.x());
+  pn.normal_y = static_cast<float>(to.y());
+  pn.normal_z = static_cast<float>(to.z());
   return pn;
 }
 

--- a/localization/yabloc/yabloc_common/src/pose_conversions.cpp
+++ b/localization/yabloc/yabloc_common/src/pose_conversions.cpp
@@ -37,8 +37,11 @@ Eigen::Affine3f pose_to_affine(const geometry_msgs::msg::Pose & pose)
 {
   const auto pos = pose.position;
   const auto ori = pose.orientation;
-  Eigen::Translation3f t(pos.x, pos.y, pos.z);
-  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
+  Eigen::Translation3f t(static_cast<float>(pos.x), static_cast<float>(pos.y),
+    static_cast<float>(pos.z));
+  Eigen::Quaternionf q(
+    static_cast<float>(ori.w), static_cast<float>(ori.x), static_cast<float>(ori.y),
+    static_cast<float>(ori.z));
   return t * q;
 }
 
@@ -46,8 +49,10 @@ Sophus::SE3f pose_to_se3(const geometry_msgs::msg::Pose & pose)
 {
   auto ori = pose.orientation;
   auto pos = pose.position;
-  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
-  Eigen::Vector3f t(pos.x, pos.y, pos.z);
+  Eigen::Quaternionf q(static_cast<float>(ori.w), static_cast<float>(ori.x),
+    static_cast<float>(ori.y), static_cast<float>(ori.z));
+  Eigen::Vector3f t(static_cast<float>(pos.x), static_cast<float>(pos.y),
+    static_cast<float>(pos.z));
   return {q, t};
 }
 

--- a/localization/yabloc/yabloc_common/src/static_tf_subscriber.cpp
+++ b/localization/yabloc/yabloc_common/src/static_tf_subscriber.cpp
@@ -35,26 +35,26 @@ std::optional<Sophus::SE3f> StaticTfSubscriber::se3f(
 std::optional<Eigen::Affine3f> StaticTfSubscriber::operator()(
   const std::string & frame_id, const std::string & parent_frame_id)
 {
-  std::optional<Eigen::Affine3f> extrinsic_{std::nullopt};
+  std::optional<Eigen::Affine3f> extrinsic{std::nullopt};
   try {
     geometry_msgs::msg::TransformStamped ts =
       tf_buffer_->lookupTransform(parent_frame_id, frame_id, tf2::TimePointZero);
     Eigen::Vector3f p;
-    p.x() = ts.transform.translation.x;
-    p.y() = ts.transform.translation.y;
-    p.z() = ts.transform.translation.z;
+    p.x() = static_cast<float>(ts.transform.translation.x);
+    p.y() = static_cast<float>(ts.transform.translation.y);
+    p.z() = static_cast<float>(ts.transform.translation.z);
 
     Eigen::Quaternionf q;
-    q.w() = ts.transform.rotation.w;
-    q.x() = ts.transform.rotation.x;
-    q.y() = ts.transform.rotation.y;
-    q.z() = ts.transform.rotation.z;
-    extrinsic_ = Eigen::Affine3f::Identity();
-    extrinsic_->translation() = p;
-    extrinsic_->matrix().topLeftCorner(3, 3) = q.toRotationMatrix();
-  } catch (tf2::TransformException & ex) {
+    q.w() = static_cast<float>(ts.transform.rotation.w);
+    q.x() = static_cast<float>(ts.transform.rotation.x);
+    q.y() = static_cast<float>(ts.transform.rotation.y);
+    q.z() = static_cast<float>(ts.transform.rotation.z);
+    extrinsic = Eigen::Affine3f::Identity();
+    extrinsic->translation() = p;
+    extrinsic->matrix().topLeftCorner(3, 3) = q.toRotationMatrix();
+  } catch (const tf2::TransformException & ex) {
   }
-  return extrinsic_;
+  return extrinsic;
 }
 
 }  // namespace yabloc::common


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `localization/yabloc/yabloc_common`.

Fixed:
- camelCase to snake_case
- use explicit cast
- math.h -> cmath
- change private variable name (adding `_`)
- change `else if` to `if` when the branch ends with return statement
- add initialization to uninitialized variable
- add or removed keyword for function/method which linter suggested
- avoid using raw loop

not Fixed:
- safe access to members of unions by `boost::variant`
  - speed concern

## Tests performed

Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

After fixing the includes,

```Text
$ ./check_linter.sh yabloc_common
...
7837 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/gamma_converter.hpp:30:30: warning: narrowing conversion from 'float' to 'unsigned char' [cppcoreguidelines-narrowing-conversions]
      lut_.at<uchar>(0, i) = 256 * std::pow(i / 256.f, gamma);
                             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/gamma_converter.hpp:30:45: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
      lut_.at<uchar>(0, i) = 256 * std::pow(i / 256.f, gamma);
                                            ^
Suppressed 7835 warnings (7835 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8449 warnings generated.
Suppressed 8449 warnings (8449 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8428 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:34:7: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  : r(rgb[2] / 255.f), g(rgb[1] / 255.f), b(rgb[0] / 255.f), a(a)
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:34:26: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  : r(rgb[2] / 255.f), g(rgb[1] / 255.f), b(rgb[0] / 255.f), a(a)
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:34:45: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  : r(rgb[2] / 255.f), g(rgb[1] / 255.f), b(rgb[0] / 255.f), a(a)
                                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:38:3: warning: 'operator unsigned int' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
  operator uint32_t() const
  ^
  explicit 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:44:5: warning: uninitialized record type: 'tmp' [cppcoreguidelines-pro-type-member-init]
    uchar4_uint32 tmp;
    ^
                     {}
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:45:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[0] = static_cast<uint8_t>(r * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:46:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[1] = static_cast<uint8_t>(g * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:47:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[2] = static_cast<uint8_t>(b * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:48:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[3] = static_cast<uint8_t>(a * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:49:16: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return tmp.u32;
               ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:51:3: warning: 'operator Scalar_' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
  operator const cv::Scalar() const { return cv::Scalar(255 * b, 255 * g, 255 * r); }
  ^
  explicit 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:51:3: warning: return type 'const cv::Scalar' (aka 'const Scalar_<double>') is 'const'-qualified at the top level, which may reduce code readability without improving const correctness [readability-const-return-type]
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:52:3: warning: 'operator ColorRGBA_' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
  operator const std_msgs::msg::ColorRGBA() const
  ^
  explicit 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:52:3: warning: return type 'const std_msgs::msg::ColorRGBA' (aka 'const ColorRGBA_<std::allocator<void>>') is 'const'-qualified at the top level, which may reduce code readability without improving const correctness [readability-const-return-type]
Suppressed 8414 warnings (8414 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8430 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/color.cpp:22:3: warning: multiple declarations in a single statement reduces readability [readability-isolate-declaration]
  float r = 1.0f, g = 1.0f, b = 1.0f;
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/color.cpp:45:3: warning: do not use 'else' after 'return' [readability-else-after-return]
  else if (h < 120)
  ^~~~~~~~~~~~~~~~~
Suppressed 8428 warnings (8428 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
9296 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/cv_decompress.cpp:31:61: error: 'find' called with a string literal consisting of a single character; consider using the more effective overload accepting a character [performance-faster-string-find,-warnings-as-errors]
  const std::string encoding = format.substr(0, format.find(";"));
                                                            ^~~
                                                            ';'
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/cv_decompress.cpp:33:17: warning: invalid case style for constexpr variable 'DECODE_GRAY' [readability-identifier-naming]
  constexpr int DECODE_GRAY = 0;
                ^~~~~~~~~~~
                decode_gray
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/cv_decompress.cpp:34:17: warning: invalid case style for constexpr variable 'DECODE_RGB' [readability-identifier-naming]
  constexpr int DECODE_RGB = 1;
                ^~~~~~~~~~
                decode_rgb
Suppressed 9293 warnings (9293 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
14775 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/filter/moving_averaging.hpp:35:13: warning: narrowing conversion from 'boost::circular_buffer<Eigen::Matrix<float, 3, 1, 0>>::size_type' (aka 'unsigned long') to 'Eigen::DenseBase<Eigen::Matrix<float, 3, 1, 0>>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    mean /= buffer_.size();
            ^
Suppressed 14776 warnings (14774 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
12858 warnings generated.
Suppressed 12860 warnings (12858 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28201 warnings generated.
Suppressed 28203 warnings (28201 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27395 warnings generated.
Suppressed 27397 warnings (27395 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27395 warnings generated.
Suppressed 27397 warnings (27395 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21390 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:49:3: warning: function 'height' should be marked [[nodiscard]] [modernize-use-nodiscard]
  float height() const { return xyz.z(); }
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:51:3: warning: function 'align_with_slope' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Eigen::Quaternionf align_with_slope(const Eigen::Quaternionf & q) const
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:56:3: warning: function 'align_with_slope' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Eigen::Matrix3f align_with_slope(const Eigen::Matrix3f & R) const
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:58:21: warning: invalid case style for variable 'R_' [readability-identifier-naming]
    Eigen::Matrix3f R_;
                    ^~
                    r
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:69:3: warning: function 'align_with_slope' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Sophus::SE3f align_with_slope(const Sophus::SE3f & pose) const
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:74:3: warning: function 'align_with_slope' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Eigen::Affine3f align_with_slope(const Eigen::Affine3f & pose) const
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:76:21: warning: invalid case style for variable 'R' [readability-identifier-naming]
    Eigen::Matrix3f R = pose.rotation();
                    ^
                    r
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_plane.hpp:81:3: warning: function 'msg' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Float32Array msg() const
  ^
  [[nodiscard]] 
Suppressed 21384 warnings (21382 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13704 warnings generated.
Suppressed 13715 warnings (13704 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28596 warnings and 1 error generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/extract_line_segments.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/extract_line_segments.cpp:24:25: warning: the const qualified variable 'pose_vector' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization]
  const Eigen::Vector3f pose_vector = transform.translation();
                        ^
                       &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/extract_line_segments.cpp:28:30: error: lambda capture 'sqrt_two' is not required to be captured for this use [clang-diagnostic-unused-lambda-capture]
  auto check_intersection = [sqrt_two, max_range,
                             ^~~~~~~~~
Suppressed 28597 warnings (28595 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
35638 warnings generated.
Suppressed 35687 warnings (35638 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
36768 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:29:6: warning: function 'upsample_line_string' defined in a header file; function definitions in header files can lead to ODR violations [misc-definitions-in-headers]
void upsample_line_string(
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:29:6: note: make as 'inline'
void upsample_line_string(
     ^
inline 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:33:21: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f f(from.x(), from.y(), from.z());
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:33:31: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f f(from.x(), from.y(), from.z());
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:33:41: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f f(from.x(), from.y(), from.z());
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:34:21: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f t(to.x(), to.y(), to.z());
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:34:29: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f t(to.x(), to.y(), to.z());
                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:34:37: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f t(to.x(), to.y(), to.z());
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:44:18: warning: function 'merge_indices' defined in a header file; function definitions in header files can lead to ODR violations [misc-definitions-in-headers]
std::vector<int> merge_indices(const std::vector<int> & indices1, const std::vector<int> & indices2)
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp:44:18: note: make as 'inline'
std::vector<int> merge_indices(const std::vector<int> & indices1, const std::vector<int> & indices2)
                 ^
inline 
Suppressed 36809 warnings (36760 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21260 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:40:26: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'Eigen::Translation<float, 3>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Translation3f t(pos.x, pos.y, pos.z);
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:40:33: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'Eigen::Translation<float, 3>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Translation3f t(pos.x, pos.y, pos.z);
                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:40:40: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'Eigen::Translation<float, 3>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Translation3f t(pos.x, pos.y, pos.z);
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:41:24: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_w_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:41:31: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_x_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:41:38: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_y_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:41:45: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_z_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:49:24: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_w_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:49:31: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_x_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:49:38: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_y_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:49:45: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_z_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
                                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:50:21: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f t(pos.x, pos.y, pos.z);
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:50:28: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f t(pos.x, pos.y, pos.z);
                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/pose_conversions.cpp:50:35: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  Eigen::Vector3f t(pos.x, pos.y, pos.z);
                                  ^
Suppressed 21248 warnings (21246 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
18071 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp:34:3: warning: function 'is_camera_info_ready' should be marked [[nodiscard]] [modernize-use-nodiscard]
  bool is_camera_info_ready() const;
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp:36:3: warning: function 'is_camera_info_nullopt' should be marked [[nodiscard]] [modernize-use-nodiscard]
  bool is_camera_info_nullopt() const;
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp:38:3: warning: function 'size' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Eigen::Vector2i size() const;
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp:40:3: warning: function 'intrinsic' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Eigen::Matrix3f intrinsic() const;
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/camera_info_subscriber.hpp:44:3: warning: function 'get_frame_id' should be marked [[nodiscard]] [modernize-use-nodiscard]
  std::string get_frame_id() const;
  ^
  [[nodiscard]] 
Suppressed 18079 warnings (18066 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
38277 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:34:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyz.x = p.x();
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:34:15: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      xyz.x = p.x();
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:35:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyz.y = p.y();
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:35:15: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      xyz.y = p.y();
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:36:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyz.z = p.z();
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:36:15: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      xyz.z = p.z();
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:48:15: warning: invalid case style for variable 'L' [readability-identifier-naming]
  const float L = (f - t).norm();
              ^
              l
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:59:13: warning: invalid case style for variable 'N' [readability-identifier-naming]
  const int N = vertices.size();
            ^
            n
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:59:17: warning: narrowing conversion from 'std::size_t' (aka 'unsigned long') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  const int N = vertices.size();
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:71:13: warning: narrowing conversion from 'std::size_t' (aka 'unsigned long') to 'Eigen::DenseBase<Eigen::Matrix<float, 3, 1, 0>>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  center /= vertices.size();
            ^
Suppressed 38316 warnings (38267 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28592 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/transform_line_segments.cpp:30:17: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    transformed.label = line.label;
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/transform_line_segments.cpp:30:30: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    transformed.label = line.label;
                             ^
Suppressed 28592 warnings (28590 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21370 warnings generated.
Suppressed 21383 warnings (21370 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21553 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp:54:25: warning: invalid case style for variable 'Kd_t' [readability-identifier-naming]
  const Eigen::Matrix3d Kd_t = Eigen::Map<const Eigen::Matrix<double, 3, 3>>(opt_info_->k.data());
                        ^~~~
                        kd_t
Suppressed 21565 warnings (21552 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
37204 warnings generated.
Suppressed 37217 warnings (37204 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43437 warnings generated.
Suppressed 43497 warnings (43437 in non-user code, 60 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27605 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/static_tf_subscriber.cpp:38:34: warning: invalid case style for variable 'extrinsic_' [readability-identifier-naming]
  std::optional<Eigen::Affine3f> extrinsic_{std::nullopt};
                                 ^~~~~~~~~~
                                 extrinsic

... (omitted)
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
(in localization/yabloc)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking yabloc_common/src/camera_info_subscriber.cpp ...
1/41 files checked 0% done
Checking yabloc_common/src/color.cpp ...
2/41 files checked 2% done
Checking yabloc_common/src/cv_decompress.cpp ...
3/41 files checked 3% done
Checking yabloc_common/src/extract_line_segments.cpp ...
yabloc_common/src/extract_line_segments.cpp:47:10: style: Consider using std::copy_if algorithm instead of a raw loop. [useStlAlgorithm]
      dst.push_back(pn);
         ^
4/41 files checked 4% done
Checking yabloc_common/src/ground_server/ground_server_core.cpp ...
5/41 files checked 9% done
Checking yabloc_common/src/ground_server/polygon_operation.cpp ...
yabloc_common/src/ground_server/polygon_operation.cpp:70:49: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
  for (const pcl::PointXYZ p : vertices) center += p.getVector3fMap();
                                                ^
6/41 files checked 11% done
Checking yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp ...
7/41 files checked 16% done
Checking yabloc_common/src/pose_conversions.cpp ...
8/41 files checked 17% done
Checking yabloc_common/src/pub_sub.cpp ...
9/41 files checked 19% done
Checking yabloc_common/src/static_tf_subscriber.cpp ...
yabloc_common/src/static_tf_subscriber.cpp:55:38: style: Variable 'ex' can be declared as reference to const [constVariableReference]
  } catch (tf2::TransformException & ex) {
                                     ^
10/41 files checked 20% done
Checking yabloc_common/src/transform_line_segments.cpp ...
11/41 files checked 21% done

... (omitted, not related to this PR)
```
</details>

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh yabloc_common
...
7835 warnings generated.
Suppressed 7835 warnings (7835 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8419 warnings generated.
Suppressed 8419 warnings (8419 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8449 warnings generated.
Suppressed 8449 warnings (8449 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
8419 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:46:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[0] = static_cast<uint8_t>(r * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:47:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[1] = static_cast<uint8_t>(g * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:48:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[2] = static_cast<uint8_t>(b * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:49:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    tmp.rgba[3] = static_cast<uint8_t>(a * 255);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/include/yabloc_common/color.hpp:50:16: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return tmp.u32;
               ^
Suppressed 8414 warnings (8414 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
9293 warnings generated.
Suppressed 9293 warnings (9293 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14774 warnings generated.
Suppressed 14776 warnings (14774 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
12858 warnings generated.
Suppressed 12860 warnings (12858 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27395 warnings generated.
Suppressed 27397 warnings (27395 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27395 warnings generated.
Suppressed 27397 warnings (27395 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28201 warnings generated.
Suppressed 28203 warnings (28201 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21382 warnings generated.
Suppressed 21384 warnings (21382 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28595 warnings generated.
Suppressed 28597 warnings (28595 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13704 warnings generated.
Suppressed 13715 warnings (13704 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
35638 warnings generated.
Suppressed 35687 warnings (35638 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
18066 warnings generated.
Suppressed 18079 warnings (18066 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21246 warnings generated.
Suppressed 21248 warnings (21246 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
36760 warnings generated.
Suppressed 36809 warnings (36760 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21370 warnings generated.
Suppressed 21383 warnings (21370 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28592 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/transform_line_segments.cpp:30:17: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    transformed.label = line.label;
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/transform_line_segments.cpp:30:30: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    transformed.label = line.label;
                             ^
Suppressed 28592 warnings (28590 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
38414 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:34:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyz.x = static_cast<float>(p.x());
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:35:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyz.y = static_cast<float>(p.y());
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/polygon_operation.cpp:36:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyz.z = static_cast<float>(p.z());
          ^
Suppressed 38460 warnings (38411 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21547 warnings generated.
Suppressed 21560 warnings (21547 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
37204 warnings generated.
Suppressed 37217 warnings (37204 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43437 warnings generated.
Suppressed 43497 warnings (43437 in non-user code, 60 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27597 warnings generated.
Suppressed 27610 warnings (27597 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
42985 warnings generated.
Suppressed 42998 warnings (42985 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
61108 warnings generated.
Suppressed 61168 warnings (61108 in non-user code, 60 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
53110 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:94:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyzl.x = static_cast<float>(p.x());
           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:95:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyzl.y = static_cast<float>(p.y());
           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:96:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      xyzl.z = static_cast<float>(p.z());
           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:178:6: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  pn.x = static_cast<float>(from.x());
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:179:6: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  pn.y = static_cast<float>(from.y());
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:180:6: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  pn.z = static_cast<float>(from.z());
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:181:6: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  pn.normal_x = static_cast<float>(to.x());
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:182:6: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  pn.normal_y = static_cast<float>(to.y());
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ll2_decomposer/ll2_decomposer_core.cpp:183:6: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  pn.normal_z = static_cast<float>(to.z());
     ^
Suppressed 53177 warnings (53101 in non-user code, 76 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
75420 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:156:28: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    const float dx = x - p.x;
                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:157:28: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    const float dy = y - p.y;
                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:160:54: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      height = std::min(height, static_cast<float>(p.z));
                                                     ^
Suppressed 75493 warnings (75417 in non-user code, 76 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

<details open>
<summary>Check with cppcheck </summary>

```
(in localization/yabloc)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/camera_info_subscriber.cpp ...
1/53 files checked 0% done
Checking src/color.cpp ...
2/53 files checked 1% done
Checking src/cv_decompress.cpp ...
3/53 files checked 2% done
Checking src/extract_line_segments.cpp ...
4/53 files checked 3% done
Checking src/ground_server/ground_server_core.cpp ...
5/53 files checked 7% done
Checking src/ground_server/polygon_operation.cpp ...
6/53 files checked 9% done
Checking src/ll2_decomposer/ll2_decomposer_core.cpp ...
7/53 files checked 13% done
Checking src/pose_conversions.cpp ...
8/53 files checked 14% done
Checking src/pub_sub.cpp ...
9/53 files checked 15% done
Checking src/static_tf_subscriber.cpp ...
10/53 files checked 16% done
Checking src/transform_line_segments.cpp ...
11/53 files checked 17% done
... (omitted, not related to this PR's codes)
```
</details>


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
