### PR TITLE
fix(autoware_mpc_lateral_controller): fix duplicateExpression warning

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -632,7 +632,7 @@ bool MpcLateralController::isValidTrajectory(const Trajectory & traj) const
       !isfinite(p.pose.position.x) || !isfinite(p.pose.position.y) ||
       !isfinite(p.pose.orientation.w) || !isfinite(p.pose.orientation.x) ||
       !isfinite(p.pose.orientation.y) || !isfinite(p.pose.orientation.z) ||
-      !isfinite(p.longitudinal_velocity_mps) || !isfinite(p.lateral_velocity_mps) ||
+      !isfinite(p.longitudinal_velocity_mps) ||
       !isfinite(p.lateral_velocity_mps) || !isfinite(p.heading_rate_rps) ||
       !isfinite(p.front_wheel_angle_rad) || !isfinite(p.rear_wheel_angle_rad)) {
       return false;

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -632,9 +632,9 @@ bool MpcLateralController::isValidTrajectory(const Trajectory & traj) const
       !isfinite(p.pose.position.x) || !isfinite(p.pose.position.y) ||
       !isfinite(p.pose.orientation.w) || !isfinite(p.pose.orientation.x) ||
       !isfinite(p.pose.orientation.y) || !isfinite(p.pose.orientation.z) ||
-      !isfinite(p.longitudinal_velocity_mps) ||
-      !isfinite(p.lateral_velocity_mps) || !isfinite(p.heading_rate_rps) ||
-      !isfinite(p.front_wheel_angle_rad) || !isfinite(p.rear_wheel_angle_rad)) {
+      !isfinite(p.longitudinal_velocity_mps) || !isfinite(p.lateral_velocity_mps) ||
+      !isfinite(p.heading_rate_rps) || !isfinite(p.front_wheel_angle_rad) ||
+      !isfinite(p.rear_wheel_angle_rad)) {
       return false;
     }
   }


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `duplicateExpression` warning

```
control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp:635:83: style: Same expression on both sides of '||'. [duplicateExpression]
      !isfinite(p.longitudinal_velocity_mps) || !isfinite(p.lateral_velocity_mps) ||
                                                                                  ^
```

`!isfinite(p.lateral_velocity_mps)` is duplicated.

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
