### PR TITLE
fix(pointcloud_preprocessor): fix redundantInitialization warning

### DIFF
--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -85,28 +85,17 @@ void DualReturnOutlierFilterComponent::onVisibilityChecker(DiagnosticStatusWrapp
   // Add values
   stat.add("value", std::to_string(visibility_));
 
-  // Judge level
   auto level = DiagnosticStatus::OK;
+  std::string msg = "OK";
   if (visibility_ < 0) {
     level = DiagnosticStatus::STALE;
+    msg = "STALE";
   } else if (visibility_ < visibility_error_threshold_) {
     level = DiagnosticStatus::ERROR;
+    msg = "ERROR: low visibility in dual outlier filter";
   } else if (visibility_ < visibility_warn_threshold_) {
     level = DiagnosticStatus::WARN;
-  } else {
-    level = DiagnosticStatus::OK;
-  }
-
-  // Set message
-  std::string msg;
-  if (level == DiagnosticStatus::OK) {
-    msg = "OK";
-  } else if (level == DiagnosticStatus::WARN) {
     msg = "WARNING: low visibility in dual outlier filter";
-  } else if (level == DiagnosticStatus::ERROR) {
-    msg = "ERROR: low visibility in dual outlier filter";
-  } else if (level == DiagnosticStatus::STALE) {
-    msg = "STALE";
   }
   stat.summary(level, msg);
 }


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantInitialization` warning

```
sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp:91:11: style: Redundant initialization for 'level'. The initialized value is overwritten before it is read. [redundantInitialization]
    level = DiagnosticStatus::STALE;
          ^
sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp:89:14: note: level is initialized
  auto level = DiagnosticStatus::OK;
             ^
sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp:91:11: note: level is overwritten
    level = DiagnosticStatus::STALE;
          ^
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
