### PR TITLE
fix(bytetrack): fix cppcheck warnings

### DIFF
--- a/perception/bytetrack/lib/src/lapjv.cpp
+++ b/perception/bytetrack/lib/src/lapjv.cpp
@@ -181,7 +181,7 @@ int_t _carr_dense(
 
 /** Find columns with minimum d[j] and put them on the SCAN list.
  */
-uint_t _find_dense(const uint_t n, uint_t lo, cost_t * d, int_t * cols, [[maybe_unused]] int_t * y)
+uint_t _find_dense(const uint_t n, uint_t lo, const cost_t * d, int_t * cols, [[maybe_unused]] int_t * y)
 {
   uint_t hi = lo + 1;
   cost_t mind = d[cols[lo]];
@@ -203,7 +203,7 @@ uint_t _find_dense(const uint_t n, uint_t lo, cost_t * d, int_t * cols, [[maybe_
 // and try to decrease d of the TODO columns using the SCAN column.
 int_t _scan_dense(
   const uint_t n, cost_t * cost[], uint_t * plo, uint_t * phi, cost_t * d, int_t * cols,
-  int_t * pred, int_t * y, cost_t * v)
+  int_t * pred, const int_t * y, const cost_t * v)
 {
   uint_t lo = *plo;
   uint_t hi = *phi;

--- a/perception/bytetrack/lib/src/lapjv.cpp
+++ b/perception/bytetrack/lib/src/lapjv.cpp
@@ -181,7 +181,8 @@ int_t _carr_dense(
 
 /** Find columns with minimum d[j] and put them on the SCAN list.
  */
-uint_t _find_dense(const uint_t n, uint_t lo, const cost_t * d, int_t * cols, [[maybe_unused]] int_t * y)
+uint_t _find_dense(
+  const uint_t n, uint_t lo, const cost_t * d, int_t * cols, [[maybe_unused]] int_t * y)
 {
   uint_t hi = lo + 1;
   cost_t mind = d[cols[lo]];

--- a/perception/bytetrack/lib/src/strack.cpp
+++ b/perception/bytetrack/lib/src/strack.cpp
@@ -117,7 +117,6 @@ void STrack::activate(int frame_id)
   _tlwh_tmp[1] = this->original_tlwh[1];
   _tlwh_tmp[2] = this->original_tlwh[2];
   _tlwh_tmp[3] = this->original_tlwh[3];
-  std::vector<float> xyah = tlwh_to_xyah(_tlwh_tmp);
   // init kf
   init_kalman_filter();
   // reflect state
@@ -132,7 +131,6 @@ void STrack::activate(int frame_id)
 
 void STrack::re_activate(STrack & new_track, int frame_id, bool new_id)
 {
-  std::vector<float> xyah = tlwh_to_xyah(new_track.tlwh);
   // TODO(me): write kf update
   Eigen::MatrixXd measurement = Eigen::MatrixXd::Zero(_kf_parameters.dim_z, 1);
   measurement << new_track.tlwh[0], new_track.tlwh[1], new_track.tlwh[2], new_track.tlwh[3];
@@ -155,8 +153,6 @@ void STrack::update(STrack & new_track, int frame_id)
 {
   this->frame_id = frame_id;
   this->tracklet_len++;
-
-  std::vector<float> xyah = tlwh_to_xyah(new_track.tlwh);
 
   // update
   // TODO(me): write update

--- a/perception/bytetrack/lib/src/strack.cpp
+++ b/perception/bytetrack/lib/src/strack.cpp
@@ -112,11 +112,6 @@ void STrack::activate(int frame_id)
   this->track_id = this->next_id();
   this->unique_id = boost::uuids::random_generator()();
 
-  std::vector<float> _tlwh_tmp(4);
-  _tlwh_tmp[0] = this->original_tlwh[0];
-  _tlwh_tmp[1] = this->original_tlwh[1];
-  _tlwh_tmp[2] = this->original_tlwh[2];
-  _tlwh_tmp[3] = this->original_tlwh[3];
   // init kf
   init_kalman_filter();
   // reflect state

--- a/perception/bytetrack/lib/src/utils.cpp
+++ b/perception/bytetrack/lib/src/utils.cpp
@@ -277,8 +277,6 @@ double ByteTracker::lapjv(
   std::vector<std::vector<float>> cost_c;
   cost_c.assign(cost.begin(), cost.end());
 
-  std::vector<std::vector<float>> cost_c_extended;
-
   int n_rows = cost.size();
   int n_cols = cost[0].size();
   rowsol.resize(n_rows);
@@ -296,6 +294,8 @@ double ByteTracker::lapjv(
   }
 
   if (extend_cost || cost_limit < LONG_MAX) {
+    std::vector<std::vector<float>> cost_c_extended;
+
     n = n_rows + n_cols;
     cost_c_extended.resize(n);
     for (size_t i = 0; i < cost_c_extended.size(); i++) cost_c_extended[i].resize(n);

--- a/perception/bytetrack/lib/src/utils.cpp
+++ b/perception/bytetrack/lib/src/utils.cpp
@@ -190,7 +190,6 @@ std::vector<std::vector<float>> ByteTracker::ious(
 
   // bbox_ious
   for (size_t k = 0; k < btlbrs.size(); k++) {
-    std::vector<float> ious_tmp;
     float box_area = (btlbrs[k][2] - btlbrs[k][0] + 1) * (btlbrs[k][3] - btlbrs[k][1] + 1);
     for (size_t n = 0; n < atlbrs.size(); n++) {
       float iw = std::min(atlbrs[n][2], btlbrs[k][2]) - std::max(atlbrs[n][0], btlbrs[k][0]) + 1;

--- a/perception/bytetrack/src/bytetrack_visualizer_node.cpp
+++ b/perception/bytetrack/src/bytetrack_visualizer_node.cpp
@@ -128,14 +128,14 @@ void ByteTrackVisualizerNode::callback(
   }
 
   std::vector<cv::Rect> bboxes;
-  for (auto & feat_obj : rect_msg->feature_objects) {
+  for (const auto & feat_obj : rect_msg->feature_objects) {
     auto roi_msg = feat_obj.feature.roi;
     cv::Rect rect(roi_msg.x_offset, roi_msg.y_offset, roi_msg.width, roi_msg.height);
     bboxes.push_back(rect);
   }
 
   std::vector<boost::uuids::uuid> uuids;
-  for (auto & dynamic_obj : uuid_msg->objects) {
+  for (const auto & dynamic_obj : uuid_msg->objects) {
     auto uuid_msg = dynamic_obj.id.uuid;
     boost::uuids::uuid uuid_raw;
     std::copy(uuid_msg.begin(), uuid_msg.end(), uuid_raw.begin());


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warnings

```
perception/bytetrack/lib/src/lapjv.cpp:184:56: style: Parameter 'd' can be declared as pointer to const [constParameterPointer]
uint_t _find_dense(const uint_t n, uint_t lo, cost_t * d, int_t * cols, [[maybe_unused]] int_t * y)
                                                       ^
perception/bytetrack/lib/src/lapjv.cpp:206:25: style: Parameter 'y' can be declared as pointer to const [constParameterPointer]
  int_t * pred, int_t * y, cost_t * v)
                        ^
perception/bytetrack/lib/src/lapjv.cpp:206:37: style: Parameter 'v' can be declared as pointer to const [constParameterPointer]
  int_t * pred, int_t * y, cost_t * v)
                                    ^
perception/bytetrack/lib/src/strack.cpp:120:27: style: Variable 'xyah' is assigned a value that is never used. [unreadVariable]
  std::vector<float> xyah = tlwh_to_xyah(_tlwh_tmp);
                          ^
perception/bytetrack/lib/src/strack.cpp:135:27: style: Variable 'xyah' is assigned a value that is never used. [unreadVariable]
  std::vector<float> xyah = tlwh_to_xyah(new_track.tlwh);
                          ^
perception/bytetrack/lib/src/strack.cpp:159:27: style: Variable 'xyah' is assigned a value that is never used. [unreadVariable]
  std::vector<float> xyah = tlwh_to_xyah(new_track.tlwh);
                          ^
perception/bytetrack/lib/src/utils.cpp:280:35: style: The scope of the variable 'cost_c_extended' can be reduced. [variableScope]
  std::vector<std::vector<float>> cost_c_extended;
                                  ^
perception/bytetrack/lib/src/utils.cpp:193:24: style: Unused variable: ious_tmp [unusedVariable]
    std::vector<float> ious_tmp;
                       ^
perception/bytetrack/src/bytetrack_visualizer_node.cpp:131:15: style: Variable 'feat_obj' can be declared as reference to const [constVariableReference]
  for (auto & feat_obj : rect_msg->feature_objects) {
              ^
perception/bytetrack/src/bytetrack_visualizer_node.cpp:138:15: style: Variable 'dynamic_obj' can be declared as reference to const [constVariableReference]
  for (auto & dynamic_obj : uuid_msg->objects) {
              ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
