### PR TITLE
docs(static_obstacle_avoidance): fix wrong flowchart

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/README.md
@@ -485,11 +485,6 @@ title Filtering flow for vehicle type objects
 start
 
 partition isSatisfiedWithVehicleCodition() {
-if(object is force avoidance target ?) then (yes)
-#FF006C :return true;
-stop
-else (\n no)
-
 if(isNeverAvoidanceTarget()) then (yes)
 #00FFB1 :return false;
 stop
@@ -534,7 +529,6 @@ endif
 
 endif
 }
-endif
 endif
 endif
 endif


### PR DESCRIPTION
## Description

Fix wrong flowchart.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/e205cad5-ade8-41a6-a54c-a257da99a9a9)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
