### PR TITLE
fix(system_diagnostic_monitor): fix local mode config

### DIFF
--- a/system/system_diagnostic_monitor/config/control.yaml
+++ b/system/system_diagnostic_monitor/config/control.yaml
@@ -13,14 +13,14 @@ units:
   - path: /autoware/control/local
     type: and
     list:
-      - { type: link, link: /autoware/control/topic_rate_check/selector }
-      - { type: link, link: /autoware/control/topic_rate_check/local }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_selector }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_converter }
 
   - path: /autoware/control/remote
     type: and
     list:
-      - { type: link, link: /autoware/control/topic_rate_check/selector }
-      - { type: link, link: /autoware/control/topic_rate_check/remote }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_selector }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_converter }
 
   - path: /autoware/control/topic_rate_check/trajectory_follower
     type: diag
@@ -57,17 +57,12 @@ units:
     node: controller_node_exe
     name: control_state
 
-  - path: /autoware/control/topic_rate_check/selector
+  - path: /autoware/control/topic_rate_check/external_cmd_selector
     type: diag
     node: external_cmd_selector
     name: heartbeat
 
-  - path: /autoware/control/topic_rate_check/local
-    type: diag
-    node: joy_controller
-    name: joy_controller_connection
-
-  - path: /autoware/control/topic_rate_check/remote
+  - path: /autoware/control/topic_rate_check/external_cmd_converter
     type: diag
     node: external_cmd_converter
     name: remote_control_topic_status


### PR DESCRIPTION
## Description

Since local commands are published from other than joy_controller, such as tier4_control_rviz_plugin, fix diagnostic graph.

## Tests performed

Launch planning simulator and check that the operation mode can be changed to local/remote.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
