### PR TITLE
fix(net_monitor): fix cppcheck warnings

### DIFF
--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -452,7 +452,6 @@ void NetMonitor::update_network_capacity(NetworkInfomation & network, int socket
   strncpy(request.ifr_name, network.interface_name.c_str(), IFNAMSIZ - 1);
   request.ifr_data = (caddr_t)&ether_request;  // NOLINT [cppcoreguidelines-pro-type-cstyle-cast]
 
-  ether_request.cmd = ETHTOOL_GSET;
   if (ioctl(socket, SIOCETHTOOL, &request) >= 0) {
     network.speed = ether_request.speed;
     return;

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -280,7 +280,6 @@ void NetMonitor::check_reassembles_failed(diagnostic_updater::DiagnosticStatusWr
   int whole_level = DiagStatus::OK;
   std::string error_message;
   uint64_t total_reassembles_failed = 0;
-  uint64_t unit_reassembles_failed = 0;
 
   if (get_reassembles_failed(total_reassembles_failed)) {
     reassembles_failed_queue_.push_back(total_reassembles_failed - last_reassembles_failed_);
@@ -288,6 +287,7 @@ void NetMonitor::check_reassembles_failed(diagnostic_updater::DiagnosticStatusWr
       reassembles_failed_queue_.pop_front();
     }
 
+    uint64_t unit_reassembles_failed = 0;
     for (auto reassembles_failed : reassembles_failed_queue_) {
       unit_reassembles_failed += reassembles_failed;
     }

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -450,6 +450,7 @@ void NetMonitor::update_network_capacity(NetworkInfomation & network, int socket
 
   // NOLINTNEXTLINE [cppcoreguidelines-pro-type-union-access]
   strncpy(request.ifr_name, network.interface_name.c_str(), IFNAMSIZ - 1);
+  ether_request.cmd = ETHTOOL_GSET;
   request.ifr_data = (caddr_t)&ether_request;  // NOLINT [cppcoreguidelines-pro-type-cstyle-cast]
 
   if (ioctl(socket, SIOCETHTOOL, &request) >= 0) {

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -156,7 +156,6 @@ void NetMonitor::check_usage(diagnostic_updater::DiagnosticStatusWrapper & statu
 
   int level = DiagStatus::OK;
   int index = 0;
-  std::vector<std::string> interface_names;
 
   for (const auto & network : network_list_) {
     // Skip if network is not supported

--- a/system/system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/system_monitor/src/net_monitor/net_monitor.cpp
@@ -156,7 +156,6 @@ void NetMonitor::check_usage(diagnostic_updater::DiagnosticStatusWrapper & statu
 
   int level = DiagStatus::OK;
   int index = 0;
-  std::string error_str;
   std::vector<std::string> interface_names;
 
   for (const auto & network : network_list_) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warnings below

```
system/system_monitor/src/net_monitor/net_monitor.cpp:285:12: style: The scope of the variable 'unit_reassembles_failed' can be reduced. [variableScope]
  uint64_t unit_reassembles_failed = 0;
           ^
system/system_monitor/src/net_monitor/net_monitor.cpp:159:15: style: Unused variable: error_str [unusedVariable]
  std::string error_str;
              ^
system/system_monitor/src/net_monitor/net_monitor.cpp:160:28: style: Unused variable: interface_names [unusedVariable]
  std::vector<std::string> interface_names;
                           ^
system/system_monitor/src/net_monitor/net_monitor.cpp:457:21: style: Variable 'ether_request.cmd' is assigned a value that is never used. [unreadVariable]
  ether_request.cmd = ETHTOOL_GSET;
                    ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
