### PR TITLE
fix(.gitignore): add config to ignore directory which is made by prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ log/
 
 # Python
 *.pyc
+
+#prettier
+node_modules/


### PR DESCRIPTION
## Description

Currently, prettier automatically makes directory `/node_modules` when I run `pre-commit run -a`.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

CI

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
