### PR TITLE
fix(autoware_behavior_path_planner_common): fix shadowArgument warning in getDistanceToCrosswalk

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -734,12 +734,11 @@ double getDistanceToCrosswalk(
           boost::geometry::intersection(centerline, polygon, points_intersection);
 
           for (const auto & point : points_intersection) {
-            lanelet::ConstLanelets lanelets = {llt};
             Pose pose_point;
             pose_point.position.x = point.x();
             pose_point.position.y = point.y();
             const lanelet::ArcCoordinates & arc_crosswalk =
-              lanelet::utils::getArcCoordinates(lanelets, pose_point);
+              lanelet::utils::getArcCoordinates({llt}, pose_point);
 
             const double distance_to_crosswalk = arc_crosswalk.length;
             if (distance_to_crosswalk < min_distance_to_crosswalk) {


### PR DESCRIPTION
## Description
```
src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:737:36: style: Local variable 'lanelets' shadows outer argument [shadowArgument]
            lanelet::ConstLanelets lanelets = {llt};
                                   ^
src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:694:61: note: Shadowed declaration
  const Pose & current_pose, const lanelet::ConstLanelets & lanelets,
                                                            ^
src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:737:36: note: Shadow variable
            lanelet::ConstLanelets lanelets = {llt};
                                   ^
```
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
