### PR TITLE
fix(tensorrt_yolox): fix duplicateBreak warning

### DIFF
--- a/perception/tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -1279,7 +1279,6 @@ void TrtYoloX::getColorizedMask(
   int height = mask.rows;
   if ((cmask.cols != mask.cols) || (cmask.rows != mask.rows)) {
     throw std::runtime_error("input and output image have difference size.");
-    return;
   }
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `duplicateBreak` warning

```
perception/tensorrt_yolox/src/tensorrt_yolox.cpp:1282:5: style: Consecutive return, break, continue, goto or throw statements are unnecessary. [duplicateBreak]
    return;
    ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
