### PR TITLE
refactor(radar_object_clustering)!: fix namespace and directory structure

### DIFF
--- a/perception/radar_object_clustering/CMakeLists.txt
+++ b/perception/radar_object_clustering/CMakeLists.txt
@@ -12,7 +12,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::radar_object_clustering::RadarObjectClusteringNode"
-  EXECUTABLE ${PROJECT_NAME}_node
+  EXECUTABLE radar_object_clustering_node
 )
 
 # Tests

--- a/perception/radar_object_clustering/CMakeLists.txt
+++ b/perception/radar_object_clustering/CMakeLists.txt
@@ -6,13 +6,13 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 # Targets
-ament_auto_add_library(radar_object_clustering_node_component SHARED
-  src/radar_object_clustering_node/radar_object_clustering_node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/radar_object_clustering_node.cpp
 )
 
-rclcpp_components_register_node(radar_object_clustering_node_component
-  PLUGIN "radar_object_clustering::RadarObjectClusteringNode"
-  EXECUTABLE radar_object_clustering_node
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::radar_object_clustering::RadarObjectClusteringNode"
+  EXECUTABLE ${PROJECT_NAME}_node
 )
 
 # Tests

--- a/perception/radar_object_clustering/include/autoware/radar_object_clustering/radar_object_clustering_node.hpp
+++ b/perception/radar_object_clustering/include/autoware/radar_object_clustering/radar_object_clustering_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
-#define RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
+#ifndef AUTOWARE__RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
+#define AUTOWARE__RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace radar_object_clustering
+namespace autoware::radar_object_clustering
 {
 using autoware_perception_msgs::msg::DetectedObject;
 using autoware_perception_msgs::msg::DetectedObjects;
@@ -72,6 +72,6 @@ private:
   bool isSameObject(const DetectedObject & object_1, const DetectedObject & object_2);
 };
 
-}  // namespace radar_object_clustering
+}  // namespace autoware::radar_object_clustering
 
-#endif  // RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
+#endif  // AUTOWARE__RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_

--- a/perception/radar_object_clustering/src/radar_object_clustering_node.cpp
+++ b/perception/radar_object_clustering/src/radar_object_clustering_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/radar_object_clustering/radar_object_clustering_node.hpp"
+#include "radar_object_clustering_node.hpp"
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/math/unit_conversion.hpp"
@@ -20,16 +20,17 @@
 
 #include <tf2/utils.h>
 
-#include <cmath>
-#include <memory>
-#include <string>
-#include <vector>
-
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/perception/radar_object_clustering/src/radar_object_clustering_node.cpp
+++ b/perception/radar_object_clustering/src/radar_object_clustering_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "radar_object_clustering/radar_object_clustering_node.hpp"
+#include "autoware/radar_object_clustering/radar_object_clustering_node.hpp"
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/math/unit_conversion.hpp"
@@ -58,7 +58,7 @@ double get_distance(const autoware_perception_msgs::msg::DetectedObject & object
 
 }  // namespace
 
-namespace radar_object_clustering
+namespace autoware::radar_object_clustering
 {
 using autoware_perception_msgs::msg::DetectedObject;
 using autoware_perception_msgs::msg::DetectedObjects;
@@ -229,7 +229,7 @@ rcl_interfaces::msg::SetParametersResult RadarObjectClusteringNode::onSetParam(
   result.reason = "success";
   return result;
 }
-}  // namespace radar_object_clustering
+}  // namespace autoware::radar_object_clustering
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(radar_object_clustering::RadarObjectClusteringNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::radar_object_clustering::RadarObjectClusteringNode)

--- a/perception/radar_object_clustering/src/radar_object_clustering_node.hpp
+++ b/perception/radar_object_clustering/src/radar_object_clustering_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
-#define AUTOWARE__RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
+#ifndef RADAR_OBJECT_CLUSTERING_NODE_HPP_
+#define RADAR_OBJECT_CLUSTERING_NODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -74,4 +74,4 @@ private:
 
 }  // namespace autoware::radar_object_clustering
 
-#endif  // AUTOWARE__RADAR_OBJECT_CLUSTERING__RADAR_OBJECT_CLUSTERING_NODE_HPP_
+#endif  // RADAR_OBJECT_CLUSTERING_NODE_HPP_


### PR DESCRIPTION
## Description

This PR puts headers in the `autoware` namespace.
Part of: https://github.com/autowarefoundation/autoware/issues/4569

Also, align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Tests performed
Not applicable.

## Effects on system behavior
Not applicable.

## Interface changes
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
