### PR TITLE
fix(autoware_behavior_path_goal_planner_module): fix lateral_offset related warnings

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -161,9 +161,7 @@ GoalCandidates GoalSearcher::search(
     original_search_poses.push_back(original_search_pose);  // for createAreaPolygon
     Pose search_pose{};
     // search goal_pose in lateral direction
-    double lateral_offset = 0.0;
     for (double dy = 0; dy <= max_lateral_offset; dy += lateral_offset_interval) {
-      lateral_offset = dy;
       search_pose = calcOffsetPose(original_search_pose, 0, sign * dy, 0);
 
       const auto transformed_vehicle_footprint =
@@ -185,7 +183,7 @@ GoalCandidates GoalSearcher::search(
 
       GoalCandidate goal_candidate{};
       goal_candidate.goal_pose = search_pose;
-      goal_candidate.lateral_offset = lateral_offset;
+      goal_candidate.lateral_offset = dy;
       goal_candidate.id = goal_id;
       goal_id++;
       // use longitudinal_distance as distance_from_original_goal


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `variableScope` and `unreadVariable` warnings

```
planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp:164:12: style: The scope of the variable 'lateral_offset' can be reduced. [variableScope]
    double lateral_offset = 0.0;
           ^
planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp:164:27: style: Variable 'lateral_offset' is assigned a value that is never used. [unreadVariable]
    double lateral_offset = 0.0;
                          ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
