### PR TITLE
chore(ci): change way to get modified files for cppcheck

### DIFF
--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -8,8 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Set PR fetch depth
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout PR branch and all PR commits
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
       - name: Install dependencies
         run: |
@@ -29,12 +35,16 @@ jobs:
           make -j $(nproc)
           sudo make install
 
+      - name: Fetch the base branch with enough history for a common merge-base commit
+        run: git fetch origin ${{ inputs.base-ref }}
+        shell: bash
+
       - name: Get changed files
         id: changed-files
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
-          git diff --name-only FETCH_HEAD ${{ github.sha }} > changed_files.txt
+          git diff --name-only "origin/${{ inputs.base-ref }}"...HEAD > changed_files.txt
           cat changed_files.txt
+        shell: bash
 
       - name: Run Cppcheck on changed files
         continue-on-error: true

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -36,13 +36,13 @@ jobs:
           sudo make install
 
       - name: Fetch the base branch with enough history for a common merge-base commit
-        run: git fetch origin ${{ inputs.base-ref }}
+        run: git fetch origin ${{ github.base_ref }}
         shell: bash
 
       - name: Get changed files
         id: changed-files
         run: |
-          git diff --name-only "origin/${{ inputs.base-ref }}"...HEAD > changed_files.txt
+          git diff --name-only "origin/$${{ github.base_ref }}"...HEAD > changed_files.txt
           cat changed_files.txt
         shell: bash
 

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         run: |
-          git diff --name-only "origin/$${{ github.base_ref }}"...HEAD > changed_files.txt
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > changed_files.txt
           cat changed_files.txt
         shell: bash
 


### PR DESCRIPTION
## Description

I tried to apply the knowledge gained from `autowarefoundation/get-modified-packages` action's development to cppcheck workflow.
https://github.com/autowarefoundation/autoware-github-actions/pull/299

## Tests performed

### when the branch is up-to-date

![image](https://github.com/autowarefoundation/autoware.universe/assets/12395284/12ccdf1d-4b7f-433c-974b-2799b7db0770)
https://github.com/autowarefoundation/autoware.universe/actions/runs/9596328091/job/26462963086

### when the branch is not up-to-date

![image](https://github.com/autowarefoundation/autoware.universe/assets/12395284/02d8b9c1-6f85-4fd9-88e9-c85ef24623be)
https://github.com/autowarefoundation/autoware.universe/actions/runs/9596328104/job/26495780548#step:7:8

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

N/A

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
