### PR TITLE
feat(autoware_test_utils): add jump_clock interface

### DIFF
--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -31,6 +31,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
@@ -527,6 +528,7 @@ public:
   AutowareTestManager()
   {
     test_node_ = std::make_shared<rclcpp::Node>("autoware_test_manager_node");
+    pub_clock_ = test_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", 1);
   }
 
   template <typename MessageType>
@@ -560,10 +562,18 @@ public:
     }
   }
 
+  void jump_clock(const rclcpp::Time & time)
+  {
+    rosgraph_msgs::msg::Clock clock;
+    clock.clock = time;
+    pub_clock_->publish(clock);
+  }
+
 protected:
   // Publisher
   std::unordered_map<std::string, std::shared_ptr<rclcpp::PublisherBase>> publishers_;
   std::unordered_map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> subscribers_;
+  rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr pub_clock_;
 
   // Node
   rclcpp::Node::SharedPtr test_node_;

--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -562,6 +562,16 @@ public:
     }
   }
 
+  /**
+   * @brief Publishes a ROS Clock message with the specified time.
+   *
+   * This function publishes a ROS Clock message with the specified time.
+   * Be careful when using this function, as it can affect the behavior of
+   * the system under test. Consider using ament_add_ros_isolated_gtest to
+   * isolate the system under test from the ROS clock.
+   *
+   * @param time The time to publish.
+   */
   void jump_clock(const rclcpp::Time & time)
   {
     rosgraph_msgs::msg::Clock clock;


### PR DESCRIPTION
## Description
Add `jump_clock` interface
<!-- Write a brief description of this PR. -->

## Tests performed

Tested with the other PR: https://github.com/autowarefoundation/autoware.universe/pull/7637
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
None

## Interface changes
None
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

None
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
