### PR TITLE
fix(traffic_light_classifier): fix zero size roi bug

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -84,7 +84,7 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
   if (classifier_ptr_.use_count() == 0) {
     return;
   }
-  if (input_rois_msg->rois.size() == 0) {
+  if (input_rois_msg->rois.empty()) {
     return;
   }
 

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -121,11 +121,11 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
     // crop the roi image to be classified
     const auto & roi_img = cv_ptr->image(cv::Rect(
       input_roi.roi.x_offset, input_roi.roi.y_offset, input_roi.roi.width, input_roi.roi.height));
-    images.push_back(roi_img);
+    images.emplace_back(roi_img);
 
     // check if the roi is a harsh backlight
     if (is_harsh_backlight(roi_img)) {
-      backlight_indices.push_back(output_msg.signals.size() - 1);
+      backlight_indices.emplace_back(output_msg.signals.size() - 1);
     }
   }
 


### PR DESCRIPTION
## Description
Even the previous fix https://github.com/autowarefoundation/autoware.universe/pull/7461, similar issue has occurred.

```
[component_container_mt-61]   what():  OpenCV(4.5.4) ./modules/imgproc/src/resize.cpp:4051: error: (-215:Assertion failed) !ssize.empty() in function 'resize'
[component_container_mt-61]   what():  OpenCV(4.5.4) ./modules/imgproc/src/resize.cpp:4051: error: (-215:Assertion failed) !ssize.empty() in function 'resize'
[component_container_mt-61] 
[component_container_mt-61] 
[component_container_mt-61] *** Aborted at 1718866324 (unix time) try "date -d @1718866324" if you are using GNU date ***
[component_container_mt-61] terminate called recursively
[component_container_mt-61] terminate called recursively
[component_container_mt-61] terminate called recursively
[component_container_mt-61] terminate called recursively
[component_container_mt-61] PC: @                0x0 (unknown)
[component_container_mt-61] *** SIGABRT (@0x3e800053712) received by PID 341778 (TID 0x7f89bbce9640) from PID 341778; stack trace: ***
[component_container_mt-61]     @     0x7f89c235d4d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-61]     @     0x7f89c1c08520 (unknown)
[component_container_mt-61]     @     0x7f89c1c5c9fc pthread_kill
[component_container_mt-61]     @     0x7f89c1c08476 raise
[component_container_mt-61]     @     0x7f89c1bee7f3 abort
[component_container_mt-61]     @     0x7f89c1eb1b9e (unknown)
[component_container_mt-61]     @     0x7f89c1ebd20c (unknown)
[component_container_mt-61]     @     0x7f89c1ebc1e9 (unknown)
[component_container_mt-61]     @     0x7f89c1ebc959 __gxx_personality_v0
[component_container_mt-61]     @     0x7f89c1e05884 (unknown)
[component_container_mt-61]     @     0x7f89c1e062dd _Unwind_Resume
[component_container_mt-61]     @     0x7f89b1ec54de (unknown)
[component_container_mt-61]     @     0x7f88d72f0f02 _ZN19tensorrt_classifier13TrtClassifier14preprocess_optERKSt6vectorIN2cv3MatESaIS3_EE._omp_fn.0
[component_container_mt-61]     @     0x7f88d4deea16 GOMP_parallel
[component_container_mt-61]     @     0x7f88d72f2437 tensorrt_classifier::TrtClassifier::preprocess_opt()
[component_container_mt-61]     @     0x7f88d72f28e3 tensorrt_classifier::TrtClassifier::doInference()
[component_container_mt-61]     @     0x7f88d7556c13 traffic_light::CNNClassifier::getTrafficSignals()
[component_container_mt-61]     @     0x7f88d755d991 traffic_light::TrafficLightClassifierNodelet::imageRoiCallback()
[component_container_mt-61]     @     0x7f88d758c367 message_filters::CallbackHelper9T<>::call()
[component_container_mt-61]     @     0x7f88d759a5cc message_filters::sync_policies::ExactTime<>::checkTuple()
[component_container_mt-61]     @     0x7f88d75a7435 message_filters::Synchronizer<>::cb<>()
[component_container_mt-61]     @     0x7f88d7596097 _ZNSt17_Function_handlerIFvSt10shared_ptrIKN21tier4_perception_msgs3msg21TrafficLightRoiArray_ISaIvEEEEEZN15message_filters10SubscriberIS5_N6rclcpp4NodeEE9subscribeEPSC_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE17rmw_qos_profile_sNSB_32SubscriptionOptionsWithAllocatorIS4_EEEUlS7_E_E9_M_invokeERKSt9_Any_dataOS7_
[component_container_mt-61]     @     0x7f88d7571ba2 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN21tier4_perception_msgs3msg21TrafficLightRoiArray_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_
[component_container_mt-61]     @     0x7f88d758759f rclcpp::Subscription<>::handle_message()
[component_container_mt-61]     @     0x7f89c21d9ba0 rclcpp::Executor::execute_subscription()
[component_container_mt-61]     @     0x7f89c21db10e rclcpp::Executor::execute_any_executable()
[component_container_mt-61]     @     0x7f89c21e1432 rclcpp::executors::MultiThreadedExecutor::run()
```

Overall process were reviewed with consideration of zero-size roi and empty roi input.

## Tests performed
Tested on a local recompute environment and [TIER IV INTERNAL cloud test](https://evaluation.tier4.jp/evaluation/reports/d552c065-01ef-5cf7-920e-8937fca66bf2?project_id=prd_jt)

Data:[TIER IV INTERNAL](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/c91a7139-7235-4e87-a737-b39e2f864770)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
