### PR TITLE
ci(comment-on-pr): make it work on forks

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -1,6 +1,6 @@
-name: Comment on PR
+name: comment-on-pr
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   comment-on-pr:


### PR DESCRIPTION
## Description

It failed on this fork pr:
- https://github.com/autowarefoundation/autoware.universe/pull/7678
With error:
- https://github.com/autowarefoundation/autoware.universe/actions/runs/9657331258/job/26636407771?pr=7678#step:3:26
   - `Error: Resource not accessible by integration`

Now changing the trigger to [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) so it can access repo's github token for commenting.

Also changing the general naming to fit the repo's other workflows. Shouldn't affect anything since I've added this new workflow just yesterday.

## Related links

**Follow up from:**

- https://github.com/autowarefoundation/autoware.universe/pull/7667

Related solution:
- https://github.com/marocchino/sticky-pull-request-comment/issues/227

## How was this PR tested?

- Can't be tested within this repo until it is merged (because `pull_request_target` trigger runs on the repo commit version).
- Could be tested on a separate repo but I didn't since it is simple.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
