### PR TITLE
fix(autoware_path_sampler): fix unusedVariable warning

### DIFF
--- a/planning/sampling_based_planner/autoware_path_sampler/src/node.cpp
+++ b/planning/sampling_based_planner/autoware_path_sampler/src/node.cpp
@@ -523,7 +523,6 @@ autoware::sampler_common::Path PathSampler::generatePath(const PlannerData & pla
 
 std::vector<TrajectoryPoint> PathSampler::generateTrajectoryPoints(const PlannerData & planner_data)
 {
-  std::vector<TrajectoryPoint> trajectory;
   time_keeper_ptr_->tic(__func__);
   const auto path = generatePath(planner_data);
   return trajectory_utils::convertToTrajectoryPoints(path);


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unusedVariable` warning

```
planning/sampling_based_planner/autoware_path_sampler/src/node.cpp:526:32: style: Unused variable: trajectory [unusedVariable]
  std::vector<TrajectoryPoint> trajectory;
                               ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
