### PR TITLE
ci(build-and-test): limit ccache size

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -56,6 +56,12 @@ jobs:
           restore-keys: |
             ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-
 
+      - name: Limit ccache size
+        run: |
+          rm -f "${CCACHE_DIR}/ccache.conf"
+          echo -e "# Set maximum cache size\nmax_size = 600MB" >> "${CCACHE_DIR}/ccache.conf"
+        shell: bash
+
       - name: Show ccache stats before build
         run: du -sh ${CCACHE_DIR} && ccache -s
         shell: bash


### PR DESCRIPTION
## Description

Default ccache `max_size=5GB` which can be too much for our github hosted machines.

This PR reduces it to `600MB`.

Related links:
- https://ccache.dev/manual/latest.html#_configuration_file_syntax
- https://ccache.dev/manual/latest.html#_configuration_options

Related issue:
- https://github.com/autowarefoundation/autoware.universe/issues/7501

## Tests performed

Ran the workflow against this branch:

- https://github.com/autowarefoundation/autoware.universe/actions/runs/9562281575/job/26358331612#step:11:20

![image](https://github.com/autowarefoundation/autoware.universe/assets/10751153/d4a010c6-c880-4662-9a4b-0a7a2258e32d)

It works ✅

## Effects on system behavior

I had a ccache cache of 30GB on my machine.

Set the max size to 5GB.

Then rebuilt the Autoware.

The ccache size gradually became smaller down to 4GB automatically.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
