### PR TITLE
fix(autoware_velocity_smoother): fix unusedVariable warning

### DIFF
--- a/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
@@ -300,7 +300,6 @@ bool calcStopDistWithJerkConstraints(
   }
 
   double x, v, a, j;
-  std::tuple<double, double, double, double> state;
 
   switch (type) {
     case AccelerationType::TRAPEZOID: {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unusedVariable` warning

```
planning/autoware_velocity_smoother/src/trajectory_utils.cpp:303:46: style: Unused variable: state [unusedVariable]
  std::tuple<double, double, double, double> state;
                                             ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
