### PR TITLE
fix(joy_controller): check for nullptr messages

### DIFF
--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -151,6 +151,10 @@ namespace autoware::joy_controller
 void AutowareJoyControllerNode::onJoy()
 {
   const auto msg = sub_joy_.takeData();
+  if (!msg) {
+    return;
+  }
+
   last_joy_received_time_ = msg->header.stamp;
   if (joy_type_ == "G29") {
     joy_ = std::make_shared<const G29JoyConverter>(*msg);
@@ -198,6 +202,10 @@ void AutowareJoyControllerNode::onOdometry()
   }
 
   const auto msg = sub_odom_.takeData();
+  if (!msg) {
+    return;
+  }
+
   auto twist = std::make_shared<geometry_msgs::msg::TwistStamped>();
   twist->header = msg->header;
   twist->twist = msg->twist.twist;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix https://github.com/orgs/autowarefoundation/discussions/4882

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
The following commands would be enough to cause a crash:
```
ros2 launch autoware_joy_controller joy_controller.launch.xml
ros2 launch autoware_vehicle_cmd_gate vehicle_cmd_gate.launch.xml
```
With this PR no crash happens.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
