### PR TITLE
fix(autoware_behavior_velocity_no_drivable_lane_module): fix containerOutOfBounds wawrning

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp
@@ -85,29 +85,36 @@ PathWithNoDrivableLanePolygonIntersection getPathIntersectionWithNoDrivableLaneP
     bg::within(first_path_point, polygon);
   auto const & is_last_path_point_inside_polygon = bg::within(last_path_point, polygon);
 
-  if (
-    intersects.empty() &&
-    path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon &&
-    is_last_path_point_inside_polygon) {
-    path_no_drivable_lane_polygon_intersection.is_path_inside_of_polygon = true;
-  } else {
-    // classify first and second intersection points
-    for (size_t i = 0; i < intersects.size(); ++i) {
-      const auto & p = intersects.at(i);
-      if (
-        (intersects.size() == 2 && i == 0) ||
-        (intersects.size() == 1 && is_last_path_point_inside_polygon)) {
-        path_no_drivable_lane_polygon_intersection.first_intersection_point =
-          createPoint(p.x(), p.y(), ego_pos.z);
-      } else if (
-        (intersects.size() == 2 && i == 1) ||
-        (intersects.size() == 1 &&
-         path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon)) {
-        path_no_drivable_lane_polygon_intersection.second_intersection_point =
-          createPoint(p.x(), p.y(), ego_pos.z);
-      }
+  if (intersects.empty()) {
+    if (path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon &&
+      is_last_path_point_inside_polygon) {
+      path_no_drivable_lane_polygon_intersection.is_path_inside_of_polygon = true;
+    } else {
+      // do nothing
     }
+  } else if (intersects.size() == 1) {
+    const auto & p = intersects.at(0);
+    if (is_last_path_point_inside_polygon) {
+       path_no_drivable_lane_polygon_intersection.first_intersection_point =
+        createPoint(p.x(), p.y(), ego_pos.z);
+    } else if (path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon) {
+      path_no_drivable_lane_polygon_intersection.second_intersection_point =
+        createPoint(p.x(), p.y(), ego_pos.z);
+    } else {
+      // do nothing
+    }
+  } else if (intersects.size() == 2) {
+    // classify first and second intersection points
+    const auto & p0 = intersects.at(0);
+    const auto & p1 = intersects.at(1);
+    path_no_drivable_lane_polygon_intersection.first_intersection_point =
+      createPoint(p0.x(), p0.y(), ego_pos.z);
+    path_no_drivable_lane_polygon_intersection.second_intersection_point =
+      createPoint(p1.x(), p1.y(), ego_pos.z);
+  } else {
+    // do nothing
   }
+
   return path_no_drivable_lane_polygon_intersection;
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp
@@ -86,7 +86,8 @@ PathWithNoDrivableLanePolygonIntersection getPathIntersectionWithNoDrivableLaneP
   auto const & is_last_path_point_inside_polygon = bg::within(last_path_point, polygon);
 
   if (intersects.empty()) {
-    if (path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon &&
+    if (
+      path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon &&
       is_last_path_point_inside_polygon) {
       path_no_drivable_lane_polygon_intersection.is_path_inside_of_polygon = true;
     } else {
@@ -95,7 +96,7 @@ PathWithNoDrivableLanePolygonIntersection getPathIntersectionWithNoDrivableLaneP
   } else if (intersects.size() == 1) {
     const auto & p = intersects.at(0);
     if (is_last_path_point_inside_polygon) {
-       path_no_drivable_lane_polygon_intersection.first_intersection_point =
+      path_no_drivable_lane_polygon_intersection.first_intersection_point =
         createPoint(p.x(), p.y(), ego_pos.z);
     } else if (path_no_drivable_lane_polygon_intersection.is_first_path_point_inside_polygon) {
       path_no_drivable_lane_polygon_intersection.second_intersection_point =


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `containerOutOfBounds` warning

```
planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp:96:37: warning: inconclusive: Either the condition 'intersects.size()==1' is redundant or size of 'intersects' can be 1. Expression 'intersects.at(i)' causes access out of bounds. [containerOutOfBounds]
      const auto & p = intersects.at(i);
                                    ^
planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp:99:28: note: Assuming that condition 'intersects.size()==1' is not redundant
        (intersects.size() == 1 && is_last_path_point_inside_polygon)) {
                           ^
planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp:96:37: note: Access out of bounds
      const auto & p = intersects.at(i);
                                    ^
planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp:103:38: note: Assuming that condition 'i==1' is not redundant
        (intersects.size() == 2 && i == 1) ||
                                     ^
planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp:96:37: note: Access out of bounds
      const auto & p = intersects.at(i);
                                    ^
```

You know the current implementation does no actually invoke `containerOutOfBounds` error.
This is just to avoid cppcheck false positive warnings.

Also, though I have tried not to change the current implementation, please check the differences carefully. Thank you.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
