### PR TITLE
fix(autoware_freespace_planning_algorithms): fix constStatement warning

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -86,8 +86,9 @@ AstarSearch::TransitionTable createTransitionTable(
   for (int i = 0; i < turning_radius_size; ++i) {
     double R = R_min + i * dR;
     double step = R * dtheta;
-    const NodeUpdate forward_left{
-      R * sin(dtheta), R * (1 - cos(dtheta)), dtheta, step, true, false};
+    const double shift_x = R * sin(dtheta);
+    const double shift_y = R * (1 - cos(dtheta));
+    const NodeUpdate forward_left{shift_x, shift_y, dtheta, step, true, false};
     const NodeUpdate forward_right = forward_left.flipped();
     forward_node_candidates.push_back(forward_left);
     forward_node_candidates.push_back(forward_right);


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `constStatement` warning.

```
planning/autoware_freespace_planning_algorithms/src/astar_search.cpp:90:9: warning: inconclusive: Found suspicious operator '*', result is not used. [constStatement]
      R * sin(dtheta), R * (1 - cos(dtheta)), dtheta, step, true, false};
        ^
```

As you know, this is a false positive of cppcheck.
However, `constStatement` feature should be enabled for entire Autoware, we should eliminate the current `constStatement` warning as much as possible.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
