### PR TITLE
fix(autoware_behavior_path_start_planner_module): fix duplicateBreak warning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -888,20 +888,16 @@ PriorityOrder StartPlannerModule::determinePriorityOrder(
         order_priority.emplace_back(i, planner);
       }
     }
-    return order_priority;
-  }
-
-  if (search_priority == "short_back_distance") {
+  } else if (search_priority == "short_back_distance") {
     for (size_t i = 0; i < start_pose_candidates_num; i++) {
       for (const auto & planner : start_planners_) {
         order_priority.emplace_back(i, planner);
       }
     }
-    return order_priority;
+  } else {
+    RCLCPP_ERROR(getLogger(), "Invalid search_priority: %s", search_priority.c_str());
+    throw std::domain_error("[start_planner] invalid search_priority");
   }
-
-  RCLCPP_ERROR(getLogger(), "Invalid search_priority: %s", search_priority.c_str());
-  throw std::domain_error("[start_planner] invalid search_priority");
   return order_priority;
 }
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `duplicateBreak` warning

```
planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp:905:3: style: Consecutive return, break, continue, goto or throw statements are unnecessary. [duplicateBreak]
  return order_priority;
  ^
```

This modification is just to avoid cppcheck warnings.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
