### PR TITLE
refactor(object_velocity_splitter)!: fix namespace and directory structure

### DIFF
--- a/perception/object_velocity_splitter/CMakeLists.txt
+++ b/perception/object_velocity_splitter/CMakeLists.txt
@@ -12,7 +12,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::object_velocity_splitter::ObjectVelocitySplitterNode"
-  EXECUTABLE ${PROJECT_NAME}_node
+  EXECUTABLE object_velocity_splitter_node
 )
 
 # Tests

--- a/perception/object_velocity_splitter/CMakeLists.txt
+++ b/perception/object_velocity_splitter/CMakeLists.txt
@@ -6,13 +6,13 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 # Targets
-ament_auto_add_library(object_velocity_splitter_node_component SHARED
-  src/object_velocity_splitter_node/object_velocity_splitter_node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/object_velocity_splitter_node.cpp
 )
 
-rclcpp_components_register_node(object_velocity_splitter_node_component
-  PLUGIN "object_velocity_splitter::ObjectVelocitySplitterNode"
-  EXECUTABLE object_velocity_splitter_node
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::object_velocity_splitter::ObjectVelocitySplitterNode"
+  EXECUTABLE ${PROJECT_NAME}_node
 )
 
 # Tests

--- a/perception/object_velocity_splitter/include/autoware/object_velocity_splitter/object_velocity_splitter_node.hpp
+++ b/perception/object_velocity_splitter/include/autoware/object_velocity_splitter/object_velocity_splitter_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
-#define OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
+#ifndef AUTOWARE__OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
+#define AUTOWARE__OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace object_velocity_splitter
+namespace autoware::object_velocity_splitter
 {
 using autoware_perception_msgs::msg::DetectedObject;
 using autoware_perception_msgs::msg::DetectedObjects;
@@ -62,6 +62,6 @@ private:
   NodeParam node_param_{};
 };
 
-}  // namespace object_velocity_splitter
+}  // namespace autoware::object_velocity_splitter
 
-#endif  // OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
+#endif  // AUTOWARE__OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_

--- a/perception/object_velocity_splitter/src/object_velocity_splitter_node.cpp
+++ b/perception/object_velocity_splitter/src/object_velocity_splitter_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "object_velocity_splitter/object_velocity_splitter_node.hpp"
+#include "autoware/object_velocity_splitter/object_velocity_splitter_node.hpp"
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
 
@@ -40,7 +40,7 @@ bool update_param(
 }
 }  // namespace
 
-namespace object_velocity_splitter
+namespace autoware::object_velocity_splitter
 {
 using autoware_perception_msgs::msg::DetectedObject;
 using autoware_perception_msgs::msg::DetectedObjects;
@@ -110,7 +110,7 @@ rcl_interfaces::msg::SetParametersResult ObjectVelocitySplitterNode::onSetParam(
   return result;
 }
 
-}  // namespace object_velocity_splitter
+}  // namespace autoware::object_velocity_splitter
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(object_velocity_splitter::ObjectVelocitySplitterNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::object_velocity_splitter::ObjectVelocitySplitterNode)

--- a/perception/object_velocity_splitter/src/object_velocity_splitter_node.cpp
+++ b/perception/object_velocity_splitter/src/object_velocity_splitter_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/object_velocity_splitter/object_velocity_splitter_node.hpp"
+#include "object_velocity_splitter_node.hpp"
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
 

--- a/perception/object_velocity_splitter/src/object_velocity_splitter_node.hpp
+++ b/perception/object_velocity_splitter/src/object_velocity_splitter_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
-#define AUTOWARE__OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
+#ifndef OBJECT_VELOCITY_SPLITTER_NODE_HPP_
+#define OBJECT_VELOCITY_SPLITTER_NODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -64,4 +64,4 @@ private:
 
 }  // namespace autoware::object_velocity_splitter
 
-#endif  // AUTOWARE__OBJECT_VELOCITY_SPLITTER__OBJECT_VELOCITY_SPLITTER_NODE_HPP_
+#endif  // OBJECT_VELOCITY_SPLITTER_NODE_HPP_


### PR DESCRIPTION
## Description

This PR puts headers in the `autoware` namespace.
Part of: https://github.com/autowarefoundation/autoware/issues/4569

Also, align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Tests performed
Not applicable.

## Effects on system behavior
Not applicable.

## Interface changes
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
