### PR TITLE
fix(system_monitor): fix unsignedLessThanZero warning

### DIFF
--- a/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -219,7 +219,7 @@ void GPUMonitor::addProcessUsage(
     return;
   }
   // Check util_count
-  if (util_count <= 0) {
+  if (util_count == 0) {
     RCLCPP_WARN(this->get_logger(), "Illegal util_count: %d", util_count);
     return;
   }


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unsignedLessThanZero` warning

```
system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp:222:18: style: Checking if unsigned expression 'util_count' is less than zero. [unsignedLessThanZero]
  if (util_count <= 0) {
                 ^
```

If the fix is different from your original intention, please add your modification commit!

## Tests performed

No

## Effects on system behavior

No

## Interface changes

No

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
