### PR TITLE
fix(tracking_object_merger): fix shadowArgument warning

### DIFF
--- a/perception/tracking_object_merger/include/tracking_object_merger/utils/utils.hpp
+++ b/perception/tracking_object_merger/include/tracking_object_merger/utils/utils.hpp
@@ -93,7 +93,7 @@ TrackedObject linearInterpolationForTrackedObject(
 TrackedObject predictPastOrFutureTrackedObject(const TrackedObject & obj, const double dt);
 
 TrackedObjects predictPastOrFutureTrackedObjects(
-  const TrackedObjects & obj, const std_msgs::msg::Header & header);
+  const TrackedObjects & input_objects, const std_msgs::msg::Header & header);
 
 // predict tracked objects
 TrackedObjects interpolateTrackedObjects(

--- a/perception/tracking_object_merger/src/utils/utils.cpp
+++ b/perception/tracking_object_merger/src/utils/utils.cpp
@@ -153,20 +153,20 @@ TrackedObject predictPastOrFutureTrackedObject(const TrackedObject & obj, const 
 /**
  * @brief predict past or future tracked objects
  *
- * @param obj
+ * @param input_objects
  * @param header
  * @return TrackedObjects
  */
 TrackedObjects predictPastOrFutureTrackedObjects(
-  const TrackedObjects & obj, const std_msgs::msg::Header & header)
+  const TrackedObjects & input_objects, const std_msgs::msg::Header & header)
 {
   // for each object, predict past or future
   TrackedObjects output_objects;
-  output_objects.header = obj.header;
+  output_objects.header = input_objects.header;
   output_objects.header.stamp = header.stamp;
 
-  const auto dt = (rclcpp::Time(header.stamp) - rclcpp::Time(obj.header.stamp)).seconds();
-  for (const auto & obj : obj.objects) {
+  const auto dt = (rclcpp::Time(header.stamp) - rclcpp::Time(input_objects.header.stamp)).seconds();
+  for (const auto & obj : input_objects.objects) {
     output_objects.objects.push_back(predictPastOrFutureTrackedObject(obj, dt));
   }
   return output_objects;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `shadowArgument` warning

```
perception/tracking_object_merger/src/utils/utils.cpp:169:21: style: Local variable 'obj' shadows outer argument [shadowArgument]
  for (const auto & obj : obj.objects) {
                    ^
perception/tracking_object_merger/src/utils/utils.cpp:161:26: note: Shadowed declaration
  const TrackedObjects & obj, const std_msgs::msg::Header & header)
                         ^
perception/tracking_object_merger/src/utils/utils.cpp:169:21: note: Shadow variable
  for (const auto & obj : obj.objects) {
                    ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
