### PR TITLE
fix(autoware_obstacle_cruise_planner): fix shadowVariable warning

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -540,8 +540,8 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::getAccelerationLimitedTrajectory(
   //       Therefore, we calculate v1 (velocity at next step) and use it for initial velocity.
   const double v1 = v0;  // + 0.1;  // a0 * 0.1;  //  + jerk * 0.1 * 0.1 / 2.0;
   const double a1 = a0;  //  + jerk * 0.1;
-  const double jerk = target_acc > a1 
-    ? longitudinal_info_.max_jerk * target_jerk_ratio 
+  const double jerk = target_acc > a1
+    ? longitudinal_info_.max_jerk * target_jerk_ratio
     : longitudinal_info_.min_jerk * target_jerk_ratio;
 
   double t_current = 0.0;

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -540,9 +540,8 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::getAccelerationLimitedTrajectory(
   //       Therefore, we calculate v1 (velocity at next step) and use it for initial velocity.
   const double v1 = v0;  // + 0.1;  // a0 * 0.1;  //  + jerk * 0.1 * 0.1 / 2.0;
   const double a1 = a0;  //  + jerk * 0.1;
-  const double jerk = target_acc > a1
-    ? longitudinal_info_.max_jerk * target_jerk_ratio
-    : longitudinal_info_.min_jerk * target_jerk_ratio;
+  const double jerk = target_acc > a1 ? longitudinal_info_.max_jerk * target_jerk_ratio
+                                      : longitudinal_info_.min_jerk * target_jerk_ratio;
 
   double t_current = 0.0;
   std::vector<double> s_vec{0.0};

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -509,7 +509,6 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::getAccelerationLimitedTrajectory(
   const double v0, const double a0, const double target_acc, const double target_jerk_ratio) const
 {
   // calculate vt function
-  const auto & i = longitudinal_info_;
   const auto vt = [&](
                     const double v0, const double a0, const double jerk, const double t,
                     const double target_acc) {
@@ -541,8 +540,9 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::getAccelerationLimitedTrajectory(
   //       Therefore, we calculate v1 (velocity at next step) and use it for initial velocity.
   const double v1 = v0;  // + 0.1;  // a0 * 0.1;  //  + jerk * 0.1 * 0.1 / 2.0;
   const double a1 = a0;  //  + jerk * 0.1;
-  const double jerk =
-    target_acc > a1 ? i.max_jerk * target_jerk_ratio : i.min_jerk * target_jerk_ratio;
+  const double jerk = target_acc > a1 
+    ? longitudinal_info_.max_jerk * target_jerk_ratio 
+    : longitudinal_info_.min_jerk * target_jerk_ratio;
 
   double t_current = 0.0;
   std::vector<double> s_vec{0.0};


### PR DESCRIPTION
## Description
This is a fix based on cppcheck warning.
```
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp:584:15: style: Local variable 'i' shadows outer variable [shadowVariable]
  for (size_t i = 0; i < s_vec.size(); ++i) {
              ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp:512:16: note: Shadowed declaration
  const auto & i = longitudinal_info_;
               ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp:584:15: note: Shadow variable
  for (size_t i = 0; i < s_vec.size(); ++i) {
              ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp:600:15: style: Local variable 'i' shadows outer variable [shadowVariable]
  for (size_t i = ego_seg_idx; i < acc_limited_traj_points.size(); ++i) {
              ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp:512:16: note: Shadowed declaration
  const auto & i = longitudinal_info_;
               ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp:600:15: note: Shadow variable
  for (size_t i = ego_seg_idx; i < acc_limited_traj_points.size(); ++i) {
              ^
```

## Tests performed

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
