### PR TITLE
fix: replace Ogre deprecated header

### DIFF
--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp
@@ -53,7 +53,7 @@
 #include <OgreQuaternion.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <OgreVector.h>
 #include <OgreViewport.h>
 
 namespace tier4_camera_view_rviz_plugin

--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp
@@ -46,7 +46,7 @@
 #include "rviz_common/frame_position_tracking_view_controller.hpp"
 
 #include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <OgreVector.h>
 
 namespace rviz_common
 {

--- a/common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.cpp
@@ -56,7 +56,7 @@
 #include <OgreQuaternion.h>
 #include <OgreRay.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <OgreVector.h>
 #include <OgreViewport.h>
 #include <stdint.h>
 

--- a/common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.hpp
+++ b/common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.hpp
@@ -45,7 +45,7 @@
 
 #include "rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp"
 
-#include <OgreVector3.h>
+#include <OgreVector.h>
 
 #include <utility>
 

--- a/common/tier4_perception_rviz_plugin/src/tools/util.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/util.hpp
@@ -17,7 +17,7 @@
 
 #include <rviz_common/viewport_mouse_event.hpp>
 
-#include <OgreVector3.h>
+#include <OgreVector.h>
 
 #include <optional>
 

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_history.hpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_history.hpp
@@ -26,7 +26,7 @@
 
 #include <OgreColourValue.h>
 #include <OgreManualObject.h>
-#include <OgreVector3.h>
+#include <OgreVector.h>
 
 #include <deque>
 #include <memory>


### PR DESCRIPTION
## Description

OgreVector3.h is deprecated in Jazzy, so this PR replace it

## Tests performed

`colcon test` passed in both Humble and Jazzy.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
