### PR TITLE
ci: show cuda and nvidia-driver version in build&test ci

### DIFF
--- a/.github/workflows/build-and-test-daily-arm64.yaml
+++ b/.github/workflows/build-and-test-daily-arm64.yaml
@@ -30,6 +30,13 @@ jobs:
       - name: Show disk space before the tasks
         run: df -h
 
+      - name: Show CUDA and NVIDIA driver version
+        if: matrix.container-suffix == '-cuda'
+        run: |
+          nvidia-smi
+          nvcc --version
+        shell: bash
+
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -30,6 +30,13 @@ jobs:
       - name: Show disk space before the tasks
         run: df -h
 
+      - name: Show CUDA and NVIDIA driver version
+        if: matrix.container-suffix == '-cuda'
+        run: |
+          nvidia-smi
+          nvcc --version
+        shell: bash
+
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -44,6 +44,13 @@ jobs:
       - name: Show disk space before the tasks
         run: df -h
 
+      - name: Show CUDA and NVIDIA driver version
+        if: matrix.container-suffix == '-cuda'
+        run: |
+          nvidia-smi
+          nvcc --version
+        shell: bash
+
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -48,6 +48,13 @@ jobs:
       - name: Show disk space before the tasks
         run: df -h
 
+      - name: Show CUDA and NVIDIA driver version
+        if: matrix.container-suffix == '-cuda'
+        run: |
+          nvidia-smi
+          nvcc --version
+        shell: bash
+
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -34,6 +34,13 @@ jobs:
       - name: Show disk space before the tasks
         run: df -h
 
+      - name: Show CUDA and NVIDIA driver version
+        if: matrix.container-suffix == '-cuda'
+        run: |
+          nvidia-smi
+          nvcc --version
+        shell: bash
+
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 


### PR DESCRIPTION
## Description

Since build and test of CUDA-related packages may fail, not only due to the package modification but also due to the environment modification in the recent GitHub Actions improvements, showing the CUDA and nvidia-driver version would be helpful for debugging in some cases.

## Related links

None

## How was this PR tested?
None

## Effects on system behavior

No effects on Autoware.
