### PR TITLE
fix(probabilistic_occupancy_grid_map): fix knownConditionTrueFalse warning

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp
@@ -225,11 +225,9 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
 
       if (dist_index + 1 == obstacle_pointcloud_angle_bin.size()) {
         const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
-        if (!no_visible_point_beyond) {
-          raytrace(
-            source.wx, source.wy, source.projected_wx, source.projected_wy,
-            occupancy_cost_value::NO_INFORMATION);
-        }
+        raytrace(
+          source.wx, source.wy, source.projected_wx, source.projected_wy,
+          occupancy_cost_value::NO_INFORMATION);
         continue;
       }
 
@@ -237,11 +235,6 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
         obstacle_pointcloud_angle_bin.at(dist_index + 1).range -
         obstacle_pointcloud_angle_bin.at(dist_index).range);
       if (next_obstacle_point_distance <= obstacle_separation_threshold_) {
-        continue;
-      } else if (no_visible_point_beyond) {
-        const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
-        const auto & target = obstacle_pointcloud_angle_bin.at(dist_index + 1);
-        raytrace(source.wx, source.wy, target.wx, target.wy, occupancy_cost_value::NO_INFORMATION);
         continue;
       }
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `knownConditionTrueFalse` warning

```
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:228:13: style: Condition '!no_visible_point_beyond' is always true [knownConditionTrueFalse]
        if (!no_visible_point_beyond) {
            ^
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:218:11: note: Assuming that condition 'no_visible_point_beyond' is not redundant
      if (no_visible_point_beyond) {
          ^
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:228:13: note: Condition '!no_visible_point_beyond' is always true
        if (!no_visible_point_beyond) {
            ^
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:241:18: style: Condition 'no_visible_point_beyond' is always false [knownConditionTrueFalse]
      } else if (no_visible_point_beyond) {
                 ^
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:218:11: note: Assuming that condition 'no_visible_point_beyond' is not redundant
      if (no_visible_point_beyond) {
          ^
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:226:26: note: Assuming condition is false
      if (dist_index + 1 == obstacle_pointcloud_angle_bin.size()) {
                         ^
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:241:18: note: Condition 'no_visible_point_beyond' is always false
      } else if (no_visible_point_beyond) {
                 ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
