### PR TITLE
fix(behavior_path_planner): fix redundantAssignment warning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_turn_signal.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_turn_signal.cpp
@@ -338,7 +338,6 @@ TEST(BehaviorPathPlanningTurnSignal, Condition3)
 
   TurnSignalInfo behavior_signal_info;
   behavior_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
-  behavior_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
   behavior_signal_info.desired_start_point.position = createPoint(5.0, 0.0, 0.0);
   behavior_signal_info.desired_start_point.orientation = createQuaternionFromYaw(0.0);
   behavior_signal_info.desired_end_point.position = createPoint(70.0, 0.0, 0.0);


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantAssignment` warning

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_turn_signal.cpp:341:44: style: Variable 'behavior_signal_info.turn_signal.command' is reassigned a value before the old one has been used. [redundantAssignment]
  behavior_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
                                           ^
planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_turn_signal.cpp:340:44: note: behavior_signal_info.turn_signal.command is assigned
  behavior_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
                                           ^
planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_turn_signal.cpp:341:44: note: behavior_signal_info.turn_signal.command is overwritten
  behavior_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
                                           ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
