### PR TITLE
fix(autoware_behavior_path_planner_common): fix containerOutOfBounds warning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -473,7 +473,7 @@ std::vector<Pose> interpolatePose(
 
   const double distance =
     autoware::universe_utils::calcDistance2d(start_pose.position, end_pose.position);
-  const std::vector<double> base_s{0, distance};
+  const std::vector<double> base_s{0.0, distance};
   const std::vector<double> base_x{start_pose.position.x, end_pose.position.x};
   const std::vector<double> base_y{start_pose.position.y, end_pose.position.y};
   std::vector<double> new_s;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -471,14 +471,15 @@ std::vector<Pose> interpolatePose(
 {
   std::vector<Pose> interpolated_poses{};  // output
 
-  const std::vector<double> base_s{
-    0, autoware::universe_utils::calcDistance2d(start_pose.position, end_pose.position)};
+  const double distance =
+    autoware::universe_utils::calcDistance2d(start_pose.position, end_pose.position);
+  const std::vector<double> base_s{0, distance};
   const std::vector<double> base_x{start_pose.position.x, end_pose.position.x};
   const std::vector<double> base_y{start_pose.position.y, end_pose.position.y};
   std::vector<double> new_s;
 
   constexpr double eps = 0.3;  // prevent overlapping
-  for (double s = eps; s < base_s.back() - eps; s += resample_interval) {
+  for (double s = eps; s < distance - eps; s += resample_interval) {
     new_s.push_back(s);
   }
 
@@ -491,7 +492,7 @@ std::vector<Pose> interpolatePose(
   for (size_t i = 0; i < interpolated_x.size(); ++i) {
     Pose pose{};
     pose = autoware::universe_utils::calcInterpolatedPose(
-      end_pose, start_pose, (base_s.back() - new_s.at(i)) / base_s.back());
+      end_pose, start_pose, (distance - new_s.at(i)) / distance);
     pose.position.x = interpolated_x.at(i);
     pose.position.y = interpolated_y.at(i);
     pose.position.z = end_pose.position.z;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `containerOutOfBounds` error

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:481:39: error: Out of bounds access in expression 'base_s.back()' because 'base_s' is empty. [containerOutOfBounds]
  for (double s = eps; s < base_s.back() - eps; s += resample_interval) {
                                      ^
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:494:41: error: Out of bounds access in expression 'base_s.back()' because 'base_s' is empty. [containerOutOfBounds]
      end_pose, start_pose, (base_s.back() - new_s.at(i)) / base_s.back());
                                        ^
```

You know this is a false positive in cppcheck.
This PR is just to avoid cppcheck warnings.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
