### PR TITLE
fix(mrm_handler): fix multiCondition warning

### DIFF
--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -91,7 +91,7 @@ void MrmHandler::onOperationModeAvailability(
   if (!is_emergency_holding_) {
     if (msg->autonomous) {
       stamp_autonomous_become_unavailable_.reset();
-    } else if (!msg->autonomous) {
+    } else {
       if (!stamp_autonomous_become_unavailable_.has_value()) {
         stamp_autonomous_become_unavailable_.emplace(this->now());
       } else {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `multiCondition` warning

```
system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp:94:16: style: Expression is always true because 'else if' condition is opposite to previous condition at line 92. [multiCondition]
    } else if (!msg->autonomous) {
               ^
system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp:92:12: note: first condition
    if (msg->autonomous) {
           ^
system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp:94:16: note: else if condition is opposite to first condition
    } else if (!msg->autonomous) {
               ^
```

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
