### PR TITLE
fix(obstacle_stop_planner): fix unreadVariable warning

### DIFF
--- a/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -639,14 +639,11 @@ double AdaptiveCruiseController::calcTargetVelocity_D(
     return 0.0;
   }
 
-  double add_vel_d = 0;
-
-  add_vel_d = diff_vel;
+  double add_vel_d = diff_vel;
   if (add_vel_d >= 0) {
-    diff_vel *= param_.d_coeff_pos;
-  }
-  if (add_vel_d < 0) {
-    diff_vel *= param_.d_coeff_neg;
+    add_vel_d *= param_.d_coeff_pos;
+  } else {
+    add_vel_d *= param_.d_coeff_neg;
   }
   add_vel_d = boost::algorithm::clamp(add_vel_d, -param_.d_max_vel_norm, param_.d_max_vel_norm);
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unreadVariable` warning

```
planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp:646:14: style: Variable 'diff_vel' is assigned a value that is never used. [unreadVariable]
    diff_vel *= param_.d_coeff_pos;
             ^
planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp:649:14: style: Variable 'diff_vel' is assigned a value that is never used. [unreadVariable]
    diff_vel *= param_.d_coeff_neg;
             ^
```

It seems to be a bug for me, so I changed it to multiply each `coeff` to `add_vel_d`, not to `diff_vel`.
Please confirm it carefully. thank you.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
