### PR TITLE
fix(autoware_obstacle_cruise_planner): fix knownConditionTrueFalse warnings

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -339,15 +339,20 @@ std::tuple<double, double> OptimizationBasedPlanner::calcInitialMotion(
       const auto stop_dist = autoware::motion_utils::calcDistanceToForwardStopPoint(
         input_traj_points, ego_pose, ego_nearest_param_.dist_threshold,
         ego_nearest_param_.yaw_threshold);
-      if ((stop_dist && *stop_dist > stop_dist_to_prohibit_engage_) || !stop_dist) {
-        initial_vel = engage_velocity_;
-        initial_acc = engage_acceleration_;
+      if (!stop_dist.has_value()) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),
+          "calcInitialMotion : vehicle speed is low (%.3f), and desired speed is high (%.3f). Use "
+          "engage speed (%.3f) until vehicle speed reaches engage_vel_thr (%.3f)",
+          vehicle_speed, target_vel, engage_velocity_, engage_vel_thr);
+        return std::make_tuple(engage_velocity_, engage_acceleration_);
+      } else if (stop_dist.value() > stop_dist_to_prohibit_engage_) {
         RCLCPP_DEBUG(
           rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),
           "calcInitialMotion : vehicle speed is low (%.3f), and desired speed is high (%.3f). Use "
           "engage speed (%.3f) until vehicle speed reaches engage_vel_thr (%.3f). stop_dist = %.3f",
           vehicle_speed, target_vel, engage_velocity_, engage_vel_thr, stop_dist.value());
-        return std::make_tuple(initial_vel, initial_acc);
+        return std::make_tuple(engage_velocity_, engage_acceleration_);
       } else {
         RCLCPP_DEBUG(
           rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),

--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -348,7 +348,7 @@ std::tuple<double, double> OptimizationBasedPlanner::calcInitialMotion(
           "engage speed (%.3f) until vehicle speed reaches engage_vel_thr (%.3f). stop_dist = %.3f",
           vehicle_speed, target_vel, engage_velocity_, engage_vel_thr, stop_dist.value());
         return std::make_tuple(initial_vel, initial_acc);
-      } else if (stop_dist) {
+      } else {
         RCLCPP_DEBUG(
           rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),
           "calcInitialMotion : stop point is close (%.3f[m]). no engage.", stop_dist.value());

--- a/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
@@ -637,7 +637,7 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     slow_down_debug_multi_array_.data.push_back(feasible_slow_down_vel);
     slow_down_debug_multi_array_.data.push_back(stable_slow_down_vel);
     slow_down_debug_multi_array_.data.push_back(slow_down_start_idx ? *slow_down_start_idx : -1.0);
-    slow_down_debug_multi_array_.data.push_back(slow_down_end_idx ? *slow_down_end_idx : -1.0);
+    slow_down_debug_multi_array_.data.push_back(*slow_down_end_idx);
 
     // add virtual wall
     if (slow_down_start_idx && slow_down_end_idx) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `knownConditionTrueFalse` warning

```
planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp:351:18: style: Condition 'stop_dist' is always true [knownConditionTrueFalse]
      } else if (stop_dist) {
                 ^
```

and 

```
planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:640:49: style: Condition 'slow_down_end_idx' is always true [knownConditionTrueFalse]
    slow_down_debug_multi_array_.data.push_back(slow_down_end_idx ? *slow_down_end_idx : -1.0);
                                                ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
