### PR TITLE
fix(multi_object_tracker): fix uselessCallsSubstr warning

### DIFF
--- a/perception/multi_object_tracker/src/debugger/debug_object.cpp
+++ b/perception/multi_object_tracker/src/debugger/debug_object.cpp
@@ -236,8 +236,9 @@ void TrackerObjectDebugger::draw(
       stream << std::fixed << std::setprecision(0) << object_data_front.existence_vector[i] * 100;
       existence_probability_text += channel_names_[i] + stream.str() + ":";
     }
-    existence_probability_text =
-      existence_probability_text.substr(0, existence_probability_text.size() - 1);
+    if (!existence_probability_text.empty()) {
+      existence_probability_text.pop_back();
+    }
     existence_probability_text += "\n" + object_data_front.uuid_str.substr(0, 6);
 
     text_marker.text = existence_probability_text;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `uselessCallsSubstr` warning

```
perception/multi_object_tracker/src/debugger/debug_object.cpp:240:7: performance: Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use resize() or pop_back() instead. [uselessCallsSubstr]
      existence_probability_text.substr(0, existence_probability_text.size() - 1);
      ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
