### PR TITLE
fix(autoware_behavior_velocity_speed_bump_module): fix containerOutOfBounds warning

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp
@@ -95,25 +95,31 @@ PathPolygonIntersectionStatus getPathPolygonIntersectionStatus(
   auto const & is_first_path_point_inside_polygon = bg::within(first_path_point, polygon);
   auto const & is_last_path_point_inside_polygon = bg::within(last_path_point, polygon);
 
-  if (
-    intersects.empty() && is_first_path_point_inside_polygon && is_last_path_point_inside_polygon) {
-    polygon_intersection_status.is_path_inside_of_polygon = true;
-  } else {
-    // classify first and second intersection points
-    for (size_t i = 0; i < intersects.size(); ++i) {
-      const auto & p = intersects.at(i);
-      if (
-        (intersects.size() == 2 && i == 0) ||
-        (intersects.size() == 1 && is_last_path_point_inside_polygon)) {
-        polygon_intersection_status.first_intersection_point = createPoint(p.x(), p.y(), ego_pos.z);
-      } else if (
-        (intersects.size() == 2 && i == 1) ||
-        (intersects.size() == 1 && is_first_path_point_inside_polygon)) {
-        polygon_intersection_status.second_intersection_point =
-          createPoint(p.x(), p.y(), ego_pos.z);
-      }
+  // classify first and second intersection points
+  if (intersects.empty()) {
+    if (is_first_path_point_inside_polygon && is_last_path_point_inside_polygon) {
+      polygon_intersection_status.is_path_inside_of_polygon = true;
+    } else {
+      // do nothing
     }
+  } else if (intersects.size() == 1) {
+    const auto & p = intersects.at(0);
+    if (is_last_path_point_inside_polygon) {
+      polygon_intersection_status.first_intersection_point = createPoint(p.x(), p.y(), ego_pos.z);
+    } else if (is_first_path_point_inside_polygon) {
+      polygon_intersection_status.second_intersection_point = createPoint(p.x(), p.y(), ego_pos.z);
+    } else {
+      // do nothing
+    }
+  } else if (intersects.size() == 2) {
+    const auto & p0 = intersects.at(0);
+    const auto & p1 = intersects.at(1);
+    polygon_intersection_status.first_intersection_point = createPoint(p0.x(), p0.y(), ego_pos.z);
+    polygon_intersection_status.second_intersection_point = createPoint(p1.x(), p1.y(), ego_pos.z);
+  } else {
+    // do nothing
   }
+
   return polygon_intersection_status;
 }
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `containerOutOfBounds` warning

```
planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp:104:37: warning: inconclusive: Either the condition 'intersects.size()==1' is redundant or size of 'intersects' can be 1. Expression 'intersects.at(i)' causes access out of bounds. [containerOutOfBounds]
      const auto & p = intersects.at(i);
                                    ^
planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp:107:28: note: Assuming that condition 'intersects.size()==1' is not redundant
        (intersects.size() == 1 && is_last_path_point_inside_polygon)) {
                           ^
planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp:104:37: note: Access out of bounds
      const auto & p = intersects.at(i);
                                    ^
planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp:110:38: note: Assuming that condition 'i==1' is not redundant
        (intersects.size() == 2 && i == 1) ||
                                     ^
planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/util.cpp:104:37: note: Access out of bounds
      const auto & p = intersects.at(i);
                                    ^
```

You know this is not technically a bug, it's just to avoid cppcheck false positive warnings.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
