### PR TITLE
fix(autoware_freespace_planning_algorithms): fix unusedScopedObject bug

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -91,7 +91,7 @@ geometry_msgs::msg::Pose local2global(
 double PlannerWaypoints::compute_length() const
 {
   if (waypoints.empty()) {
-    std::runtime_error("cannot compute cost because waypoint has size 0");
+    throw std::runtime_error("cannot compute cost because waypoint has size 0");
   }
   double total_cost = 0.0;
   for (size_t i = 0; i < waypoints.size() - 1; ++i) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unusedScopedObject` warning

```
planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp:94:10: style: Instance of 'std::runtime_error' object is destroyed immediately. [unusedScopedObject]
    std::runtime_error("cannot compute cost because waypoint has size 0");
         ^
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
