### PR TITLE
fix(autoware_obstacle_cruise_planner): fix shadowVariable warning in generateSlowDownTrajectory

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
@@ -623,9 +623,9 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     }();
 
     // insert slow down velocity between slow start and end
-    for (size_t i = (slow_down_start_idx ? *slow_down_start_idx : 0); i <= *slow_down_end_idx;
-         ++i) {
-      auto & traj_point = slow_down_traj_points.at(i);
+    for (size_t j = (slow_down_start_idx ? *slow_down_start_idx : 0); j <= *slow_down_end_idx;
+         ++j) {
+      auto & traj_point = slow_down_traj_points.at(j);
       traj_point.longitudinal_velocity_mps =
         std::min(traj_point.longitudinal_velocity_mps, static_cast<float>(stable_slow_down_vel));
     }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck warning.
```
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:626:17: style: Local variable 'i' shadows outer variable [shadowVariable]
    for (size_t i = (slow_down_start_idx ? *slow_down_start_idx : 0); i <= *slow_down_end_idx;
                ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:579:15: note: Shadowed declaration
  for (size_t i = 0; i < obstacles.size(); ++i) {
              ^
src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:626:17: note: Shadow variable
    for (size_t i = (slow_down_start_idx ? *slow_down_start_idx : 0); i <= *slow_down_end_idx;
```
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.