### PR TITLE
fix(behavior_path_planner): reset current route lanelet in manual drive

### DIFF
--- a/planning/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -417,7 +417,9 @@ void BehaviorPathPlannerNode::run()
   const auto controlled_by_autoware_autonomously =
     planner_data_->operation_mode->mode == OperationModeState::AUTONOMOUS &&
     planner_data_->operation_mode->is_autoware_control_enabled;
-  if (!controlled_by_autoware_autonomously && !planner_manager_->hasApprovedModules())
+  if (
+    !controlled_by_autoware_autonomously &&
+    !planner_manager_->hasNonAlwaysExecutableApprovedModules())
     planner_manager_->resetCurrentRouteLanelet(planner_data_);
 
   // run behavior planner


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR fixes a bug where the current route lanelet was not properly reset when driving manually.

The previous condition used `planner_manager_->hasApprovedModules()` which would be true when the goal or dynamic obstacle avoidance modules were running.
The new condition uses `planner_manager_->hasNonAlwaysExecutableApprovedModules()` which ignores the goal and dynamic obstacle avoidance modules.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim and made sure that a previously failing scenario is now passing.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
