### PR TITLE
feat(autonomous_emergency_braking): add predicted object support for aeb

### DIFF
--- a/control/autoware_autonomous_emergency_braking/CMakeLists.txt
+++ b/control/autoware_autonomous_emergency_braking/CMakeLists.txt
@@ -12,11 +12,18 @@ include_directories(
   ${PCL_INCLUDE_DIRS}
 )
 
+ament_auto_add_library(autoware_autonomous_emergency_braking_helpers SHARED
+  include/autoware/autonomous_emergency_braking/utils.hpp
+  src/utils.cpp
+)
+
 set(AEB_NODE ${PROJECT_NAME}_node)
 ament_auto_add_library(${AEB_NODE} SHARED
+  include/autoware/autonomous_emergency_braking/node.hpp
   src/node.cpp
 )
 
+target_link_libraries(${AEB_NODE} autoware_autonomous_emergency_braking_helpers)
 rclcpp_components_register_node(${AEB_NODE}
   PLUGIN "autoware::motion::control::autonomous_emergency_braking::AEB"
   EXECUTABLE ${PROJECT_NAME}

--- a/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -3,6 +3,8 @@
     # Ego path calculation
     use_predicted_trajectory: true
     use_imu_path: false
+    use_pointcloud_data: true
+    use_predicted_object_data: true
     use_object_velocity_calculation: true
     min_generated_path_length: 0.5
     imu_prediction_time_horizon: 1.5

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -65,8 +65,6 @@ using autoware_universe_utils::Point2d;
 using autoware_universe_utils::Polygon2d;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
-using tier4_autoware_utils::Point2d;
-using tier4_autoware_utils::Polygon2d;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 using Path = std::vector<geometry_msgs::msg::Pose>;
@@ -256,9 +254,9 @@ public:
   autoware_universe_utils::InterProcessPollingSubscriber<Imu> sub_imu_{this, "~/input/imu"};
   autoware_universe_utils::InterProcessPollingSubscriber<Trajectory> sub_predicted_traj_{
     this, "~/input/predicted_trajectory"};
-  tier4_autoware_utils::InterProcessPollingSubscriber<PredictedObjects> predicted_objects_sub_{
+  autoware_universe_utils::InterProcessPollingSubscriber<PredictedObjects> predicted_objects_sub_{
     this, "~/input/objects"};
-  tier4_autoware_utils::InterProcessPollingSubscriber<AutowareState> sub_autoware_state_{
+  autoware_universe_utils::InterProcessPollingSubscriber<AutowareState> sub_autoware_state_{
     this, "/autoware/state"};
   // publisher
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_obstacle_pointcloud_;

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -65,7 +65,6 @@ using autoware_universe_utils::Point2d;
 using autoware_universe_utils::Polygon2d;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
-using tier4_autoware_utils::LineString2d;
 using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 using visualization_msgs::msg::Marker;

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -23,6 +23,7 @@
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
@@ -68,6 +69,7 @@ using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 using Path = std::vector<geometry_msgs::msg::Pose>;
 using Vector3 = geometry_msgs::msg::Vector3;
+using autoware_perception_msgs::msg::PredictedObjects;
 struct ObjectData
 {
   rclcpp::Time stamp;
@@ -243,7 +245,9 @@ public:
   autoware_universe_utils::InterProcessPollingSubscriber<Imu> sub_imu_{this, "~/input/imu"};
   autoware_universe_utils::InterProcessPollingSubscriber<Trajectory> sub_predicted_traj_{
     this, "~/input/predicted_trajectory"};
-  autoware_universe_utils::InterProcessPollingSubscriber<AutowareState> sub_autoware_state_{
+  tier4_autoware_utils::InterProcessPollingSubscriber<PredictedObjects> predicted_objects_sub_{
+    this, "~/input/objects"};
+  tier4_autoware_utils::InterProcessPollingSubscriber<AutowareState> sub_autoware_state_{
     this, "/autoware/state"};
   // publisher
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_obstacle_pointcloud_;
@@ -298,6 +302,7 @@ public:
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
   Vector3::SharedPtr angular_velocity_ptr_{nullptr};
   Trajectory::ConstSharedPtr predicted_traj_ptr_{nullptr};
+  PredictedObjects::ConstSharedPtr predicted_objects_ptr_{nullptr};
   AutowareState::ConstSharedPtr autoware_state_{nullptr};
 
   tf2_ros::Buffer tf_buffer_{get_clock()};

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -65,11 +65,16 @@ using autoware_universe_utils::Point2d;
 using autoware_universe_utils::Polygon2d;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
+using tier4_autoware_utils::LineString2d;
+using tier4_autoware_utils::Point2d;
+using tier4_autoware_utils::Polygon2d;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 using Path = std::vector<geometry_msgs::msg::Pose>;
 using Vector3 = geometry_msgs::msg::Vector3;
+using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+
 struct ObjectData
 {
   rclcpp::Time stamp;
@@ -278,6 +283,10 @@ public:
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
     std::vector<ObjectData> & objects,
     const pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_points_ptr);
+
+  void createObjectDataUsingPredictedObjects(
+    const Path & ego_path, const std::vector<Polygon2d> & ego_polys,
+    std::vector<ObjectData> & objects);
 
   void cropPointCloudWithEgoFootprintPath(
     const std::vector<Polygon2d> & ego_polys, pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects);

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -183,6 +183,13 @@ public:
   std::optional<double> calcObjectSpeedFromHistory(
     const ObjectData & closest_object, const Path & path, const double current_ego_speed)
   {
+    // in case the object comes from predicted objects info, we reuse the speed.
+    if (closest_object.velocity > 0.0) {
+      this->setPreviousObjectData(closest_object);
+      this->updateVelocityHistory(closest_object.velocity, closest_object.stamp);
+      return this->getMedianObstacleVelocity();
+    }
+
     if (this->checkPreviousObjectDataExpired()) {
       this->setPreviousObjectData(closest_object);
       this->resetVelocityHistory();
@@ -327,6 +334,8 @@ public:
   bool publish_debug_pointcloud_;
   bool use_predicted_trajectory_;
   bool use_imu_path_;
+  bool use_pointcloud_data_;
+  bool use_predicted_object_data_;
   bool use_object_velocity_calculation_;
   double path_footprint_extra_margin_;
   double detection_range_min_height_;

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
 #define AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
 
-#include <tier4_autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware/universe_utils/geometry/boost_polygon_utils.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -35,11 +35,11 @@ namespace autoware::motion::control::autonomous_emergency_braking::utils
 {
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_universe_utils::Point2d;
+using autoware_universe_utils::Polygon2d;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::TransformStamped;
-using tier4_autoware_utils::Point2d;
-using tier4_autoware_utils::Polygon2d;
 
 inline PredictedObject transformObjectFrame(
   const PredictedObject & input, geometry_msgs::msg::TransformStamped transform_stamped)

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -41,6 +41,28 @@ using geometry_msgs::msg::TransformStamped;
 using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 
+inline PredictedObject transformObjectFrame(
+  const PredictedObject & input, geometry_msgs::msg::TransformStamped transform_stamped)
+{
+  PredictedObject output = input;
+  const auto & linear_twist = input.kinematics.initial_twist_with_covariance.twist.linear;
+  const auto & angular_twist = input.kinematics.initial_twist_with_covariance.twist.angular;
+  const auto & pose = input.kinematics.initial_pose_with_covariance.pose;
+
+  geometry_msgs::msg::Pose t_pose;
+  Vector3 t_linear_twist;
+  Vector3 t_angular_twist;
+
+  tf2::doTransform(pose, t_pose, transform_stamped);
+  tf2::doTransform(linear_twist, t_linear_twist, transform_stamped);
+  tf2::doTransform(angular_twist, t_angular_twist, transform_stamped);
+
+  output.kinematics.initial_pose_with_covariance.pose = t_pose;
+  output.kinematics.initial_twist_with_covariance.twist.linear = t_linear_twist;
+  output.kinematics.initial_twist_with_covariance.twist.angular = t_angular_twist;
+  return output;
+}
+
 inline Polygon2d convertPolygonObjectToGeometryPolygon(
   const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
 {

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -41,7 +41,7 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::TransformStamped;
 
-inline PredictedObject transformObjectFrame(
+PredictedObject transformObjectFrame(
   const PredictedObject & input, geometry_msgs::msg::TransformStamped transform_stamped)
 {
   PredictedObject output = input;
@@ -63,7 +63,7 @@ inline PredictedObject transformObjectFrame(
   return output;
 }
 
-inline Polygon2d convertPolygonObjectToGeometryPolygon(
+Polygon2d convertPolygonObjectToGeometryPolygon(
   const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
 {
   Polygon2d object_polygon;
@@ -82,7 +82,7 @@ inline Polygon2d convertPolygonObjectToGeometryPolygon(
   return object_polygon;
 }
 
-inline Polygon2d convertCylindricalObjectToGeometryPolygon(
+Polygon2d convertCylindricalObjectToGeometryPolygon(
   const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
 {
   Polygon2d object_polygon;
@@ -104,7 +104,7 @@ inline Polygon2d convertCylindricalObjectToGeometryPolygon(
   return object_polygon;
 }
 
-inline Polygon2d convertBoundingBoxObjectToGeometryPolygon(
+Polygon2d convertBoundingBoxObjectToGeometryPolygon(
   const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
   const double & base_to_width)
 {
@@ -144,7 +144,7 @@ inline Polygon2d convertBoundingBoxObjectToGeometryPolygon(
   return object_polygon;
 }
 
-inline Polygon2d convertObjToPolygon(const PredictedObject & obj)
+Polygon2d convertObjToPolygon(const PredictedObject & obj)
 {
   Polygon2d object_polygon{};
   if (obj.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
-#define AUTOWARE_AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
+#ifndef AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
+#define AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
 
 #include <tier4_autoware_utils/geometry/boost_polygon_utils.hpp>
 
@@ -165,4 +165,4 @@ inline Polygon2d convertObjToPolygon(const PredictedObject & obj)
 }
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils
 
-#endif  // AUTOWARE_AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
+#endif  // AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -1,0 +1,146 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
+#define AUTOWARE_AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_
+
+#include <tier4_autoware_utils/geometry/boost_polygon_utils.hpp>
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <boost/geometry/algorithms/convex_hull.hpp>
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/optional.hpp>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion::control::autonomous_emergency_braking::utils
+{
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::TransformStamped;
+using tier4_autoware_utils::Point2d;
+using tier4_autoware_utils::Polygon2d;
+
+inline Polygon2d convertPolygonObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
+{
+  Polygon2d object_polygon;
+  tf2::Transform tf_map2obj;
+  fromMsg(current_pose, tf_map2obj);
+  const auto obj_points = obj_shape.footprint.points;
+  object_polygon.outer().reserve(obj_points.size() + 1);
+  for (const auto & obj_point : obj_points) {
+    tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);
+    tf2::Vector3 tf_obj = tf_map2obj * obj;
+    object_polygon.outer().emplace_back(tf_obj.x(), tf_obj.y());
+  }
+  object_polygon.outer().push_back(object_polygon.outer().front());
+  boost::geometry::correct(object_polygon);
+
+  return object_polygon;
+}
+
+inline Polygon2d convertCylindricalObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
+{
+  Polygon2d object_polygon;
+
+  const double obj_x = current_pose.position.x;
+  const double obj_y = current_pose.position.y;
+
+  constexpr int N = 20;
+  const double r = obj_shape.dimensions.x / 2;
+  object_polygon.outer().reserve(N + 1);
+  for (int i = 0; i < N; ++i) {
+    object_polygon.outer().emplace_back(
+      obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i));
+  }
+
+  object_polygon.outer().push_back(object_polygon.outer().front());
+  boost::geometry::correct(object_polygon);
+
+  return object_polygon;
+}
+
+inline Polygon2d convertBoundingBoxObjectToGeometryPolygon(
+  const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
+  const double & base_to_width)
+{
+  const auto mapped_point = [](const double & length_scalar, const double & width_scalar) {
+    tf2::Vector3 map;
+    map.setX(length_scalar);
+    map.setY(width_scalar);
+    map.setZ(0.0);
+    map.setW(1.0);
+    return map;
+  };
+
+  // set vertices at map coordinate
+  const tf2::Vector3 p1_map = std::invoke(mapped_point, base_to_front, -base_to_width);
+  const tf2::Vector3 p2_map = std::invoke(mapped_point, base_to_front, base_to_width);
+  const tf2::Vector3 p3_map = std::invoke(mapped_point, -base_to_rear, base_to_width);
+  const tf2::Vector3 p4_map = std::invoke(mapped_point, -base_to_rear, -base_to_width);
+
+  // transform vertices from map coordinate to object coordinate
+  tf2::Transform tf_map2obj;
+  tf2::fromMsg(current_pose, tf_map2obj);
+  const tf2::Vector3 p1_obj = tf_map2obj * p1_map;
+  const tf2::Vector3 p2_obj = tf_map2obj * p2_map;
+  const tf2::Vector3 p3_obj = tf_map2obj * p3_map;
+  const tf2::Vector3 p4_obj = tf_map2obj * p4_map;
+
+  Polygon2d object_polygon;
+  object_polygon.outer().reserve(5);
+  object_polygon.outer().emplace_back(p1_obj.x(), p1_obj.y());
+  object_polygon.outer().emplace_back(p2_obj.x(), p2_obj.y());
+  object_polygon.outer().emplace_back(p3_obj.x(), p3_obj.y());
+  object_polygon.outer().emplace_back(p4_obj.x(), p4_obj.y());
+
+  object_polygon.outer().push_back(object_polygon.outer().front());
+  boost::geometry::correct(object_polygon);
+
+  return object_polygon;
+}
+
+inline Polygon2d convertObjToPolygon(const PredictedObject & obj)
+{
+  Polygon2d object_polygon{};
+  if (obj.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    object_polygon = utils::convertCylindricalObjectToGeometryPolygon(
+      obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+  } else if (obj.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    const double & length_m = obj.shape.dimensions.x / 2;
+    const double & width_m = obj.shape.dimensions.y / 2;
+    object_polygon = utils::convertBoundingBoxObjectToGeometryPolygon(
+      obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+  } else if (obj.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    object_polygon = utils::convertPolygonObjectToGeometryPolygon(
+      obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+  } else {
+    throw std::runtime_error("Unsupported shape type");
+  }
+  return object_polygon;
+}
+}  // namespace autoware::motion::control::autonomous_emergency_braking::utils
+
+#endif  // AUTOWARE_AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -21,14 +21,8 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
-#include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/correct.hpp>
-#include <boost/geometry/algorithms/distance.hpp>
-#include <boost/optional.hpp>
 
-#include <map>
-#include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::motion::control::autonomous_emergency_braking::utils

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -23,6 +23,16 @@
 
 #include <boost/geometry/algorithms/correct.hpp>
 
+#include <tf2/utils.h>
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <vector>
 
 namespace autoware::motion::control::autonomous_emergency_braking::utils
@@ -35,128 +45,44 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::TransformStamped;
 
+/**
+ * @brief Apply a transform to a predicted object
+ * @param input the predicted object
+ * @param transform_stamped the tf2 transform
+ */
 PredictedObject transformObjectFrame(
-  const PredictedObject & input, geometry_msgs::msg::TransformStamped transform_stamped)
-{
-  PredictedObject output = input;
-  const auto & linear_twist = input.kinematics.initial_twist_with_covariance.twist.linear;
-  const auto & angular_twist = input.kinematics.initial_twist_with_covariance.twist.angular;
-  const auto & pose = input.kinematics.initial_pose_with_covariance.pose;
+  const PredictedObject & input, geometry_msgs::msg::TransformStamped transform_stamped);
 
-  geometry_msgs::msg::Pose t_pose;
-  Vector3 t_linear_twist;
-  Vector3 t_angular_twist;
-
-  tf2::doTransform(pose, t_pose, transform_stamped);
-  tf2::doTransform(linear_twist, t_linear_twist, transform_stamped);
-  tf2::doTransform(angular_twist, t_angular_twist, transform_stamped);
-
-  output.kinematics.initial_pose_with_covariance.pose = t_pose;
-  output.kinematics.initial_twist_with_covariance.twist.linear = t_linear_twist;
-  output.kinematics.initial_twist_with_covariance.twist.angular = t_angular_twist;
-  return output;
-}
-
+/**
+ * @brief Get the predicted objects polygon as a geometry polygon
+ * @param current_pose the predicted object's pose
+ * @param obj_shape the object's shape
+ */
 Polygon2d convertPolygonObjectToGeometryPolygon(
-  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
-{
-  Polygon2d object_polygon;
-  tf2::Transform tf_map2obj;
-  fromMsg(current_pose, tf_map2obj);
-  const auto obj_points = obj_shape.footprint.points;
-  object_polygon.outer().reserve(obj_points.size() + 1);
-  for (const auto & obj_point : obj_points) {
-    tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);
-    tf2::Vector3 tf_obj = tf_map2obj * obj;
-    object_polygon.outer().emplace_back(tf_obj.x(), tf_obj.y());
-  }
-  object_polygon.outer().push_back(object_polygon.outer().front());
-  boost::geometry::correct(object_polygon);
+  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape);
 
-  return object_polygon;
-}
-
+/**
+ * @brief Get the predicted objects cylindrical shape as a geometry polygon
+ * @param current_pose the predicted object's pose
+ * @param obj_shape the object's shape
+ */
 Polygon2d convertCylindricalObjectToGeometryPolygon(
-  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
-{
-  Polygon2d object_polygon;
+  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape);
 
-  const double obj_x = current_pose.position.x;
-  const double obj_y = current_pose.position.y;
-
-  constexpr int N = 20;
-  const double r = obj_shape.dimensions.x / 2;
-  object_polygon.outer().reserve(N + 1);
-  for (int i = 0; i < N; ++i) {
-    object_polygon.outer().emplace_back(
-      obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i));
-  }
-
-  object_polygon.outer().push_back(object_polygon.outer().front());
-  boost::geometry::correct(object_polygon);
-
-  return object_polygon;
-}
-
+/**
+ * @brief Get the predicted objects bounding box shape as a geometry polygon
+ * @param current_pose the predicted object's pose
+ * @param obj_shape the object's shape
+ */
 Polygon2d convertBoundingBoxObjectToGeometryPolygon(
   const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
-  const double & base_to_width)
-{
-  const auto mapped_point = [](const double & length_scalar, const double & width_scalar) {
-    tf2::Vector3 map;
-    map.setX(length_scalar);
-    map.setY(width_scalar);
-    map.setZ(0.0);
-    map.setW(1.0);
-    return map;
-  };
+  const double & base_to_width);
 
-  // set vertices at map coordinate
-  const tf2::Vector3 p1_map = std::invoke(mapped_point, base_to_front, -base_to_width);
-  const tf2::Vector3 p2_map = std::invoke(mapped_point, base_to_front, base_to_width);
-  const tf2::Vector3 p3_map = std::invoke(mapped_point, -base_to_rear, base_to_width);
-  const tf2::Vector3 p4_map = std::invoke(mapped_point, -base_to_rear, -base_to_width);
-
-  // transform vertices from map coordinate to object coordinate
-  tf2::Transform tf_map2obj;
-  tf2::fromMsg(current_pose, tf_map2obj);
-  const tf2::Vector3 p1_obj = tf_map2obj * p1_map;
-  const tf2::Vector3 p2_obj = tf_map2obj * p2_map;
-  const tf2::Vector3 p3_obj = tf_map2obj * p3_map;
-  const tf2::Vector3 p4_obj = tf_map2obj * p4_map;
-
-  Polygon2d object_polygon;
-  object_polygon.outer().reserve(5);
-  object_polygon.outer().emplace_back(p1_obj.x(), p1_obj.y());
-  object_polygon.outer().emplace_back(p2_obj.x(), p2_obj.y());
-  object_polygon.outer().emplace_back(p3_obj.x(), p3_obj.y());
-  object_polygon.outer().emplace_back(p4_obj.x(), p4_obj.y());
-
-  object_polygon.outer().push_back(object_polygon.outer().front());
-  boost::geometry::correct(object_polygon);
-
-  return object_polygon;
-}
-
-Polygon2d convertObjToPolygon(const PredictedObject & obj)
-{
-  Polygon2d object_polygon{};
-  if (obj.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
-    object_polygon = utils::convertCylindricalObjectToGeometryPolygon(
-      obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
-  } else if (obj.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    const double & length_m = obj.shape.dimensions.x / 2;
-    const double & width_m = obj.shape.dimensions.y / 2;
-    object_polygon = utils::convertBoundingBoxObjectToGeometryPolygon(
-      obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
-  } else if (obj.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
-    object_polygon = utils::convertPolygonObjectToGeometryPolygon(
-      obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
-  } else {
-    throw std::runtime_error("Unsupported shape type");
-  }
-  return object_polygon;
-}
+/**
+ * @brief Get the predicted object's shape as a geometry polygon
+ * @param obj the object
+ */
+Polygon2d convertObjToPolygon(const PredictedObject & obj);
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils
 
 #endif  // AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_

--- a/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
+++ b/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
@@ -5,6 +5,7 @@
   <arg name="input_imu" default="/sensing/imu/imu_data"/>
   <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
+  <arg name="input_objects" default="/perception/object_recognition/objects"/>
 
   <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
     <!-- load config files -->
@@ -15,5 +16,6 @@
     <remap from="~/input/imu" to="$(var input_imu)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
     <remap from="~/input/predicted_trajectory" to="$(var input_predicted_trajectory)"/>
+    <remap from="~/input/objects" to="$(var input_objects)"/>
   </node>
 </launch>

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -634,7 +634,7 @@ void AEB::createObjectDataUsingPredictedObjects(
         predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
 
       const auto obj_yaw = tf2::getYaw(obj_pose.orientation);
-      const auto obj_idx = motion_utils::findNearestIndex(ego_path, obj_pose.position);
+      const auto obj_idx = autoware_motion_utils::findNearestIndex(ego_path, obj_pose.position);
       const auto path_yaw = (current_ego_speed > 0.0)
                               ? tf2::getYaw(ego_path.at(obj_idx).orientation)
                               : tf2::getYaw(ego_path.at(obj_idx).orientation) + M_PI;
@@ -672,7 +672,7 @@ void AEB::createObjectDataUsingPredictedObjects(
         const auto obj_position =
           autoware_universe_utils::createPoint(collision_point.x(), collision_point.y(), 0.0);
         const double obj_arc_length =
-          motion_utils::calcSignedArcLength(ego_path, current_p, obj_position);
+          autoware_motion_utils::calcSignedArcLength(ego_path, current_p, obj_position);
         if (std::isnan(obj_arc_length)) continue;
 
         // If the object is behind the ego, we need to use the backward long offset. The

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -495,9 +495,9 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
   // Debug print
   if (!filtered_objects->empty() && publish_debug_pointcloud_) {
-    const auto filtered_objects_ros_pointcloud_ptr_ = std::make_shared<PointCloud2>();
-    pcl::toROSMsg(*filtered_objects, *filtered_objects_ros_pointcloud_ptr_);
-    pub_obstacle_pointcloud_->publish(*filtered_objects_ros_pointcloud_ptr_);
+    const auto filtered_objects_ros_pointcloud_ptr = std::make_shared<PointCloud2>();
+    pcl::toROSMsg(*filtered_objects, *filtered_objects_ros_pointcloud_ptr);
+    pub_obstacle_pointcloud_->publish(*filtered_objects_ros_pointcloud_ptr);
   }
   return has_collision;
 }

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -669,6 +669,7 @@ void AEB::createObjectDataUsingPredictedObjects(
       if (collision_points_bg.empty()) continue;
 
       // Create an object for each intersection point
+      bool collision_points_added{false};
       for (const auto & collision_point : collision_points_bg) {
         const auto obj_position =
           tier4_autoware_utils::createPoint(collision_point.x(), collision_point.y(), 0.0);
@@ -689,7 +690,11 @@ void AEB::createObjectDataUsingPredictedObjects(
         obj.velocity = (obj_tangent_velocity > 0.0) ? obj_tangent_velocity : 0.0;
         obj.distance_to_object = std::abs(dist_ego_to_object);
         object_data_vector.push_back(obj);
+        collision_points_added = true;
       }
+      // The ego polygons are in order, so the first intersection points found are the closest
+      // points. It is not necessary to continue iterating the ego polys for the same object.
+      if (collision_points_added) break;
     }
   });
 }

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/autonomous_emergency_braking/node.hpp"
-
-#include "autoware/autonomous_emergency_braking/utils.hpp"
-
+#include <autoware/autonomous_emergency_braking/node.hpp>
+#include <autoware/autonomous_emergency_braking/utils.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -324,6 +324,11 @@ bool AEB::fetchLatestData()
     return missing("control predicted trajectory");
   }
 
+  predicted_objects_ptr_ = predicted_objects_sub_.takeData();
+  if (!predicted_objects_ptr_) {
+    return missing("predicted objects");
+  }
+
   autoware_state_ = sub_autoware_state_.takeData();
   if (!autoware_state_) {
     return missing("autoware_state");

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -624,7 +624,7 @@ void AEB::createObjectDataUsingPredictedObjects(
   const auto current_p = [&]() {
     const auto & first_point_of_path = ego_path.front();
     const auto & p = first_point_of_path.position;
-    return tier4_autoware_utils::createPoint(p.x, p.y, p.z);
+    return autoware_universe_utils::createPoint(p.x, p.y, p.z);
   }();
 
   auto get_object_tangent_velocity =
@@ -670,7 +670,7 @@ void AEB::createObjectDataUsingPredictedObjects(
       bool collision_points_added{false};
       for (const auto & collision_point : collision_points_bg) {
         const auto obj_position =
-          tier4_autoware_utils::createPoint(collision_point.x(), collision_point.y(), 0.0);
+          autoware_universe_utils::createPoint(collision_point.x(), collision_point.y(), 0.0);
         const double obj_arc_length =
           motion_utils::calcSignedArcLength(ego_path, current_p, obj_position);
         if (std::isnan(obj_arc_length)) continue;

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/autonomous_emergency_braking/node.hpp"
 
-#include "autoware_autonomous_emergency_braking/utils.hpp"
+#include "autoware/autonomous_emergency_braking/utils.hpp"
 
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/geometry/boost_polygon_utils.hpp>

--- a/control/autoware_autonomous_emergency_braking/src/utils.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/utils.cpp
@@ -1,0 +1,13 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/control/autoware_autonomous_emergency_braking/src/utils.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/utils.cpp
@@ -11,3 +11,140 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <autoware/autonomous_emergency_braking/utils.hpp>
+
+namespace autoware::motion::control::autonomous_emergency_braking::utils
+{
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_universe_utils::Point2d;
+using autoware_universe_utils::Polygon2d;
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::TransformStamped;
+using geometry_msgs::msg::Vector3;
+
+PredictedObject transformObjectFrame(
+  const PredictedObject & input, geometry_msgs::msg::TransformStamped transform_stamped)
+{
+  PredictedObject output = input;
+  const auto & linear_twist = input.kinematics.initial_twist_with_covariance.twist.linear;
+  const auto & angular_twist = input.kinematics.initial_twist_with_covariance.twist.angular;
+  const auto & pose = input.kinematics.initial_pose_with_covariance.pose;
+
+  geometry_msgs::msg::Pose t_pose;
+  Vector3 t_linear_twist;
+  Vector3 t_angular_twist;
+
+  tf2::doTransform(pose, t_pose, transform_stamped);
+  tf2::doTransform(linear_twist, t_linear_twist, transform_stamped);
+  tf2::doTransform(angular_twist, t_angular_twist, transform_stamped);
+
+  output.kinematics.initial_pose_with_covariance.pose = t_pose;
+  output.kinematics.initial_twist_with_covariance.twist.linear = t_linear_twist;
+  output.kinematics.initial_twist_with_covariance.twist.angular = t_angular_twist;
+  return output;
+}
+
+Polygon2d convertPolygonObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
+{
+  Polygon2d object_polygon;
+  tf2::Transform tf_map2obj;
+  fromMsg(current_pose, tf_map2obj);
+  const auto obj_points = obj_shape.footprint.points;
+  object_polygon.outer().reserve(obj_points.size() + 1);
+  for (const auto & obj_point : obj_points) {
+    tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);
+    tf2::Vector3 tf_obj = tf_map2obj * obj;
+    object_polygon.outer().emplace_back(tf_obj.x(), tf_obj.y());
+  }
+  object_polygon.outer().push_back(object_polygon.outer().front());
+  boost::geometry::correct(object_polygon);
+
+  return object_polygon;
+}
+
+Polygon2d convertCylindricalObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_perception_msgs::msg::Shape & obj_shape)
+{
+  Polygon2d object_polygon;
+
+  const double obj_x = current_pose.position.x;
+  const double obj_y = current_pose.position.y;
+
+  constexpr int N = 20;
+  const double r = obj_shape.dimensions.x / 2;
+  object_polygon.outer().reserve(N + 1);
+  for (int i = 0; i < N; ++i) {
+    object_polygon.outer().emplace_back(
+      obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i));
+  }
+
+  object_polygon.outer().push_back(object_polygon.outer().front());
+  boost::geometry::correct(object_polygon);
+
+  return object_polygon;
+}
+
+Polygon2d convertBoundingBoxObjectToGeometryPolygon(
+  const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
+  const double & base_to_width)
+{
+  const auto mapped_point = [](const double & length_scalar, const double & width_scalar) {
+    tf2::Vector3 map;
+    map.setX(length_scalar);
+    map.setY(width_scalar);
+    map.setZ(0.0);
+    map.setW(1.0);
+    return map;
+  };
+
+  // set vertices at map coordinate
+  const tf2::Vector3 p1_map = std::invoke(mapped_point, base_to_front, -base_to_width);
+  const tf2::Vector3 p2_map = std::invoke(mapped_point, base_to_front, base_to_width);
+  const tf2::Vector3 p3_map = std::invoke(mapped_point, -base_to_rear, base_to_width);
+  const tf2::Vector3 p4_map = std::invoke(mapped_point, -base_to_rear, -base_to_width);
+
+  // transform vertices from map coordinate to object coordinate
+  tf2::Transform tf_map2obj;
+  tf2::fromMsg(current_pose, tf_map2obj);
+  const tf2::Vector3 p1_obj = tf_map2obj * p1_map;
+  const tf2::Vector3 p2_obj = tf_map2obj * p2_map;
+  const tf2::Vector3 p3_obj = tf_map2obj * p3_map;
+  const tf2::Vector3 p4_obj = tf_map2obj * p4_map;
+
+  Polygon2d object_polygon;
+  object_polygon.outer().reserve(5);
+  object_polygon.outer().emplace_back(p1_obj.x(), p1_obj.y());
+  object_polygon.outer().emplace_back(p2_obj.x(), p2_obj.y());
+  object_polygon.outer().emplace_back(p3_obj.x(), p3_obj.y());
+  object_polygon.outer().emplace_back(p4_obj.x(), p4_obj.y());
+
+  object_polygon.outer().push_back(object_polygon.outer().front());
+  boost::geometry::correct(object_polygon);
+
+  return object_polygon;
+}
+
+Polygon2d convertObjToPolygon(const PredictedObject & obj)
+{
+  Polygon2d object_polygon{};
+  if (obj.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    object_polygon = utils::convertCylindricalObjectToGeometryPolygon(
+      obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+  } else if (obj.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    const double & length_m = obj.shape.dimensions.x / 2;
+    const double & width_m = obj.shape.dimensions.y / 2;
+    object_polygon = utils::convertBoundingBoxObjectToGeometryPolygon(
+      obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+  } else if (obj.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    object_polygon = utils::convertPolygonObjectToGeometryPolygon(
+      obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+  } else {
+    throw std::runtime_error("Unsupported shape type");
+  }
+  return object_polygon;
+}
+}  // namespace autoware::motion::control::autonomous_emergency_braking::utils

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -148,6 +148,7 @@ def launch_setup(context, *args, **kwargs):
             ("~/input/velocity", "/vehicle/status/velocity_status"),
             ("~/input/imu", "/sensing/imu/imu_data"),
             ("~/input/odometry", "/localization/kinematic_state"),
+            ("~/input/objects", "/perception/object_recognition/objects"),
             (
                 "~/input/predicted_trajectory",
                 "/control/trajectory_follower/lateral/predicted_trajectory",


### PR DESCRIPTION
## Description

This PR introduces support for using predicted objects on AEB collision checking. It also enables toggling on and off pointcloud based and predicted object based collision checking. 

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

PSim

The attached video shows the predicted object usage alongside the usual pointcloud method, I also turn off the point cloud method while the ego is moving and detecting an obstacle, and there is no problem with the transition.


https://github.com/autowarefoundation/autoware.universe/assets/25967964/248fd524-a8d1-4bdb-b424-d426a4a13783


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
