### PR TITLE
fix(autoware_mpc_lateral_controller): fix duplicateAssignExpression warning

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -497,7 +497,7 @@ bool MpcLateralController::isMpcConverged()
 
   // Find the maximum and minimum values of the steering angle in the past 1 second.
   double min_steering_value = m_mpc_steering_history[0].first.steering_tire_angle;
-  double max_steering_value = m_mpc_steering_history[0].first.steering_tire_angle;
+  double max_steering_value = min_steering_value;
   for (size_t i = 1; i < m_mpc_steering_history.size(); i++) {
     if (m_mpc_steering_history.at(i).first.steering_tire_angle < min_steering_value) {
       min_steering_value = m_mpc_steering_history.at(i).first.steering_tire_angle;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `duplicateAssignExpression` warning

```
control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp:499:10: style: inconclusive: Same expression used in consecutive assignments of 'min_steering_value' and 'max_steering_value'. [duplicateAssignExpression]
  double min_steering_value = m_mpc_steering_history[0].first.steering_tire_angle;
         ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
