### PR TITLE
fix(lidar_apollo_segmentation_tvm): fix unpreciseMathCall warning

### DIFF
--- a/perception/lidar_apollo_segmentation_tvm/src/log_table.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/log_table.cpp
@@ -46,7 +46,7 @@ float calcApproximateLog(float num)
       return log_table.data[integer_num];
     }
   }
-  return std::log(1.0f + num);
+  return std::log1p(num);
 }
 }  // namespace lidar_apollo_segmentation_tvm
 }  // namespace perception


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unpreciseMathCall` warning

```
perception/lidar_apollo_segmentation_tvm/src/log_table.cpp:49:15: style: Expression 'log(1 + x)' can be replaced by 'log1p(x)' to avoid loss of precision. [unpreciseMathCall]
  return std::log(1.0f + num);
              ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
