### PR TITLE
fix(gnss_poser): give msg_gnss_ins_orientation_stamped_ initial rmse values

### DIFF
--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -61,7 +61,8 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
     "gnss_pose_cov", rclcpp::QoS{1});
   fixed_pub_ = create_publisher<tier4_debug_msgs::msg::BoolStamped>("gnss_fixed", rclcpp::QoS{1});
 
-  // Set msg_gnss_ins_orientation_stamped_ with temoporary values (not to publish zero value covariances)
+  // Set msg_gnss_ins_orientation_stamped_ with temoporary values (not to publish zero value
+  // covariances)
   msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_x = 1.0;
   msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_y = 1.0;
   msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_z = 1.0;

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -44,9 +44,11 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
     sub_map_projector_info_,
     [this](const MapProjectorInfo::Message::ConstSharedPtr msg) { callbackMapProjectorInfo(msg); });
 
+  // Set up position buffer
   int buff_epoch = declare_parameter<int>("buff_epoch");
   position_buffer_.set_capacity(buff_epoch);
 
+  // Set subscribers and publishers
   nav_sat_fix_sub_ = create_subscription<sensor_msgs::msg::NavSatFix>(
     "fix", rclcpp::QoS{1}, std::bind(&GNSSPoser::callbackNavSatFix, this, std::placeholders::_1));
   autoware_orientation_sub_ =
@@ -58,6 +60,11 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   pose_cov_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "gnss_pose_cov", rclcpp::QoS{1});
   fixed_pub_ = create_publisher<tier4_debug_msgs::msg::BoolStamped>("gnss_fixed", rclcpp::QoS{1});
+
+  // Set msg_gnss_ins_orientation_stamped_ with temoporary values (not to publish zero value covariances)
+  msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_x = 1.0;
+  msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_y = 1.0;
+  msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_z = 1.0;
 }
 
 void GNSSPoser::callbackMapProjectorInfo(const MapProjectorInfo::Message::ConstSharedPtr msg)


### PR DESCRIPTION
## Description

When `use_gnss_ins_orientation` is true, gnss_poser will create
```cpp
msg_gnss_ins_orientation_stamped_ = std::make_shared<autoware_sensing_msgs::msg::GnssInsOrientationStamped>())
```
first, and then publish this as a PoseWithCovarianceStamped object. (This declaration is done at Line 36 of gnss_poser_core.cpp)

On this initialization, `msg_gnss_ins_orientaiton_stamped_` will have zero angular variance and it will be published as it is if no orientation topic have arrived yet, which will leads to transformation error mentioned in this issue. (https://github.com/orgs/autowarefoundation/discussions/4667). So technically Autoware only works if the orientation arrives late, but this is less noticed since few people use transformation to this pose. 

**Hence, this PR will set initial values for rmse values of `msg_gnss_ins_orientation_stamped_`, so that gnss_poser will not publish zero angular variances.**

## Tests performed

Tested in the [rosbag replay simulation tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/). This data doesn't have gnss orientation so the covariance should be a constant value like this.

```bash
---
header:
  stamp:
    sec: 1585897285
    nanosec: 18186
  frame_id: map
pose:
  pose:
    position:
      x: 89533.82696335175
      y: 42408.042296301326
      z: 43.06070269805477
    orientation:
      x: 0.0003634119436112312
      y: -0.007507785887620079
      z: 0.01819473179251916
      w: 0.9998062076311705
  covariance:
  - 3.728761
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 3.728761
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 10.666756
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 1.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 1.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 0.0
  - 1.0
---
```
 

## Effects on system behavior

If `use_gnss_ins_orientation` is true, the output pose_with_covariance will have none zero angular variance.

## Interface changes

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
