### PR TITLE
fix(pointcloud_preprocessor): fix arrayIndexThenCheck warning

### DIFF
--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -231,14 +231,13 @@ void DualReturnOutlierFilterComponent::filter(
       if (deleted_azimuths.size() == 0) {
         continue;
       }
-      while (current_deleted_index < deleted_azimuths.size()) &&
+      while (current_deleted_index < deleted_azimuths.size() &&
              (uint)deleted_azimuths[current_deleted_index] <
                ((i + static_cast<uint>(min_azimuth / horizontal_resolution) + 1) *
-                horizontal_resolution))
-        {
-          noise_frequency[i] = noise_frequency[i] + 1;
-          current_deleted_index++;
-        }
+                horizontal_resolution)) {
+        noise_frequency[i] = noise_frequency[i] + 1;
+        current_deleted_index++;
+      }
       if (temp_segment.points.size() > 0) {
         while ((temp_segment.points[current_temp_segment_index].azimuth < 0.f
                   ? 0.f

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -231,10 +231,10 @@ void DualReturnOutlierFilterComponent::filter(
       if (deleted_azimuths.size() == 0) {
         continue;
       }
-      while ((uint)deleted_azimuths[current_deleted_index] <
+      while (current_deleted_index < (deleted_azimuths.size() - 1) &&
+             (uint)deleted_azimuths[current_deleted_index] <
                ((i + static_cast<uint>(min_azimuth / horizontal_resolution) + 1) *
-                horizontal_resolution) &&
-             current_deleted_index < (deleted_azimuths.size() - 1)) {
+                horizontal_resolution)) {
         noise_frequency[i] = noise_frequency[i] + 1;
         current_deleted_index++;
       }

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -234,10 +234,11 @@ void DualReturnOutlierFilterComponent::filter(
       while (current_deleted_index < deleted_azimuths.size()) &&
              (uint)deleted_azimuths[current_deleted_index] <
                ((i + static_cast<uint>(min_azimuth / horizontal_resolution) + 1) *
-                horizontal_resolution)) {
-        noise_frequency[i] = noise_frequency[i] + 1;
-        current_deleted_index++;
-      }
+                horizontal_resolution))
+        {
+          noise_frequency[i] = noise_frequency[i] + 1;
+          current_deleted_index++;
+        }
       if (temp_segment.points.size() > 0) {
         while ((temp_segment.points[current_temp_segment_index].azimuth < 0.f
                   ? 0.f

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -231,7 +231,7 @@ void DualReturnOutlierFilterComponent::filter(
       if (deleted_azimuths.size() == 0) {
         continue;
       }
-      while (current_deleted_index < (deleted_azimuths.size() - 1) &&
+      while (current_deleted_index < deleted_azimuths.size()) &&
              (uint)deleted_azimuths[current_deleted_index] <
                ((i + static_cast<uint>(min_azimuth / horizontal_resolution) + 1) *
                 horizontal_resolution)) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `arrayIndexThenCheck` warning

```
sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp:234:36: style: Array index 'current_deleted_index' is used before limits check. [arrayIndexThenCheck]
      while ((uint)deleted_azimuths[current_deleted_index] <
                                   ^
```

You know the current implementation is correct.
This fix is just to avoid cppcheck warning by changing the evaluation order in while loop condition.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
