### PR TITLE
feat(system error monitor): use polling subscriber

### DIFF
--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -16,6 +16,7 @@
 #define SYSTEM_ERROR_MONITOR__SYSTEM_ERROR_MONITOR_CORE_HPP_
 
 #include "tier4_autoware_utils/ros/logger_level_configure.hpp"
+#include "tier4_autoware_utils/ros/polling_subscriber.hpp"
 
 #include <rclcpp/create_timer.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -101,12 +102,14 @@ private:
 
   // Subscriber
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_diag_array_;
-  rclcpp::Subscription<autoware_system_msgs::msg::AutowareState>::SharedPtr sub_autoware_state_;
-  rclcpp::Subscription<tier4_control_msgs::msg::GateMode>::SharedPtr sub_current_gate_mode_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr sub_control_mode_;
-  void onAutowareState(const autoware_system_msgs::msg::AutowareState::ConstSharedPtr msg);
-  void onCurrentGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg);
-  void onControlMode(const autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
+  // polling subscribers
+  tier4_autoware_utils::InterProcessPollingSubscriber<autoware_system_msgs::msg::AutowareState> sub_autoware_state_{
+    this, "~/input/current_gate_mode"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<tier4_control_msgs::msg::GateMode> sub_current_gate_mode_{
+    this, "~/input/autoware_state"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<autoware_vehicle_msgs::msg::ControlModeReport> sub_control_mode_{
+    this, "~/input/control_mode"};
+  
   void onDiagArray(const diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg);
 
   const size_t diag_buffer_size_ = 100;

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -103,13 +103,13 @@ private:
   // Subscriber
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_diag_array_;
   // polling subscribers
-  tier4_autoware_utils::InterProcessPollingSubscriber<autoware_system_msgs::msg::AutowareState> sub_autoware_state_{
-    this, "~/input/current_gate_mode"};
-  tier4_autoware_utils::InterProcessPollingSubscriber<tier4_control_msgs::msg::GateMode> sub_current_gate_mode_{
-    this, "~/input/autoware_state"};
-  tier4_autoware_utils::InterProcessPollingSubscriber<autoware_vehicle_msgs::msg::ControlModeReport> sub_control_mode_{
-    this, "~/input/control_mode"};
-  
+  tier4_autoware_utils::InterProcessPollingSubscriber<autoware_system_msgs::msg::AutowareState>
+    sub_autoware_state_{this, "~/input/current_gate_mode"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<tier4_control_msgs::msg::GateMode>
+    sub_current_gate_mode_{this, "~/input/autoware_state"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<autoware_vehicle_msgs::msg::ControlModeReport>
+    sub_control_mode_{this, "~/input/control_mode"};
+
   void onDiagArray(const diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg);
 
   const size_t diag_buffer_size_ = 100;

--- a/system/system_error_monitor/package.xml
+++ b/system/system_error_monitor/package.xml
@@ -5,6 +5,7 @@
   <version>0.1.1</version>
   <description>The system_error_monitor package in ROS 2</description>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
+  <maintainer email="masahiro.kubota@tier4.jp">Masahiro Kubota</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -434,7 +434,7 @@ void AutowareErrorMonitor::onTimer()
   const auto autoware_state_msg = sub_autoware_state_.takeData();
   const auto current_gate_msg = sub_current_gate_mode_.takeData();
   const auto control_mode_msg = sub_control_mode_.takeData();
-  
+
   if (autoware_state_msg) {
     autoware_state_ = autoware_state_msg;
     // for Heartbeat
@@ -452,7 +452,6 @@ void AutowareErrorMonitor::onTimer()
     // for Heartbeat
     control_mode_stamp_ = this->now();
   }
-  
 
   // for Heartbeat
   current_gate_mode_stamp_ = this->now();

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -232,15 +232,6 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
   // Subscriber
   sub_diag_array_ = create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
     "input/diag_array", rclcpp::QoS{1}, std::bind(&AutowareErrorMonitor::onDiagArray, this, _1));
-  sub_current_gate_mode_ = create_subscription<tier4_control_msgs::msg::GateMode>(
-    "~/input/current_gate_mode", rclcpp::QoS{1},
-    std::bind(&AutowareErrorMonitor::onCurrentGateMode, this, _1));
-  sub_autoware_state_ = create_subscription<autoware_system_msgs::msg::AutowareState>(
-    "~/input/autoware_state", rclcpp::QoS{1},
-    std::bind(&AutowareErrorMonitor::onAutowareState, this, _1));
-  sub_control_mode_ = create_subscription<autoware_vehicle_msgs::msg::ControlModeReport>(
-    "~/input/control_mode", rclcpp::QoS{1},
-    std::bind(&AutowareErrorMonitor::onControlMode, this, _1));
 
   // Publisher
   pub_hazard_status_ = create_publisher<autoware_system_msgs::msg::HazardStatusStamped>(
@@ -440,6 +431,31 @@ bool AutowareErrorMonitor::isDataHeartbeatTimeout()
 
 void AutowareErrorMonitor::onTimer()
 {
+  const auto autoware_state_msg = sub_autoware_state_.takeData();
+  const auto current_gate_msg = sub_current_gate_mode_.takeData();
+  const auto control_mode_msg = sub_control_mode_.takeData();
+  
+  if (autoware_state_msg) {
+    autoware_state_ = autoware_state_msg;
+    // for Heartbeat
+    autoware_state_stamp_ = this->now();
+  }
+
+  if (current_gate_msg) {
+    current_gate_mode_ = current_gate_msg;
+    // for Heartbeat
+    current_gate_mode_stamp_ = this->now();
+  }
+
+  if (control_mode_msg) {
+    control_mode_ = control_mode_msg;
+    // for Heartbeat
+    control_mode_stamp_ = this->now();
+  }
+  
+
+  // for Heartbeat
+  current_gate_mode_stamp_ = this->now();
   if (!isDataReady()) {
     if ((this->now() - initialized_time_).seconds() > params_.data_ready_timeout) {
       RCLCPP_WARN_THROTTLE(


### PR DESCRIPTION
## Description

The same as https://github.com/autowarefoundation/autoware.universe/pull/6997 based on [the discussion](https://github.com/orgs/autowarefoundation/discussions/4612), the polling subscriber is used in the system error monitor.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
psim test were performed
Since there was no ROSbag file for the new topic type, I changed the topic type in the code and verified that the topic was output using the ROSbag file of the old topic type.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing but more efficient CPU usage

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
