### PR TITLE
chore(cspell): ignore some words in .cppcheck_suppressions

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -6,6 +6,7 @@ constParameterReference
 constVariable
 constVariableReference
 containerOutOfBounds
+// cspell: ignore cstyle
 cstyleCast
 duplicateBranch
 duplicateBreak
@@ -27,6 +28,7 @@ shadowArgument
 shadowFunction
 shadowVariable
 syntaxError
+// cspell: ignore uninit
 uninitMemberVar
 unknownMacro
 unmatchedSuppression


### PR DESCRIPTION
## Description

Ignore `cstyle` and `uninit` in `.cppcheck_suppressions` as typo.

## Tests performed

No errors on `spell-check-differential`

https://github.com/autowarefoundation/autoware.universe/actions/runs/9640760877/job/26585111573?pr=7647

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
