### PR TITLE
fix(behavior_path_planner): fix redundantIfRemove warning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -249,9 +249,7 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
 
     if (dist_to_back_point < 0.0) {
       // Vehicle is already passed this lane
-      if (desired_start_point_map_.find(lane_id) != desired_start_point_map_.end()) {
-        desired_start_point_map_.erase(lane_id);
-      }
+      desired_start_point_map_.erase(lane_id);
       continue;
     } else if (search_distance <= dist_to_front_point) {
       continue;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantIfRemove` warning

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp:252:11: style: Redundant checking of STL container element existence before removing it. [redundantIfRemove]
      if (desired_start_point_map_.find(lane_id) != desired_start_point_map_.end()) {
          ^
```

You may check how the `erace` works when there exists no matching value or iterator:
https://cpprefjp.github.io/reference/map/map/erase.html

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
