### PR TITLE
fix(autoware_behavior_velocity_occlusion_spot_module): fix redundantAssignment bug

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/utils.hpp
@@ -86,7 +86,7 @@ inline void generatePossibleCollisions(
     // intersection
     geometry_msgs::msg::Pose intersection_pose{};
     intersection_pose.position.x = x0 + x_step * i + lon;
-    intersection_pose.position.x = y0 + y_step * i;
+    intersection_pose.position.y = y0 + y_step * i;
 
     // collision path point
     autoware_planning_msgs::msg::PathPoint collision_with_margin{};


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantAssignment` warning

```
planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/utils.hpp:89:34: style: Variable 'intersection_pose.position.x' is reassigned a value before the old one has been used. [redundantAssignment]
    intersection_pose.position.x = y0 + y_step * i;
                                 ^
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
