### PR TITLE
chore(ci): remove unnecessary cppcheck suppressions

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -6,7 +6,6 @@ constVariableReference
 // cspell: ignore cstyle
 cstyleCast
 duplicateBranch
-duplicateBreak
 funcArgNamesDifferent
 functionConst
 functionStatic

--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -4,7 +4,6 @@ checkersReport
 constParameterReference
 constVariable
 constVariableReference
-containerOutOfBounds
 // cspell: ignore cstyle
 cstyleCast
 duplicateBranch
@@ -32,7 +31,6 @@ unmatchedSuppression
 unreadVariable
 unusedFunction
 unusedStructMember
-unusedVariable
 useInitializationList
 useStlAlgorithm
 uselessOverride

--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -2,7 +2,6 @@
 
 checkersReport
 constParameterReference
-constVariable
 constVariableReference
 // cspell: ignore cstyle
 cstyleCast


### PR DESCRIPTION
## Description

Could be merged after https://github.com/autowarefoundation/autoware.universe/pull/7671 is merged.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
