### PR TITLE
fix(image_transport_decompressor): missing config setting

### DIFF
--- a/sensing/image_transport_decompressor/CMakeLists.txt
+++ b/sensing/image_transport_decompressor/CMakeLists.txt
@@ -24,4 +24,5 @@ rclcpp_components_register_node(image_transport_decompressor
 
 ament_auto_package(INSTALL_TO_SHARE
   launch
+  config
 )


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- To fix bug: `[ERROR] [launch]: Caught exception in launch (see debug for traceback): [Errno 2] No such file or directory: '/home/autoware/autoware/install/image_transport_decompressor/share/image_transport_decompressor/config/image_transport_decompressor.param.yaml'`

when running `ros2 launch image_transport_decompressor image_transport_decompressor.launch.xml`

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- Confimed that after change is able to run `ros2 launch image_transport_decompressor image_transport_decompressor.launch.xml`

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
