### PR TITLE
fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix unreadVariable warning

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
@@ -68,7 +68,6 @@ TrajectoryPoints downsampleTrajectory(
 
 void calculateSteeringAngles(TrajectoryPoints & trajectory, const double wheel_base)
 {
-  auto t = 0.0;
   auto prev_point = trajectory.front();
   auto prev_heading = tf2::getYaw(prev_point.pose.orientation);
   for (auto i = 1ul; i < trajectory.size(); ++i) {
@@ -76,7 +75,6 @@ void calculateSteeringAngles(TrajectoryPoints & trajectory, const double wheel_b
     auto & point = trajectory[i];
     const auto dt = autoware::universe_utils::calcDistance2d(prev_point, point) /
                     prev_point.longitudinal_velocity_mps;
-    t += dt;
     const auto heading = tf2::getYaw(point.pose.orientation);
     const auto d_heading = heading - prev_heading;
     prev_heading = heading;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unreadVariable` warning

```
planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp:71:10: style: Variable 't' is assigned a value that is never used. [unreadVariable]
  auto t = 0.0;
         ^
planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp:79:7: style: Variable 't' is assigned a value that is never used. [unreadVariable]
    t += dt;
      ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
