### PR TITLE
fix(autoware_obstacle_cruise_planner): fix unreadVariable warning

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -702,7 +702,6 @@ void OptimizationBasedPlanner::publishDebugTrajectory(
   const SBoundaries & s_boundaries, const VelocityOptimizer::OptimizationResult & opt_result)
 {
   const auto & current_time = planner_data.current_time;
-  const std::vector<double> time = opt_result.t;
   // Publish optimized result and boundary
   Trajectory boundary_traj;
   boundary_traj.header.stamp = current_time;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `unreadVariable` warning

```
planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp:705:34: style: Variable 'time' is assigned a value that is never used. [unreadVariable]
  const std::vector<double> time = opt_result.t;
                                 ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
