### PR TITLE
fix(planning): set single depth sensor data qos for pointlcoud polling subscribers

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/polling_subscriber.hpp
@@ -26,6 +26,13 @@
 namespace tier4_autoware_utils
 {
 
+inline rclcpp::SensorDataQoS SingleDepthSensorQoS()
+{
+  rclcpp::SensorDataQoS qos;
+  qos.get_rmw_qos_profile().depth = 1;
+  return qos;
+}
+
 template <typename T, int N = 1, typename Enable = void>
 class InterProcessPollingSubscriber;
 

--- a/control/autoware_autonomous_emergency_braking/include/autoware_autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware_autonomous_emergency_braking/node.hpp
@@ -229,13 +229,6 @@ private:
   rclcpp::Clock::SharedPtr clock_;
 };
 
-static rclcpp::SensorDataQoS SingleDepthSensorQoS()
-{
-  rclcpp::SensorDataQoS qos;
-  qos.get_rmw_qos_profile().depth = 1;
-  return qos;
-}
-
 class AEB : public rclcpp::Node
 {
 public:
@@ -243,7 +236,7 @@ public:
 
   // subscriber
   tier4_autoware_utils::InterProcessPollingSubscriber<PointCloud2> sub_point_cloud_{
-    this, "~/input/pointcloud", SingleDepthSensorQoS()};
+    this, "~/input/pointcloud", tier4_autoware_utils::SingleDepthSensorQoS()};
   tier4_autoware_utils::InterProcessPollingSubscriber<VelocityReport> sub_velocity_{
     this, "~/input/velocity"};
   tier4_autoware_utils::InterProcessPollingSubscriber<Imu> sub_imu_{this, "~/input/imu"};

--- a/planning/autoware_behavior_velocity_planner/src/node.hpp
+++ b/planning/autoware_behavior_velocity_planner/src/node.hpp
@@ -74,7 +74,8 @@ private:
     sub_predicted_objects_{this, "~/input/dynamic_objects"};
 
   tier4_autoware_utils::InterProcessPollingSubscriber<sensor_msgs::msg::PointCloud2>
-    sub_no_ground_pointcloud_{this, "~/input/no_ground_pointcloud"};
+    sub_no_ground_pointcloud_{
+      this, "~/input/no_ground_pointcloud", tier4_autoware_utils::SingleDepthSensorQoS()};
 
   tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>
     sub_vehicle_odometry_{this, "~/input/vehicle_odometry"};

--- a/planning/autoware_surround_obstacle_checker/include/autoware_surround_obstacle_checker/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/include/autoware_surround_obstacle_checker/node.hpp
@@ -114,7 +114,7 @@ private:
   tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry> sub_odometry_{
     this, "~/input/odometry"};
   tier4_autoware_utils::InterProcessPollingSubscriber<sensor_msgs::msg::PointCloud2>
-    sub_pointcloud_{this, "~/input/pointcloud"};
+    sub_pointcloud_{this, "~/input/pointcloud", tier4_autoware_utils::SingleDepthSensorQoS()};
   tier4_autoware_utils::InterProcessPollingSubscriber<PredictedObjects> sub_dynamic_objects_{
     this, "~/input/objects"};
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr pub_stop_reason_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
@@ -66,7 +66,8 @@ private:
     autoware_perception_msgs::msg::PredictedObjects>
     sub_predicted_objects_{this, "~/input/dynamic_objects"};
   tier4_autoware_utils::InterProcessPollingSubscriber<sensor_msgs::msg::PointCloud2>
-    sub_no_ground_pointcloud_{this, "~/input/no_ground_pointcloud"};
+    sub_no_ground_pointcloud_{
+      this, "~/input/no_ground_pointcloud", tier4_autoware_utils::SingleDepthSensorQoS()};
   tier4_autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>
     sub_vehicle_odometry_{this, "~/input/vehicle_odometry"};
   tier4_autoware_utils::InterProcessPollingSubscriber<


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Use single depth sensor data qos for PointCloud polling subscribers

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/