### PR TITLE
fix(learning_based_vehicle_model): fix constVariablePointer warning

### DIFF
--- a/simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp
+++ b/simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp
@@ -32,7 +32,7 @@ std::vector<int> createConnectionsMap(
   std::vector<int> connection_map;
   // index in "connection_map" is index in "connection_names_2" and value in "connection_map" is
   // index in "connection_names_1"
-  for (auto name_2 : connection_names_2) {
+  for (const auto name_2 : connection_names_2) {
     int mapped_idx = -1;  // -1 means that we cannot create a connection between some signals
     for (std::size_t NAME_1_IDX = 0; NAME_1_IDX < connection_names_1.size(); NAME_1_IDX++) {
       if (strcmp(name_2, connection_names_1[NAME_1_IDX]) == 0) {  // 0 means strings are the same

--- a/simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp
+++ b/simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp
@@ -32,7 +32,7 @@ std::vector<int> createConnectionsMap(
   std::vector<int> connection_map;
   // index in "connection_map" is index in "connection_names_2" and value in "connection_map" is
   // index in "connection_names_1"
-  for (const auto name_2 : connection_names_2) {
+  for (const auto & name_2 : connection_names_2) {
     int mapped_idx = -1;  // -1 means that we cannot create a connection between some signals
     for (std::size_t NAME_1_IDX = 0; NAME_1_IDX < connection_names_1.size(); NAME_1_IDX++) {
       if (strcmp(name_2, connection_names_1[NAME_1_IDX]) == 0) {  // 0 means strings are the same


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `constVariablePointer` warning

```
simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp:35:13: style: Variable 'name_2' can be declared as pointer to const [constVariablePointer]
  for (auto name_2 : connection_names_2) {
            ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
