### PR TITLE
refactor(yabloc_image_processing): apply static analysis

### DIFF
--- a/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/graph_segment/histogram.hpp
+++ b/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/graph_segment/histogram.hpp
@@ -27,7 +27,7 @@ struct Histogram
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   explicit Histogram(int bin = 10) : bin(bin) { data = Eigen::MatrixXf::Zero(3, bin); }
 
-  Eigen::MatrixXf eval() const
+  [[nodiscard]] Eigen::MatrixXf eval() const
   {
     float sum = data.sum();
     if (sum < 1e-6f) throw std::runtime_error("invalid division");
@@ -37,7 +37,12 @@ struct Histogram
   void add(const cv::Vec3b & rgb)
   {
     for (int ch = 0; ch < 3; ++ch) {
-      int index = std::clamp(static_cast<int>(rgb[ch] * bin / 255.f), 0, bin - 1);
+      int index =
+        std::clamp(
+          static_cast<int>(static_cast<float>(rgb[ch]) * static_cast<float>(bin) / 255.f),
+          0,
+          bin - 1
+        );
       data(ch, index) += 1.0f;
     }
   }

--- a/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/graph_segment/histogram.hpp
+++ b/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/graph_segment/histogram.hpp
@@ -37,12 +37,9 @@ struct Histogram
   void add(const cv::Vec3b & rgb)
   {
     for (int ch = 0; ch < 3; ++ch) {
-      int index =
-        std::clamp(
-          static_cast<int>(static_cast<float>(rgb[ch]) * static_cast<float>(bin) / 255.f),
-          0,
-          bin - 1
-        );
+      int index = std::clamp(
+        static_cast<int>(static_cast<float>(rgb[ch]) * static_cast<float>(bin) / 255.f), 0,
+        bin - 1);
       data(ch, index) += 1.0f;
     }
   }

--- a/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/lanelet2_overlay/lanelet2_overlay.hpp
+++ b/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/lanelet2_overlay/lanelet2_overlay.hpp
@@ -76,7 +76,7 @@ private:
   void draw_overlay(
     const cv::Mat & image, const std::optional<Pose> & pose, const rclcpp::Time & stamp);
   void draw_overlay_line_segments(
-    cv::Mat & image, const Pose & pose, const LineSegments & line_segments);
+    cv::Mat & image, const Pose & pose, const LineSegments & near_segments);
 
   void make_vis_marker(const LineSegments & ls, const Pose & pose, const rclcpp::Time & stamp);
 };

--- a/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/line_segment_detector/line_segment_detector.hpp
+++ b/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/line_segment_detector/line_segment_detector.hpp
@@ -51,8 +51,8 @@ private:
 
   cv::Ptr<cv::LineSegmentDetector> line_segment_detector_;
 
-  std::vector<cv::Mat> remove_too_outer_elements(
-    const cv::Mat & lines, const cv::Size & size) const;
+  static std::vector<cv::Mat> remove_too_outer_elements(
+    const cv::Mat & lines, const cv::Size & size) ;
   void on_image(const sensor_msgs::msg::Image & msg);
   void execute(const cv::Mat & image, const rclcpp::Time & stamp);
 };

--- a/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/line_segment_detector/line_segment_detector.hpp
+++ b/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/line_segment_detector/line_segment_detector.hpp
@@ -52,7 +52,7 @@ private:
   cv::Ptr<cv::LineSegmentDetector> line_segment_detector_;
 
   static std::vector<cv::Mat> remove_too_outer_elements(
-    const cv::Mat & lines, const cv::Size & size) ;
+    const cv::Mat & lines, const cv::Size & size);
   void on_image(const sensor_msgs::msg::Image & msg);
   void execute(const cv::Mat & image, const rclcpp::Time & stamp);
 };

--- a/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/segment_filter/segment_filter.hpp
+++ b/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/segment_filter/segment_filter.hpp
@@ -63,14 +63,14 @@ private:
   bool define_project_func();
 
   pcl::PointCloud<pcl::PointNormal> project_lines(
-    const pcl::PointCloud<pcl::PointNormal> & lines, const std::set<int> & indices,
+    const pcl::PointCloud<pcl::PointNormal> & points, const std::set<int> & indices,
     bool negative = false) const;
 
-  std::set<int> filter_by_mask(
+  static std::set<int> filter_by_mask(
     const cv::Mat & mask, const pcl::PointCloud<pcl::PointNormal> & edges);
 
   cv::Point2i to_cv_point(const Eigen::Vector3f & v) const;
-  void execute(const PointCloud2 & msg1, const Image & msg2);
+  void execute(const PointCloud2 & line_segments_msg, const Image & segment_msg);
 
   bool is_near_element(const pcl::PointNormal & pn, pcl::PointNormal & truncated_pn) const;
 };

--- a/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp
@@ -27,8 +27,7 @@ GraphSegment::GraphSegment(const rclcpp::NodeOptions & options)
 : Node("graph_segment", options),
   target_height_ratio_(static_cast<float>(declare_parameter<float>("target_height_ratio"))),
   target_candidate_box_width_(
-    static_cast<int>(declare_parameter<int>("target_candidate_box_width"))
-  )
+    static_cast<int>(declare_parameter<int>("target_candidate_box_width")))
 {
   using std::placeholders::_1;
 
@@ -47,9 +46,7 @@ GraphSegment::GraphSegment(const rclcpp::NodeOptions & options)
   // additional area pickup module
   if (declare_parameter<bool>("pickup_additional_areas", true)) {
     similar_area_searcher_ =
-      std::make_unique<SimilarAreaSearcher>(
-        declare_parameter<float>("similarity_score_threshold")
-      );
+      std::make_unique<SimilarAreaSearcher>(declare_parameter<float>("similarity_score_threshold"));
   }
 }
 
@@ -59,9 +56,7 @@ cv::Vec3b random_hsv(int index)
   auto base = static_cast<double>(index);
   return {
     static_cast<unsigned char>(std::fmod(base * 0.7, 1.0) * 180),
-    static_cast<unsigned char>(0.7 * 255),
-    static_cast<unsigned char>(0.5 * 255)
-  };
+    static_cast<unsigned char>(0.7 * 255), static_cast<unsigned char>(0.5 * 255)};
 };
 
 int GraphSegment::search_most_road_like_class(const cv::Mat & segmented) const
@@ -70,8 +65,7 @@ int GraphSegment::search_most_road_like_class(const cv::Mat & segmented) const
   const float r = target_height_ratio_;
   cv::Point2i target_px(
     static_cast<int>(static_cast<float>(segmented.cols) * 0.5),
-    static_cast<int>(static_cast<float>(segmented.rows) * r)
-  );
+    static_cast<int>(static_cast<float>(segmented.rows) * r));
   cv::Rect2i rect(target_px + cv::Point2i(-bw, -bw), target_px + cv::Point2i(bw, bw));
 
   std::unordered_map<int, int> areas;

--- a/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp
@@ -25,8 +25,10 @@ namespace yabloc::graph_segment
 {
 GraphSegment::GraphSegment(const rclcpp::NodeOptions & options)
 : Node("graph_segment", options),
-  target_height_ratio_(declare_parameter<float>("target_height_ratio")),
-  target_candidate_box_width_(declare_parameter<int>("target_candidate_box_width"))
+  target_height_ratio_(static_cast<float>(declare_parameter<float>("target_height_ratio"))),
+  target_candidate_box_width_(
+    static_cast<int>(declare_parameter<int>("target_candidate_box_width"))
+  )
 {
   using std::placeholders::_1;
 
@@ -38,30 +40,39 @@ GraphSegment::GraphSegment(const rclcpp::NodeOptions & options)
   pub_debug_image_ = create_publisher<Image>("~/debug/segmented_image", 10);
 
   const double sigma = declare_parameter<double>("sigma");
-  const float k = declare_parameter<float>("k");
-  const int min_size = declare_parameter<double>("min_size");
+  const float k = static_cast<float>(declare_parameter<float>("k"));
+  const int min_size = static_cast<int>(declare_parameter<double>("min_size"));
   segmentation_ = cv::ximgproc::segmentation::createGraphSegmentation(sigma, k, min_size);
 
   // additional area pickup module
   if (declare_parameter<bool>("pickup_additional_areas", true)) {
     similar_area_searcher_ =
-      std::make_unique<SimilarAreaSearcher>(declare_parameter<float>("similarity_score_threshold"));
+      std::make_unique<SimilarAreaSearcher>(
+        declare_parameter<float>("similarity_score_threshold")
+      );
   }
 }
 
 cv::Vec3b random_hsv(int index)
 {
   // It generates colors that are not too bright or too vivid, but rich in hues.
-  double base = static_cast<double>(index);
-  return cv::Vec3b(std::fmod(base * 0.7, 1.0) * 180, 0.7 * 255, 0.5 * 255);
+  auto base = static_cast<double>(index);
+  return {
+    static_cast<unsigned char>(std::fmod(base * 0.7, 1.0) * 180),
+    static_cast<unsigned char>(0.7 * 255),
+    static_cast<unsigned char>(0.5 * 255)
+  };
 };
 
 int GraphSegment::search_most_road_like_class(const cv::Mat & segmented) const
 {
-  const int W = target_candidate_box_width_;
-  const float R = target_height_ratio_;
-  cv::Point2i target_px(segmented.cols * 0.5, segmented.rows * R);
-  cv::Rect2i rect(target_px + cv::Point2i(-W, -W), target_px + cv::Point2i(W, W));
+  const int bw = target_candidate_box_width_;
+  const float r = target_height_ratio_;
+  cv::Point2i target_px(
+    static_cast<int>(static_cast<float>(segmented.cols) * 0.5),
+    static_cast<int>(static_cast<float>(segmented.rows) * r)
+  );
+  cv::Rect2i rect(target_px + cv::Point2i(-bw, -bw), target_px + cv::Point2i(bw, bw));
 
   std::unordered_map<int, int> areas;
   std::unordered_set<int> candidates;
@@ -69,7 +80,7 @@ int GraphSegment::search_most_road_like_class(const cv::Mat & segmented) const
     const int * seg_ptr = segmented.ptr<int>(h);
     for (int w = 0; w < segmented.cols; w++) {
       int key = seg_ptr[w];
-      if (areas.count(key) == 0) areas[key] = 0;
+      areas.try_emplace(key, 0);
       areas[key]++;
       if (rect.contains(cv::Point2i{w, h})) candidates.insert(key);
     }
@@ -111,8 +122,8 @@ void GraphSegment::on_image(const Image & msg)
   cv::Mat debug_image = cv::Mat::zeros(resized.size(), CV_8UC3);
   for (int h = 0; h < resized.rows; h++) {
     // NOTE: Accessing through ptr() is faster than at()
-    cv::Vec3b * const debug_image_ptr = debug_image.ptr<cv::Vec3b>(h);
-    uchar * const output_image_ptr = output_image.ptr<uchar>(h);
+    auto * const debug_image_ptr = debug_image.ptr<cv::Vec3b>(h);
+    auto * const output_image_ptr = output_image.ptr<uchar>(h);
     const int * const segmented_image_ptr = segmented.ptr<int>(h);
 
     for (int w = 0; w < resized.cols; w++) {
@@ -148,10 +159,10 @@ void GraphSegment::draw_and_publish_image(
 
   // Draw target rectangle
   {
-    const int W = target_candidate_box_width_;
-    const float R = target_height_ratio_;
-    cv::Point2i target(size.width / 2, size.height * R);
-    cv::Rect2i rect(target + cv::Point2i(-W, -W), target + cv::Point2i(W, W));
+    const int w = target_candidate_box_width_;
+    const float r = target_height_ratio_;
+    cv::Point2i target(size.width / 2, static_cast<int>(static_cast<float>(size.height) * r));
+    cv::Rect2i rect(target + cv::Point2i(-w, -w), target + cv::Point2i(w, w));
     cv::rectangle(show_image, rect, cv::Scalar::all(0), 2);
   }
 

--- a/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp
@@ -37,7 +37,7 @@ std::set<int> SimilarAreaSearcher::search(
 
   for (int h = 0; h < rgb_image.rows; h++) {
     const int * seg_ptr = segmented.ptr<int>(h);
-    const cv::Vec3b * rgb_ptr = rgb_image.ptr<cv::Vec3b>(h);
+    const auto * rgb_ptr = rgb_image.ptr<cv::Vec3b>(h);
 
     for (int w = 0; w < rgb_image.cols; w++) {
       int key = seg_ptr[w];

--- a/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp
@@ -72,7 +72,7 @@ void Lanelet2Overlay::on_image(const sensor_msgs::msg::Image & msg)
   // Search synchronized pose
   float min_abs_dt = std::numeric_limits<float>::max();
   std::optional<Pose> synched_pose{std::nullopt};
-  for (const auto& pose : pose_buffer_) {
+  for (const auto & pose : pose_buffer_) {
     auto dt = (rclcpp::Time(pose.header.stamp) - stamp);
     auto abs_dt = std::abs(dt.seconds());
     if (abs_dt < min_abs_dt) {
@@ -93,7 +93,7 @@ void Lanelet2Overlay::on_line_segments(const PointCloud2 & msg)
   // Search synchronized pose
   float min_dt = std::numeric_limits<float>::max();
   geometry_msgs::msg::PoseStamped synched_pose;
-  for (const auto& pose : pose_buffer_) {
+  for (const auto & pose : pose_buffer_) {
     auto dt = (rclcpp::Time(pose.header.stamp) - stamp);
     auto abs_dt = std::abs(dt.seconds());
     if (abs_dt < min_dt) {
@@ -160,8 +160,9 @@ void Lanelet2Overlay::draw_overlay_line_segments(
     if (p2_is_visible) uv2 = from_camera2 / from_camera2.z();
 
     if ((p1_is_visible) && (p2_is_visible))
-      return {true, cv::Point2i(static_cast<int>(uv1.x()), static_cast<int>(uv1.y())),
-    cv::Point2i(static_cast<int>(uv2.x()), static_cast<int>(uv2.y()))};
+      return {
+        true, cv::Point2i(static_cast<int>(uv1.x()), static_cast<int>(uv1.y())),
+        cv::Point2i(static_cast<int>(uv2.x()), static_cast<int>(uv2.y()))};
 
     Eigen::Vector3f tangent = from_camera2 - from_camera1;
     float mu = (epsilon - from_camera1.z()) / (tangent.z());
@@ -173,8 +174,9 @@ void Lanelet2Overlay::draw_overlay_line_segments(
       from_camera2 = from_camera1 + mu * tangent;
       uv2 = from_camera2 / from_camera2.z();
     }
-    return {true, cv::Point2i(static_cast<int>(uv1.x()), static_cast<int>(uv1.y())),
-    cv::Point2i(static_cast<int>(uv2.x()), static_cast<int>(uv2.y()))};
+    return {
+      true, cv::Point2i(static_cast<int>(uv1.x()), static_cast<int>(uv1.y())),
+      cv::Point2i(static_cast<int>(uv2.x()), static_cast<int>(uv2.y()))};
   };
 
   for (const pcl::PointNormal & pn : near_segments) {

--- a/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp
@@ -72,11 +72,11 @@ void Lanelet2Overlay::on_image(const sensor_msgs::msg::Image & msg)
   // Search synchronized pose
   float min_abs_dt = std::numeric_limits<float>::max();
   std::optional<Pose> synched_pose{std::nullopt};
-  for (auto pose : pose_buffer_) {
+  for (const auto& pose : pose_buffer_) {
     auto dt = (rclcpp::Time(pose.header.stamp) - stamp);
     auto abs_dt = std::abs(dt.seconds());
     if (abs_dt < min_abs_dt) {
-      min_abs_dt = abs_dt;
+      min_abs_dt = static_cast<float>(abs_dt);
       synched_pose = pose.pose;
     }
   }
@@ -93,18 +93,16 @@ void Lanelet2Overlay::on_line_segments(const PointCloud2 & msg)
   // Search synchronized pose
   float min_dt = std::numeric_limits<float>::max();
   geometry_msgs::msg::PoseStamped synched_pose;
-  for (auto pose : pose_buffer_) {
+  for (const auto& pose : pose_buffer_) {
     auto dt = (rclcpp::Time(pose.header.stamp) - stamp);
     auto abs_dt = std::abs(dt.seconds());
     if (abs_dt < min_dt) {
-      min_dt = abs_dt;
+      min_dt = static_cast<float>(abs_dt);
       synched_pose = pose;
     }
   }
   if (min_dt > 0.1) return;
   auto latest_pose_stamp = rclcpp::Time(pose_buffer_.back().header.stamp);
-
-  std::vector<int> a;
 
   LineSegments line_segments_cloud;
   pcl::fromROSMsg(msg, line_segments_cloud);
@@ -139,32 +137,34 @@ void Lanelet2Overlay::draw_overlay_line_segments(
   if (!camera_extrinsic_.has_value()) return;
   if (!info_.has_value()) return;
 
-  Eigen::Matrix3f K =
+  Eigen::Matrix3f k =
     Eigen::Map<Eigen::Matrix<double, 3, 3> >(info_->k.data()).cast<float>().transpose();
-  Eigen::Affine3f T = camera_extrinsic_.value();
+  Eigen::Affine3f t = camera_extrinsic_.value();
 
   Eigen::Affine3f transform = ground_plane_.align_with_slope(common::pose_to_affine(pose));
 
-  auto projectLineSegment =
-    [K, T, transform](
+  auto project_line_segment =
+    [k, t, transform](
       const Eigen::Vector3f & p1,
       const Eigen::Vector3f & p2) -> std::tuple<bool, cv::Point2i, cv::Point2i> {
-    Eigen::Vector3f from_camera1 = K * T.inverse() * transform.inverse() * p1;
-    Eigen::Vector3f from_camera2 = K * T.inverse() * transform.inverse() * p2;
-    constexpr float EPSILON = 0.1f;
-    bool p1_is_visible = from_camera1.z() > EPSILON;
-    bool p2_is_visible = from_camera2.z() > EPSILON;
+    Eigen::Vector3f from_camera1 = k * t.inverse() * transform.inverse() * p1;
+    Eigen::Vector3f from_camera2 = k * t.inverse() * transform.inverse() * p2;
+    constexpr float epsilon = 0.1f;
+    bool p1_is_visible = from_camera1.z() > epsilon;
+    bool p2_is_visible = from_camera2.z() > epsilon;
     if ((!p1_is_visible) && (!p2_is_visible)) return {false, cv::Point2i{}, cv::Point2i{}};
 
-    Eigen::Vector3f uv1, uv2;
+    Eigen::Vector3f uv1;
+    Eigen::Vector3f uv2;
     if (p1_is_visible) uv1 = from_camera1 / from_camera1.z();
     if (p2_is_visible) uv2 = from_camera2 / from_camera2.z();
 
     if ((p1_is_visible) && (p2_is_visible))
-      return {true, cv::Point2i(uv1.x(), uv1.y()), cv::Point2i(uv2.x(), uv2.y())};
+      return {true, cv::Point2i(static_cast<int>(uv1.x()), static_cast<int>(uv1.y())),
+    cv::Point2i(static_cast<int>(uv2.x()), static_cast<int>(uv2.y()))};
 
     Eigen::Vector3f tangent = from_camera2 - from_camera1;
-    float mu = (EPSILON - from_camera1.z()) / (tangent.z());
+    float mu = (epsilon - from_camera1.z()) / (tangent.z());
     if (!p1_is_visible) {
       from_camera1 = from_camera1 + mu * tangent;
       uv1 = from_camera1 / from_camera1.z();
@@ -173,11 +173,12 @@ void Lanelet2Overlay::draw_overlay_line_segments(
       from_camera2 = from_camera1 + mu * tangent;
       uv2 = from_camera2 / from_camera2.z();
     }
-    return {true, cv::Point2i(uv1.x(), uv1.y()), cv::Point2i(uv2.x(), uv2.y())};
+    return {true, cv::Point2i(static_cast<int>(uv1.x()), static_cast<int>(uv1.y())),
+    cv::Point2i(static_cast<int>(uv2.x()), static_cast<int>(uv2.y()))};
   };
 
   for (const pcl::PointNormal & pn : near_segments) {
-    auto [success, u1, u2] = projectLineSegment(pn.getVector3fMap(), pn.getNormalVector3fMap());
+    auto [success, u1, u2] = project_line_segment(pn.getVector3fMap(), pn.getNormalVector3fMap());
     if (success) cv::line(image, u1, u2, cv::Scalar(0, 255, 255), 2);
   }
 }
@@ -197,7 +198,8 @@ void Lanelet2Overlay::make_vis_marker(
   marker.color.a = 0.7f;
 
   for (const auto pn : ls) {
-    geometry_msgs::msg::Point p1, p2;
+    geometry_msgs::msg::Point p1;
+    geometry_msgs::msg::Point p2;
     p1.x = pn.x;
     p1.y = pn.y;
     p1.z = pn.z;

--- a/localization/yabloc/yabloc_image_processing/src/line_segment_detector/line_segment_detector_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/line_segment_detector/line_segment_detector_core.cpp
@@ -67,7 +67,8 @@ void LineSegmentDetector::execute(const cv::Mat & image, const rclcpp::Time & st
   std::vector<cv::Mat> filtered_lines = remove_too_outer_elements(lines, image.size());
 
   for (const cv::Mat & xy_xy : filtered_lines) {
-    Eigen::Vector3f xy1, xy2;
+    Eigen::Vector3f xy1;
+    Eigen::Vector3f xy2;
     xy1 << xy_xy.at<float>(0), xy_xy.at<float>(1), 0;
     xy2 << xy_xy.at<float>(2), xy_xy.at<float>(3), 0;
     pcl::PointNormal pn;
@@ -79,7 +80,7 @@ void LineSegmentDetector::execute(const cv::Mat & image, const rclcpp::Time & st
 }
 
 std::vector<cv::Mat> LineSegmentDetector::remove_too_outer_elements(
-  const cv::Mat & lines, const cv::Size & size) const
+  const cv::Mat & lines, const cv::Size & size)
 {
   std::vector<cv::Rect2i> rect_vector;
   rect_vector.emplace_back(0, 0, size.width, 3);

--- a/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
@@ -30,11 +30,11 @@ LineSegmentsOverlay::LineSegmentsOverlay(const rclcpp::NodeOptions & options)
   using std::placeholders::_1;
 
   auto cb_image = std::bind(&LineSegmentsOverlay::on_image, this, _1);
-  auto cb_line_segments_ = std::bind(&LineSegmentsOverlay::on_line_segments, this, _1);
+  auto cb_line_segments = std::bind(&LineSegmentsOverlay::on_line_segments, this, _1);
 
   sub_image_ = create_subscription<Image>("~/input/image_raw", 10, cb_image);
   sub_line_segments_ =
-    create_subscription<PointCloud2>("~/input/line_segments", 10, cb_line_segments_);
+    create_subscription<PointCloud2>("~/input/line_segments", 10, cb_line_segments);
 
   pub_debug_image_ = create_publisher<Image>("~/debug/image_with_colored_line_segments", 10);
 }
@@ -73,8 +73,7 @@ void LineSegmentsOverlay::on_line_segments(const PointCloud2::ConstSharedPtr & l
   LineSegments line_segments_cloud;
   pcl::fromROSMsg(*line_segments_msg, line_segments_cloud);
 
-  for (size_t index = 0; index < line_segments_cloud.size(); ++index) {
-    const LineSegment & pn = line_segments_cloud.at(index);
+  for (auto & pn : line_segments_cloud) {
     Eigen::Vector3f xy1 = pn.getVector3fMap();
     Eigen::Vector3f xy2 = pn.getNormalVector3fMap();
 
@@ -83,7 +82,8 @@ void LineSegmentsOverlay::on_line_segments(const PointCloud2::ConstSharedPtr & l
       color = cv::Scalar(0, 0, 255);  // Red
     }
 
-    cv::line(image, cv::Point(xy1(0), xy1(1)), cv::Point(xy2(0), xy2(1)), color, 2);
+    cv::line(image, cv::Point(static_cast<int>(xy1(0)), static_cast<int>(xy1(1))),
+      cv::Point(static_cast<int>(xy2(0)), static_cast<int>(xy2(1))), color, 2);
   }
 
   common::publish_image(*pub_debug_image_, image, stamp);

--- a/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
@@ -82,7 +82,8 @@ void LineSegmentsOverlay::on_line_segments(const PointCloud2::ConstSharedPtr & l
       color = cv::Scalar(0, 0, 255);  // Red
     }
 
-    cv::line(image, cv::Point(static_cast<int>(xy1(0)), static_cast<int>(xy1(1))),
+    cv::line(
+      image, cv::Point(static_cast<int>(xy1(0)), static_cast<int>(xy1(1))),
       cv::Point(static_cast<int>(xy2(0)), static_cast<int>(xy2(1))), color, 2);
   }
 

--- a/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp
@@ -48,10 +48,11 @@ SegmentFilter::SegmentFilter(const rclcpp::NodeOptions & options)
 cv::Point2i SegmentFilter::to_cv_point(const Eigen::Vector3f & v) const
 {
   cv::Point2i pt;
-  pt.x = static_cast<int>(-v.y() / max_range_ * static_cast<float>(image_size_) * 0.5f +
+  pt.x = static_cast<int>(
+    -v.y() / max_range_ * static_cast<float>(image_size_) * 0.5f +
     static_cast<float>(image_size_) / 2.0);
-  pt.y = static_cast<int>(-v.x() / max_range_ * static_cast<float>(image_size_) * 0.5f +
-    static_cast<float>(image_size_));
+  pt.y = static_cast<int>(
+    -v.x() / max_range_ * static_cast<float>(image_size_) * 0.5f + static_cast<float>(image_size_));
   return pt;
 }
 

--- a/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp
@@ -25,11 +25,11 @@ namespace yabloc::segment_filter
 {
 SegmentFilter::SegmentFilter(const rclcpp::NodeOptions & options)
 : Node("segment_filter", options),
-  image_size_(declare_parameter<int>("image_size")),
-  max_range_(declare_parameter<float>("max_range")),
-  min_segment_length_(declare_parameter<float>("min_segment_length")),
-  max_segment_distance_(declare_parameter<float>("max_segment_distance")),
-  max_lateral_distance_(declare_parameter<float>("max_lateral_distance")),
+  image_size_(static_cast<int>(declare_parameter<int>("image_size"))),
+  max_range_(static_cast<float>(declare_parameter<float>("max_range"))),
+  min_segment_length_(static_cast<float>(declare_parameter<float>("min_segment_length"))),
+  max_segment_distance_(static_cast<float>(declare_parameter<float>("max_segment_distance"))),
+  max_lateral_distance_(static_cast<float>(declare_parameter<float>("max_lateral_distance"))),
   info_(this),
   synchro_subscriber_(this, "~/input/line_segments_cloud", "~/input/graph_segmented"),
   tf_subscriber_(this->get_clock())
@@ -47,9 +47,11 @@ SegmentFilter::SegmentFilter(const rclcpp::NodeOptions & options)
 
 cv::Point2i SegmentFilter::to_cv_point(const Eigen::Vector3f & v) const
 {
-  cv::Point pt;
-  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2;
-  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_;
+  cv::Point2i pt;
+  pt.x = static_cast<int>(-v.y() / max_range_ * static_cast<float>(image_size_) * 0.5f +
+    static_cast<float>(image_size_) / 2.0);
+  pt.y = static_cast<int>(-v.x() / max_range_ * static_cast<float>(image_size_) * 0.5f +
+    static_cast<float>(image_size_));
   return pt;
 }
 
@@ -149,7 +151,7 @@ void SegmentFilter::execute(const PointCloud2 & line_segments_msg, const Image &
       pcl::PointXYZLNormal pln;
       pln.getVector3fMap() = pn.getVector3fMap();
       pln.getNormalVector3fMap() = pn.getNormalVector3fMap();
-      if (indices.count(index) > 0)
+      if (indices.count(static_cast<int>(index)) > 0)
         pln.label = 255;
       else
         pln.label = 0;
@@ -194,7 +196,7 @@ std::set<ushort> get_unique_pixel_value(cv::Mat & image)
   auto last = std::unique(begin, image.end<ushort>());
   std::sort(begin, last);
   last = std::unique(begin, last);
-  return std::set<ushort>(begin, last);
+  return {begin, last};
 }
 
 pcl::PointCloud<pcl::PointNormal> SegmentFilter::project_lines(
@@ -204,9 +206,9 @@ pcl::PointCloud<pcl::PointNormal> SegmentFilter::project_lines(
   pcl::PointCloud<pcl::PointNormal> projected_points;
   for (size_t index = 0; index < points.size(); ++index) {
     if (negative) {
-      if (indices.count(index) > 0) continue;
+      if (indices.count(static_cast<int>(index)) > 0) continue;
     } else {
-      if (indices.count(index) == 0) continue;
+      if (indices.count(static_cast<int>(index)) == 0) continue;
     }
 
     pcl::PointNormal truncated_pn = points.at(index);
@@ -254,9 +256,10 @@ std::set<int> SegmentFilter::filter_by_mask(
     auto & pn = edges.at(i);
     Eigen::Vector3f p1 = pn.getVector3fMap();
     Eigen::Vector3f p2 = pn.getNormalVector3fMap();
-    cv::Scalar color = cv::Scalar::all(i + 1);
+    cv::Scalar color = cv::Scalar::all(static_cast<double>(i + 1));
     cv::line(
-      line_image, cv::Point2i(p1.x(), p1.y()), cv::Point2i(p2.x(), p2.y()), color, 1,
+      line_image, cv::Point2i(static_cast<int>(p1.x()), static_cast<int>(p1.y())),
+      cv::Point2i(static_cast<int>(p2.x()), static_cast<int>(p2.y())), color, 1,
       cv::LineTypes::LINE_4);
   }
 
@@ -275,7 +278,7 @@ std::set<int> SegmentFilter::filter_by_mask(
   // Extract edges within masks
   std::set<int> reliable_indices;
   for (size_t i = 0; i < edges.size(); i++) {
-    if (pixel_values.count(i + 1) != 0) reliable_indices.insert(i);
+    if (pixel_values.count(i + 1) != 0) reliable_indices.insert(static_cast<int>(i));
   }
 
   return reliable_indices;

--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -39,8 +39,8 @@ public:
 
   explicit UndistortNode(const rclcpp::NodeOptions & options)
   : Node("undistort", options),
-    OUTPUT_WIDTH(declare_parameter<int>("width")),
-    OVERRIDE_FRAME_ID(declare_parameter<std::string>("override_frame_id"))
+    OUTPUT_WIDTH_(static_cast<int>(declare_parameter<int>("width"))),
+    OVERRIDE_FRAME_ID_(declare_parameter<std::string>("override_frame_id"))
   {
     using std::placeholders::_1;
 
@@ -63,8 +63,8 @@ public:
   }
 
 private:
-  const int OUTPUT_WIDTH;
-  const std::string OVERRIDE_FRAME_ID;
+  const int OUTPUT_WIDTH_;
+  const std::string OVERRIDE_FRAME_ID_;
 
   rclcpp::Subscription<Image>::SharedPtr sub_image_;
   rclcpp::Subscription<CompressedImage>::SharedPtr sub_compressed_image_;
@@ -74,29 +74,32 @@ private:
   std::optional<CameraInfo> info_{std::nullopt};
   std::optional<CameraInfo> scaled_info_{std::nullopt};
 
-  cv::Mat undistort_map_x, undistort_map_y;
+  cv::Mat undistort_map_x_, undistort_map_y_;
 
   void make_remap_lut()
   {
     if (!info_.has_value()) return;
-    cv::Mat K = cv::Mat(cv::Size(3, 3), CV_64FC1, reinterpret_cast<void *>(info_->k.data()));
-    cv::Mat D = cv::Mat(cv::Size(5, 1), CV_64FC1, reinterpret_cast<void *>(info_->d.data()));
-    cv::Size size(info_->width, info_->height);
+    cv::Mat k = cv::Mat(cv::Size(3, 3), CV_64FC1, info_->k.data());
+    cv::Mat d = cv::Mat(cv::Size(5, 1), CV_64FC1, info_->d.data());
+    cv::Size size(static_cast<int>(info_->width), static_cast<int>(info_->height));
 
     cv::Size new_size = size;
-    if (OUTPUT_WIDTH > 0)
-      new_size = cv::Size(OUTPUT_WIDTH, 1.0f * OUTPUT_WIDTH / size.width * size.height);
+    if (OUTPUT_WIDTH_ > 0)
+      // set new_size along with aspect ratio
+      new_size = cv::Size(OUTPUT_WIDTH_,
+        static_cast<int>(static_cast<float>(OUTPUT_WIDTH_) *
+        (static_cast<float>(size.height) / static_cast<float>(size.width))));
 
-    cv::Mat new_K = cv::getOptimalNewCameraMatrix(K, D, size, 0, new_size);
+    cv::Mat new_k = cv::getOptimalNewCameraMatrix(k, d, size, 0, new_size);
 
     cv::initUndistortRectifyMap(
-      K, D, cv::Mat(), new_K, new_size, CV_32FC1, undistort_map_x, undistort_map_y);
+      k, d, cv::Mat(), new_k, new_size, CV_32FC1, undistort_map_x_, undistort_map_y_);
 
     scaled_info_ = sensor_msgs::msg::CameraInfo{};
-    scaled_info_->k.at(0) = new_K.at<double>(0, 0);
-    scaled_info_->k.at(2) = new_K.at<double>(0, 2);
-    scaled_info_->k.at(4) = new_K.at<double>(1, 1);
-    scaled_info_->k.at(5) = new_K.at<double>(1, 2);
+    scaled_info_->k.at(0) = new_k.at<double>(0, 0);
+    scaled_info_->k.at(2) = new_k.at<double>(0, 2);
+    scaled_info_->k.at(4) = new_k.at<double>(1, 1);
+    scaled_info_->k.at(5) = new_k.at<double>(1, 2);
     scaled_info_->k.at(8) = 1;
     scaled_info_->d.resize(5);
     scaled_info_->width = new_size.width;
@@ -106,12 +109,12 @@ private:
   void remap_and_publish(const cv::Mat & image, const std_msgs::msg::Header & header)
   {
     cv::Mat undistorted_image;
-    cv::remap(image, undistorted_image, undistort_map_x, undistort_map_y, cv::INTER_LINEAR);
+    cv::remap(image, undistorted_image, undistort_map_x_, undistort_map_y_, cv::INTER_LINEAR);
 
     // Publish CameraInfo
     {
       scaled_info_->header = info_->header;
-      if (OVERRIDE_FRAME_ID != "") scaled_info_->header.frame_id = OVERRIDE_FRAME_ID;
+      if (!OVERRIDE_FRAME_ID_.empty()) scaled_info_->header.frame_id = OVERRIDE_FRAME_ID_;
       pub_info_->publish(scaled_info_.value());
     }
 
@@ -119,8 +122,8 @@ private:
     {
       cv_bridge::CvImage bridge;
       bridge.header.stamp = header.stamp;
-      if (OVERRIDE_FRAME_ID != "")
-        bridge.header.frame_id = OVERRIDE_FRAME_ID;
+      if (!OVERRIDE_FRAME_ID_.empty())
+        bridge.header.frame_id = OVERRIDE_FRAME_ID_;
       else
         bridge.header.frame_id = header.frame_id;
       bridge.encoding = "bgr8";
@@ -134,7 +137,7 @@ private:
     if (!info_.has_value()) {
       return;
     }
-    if (undistort_map_x.empty()) {
+    if (undistort_map_x_.empty()) {
       make_remap_lut();
     }
 
@@ -153,7 +156,7 @@ private:
     if (!info_.has_value()) {
       return;
     }
-    if (undistort_map_x.empty()) {
+    if (undistort_map_x_.empty()) {
       make_remap_lut();
     }
 

--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -86,9 +86,10 @@ private:
     cv::Size new_size = size;
     if (OUTPUT_WIDTH_ > 0)
       // set new_size along with aspect ratio
-      new_size = cv::Size(OUTPUT_WIDTH_,
-        static_cast<int>(static_cast<float>(OUTPUT_WIDTH_) *
-        (static_cast<float>(size.height) / static_cast<float>(size.width))));
+      new_size = cv::Size(
+        OUTPUT_WIDTH_, static_cast<int>(
+                         static_cast<float>(OUTPUT_WIDTH_) *
+                         (static_cast<float>(size.height) / static_cast<float>(size.width))));
 
     cv::Mat new_k = cv::getOptimalNewCameraMatrix(k, d, size, 0, new_size);
 


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `localization/yabloc/yabloc_image_processing`.
Checked with clang-tidy and cppcheck.

Fixed:
- camelCase to snake_case
- use explicit cast
- change variable names
  - add `_` to private variable
  - align variable name in header's definition and the implementation
  - LOCAL_VAR to local_var
- add or removed keyword from function/method which linter suggested
- remove `reinterpret_cast`
  - [cv::Mat](https://docs.opencv.org/4.5.4/d3/d63/classcv_1_1Mat.html) takes `void *data`

not Fixed:
- safe access to members of unions by `boost::variant`
  - speed concern
- pointer arithmetic ([cppcoreguidelines-pro-bounds-pointer-arithmetic](https://releases.llvm.org/13.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html))
  - https://github.com/autowarefoundation/autoware.universe/blob/9c4155448290fdb579f17752c73a9832ab347873/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp#L38-L53 https://github.com/autowarefoundation/autoware.universe/blob/9c4155448290fdb579f17752c73a9832ab347873/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp#L68-L76: speed concern, not sure pointer access is the fastest way to access the data
- [readability-function-cognitive-complexity](https://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html) for `SegmentFilter::project_lines`
- notes for nesting level

## Tests performed
Checked with clang-tidy and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

```Text
$ ./check_linter.sh yabloc_image_processing
...
13154 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/graph_segment/histogram.hpp:30:3: warning: function 'eval' should be marked [[nodiscard]] [modernize-use-nodiscard]
  Eigen::MatrixXf eval() const
  ^
  [[nodiscard]] 
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/graph_segment/histogram.hpp:40:47: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
      int index = std::clamp(static_cast<int>(rgb[ch] * bin / 255.f), 0, bin - 1);
                                              ^
Suppressed 13154 warnings (13152 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14565 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp:40:11: warning: use auto when initializing with a template cast to avoid duplicating the type name [modernize-use-auto]
    const cv::Vec3b * rgb_ptr = rgb_image.ptr<cv::Vec3b>(h);
          ^~~~~~~~~
          auto
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp:43:17: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      int key = seg_ptr[w];
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp:44:23: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      cv::Vec3b rgb = rgb_ptr[w];
                      ^
Suppressed 14564 warnings (14562 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
12970 warnings generated.
Suppressed 12972 warnings (12970 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
20454 warnings generated.
Suppressed 20467 warnings (20454 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
35145 warnings generated.
Suppressed 35158 warnings (35145 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
40369 warnings generated.
Suppressed 40382 warnings (40369 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
41096 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:28:24: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  target_height_ratio_(declare_parameter<float>("target_height_ratio")),
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:29:31: warning: narrowing conversion from 'long' to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  target_candidate_box_width_(declare_parameter<int>("target_candidate_box_width"))
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:41:19: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  const float k = declare_parameter<float>("k");
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:42:24: warning: narrowing conversion from 'double' to 'int' [cppcoreguidelines-narrowing-conversions]
  const int min_size = declare_parameter<double>("min_size");
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:55:3: warning: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto]
  double base = static_cast<double>(index);
  ^~~~~~
  auto
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:56:10: warning: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list]
  return cv::Vec3b(std::fmod(base * 0.7, 1.0) * 180, 0.7 * 255, 0.5 * 255);
         ^~~~~~~~~~                                                      ~
         {                                                               }
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:56:20: warning: narrowing conversion from 'double' to 'unsigned char' [cppcoreguidelines-narrowing-conversions]
  return cv::Vec3b(std::fmod(base * 0.7, 1.0) * 180, 0.7 * 255, 0.5 * 255);
                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:56:54: warning: narrowing conversion from constant 'double' to 'unsigned char' [cppcoreguidelines-narrowing-conversions]
  return cv::Vec3b(std::fmod(base * 0.7, 1.0) * 180, 0.7 * 255, 0.5 * 255);
                                                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:56:65: warning: narrowing conversion from constant 'double' to 'unsigned char' [cppcoreguidelines-narrowing-conversions]
  return cv::Vec3b(std::fmod(base * 0.7, 1.0) * 180, 0.7 * 255, 0.5 * 255);
                                                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:61:13: warning: invalid case style for variable 'W' [readability-identifier-naming]
  const int W = target_candidate_box_width_;
            ^
            w
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:62:15: warning: invalid case style for variable 'R' [readability-identifier-naming]
  const float R = target_height_ratio_;
              ^
              r
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:63:25: warning: narrowing conversion from 'double' to 'int' [cppcoreguidelines-narrowing-conversions]
  cv::Point2i target_px(segmented.cols * 0.5, segmented.rows * R);
                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:63:47: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  cv::Point2i target_px(segmented.cols * 0.5, segmented.rows * R);
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:63:47: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:71:17: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      int key = seg_ptr[w];
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:114:5: warning: use auto when initializing with a template cast to avoid duplicating the type name [modernize-use-auto]
    cv::Vec3b * const debug_image_ptr = debug_image.ptr<cv::Vec3b>(h);
    ^~~~~~~~~
    auto
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:115:5: warning: use auto when initializing with a template cast to avoid duplicating the type name [modernize-use-auto]
    uchar * const output_image_ptr = output_image.ptr<uchar>(h);
    ^~~~~
    auto
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:120:23: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      const int key = segmented_image_ptr[w];
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:122:9: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
        output_image_ptr[w] = 255;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:124:11: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
          debug_image_ptr[w] = cv::Vec3b(30, 255, 255);
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:126:11: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
          debug_image_ptr[w] = cv::Vec3b(10, 255, 255);
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:128:9: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
        debug_image_ptr[w] = random_hsv(key);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:151:15: warning: invalid case style for variable 'W' [readability-identifier-naming]
    const int W = target_candidate_box_width_;
              ^
              w
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:152:17: warning: invalid case style for variable 'R' [readability-identifier-naming]
    const float R = target_height_ratio_;
                ^
                r
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:153:40: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
    cv::Point2i target(size.width / 2, size.height * R);
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:153:40: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
Suppressed 41083 warnings (41070 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
40245 warnings generated.
Suppressed 40258 warnings (40245 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
49305 warnings generated.
Suppressed 49318 warnings (49305 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
44583 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:42:18: warning: narrowing conversion from 'long' to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
    OUTPUT_WIDTH(declare_parameter<int>("width")),
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:66:13: warning: invalid case style for private member 'OUTPUT_WIDTH' [readability-identifier-naming]
  const int OUTPUT_WIDTH;
            ^~~~~~~~~~~~
            OUTPUT_WIDTH_
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:67:21: warning: invalid case style for private member 'OVERRIDE_FRAME_ID' [readability-identifier-naming]
  const std::string OVERRIDE_FRAME_ID;
                    ^
note: this fix will not be applied because it overlaps with another fix
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:77:11: warning: invalid case style for private member 'undistort_map_x' [readability-identifier-naming]
  cv::Mat undistort_map_x, undistort_map_y;
          ^~~~~~~~~~~~~~~
          undistort_map_x_
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:77:28: warning: invalid case style for private member 'undistort_map_y' [readability-identifier-naming]
  cv::Mat undistort_map_x, undistort_map_y;
                           ^~~~~~~~~~~~~~~
                           undistort_map_y_
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:82:13: warning: invalid case style for variable 'K' [readability-identifier-naming]
    cv::Mat K = cv::Mat(cv::Size(3, 3), CV_64FC1, reinterpret_cast<void *>(info_->k.data()));
            ^
            k
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:82:51: warning: do not use reinterpret_cast [cppcoreguidelines-pro-type-reinterpret-cast]
    cv::Mat K = cv::Mat(cv::Size(3, 3), CV_64FC1, reinterpret_cast<void *>(info_->k.data()));
                                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:83:13: warning: invalid case style for variable 'D' [readability-identifier-naming]
    cv::Mat D = cv::Mat(cv::Size(5, 1), CV_64FC1, reinterpret_cast<void *>(info_->d.data()));
            ^
            d
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:83:51: warning: do not use reinterpret_cast [cppcoreguidelines-pro-type-reinterpret-cast]
    cv::Mat D = cv::Mat(cv::Size(5, 1), CV_64FC1, reinterpret_cast<void *>(info_->d.data()));
                                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:84:19: warning: narrowing conversion from 'sensor_msgs::msg::CameraInfo_::_width_type' (aka 'unsigned int') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
    cv::Size size(info_->width, info_->height);
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:84:33: warning: narrowing conversion from 'sensor_msgs::msg::CameraInfo_::_height_type' (aka 'unsigned int') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
    cv::Size size(info_->width, info_->height);
                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:88:41: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
      new_size = cv::Size(OUTPUT_WIDTH, 1.0f * OUTPUT_WIDTH / size.width * size.height);
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:88:48: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
      new_size = cv::Size(OUTPUT_WIDTH, 1.0f * OUTPUT_WIDTH / size.width * size.height);
                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:88:63: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
      new_size = cv::Size(OUTPUT_WIDTH, 1.0f * OUTPUT_WIDTH / size.width * size.height);
                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:88:76: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
      new_size = cv::Size(OUTPUT_WIDTH, 1.0f * OUTPUT_WIDTH / size.width * size.height);
                                                                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:90:13: warning: invalid case style for variable 'new_K' [readability-identifier-naming]
    cv::Mat new_K = cv::getOptimalNewCameraMatrix(K, D, size, 0, new_size);
            ^~~~~
            new_k
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:114:11: warning: the 'empty' method should be used to check for emptiness instead of comparing to an empty object [readability-container-size-empty]
      if (OVERRIDE_FRAME_ID != "") scaled_info_->header.frame_id = OVERRIDE_FRAME_ID;
          ^~~~~~~~~~~~~~~~~~~~~~~
          !OVERRIDE_FRAME_ID.empty()
/usr/include/c++/11/bits/basic_string.h:1023:7: note: method 'basic_string<char>'::empty() defined here
      empty() const _GLIBCXX_NOEXCEPT
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:122:11: warning: the 'empty' method should be used to check for emptiness instead of comparing to an empty object [readability-container-size-empty]
      if (OVERRIDE_FRAME_ID != "")
          ^~~~~~~~~~~~~~~~~~~~~~~
          !OVERRIDE_FRAME_ID.empty()
/usr/include/c++/11/bits/basic_string.h:1023:7: note: method 'basic_string<char>'::empty() defined here
      empty() const _GLIBCXX_NOEXCEPT
      ^
Suppressed 44578 warnings (44565 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
47883 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segment_detector/line_segment_detector_core.cpp:70:5: warning: multiple declarations in a single statement reduces readability [readability-isolate-declaration]
    Eigen::Vector3f xy1, xy2;
    ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segment_detector/line_segment_detector_core.cpp:81:43: warning: method 'remove_too_outer_elements' can be made static [readability-convert-member-functions-to-static]
std::vector<cv::Mat> LineSegmentDetector::remove_too_outer_elements(
                                          ^
Suppressed 47894 warnings (47881 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
49742 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:33:8: warning: invalid case style for variable 'cb_line_segments_' [readability-identifier-naming]
  auto cb_line_segments_ = std::bind(&LineSegmentsOverlay::on_line_segments, this, _1);
       ^~~~~~~~~~~~~~~~~
       cb_line_segments
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:76:3: warning: use range-based for loop instead [modernize-loop-convert]
  for (size_t index = 0; index < line_segments_cloud.size(); ++index) {
  ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      (auto & pn : line_segments_cloud)
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:82:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    if (pn.label == 0) {              // if unreliable
           ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:86:31: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0>, 1>::Scalar' (aka 'float') to 'int' [cppcoreguidelines-narrowing-conversions]
    cv::line(image, cv::Point(xy1(0), xy1(1)), cv::Point(xy2(0), xy2(1)), color, 2);
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:86:39: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0>, 1>::Scalar' (aka 'float') to 'int' [cppcoreguidelines-narrowing-conversions]
    cv::line(image, cv::Point(xy1(0), xy1(1)), cv::Point(xy2(0), xy2(1)), color, 2);
                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:86:58: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0>, 1>::Scalar' (aka 'float') to 'int' [cppcoreguidelines-narrowing-conversions]
    cv::line(image, cv::Point(xy1(0), xy1(1)), cv::Point(xy2(0), xy2(1)), color, 2);
                                                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:86:66: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0>, 1>::Scalar' (aka 'float') to 'int' [cppcoreguidelines-narrowing-conversions]
    cv::line(image, cv::Point(xy1(0), xy1(1)), cv::Point(xy2(0), xy2(1)), color, 2);
                                                                 ^
Suppressed 49748 warnings (49735 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
58606 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/segment_filter/segment_filter.hpp:65:37: warning: function 'yabloc::segment_filter::SegmentFilter::project_lines' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]
  pcl::PointCloud<pcl::PointNormal> project_lines(
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:200:50: note: the definition seen here
pcl::PointCloud<pcl::PointNormal> SegmentFilter::project_lines(
                                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/segment_filter/segment_filter.hpp:65:37: note: differing parameters are named here: ('lines'), in definition: ('points')
  pcl::PointCloud<pcl::PointNormal> project_lines(
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/segment_filter/segment_filter.hpp:73:8: warning: function 'yabloc::segment_filter::SegmentFilter::execute' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]
  void execute(const PointCloud2 & msg1, const Image & msg2);
       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:86:21: note: the definition seen here
void SegmentFilter::execute(const PointCloud2 & line_segments_msg, const Image & segment_msg)
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/include/yabloc_image_processing/segment_filter/segment_filter.hpp:73:8: note: differing parameters are named here: ('msg1', 'msg2'), in definition: ('line_segments_msg', 'segment_msg')
  void execute(const PointCloud2 & msg1, const Image & msg2);
       ^                           ~~~~                ~~~~
                                   line_segments_msg   segment_msg
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:28:15: warning: narrowing conversion from 'long' to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  image_size_(declare_parameter<int>("image_size")),
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:29:14: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  max_range_(declare_parameter<float>("max_range")),
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:30:23: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  min_segment_length_(declare_parameter<float>("min_segment_length")),
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:31:25: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  max_segment_distance_(declare_parameter<float>("max_segment_distance")),
                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:32:25: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  max_lateral_distance_(declare_parameter<float>("max_lateral_distance")),
                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:51:10: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2;
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:51:32: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2;
                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:51:53: warning: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division]
  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2;
                                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:51:53: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:52:10: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_;
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:52:32: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_;
                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:52:53: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_;
                                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:115:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pln.label = 255;
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:122:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pln.label = 0;
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:152:25: warning: narrowing conversion from 'size_t' (aka 'unsigned long') to signed type 'std::set<int>::key_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
      if (indices.count(index) > 0)
                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:153:13: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
        pln.label = 255;
            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:155:13: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
        pln.label = 0;
            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:165:36: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float min_distance = std::min(pn.x, pn.normal_x);
                                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:165:42: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float min_distance = std::min(pn.x, pn.normal_x);
                                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:166:36: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float max_distance = std::max(pn.x, pn.normal_x);
                                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:166:42: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float max_distance = std::max(pn.x, pn.normal_x);
                                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:176:46: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float lambda = (max_segment_distance_ - pn.x) / not_zero_tx;
                                             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:178:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  if (pn.x > pn.normal_x)
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:178:17: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  if (pn.x > pn.normal_x)
                ^
... (omitted)
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
(in localization/yabloc)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

... (omitted)
Checking yabloc_image_processing/src/graph_segment/graph_segment_core.cpp ...
yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:72:47: performance: Searching before insertion is not necessary. Instead of 'areas[key]=0' consider using 'areas.try_emplace(key, 0);'. [stlFindInsert]
      if (areas.count(key) == 0) areas[key] = 0;
                                              ^
12/41 files checked 24% done
Checking yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp ...
13/41 files checked 25% done
Checking yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp ...
yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:107:20: style: Unused variable: a [unusedVariable]
  std::vector<int> a;
                   ^
14/41 files checked 30% done
Checking yabloc_image_processing/src/line_segment_detector/line_segment_detector_core.cpp ...
15/41 files checked 32% done
Checking yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp ...
16/41 files checked 34% done
Checking yabloc_image_processing/src/segment_filter/segment_filter_core.cpp ...
17/41 files checked 40% done
Checking yabloc_image_processing/src/undistort/undistort_node.cpp ...
18/41 files checked 43% done
... (omitted)
```
</details>

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh yabloc_image_processing
...
13152 warnings generated.
Suppressed 13154 warnings (13152 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
12970 warnings generated.
Suppressed 12972 warnings (12970 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
14562 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp:43:17: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      int key = seg_ptr[w];
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp:44:23: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      cv::Vec3b rgb = rgb_ptr[w];
                      ^
Suppressed 14562 warnings (14560 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
20454 warnings generated.
Suppressed 20467 warnings (20454 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
35145 warnings generated.
Suppressed 35158 warnings (35145 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
40245 warnings generated.
Suppressed 40258 warnings (40245 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
40369 warnings generated.
Suppressed 40382 warnings (40369 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
41074 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:82:17: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      int key = seg_ptr[w];
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:131:23: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      const int key = segmented_image_ptr[w];
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:133:9: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
        output_image_ptr[w] = 255;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:135:11: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
          debug_image_ptr[w] = cv::Vec3b(30, 255, 255);
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:137:11: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
          debug_image_ptr[w] = cv::Vec3b(10, 255, 255);
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/graph_segment/graph_segment_core.cpp:139:9: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
        debug_image_ptr[w] = random_hsv(key);
        ^
Suppressed 41081 warnings (41068 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
49305 warnings generated.
Suppressed 49318 warnings (49305 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
47881 warnings generated.
Suppressed 47894 warnings (47881 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
44565 warnings generated.
Suppressed 44578 warnings (44565 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
49737 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp:81:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    if (pn.label == 0) {              // if unreliable
           ^
Suppressed 49749 warnings (49736 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
58581 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:117:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pln.label = 255;
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:124:11: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pln.label = 0;
          ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:155:13: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
        pln.label = 255;
            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:157:13: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
        pln.label = 0;
            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:167:36: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float min_distance = std::min(pn.x, pn.normal_x);
                                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:167:42: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float min_distance = std::min(pn.x, pn.normal_x);
                                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:168:36: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float max_distance = std::max(pn.x, pn.normal_x);
                                   ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:168:42: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float max_distance = std::max(pn.x, pn.normal_x);
                                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:178:46: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  float lambda = (max_segment_distance_ - pn.x) / not_zero_tx;
                                             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:180:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  if (pn.x > pn.normal_x)
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:180:17: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  if (pn.x > pn.normal_x)
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:202:50: warning: function 'project_lines' has cognitive complexity of 29 (threshold 25) [readability-function-cognitive-complexity]
pcl::PointCloud<pcl::PointNormal> SegmentFilter::project_lines(
                                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:207:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  for (size_t index = 0; index < points.size(); ++index) {
  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:208:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (negative) {
    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:209:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (indices.count(static_cast<int>(index)) > 0) continue;
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:210:7: note: +1, nesting level increased to 2
    } else {
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:211:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (indices.count(static_cast<int>(index)) == 0) continue;
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:218:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (!opt1.has_value()) continue;
    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:219:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (!opt2.has_value()) continue;
    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:222:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (min_segment_length_ > 0) {
    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:224:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (length < min_segment_length_) continue;
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:226:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (max_lateral_distance_ > 0) {
    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:229:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (std::min(abs_lateral1, abs_lateral2) > max_lateral_distance_) continue;
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:242:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (max_segment_distance_ > 0)
    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:243:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (!is_near_element(xyz, truncated_xyz)) continue;
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:233:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.x = opt1->x();
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:234:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.y = opt1->y();
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:235:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.z = opt1->z();
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:236:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.normal_x = opt2->x();
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:237:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.normal_y = opt2->y();
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/segment_filter/segment_filter_core.cpp:238:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    xyz.normal_z = opt2->z();
        ^
Suppressed 58576 warnings (58563 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
71318 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:205:15: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    p1.x = pn.x;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:206:15: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    p1.y = pn.y;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:207:15: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    p1.z = pn.z;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:208:15: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    p2.x = pn.normal_x;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:209:15: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    p2.y = pn.normal_y;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp:210:15: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    p2.z = pn.normal_z;
              ^
Suppressed 71325 warnings (71312 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

<details open>
<summary>Check with cppcheck </summary>

```
(in localization/yabloc)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

... (omitted)
11/41 files checked 21% done
Checking yabloc_image_processing/src/graph_segment/graph_segment_core.cpp ...
12/41 files checked 24% done
Checking yabloc_image_processing/src/graph_segment/similar_area_searcher.cpp ...
13/41 files checked 25% done
Checking yabloc_image_processing/src/lanelet2_overlay/lanelet2_overlay_core.cpp ...
14/41 files checked 30% done
Checking yabloc_image_processing/src/line_segment_detector/line_segment_detector_core.cpp ...
15/41 files checked 32% done
Checking yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp ...
16/41 files checked 34% done
Checking yabloc_image_processing/src/segment_filter/segment_filter_core.cpp ...
17/41 files checked 40% done
Checking yabloc_image_processing/src/undistort/undistort_node.cpp ...
18/41 files checked 43% done
... (omitted)
```
</details>

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
