### PR TITLE
fix(autoware_path_optimizer): fix redundantContinue warnings

### DIFF
--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -954,7 +954,6 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
       // much.
       b.lower_bound =
         std::min(b.lower_bound, original_b.upper_bound - min_dynamic_drivable_width_vec.at(p_idx));
-      continue;
     }
     // extend longitudinal if it overlaps out_of_upper_bound_sections
     if (upper_bound_start_idx) {
@@ -1004,7 +1003,6 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
       // much.
       b.upper_bound =
         std::max(b.upper_bound, original_b.lower_bound + min_dynamic_drivable_width_vec.at(p_idx));
-      continue;
     }
     // extend longitudinal if it overlaps out_of_lower_bound_sections
     if (lower_bound_start_idx) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantContinue` warning

```
planning/autoware_path_optimizer/src/mpt_optimizer.cpp:957:7: style: 'continue' is redundant since it is the last statement in a loop. [redundantContinue]
      continue;
      ^
planning/autoware_path_optimizer/src/mpt_optimizer.cpp:1007:7: style: 'continue' is redundant since it is the last statement in a loop. [redundantContinue]
      continue;
      ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
