### PR TITLE
fix(autoware_obstacle_cruise_planner): fix unusedScopedObject bug

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -409,7 +409,7 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
       planner_ptr_ = std::make_unique<PIDBasedPlanner>(
         *this, longitudinal_info, vehicle_info_, ego_nearest_param_, debug_data_ptr_);
     } else {
-      std::logic_error("Designated algorithm is not supported.");
+      throw std::logic_error("Designated algorithm is not supported.");
     }
 
     min_behavior_stop_margin_ = declare_parameter<double>("common.min_behavior_stop_margin");

--- a/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
@@ -143,7 +143,7 @@ double findReachTime(
     return j * t * t * t / 6.0 + a * t * t / 2.0 + v * t - d;
   };
   if (f(min, j, a, v, d) > 0 || f(max, j, a, v, d) < 0) {
-    std::logic_error("[obstacle_cruise_planner](findReachTime): search range is invalid");
+    throw std::logic_error("[obstacle_cruise_planner](findReachTime): search range is invalid");
   }
   const double eps = 1e-5;
   const int warn_iter = 100;
@@ -175,7 +175,7 @@ double calcDecelerationVelocityFromDistanceToTarget(
   const double current_velocity, const double distance_to_target)
 {
   if (max_slowdown_jerk > 0 || max_slowdown_accel > 0) {
-    std::logic_error("max_slowdown_jerk and max_slowdown_accel should be negative");
+    throw std::logic_error("max_slowdown_jerk and max_slowdown_accel should be negative");
   }
   // case0: distance to target is behind ego
   if (distance_to_target <= 0) return current_velocity;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unusedScopedObject` bug

```
planning/autoware_obstacle_cruise_planner/src/node.cpp:409:12: style: Instance of 'std::logic_error' object is destroyed immediately. [unusedScopedObject]
      std::logic_error("Designated algorithm is not supported.");
           ^
planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:146:10: style: Instance of 'std::logic_error' object is destroyed immediately. [unusedScopedObject]
    std::logic_error("[obstacle_cruise_planner](findReachTime): search range is invalid");
         ^
planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:178:10: style: Instance of 'std::logic_error' object is destroyed immediately. [unusedScopedObject]
    std::logic_error("max_slowdown_jerk and max_slowdown_accel should be negative");
         ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
