### PR TITLE
fix(simple_planning_simulator): fix duplicateBranch warnings

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
@@ -177,9 +177,7 @@ void SimModelDelaySteerAccGeared::updateStateWithGear(
     if (state(IDX::VX) > 0.0) {
       setStopState();
     }
-  } else if (gear == GearCommand::PARK) {
-    setStopState();
-  } else {
+  } else { // including 'gear == GearCommand::PARK'
     setStopState();
   }
 }

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
@@ -177,7 +177,7 @@ void SimModelDelaySteerAccGeared::updateStateWithGear(
     if (state(IDX::VX) > 0.0) {
       setStopState();
     }
-  } else { // including 'gear == GearCommand::PARK'
+  } else {  // including 'gear == GearCommand::PARK'
     setStopState();
   }
 }

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
@@ -159,13 +159,7 @@ void SimModelDelaySteerMapAccGeared::updateStateWithGear(
       state(IDX::YAW) = prev_state(IDX::YAW);
       state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
     }
-  } else if (gear == GearCommand::PARK) {
-    state(IDX::VX) = 0.0;
-    state(IDX::X) = prev_state(IDX::X);
-    state(IDX::Y) = prev_state(IDX::Y);
-    state(IDX::YAW) = prev_state(IDX::YAW);
-    state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
-  } else {
+  } else { // including 'gear == GearCommand::PARK'
     state(IDX::VX) = 0.0;
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
@@ -159,7 +159,7 @@ void SimModelDelaySteerMapAccGeared::updateStateWithGear(
       state(IDX::YAW) = prev_state(IDX::YAW);
       state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
     }
-  } else { // including 'gear == GearCommand::PARK'
+  } else {  // including 'gear == GearCommand::PARK'
     state(IDX::VX) = 0.0;
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
@@ -109,9 +109,7 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
     if (state(IDX::VX) > 0.0) {
       setStopState();
     }
-  } else if (gear == GearCommand::PARK) {
-    setStopState();
-  } else {
+  } else { // including 'gear == GearCommand::PARK'
     setStopState();
   }
   // calculate acc from velocity diff

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
@@ -109,7 +109,7 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
     if (state(IDX::VX) > 0.0) {
       setStopState();
     }
-  } else { // including 'gear == GearCommand::PARK'
+  } else {  // including 'gear == GearCommand::PARK'
     setStopState();
   }
   // calculate acc from velocity diff


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning

```
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp:180:10: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
  } else if (gear == GearCommand::PARK) {
         ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp:182:5: note: Found duplicate branches for 'if' and 'else'.
  } else {
    ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp:180:10: note: Found duplicate branches for 'if' and 'else'.
  } else if (gear == GearCommand::PARK) {
         ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp:162:10: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
  } else if (gear == GearCommand::PARK) {
         ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp:168:5: note: Found duplicate branches for 'if' and 'else'.
  } else {
    ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp:162:10: note: Found duplicate branches for 'if' and 'else'.
  } else if (gear == GearCommand::PARK) {
         ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp:112:10: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
  } else if (gear == GearCommand::PARK) {
         ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp:114:5: note: Found duplicate branches for 'if' and 'else'.
  } else {
    ^
simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp:112:10: note: Found duplicate branches for 'if' and 'else'.
  } else if (gear == GearCommand::PARK) {
         ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
