### PR TITLE
fix(tier4_camera_view_rviz_plugin): fix funcArgNamesDifferent warnings

### DIFF
--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp
@@ -72,7 +72,7 @@ public:
 
   void onInitialize() override;
 
-  void handleMouseEvent(rviz_common::ViewportMouseEvent & evt) override;
+  void handleMouseEvent(rviz_common::ViewportMouseEvent & event) override;
 
   void lookAt(const Ogre::Vector3 & point) override;
 
@@ -96,7 +96,7 @@ protected:
   void orientCamera();
 
   void setPosition(const Ogre::Vector3 & pos_rel_target);
-  void move_camera(float x, float y);
+  void move_camera(float dx, float dy);
   void updateCamera();
   Ogre::SceneNode * getCameraParent(Ogre::Camera * camera);
 

--- a/common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.hpp
+++ b/common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.hpp
@@ -68,7 +68,7 @@ class ThirdPersonViewController : public rviz_default_plugins::view_controllers:
 public:
   void onInitialize() override;
 
-  void handleMouseEvent(rviz_common::ViewportMouseEvent & evt) override;
+  void handleMouseEvent(rviz_common::ViewportMouseEvent & event) override;
 
   void lookAt(const Ogre::Vector3 & point) override;
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `funcArgNamesDifferent` warnings

```
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:102:80: style: inconclusive: Function 'handleMouseEvent' argument 1 names different: declaration 'evt' definition 'event'. [funcArgNamesDifferent]
void BirdEyeViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
                                                                               ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp:75:59: note: Function 'handleMouseEvent' argument 1 names different: declaration 'evt' definition 'event'.
  void handleMouseEvent(rviz_common::ViewportMouseEvent & evt) override;
                                                          ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:102:80: note: Function 'handleMouseEvent' argument 1 names different: declaration 'evt' definition 'event'.
void BirdEyeViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
                                                                               ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:231:47: style: inconclusive: Function 'move_camera' argument 1 names different: declaration 'x' definition 'dx'. [funcArgNamesDifferent]
void BirdEyeViewController::move_camera(float dx, float dy)
                                              ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp:99:26: note: Function 'move_camera' argument 1 names different: declaration 'x' definition 'dx'.
  void move_camera(float x, float y);
                         ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:231:47: note: Function 'move_camera' argument 1 names different: declaration 'x' definition 'dx'.
void BirdEyeViewController::move_camera(float dx, float dy)
                                              ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:231:57: style: inconclusive: Function 'move_camera' argument 2 names different: declaration 'y' definition 'dy'. [funcArgNamesDifferent]
void BirdEyeViewController::move_camera(float dx, float dy)
                                                        ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.hpp:99:35: note: Function 'move_camera' argument 2 names different: declaration 'y' definition 'dy'.
  void move_camera(float x, float y);
                                  ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:231:57: note: Function 'move_camera' argument 2 names different: declaration 'y' definition 'dy'.
void BirdEyeViewController::move_camera(float dx, float dy)
                                                        ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.cpp:108:84: style: inconclusive: Function 'handleMouseEvent' argument 1 names different: declaration 'evt' definition 'event'. [funcArgNamesDifferent]
void ThirdPersonViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
                                                                                   ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.hpp:71:59: note: Function 'handleMouseEvent' argument 1 names different: declaration 'evt' definition 'event'.
  void handleMouseEvent(rviz_common::ViewportMouseEvent & evt) override;
                                                          ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_controller.cpp:108:84: note: Function 'handleMouseEvent' argument 1 names different: declaration 'evt' definition 'event'.
void ThirdPersonViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
                                                                                   ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
