### PR TITLE
fix: replace deprecated header in Jazzy

### DIFF
--- a/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/src/ar_tag_based_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/src/ar_tag_based_localizer.cpp
@@ -51,7 +51,11 @@
 #include <opencv4/opencv2/calib3d.hpp>
 #include <opencv4/opencv2/core/quaternion.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <tf2/LinearMath/Transform.h>
 
 #include <algorithm>

--- a/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/src/ar_tag_based_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/src/ar_tag_based_localizer.cpp
@@ -52,9 +52,9 @@
 #include <opencv4/opencv2/core/quaternion.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 #include <tf2/LinearMath/Transform.h>
 

--- a/localization/yabloc/yabloc_common/src/cv_decompress.cpp
+++ b/localization/yabloc/yabloc_common/src/cv_decompress.cpp
@@ -18,9 +18,9 @@
 #include <opencv4/opencv2/imgproc.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 
 #include <iostream>

--- a/localization/yabloc/yabloc_common/src/cv_decompress.cpp
+++ b/localization/yabloc/yabloc_common/src/cv_decompress.cpp
@@ -17,7 +17,11 @@
 #include <opencv4/opencv2/imgcodecs.hpp>
 #include <opencv4/opencv2/imgproc.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <iostream>
 

--- a/localization/yabloc/yabloc_common/src/pub_sub.cpp
+++ b/localization/yabloc/yabloc_common/src/pub_sub.cpp
@@ -15,9 +15,9 @@
 #include "yabloc_common/pub_sub.hpp"
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 #include <pcl_conversions/pcl_conversions.h>
 

--- a/localization/yabloc/yabloc_common/src/pub_sub.cpp
+++ b/localization/yabloc/yabloc_common/src/pub_sub.cpp
@@ -14,7 +14,11 @@
 
 #include "yabloc_common/pub_sub.hpp"
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <pcl_conversions/pcl_conversions.h>
 
 namespace yabloc::common

--- a/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
@@ -18,7 +18,11 @@
 #include <yabloc_common/cv_decompress.hpp>
 #include <yabloc_common/pub_sub.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <pcl_conversions/pcl_conversions.h>
 
 namespace yabloc::line_segments_overlay

--- a/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/line_segments_overlay/line_segments_overlay_core.cpp
@@ -19,9 +19,9 @@
 #include <yabloc_common/pub_sub.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 #include <pcl_conversions/pcl_conversions.h>
 

--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -24,7 +24,11 @@
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <optional>
 

--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -25,9 +25,9 @@
 #include <sensor_msgs/msg/image.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 
 #include <optional>

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
@@ -21,9 +21,9 @@
 #include <opencv2/imgproc.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 
 #include <filesystem>

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
@@ -20,7 +20,11 @@
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <filesystem>
 

--- a/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -26,9 +26,9 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #if __has_include(<image_geometry/pinhole_camera_model.hpp>)
-#include <image_geometry/pinhole_camera_model.hpp>
+#include <image_geometry/pinhole_camera_model.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <image_geometry/pinhole_camera_model.h>
+#include <image_geometry/pinhole_camera_model.h>  // for ROS 2 Humble or older
 #endif
 
 #include <lanelet2_core/LaneletMap.h>

--- a/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -25,7 +25,12 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#if __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>
+#else
 #include <image_geometry/pinhole_camera_model.h>
+#endif
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
@@ -28,9 +28,9 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #if __has_include(<image_geometry/pinhole_camera_model.hpp>)
-#include <image_geometry/pinhole_camera_model.hpp>
+#include <image_geometry/pinhole_camera_model.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <image_geometry/pinhole_camera_model.h>
+#include <image_geometry/pinhole_camera_model.h>  // for ROS 2 Humble or older
 #endif
 
 #include <message_filters/subscriber.h>

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/nodelet.hpp
@@ -27,7 +27,12 @@
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
+#if __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>
+#else
 #include <image_geometry/pinhole_camera_model.h>
+#endif
+
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/time_synchronizer.h>

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/occlusion_predictor.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/occlusion_predictor.hpp
@@ -25,9 +25,9 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #if __has_include(<image_geometry/pinhole_camera_model.hpp>)
-#include <image_geometry/pinhole_camera_model.hpp>
+#include <image_geometry/pinhole_camera_model.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <image_geometry/pinhole_camera_model.h>
+#include <image_geometry/pinhole_camera_model.h>  // for ROS 2 Humble or older
 #endif
 
 #include <lanelet2_core/Forward.h>

--- a/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/occlusion_predictor.hpp
+++ b/perception/traffic_light_occlusion_predictor/include/traffic_light_occlusion_predictor/occlusion_predictor.hpp
@@ -24,7 +24,12 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
+#if __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>
+#else
 #include <image_geometry/pinhole_camera_model.h>
+#endif
+
 #include <lanelet2_core/Forward.h>
 #include <pcl/common/transforms.h>
 #include <pcl/point_cloud.h>

--- a/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
@@ -23,7 +23,11 @@
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>

--- a/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_visualization/traffic_light_roi_visualizer/nodelet.hpp
@@ -24,9 +24,9 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
 #else
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>


### PR DESCRIPTION
## Description

With the release of Jazzy, some packages have deprecated old header files.
On the other hand, some newer header files are not available in Humble, so I would like to introduce `__has_include` macro.

Ref: https://github.com/orgs/autowarefoundation/discussions/4893

## Tests performed

`colcon test` passed in both Humble and Jazzy environment.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
