### PR TITLE
fix(autoware_behavior_path_planner_common): fix shadowArgument warning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -745,9 +745,9 @@ std::vector<DrivableLanes> cutOverlappedLanes(
   }
 
   // Step2. pick up only path points within drivable lanes
-  for (const auto & lanes : shorten_lanes) {
+  for (const auto & drivable_lanes : shorten_lanes) {
     for (size_t i = start_point_idx; i < original_points.size(); ++i) {
-      if (is_point_in_drivable_lanes(lanes, original_points.at(i))) {
+      if (is_point_in_drivable_lanes(drivable_lanes, original_points.at(i))) {
         path.points.push_back(original_points.at(i));
         continue;
       }


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `shadowArgument` warning

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:748:21: style: Local variable 'lanes' shadows outer argument [shadowArgument]
  for (const auto & lanes : shorten_lanes) {
                    ^
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:690:61: note: Shadowed declaration
  PathWithLaneId & path, const std::vector<DrivableLanes> & lanes)
                                                            ^
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:748:21: note: Shadow variable
  for (const auto & lanes : shorten_lanes) {
                    ^
```

Since this is just to avoid shadowArgument, if you come up with more suitable word, please tell me!

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
