### PR TITLE
fix(pose_instability_detector): fix a rare error

### DIFF
--- a/localization/pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/pose_instability_detector/src/pose_instability_detector.cpp
@@ -354,6 +354,9 @@ PoseInstabilityDetector::clip_out_necessary_twist(
     start_twist.header.stamp = start_time;
     result_deque.push_front(start_twist);
   } else {
+    if (result_deque.size() < 2) {
+      return result_deque;
+    }
     // If the first element is earlier than start_time, interpolate the first element
     rclcpp::Time time0 = rclcpp::Time(result_deque[0].header.stamp);
     rclcpp::Time time1 = rclcpp::Time(result_deque[1].header.stamp);
@@ -380,6 +383,9 @@ PoseInstabilityDetector::clip_out_necessary_twist(
     end_twist.header.stamp = end_time;
     result_deque.push_back(end_twist);
   } else {
+    if (result_deque.size() < 2) {
+      return result_deque;
+    }
     // If the last element is later than end_time, interpolate the last element
     rclcpp::Time time0 = rclcpp::Time(result_deque[result_deque.size() - 2].header.stamp);
     rclcpp::Time time1 = rclcpp::Time(result_deque[result_deque.size() - 1].header.stamp);

--- a/localization/pose_instability_detector/test/test.cpp
+++ b/localization/pose_instability_detector/test/test.cpp
@@ -167,16 +167,17 @@ TEST_F(TestPoseInstabilityDetector, does_not_crash_even_if_abnormal_odometry_dat
 {
   // [Condition] There is no twist_msg between the two target odometry_msgs.
   // Normally this doesn't seem to happen.
-  // As far as I can think, this happens when
-  //  (case A) the twist msg stops
-  //  (case B) the odometry msg stops (so the next timer callback will refer to the same odometry
-  //  msg, and the timestamp difference will be calculated as 0)
+  // As far as I can think, this happens when the odometry msg stops (so the next timer callback
+  // will refer to the same odometry msg, and the timestamp difference will be calculated as 0)
+  // This test case shows that an error occurs when two odometry msgs come in close succession and
+  // there is no other odometry msg.
+  // Referring again, this doesn't normally seem to happen in usual operation.
 
   builtin_interfaces::msg::Time timestamp{};
 
   // send the twist message1
   timestamp.sec = 0;
-  timestamp.nanosec = 5e8;  // timestamp is the same as the first odometry message
+  timestamp.nanosec = 0;
   helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
 
   // send the first odometry message after the first twist message
@@ -196,12 +197,7 @@ TEST_F(TestPoseInstabilityDetector, does_not_crash_even_if_abnormal_odometry_dat
   timestamp.nanosec = 5e8 + 1e7;
   helper_->send_odometry_message(timestamp, 12.0, 0.0, 0.0);
 
-  // send the twist message2 (move 0.1m in x direction)
-  timestamp.sec = 0;
-  timestamp.nanosec = 7e8 + 5e7;
-  helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
-
-  // send the twist message3 (move 0.1m in x direction)
+  // send the twist message2
   timestamp.sec = 1;
   timestamp.nanosec = 0;
   helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
@@ -215,10 +211,9 @@ TEST_F(TestPoseInstabilityDetector, does_not_crash_even_if_abnormal_odometry_dat
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
-  // check result
-  const diagnostic_msgs::msg::DiagnosticStatus & diagnostic_status =
-    helper_->received_diagnostic_array.status[0];
-  EXPECT_TRUE(diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  // This test is OK if pose_instability_detector does not crash. The diagnostics status is not
+  // checked.
+  SUCCEED();
 }
 
 int main(int argc, char ** argv)

--- a/localization/pose_instability_detector/test/test.cpp
+++ b/localization/pose_instability_detector/test/test.cpp
@@ -202,9 +202,14 @@ TEST_F(TestPoseInstabilityDetector, does_not_crash_even_if_abnormal_odometry_dat
   timestamp.nanosec = 0;
   helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
 
-  executor_.spin_some();
-
   // process the above messages (by timer_callback)
+  helper_->received_diagnostic_array_flag = false;
+  while (!helper_->received_diagnostic_array_flag) {
+    executor_.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // provoke timer callback again
   helper_->received_diagnostic_array_flag = false;
   while (!helper_->received_diagnostic_array_flag) {
     executor_.spin_some();

--- a/localization/pose_instability_detector/test/test.cpp
+++ b/localization/pose_instability_detector/test/test.cpp
@@ -163,6 +163,64 @@ TEST_F(TestPoseInstabilityDetector, output_warn_when_twist_is_too_small)  // NOL
   EXPECT_TRUE(diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::WARN);
 }
 
+TEST_F(TestPoseInstabilityDetector, does_not_crash_even_if_abnormal_odometry_data_comes)  // NOLINT
+{
+  // [Condition] There is no twist_msg between the two target odometry_msgs.
+  // Normally this doesn't seem to happen.
+  // As far as I can think, this happens when
+  //  (case A) the twist msg stops
+  //  (case B) the odometry msg stops (so the next timer callback will refer to the same odometry
+  //  msg, and the timestamp difference will be calculated as 0)
+
+  builtin_interfaces::msg::Time timestamp{};
+
+  // send the twist message1
+  timestamp.sec = 0;
+  timestamp.nanosec = 5e8;  // timestamp is the same as the first odometry message
+  helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
+
+  // send the first odometry message after the first twist message
+  timestamp.sec = 0;
+  timestamp.nanosec = 5e8 + 1;
+  helper_->send_odometry_message(timestamp, 10.0, 0.0, 0.0);
+
+  // process the above message (by timer_callback)
+  helper_->received_diagnostic_array_flag = false;
+  while (!helper_->received_diagnostic_array_flag) {
+    executor_.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // send the second odometry message before the second twist message
+  timestamp.sec = 0;
+  timestamp.nanosec = 5e8 + 1e7;
+  helper_->send_odometry_message(timestamp, 12.0, 0.0, 0.0);
+
+  // send the twist message2 (move 0.1m in x direction)
+  timestamp.sec = 0;
+  timestamp.nanosec = 7e8 + 5e7;
+  helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
+
+  // send the twist message3 (move 0.1m in x direction)
+  timestamp.sec = 1;
+  timestamp.nanosec = 0;
+  helper_->send_twist_message(timestamp, 0.2, 0.0, 0.0);
+
+  executor_.spin_some();
+
+  // process the above messages (by timer_callback)
+  helper_->received_diagnostic_array_flag = false;
+  while (!helper_->received_diagnostic_array_flag) {
+    executor_.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // check result
+  const diagnostic_msgs::msg::DiagnosticStatus & diagnostic_status =
+    helper_->received_diagnostic_array.status[0];
+  EXPECT_TRUE(diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::WARN);
+}
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);


### PR DESCRIPTION
## Description
In `pose_instability_detector`, a bug has been fixed that in rare abnormal cases, it may access to outside the queue size and crash, or it may show abnormal values.

I have added test cases that cause this, and I have confirmed that it fails probabilistically if it is not fixed.
Since accessing outside the range is undefined behavior, it does not necessarily always fail.

By making a modification of pose_instability_detector.cpp, the test will no longer fail even after 100 consecutive attempts.

## Related links

None.

## How was this PR tested?
The following script was used.

```
./test_loop.sh pose_instability_detector
```

```bash
#!/bin/bash
set -eux

TEST_TARGET_PKG=$1
LOOP_NUM=${2:-100}

colcon build --symlink-install \
  --cmake-args \
    -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_TESTING=ON \
  --packages-select $TEST_TARGET_PKG

for ((i=1; i<=LOOP_NUM; i++))
do
  colcon test --packages-select ${TEST_TARGET_PKG} --event-handlers console_cohesion+ --return-code-on-test-failure
  echo "Finish test $i"
done
```

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
