### PR TITLE
refactor(localization_util): add covariance_ellipse to localization_util

### DIFF
--- a/localization/localization_error_monitor/include/localization_error_monitor/localization_error_monitor.hpp
+++ b/localization/localization_error_monitor/include/localization_error_monitor/localization_error_monitor.hpp
@@ -15,6 +15,8 @@
 #ifndef LOCALIZATION_ERROR_MONITOR__LOCALIZATION_ERROR_MONITOR_HPP_
 #define LOCALIZATION_ERROR_MONITOR__LOCALIZATION_ERROR_MONITOR_HPP_
 
+#include "localization_util/covariance_ellipse.hpp"
+
 #include <Eigen/Dense>
 #include <autoware/universe_utils/ros/logger_level_configure.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -24,15 +26,6 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
-
-struct Ellipse
-{
-  double long_radius;
-  double short_radius;
-  double yaw;
-  Eigen::Matrix2d P;
-  double size_lateral_direction;
-};
 
 class LocalizationErrorMonitor : public rclcpp::Node
 {
@@ -50,12 +43,9 @@ private:
   double warn_ellipse_size_;
   double error_ellipse_size_lateral_direction_;
   double warn_ellipse_size_lateral_direction_;
-  Ellipse ellipse_;
+  autoware::localization_util::Ellipse ellipse_;
 
   void on_odom(nav_msgs::msg::Odometry::ConstSharedPtr input_msg);
-  visualization_msgs::msg::Marker create_ellipse_marker(
-    const Ellipse & ellipse, nav_msgs::msg::Odometry::ConstSharedPtr odom);
-  static double measure_size_ellipse_along_body_frame(const Eigen::Matrix2d & Pinv, double theta);
 
 public:
   explicit LocalizationErrorMonitor(const rclcpp::NodeOptions & options);

--- a/localization/localization_error_monitor/package.xml
+++ b/localization/localization_error_monitor/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_universe_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
+  <depend>localization_util</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>

--- a/localization/localization_util/CMakeLists.txt
+++ b/localization/localization_util/CMakeLists.txt
@@ -8,6 +8,7 @@ ament_auto_add_library(localization_util SHARED
   src/util_func.cpp
   src/smart_pose_buffer.cpp
   src/tree_structured_parzen_estimator.cpp
+  src/covariance_ellipse.cpp
 )
 
 if(BUILD_TESTING)

--- a/localization/localization_util/include/localization_util/covariance_ellipse.hpp
+++ b/localization/localization_util/include/localization_util/covariance_ellipse.hpp
@@ -1,0 +1,44 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LOCALIZATION_UTIL__COVARIANCE_ELLIPSE_HPP_
+#define LOCALIZATION_UTIL__COVARIANCE_ELLIPSE_HPP_
+
+#include <Eigen/Dense>
+
+#include <geometry_msgs/msg/pose_with_covariance.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+namespace autoware::localization_util
+{
+
+struct Ellipse
+{
+  double long_radius;
+  double short_radius;
+  double yaw;
+  Eigen::Matrix2d P;
+  double size_lateral_direction;
+};
+
+Ellipse calculate_xy_ellipse(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double scale);
+
+visualization_msgs::msg::Marker create_ellipse_marker(
+  const Ellipse & ellipse, const std_msgs::msg::Header & header,
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance);
+
+}  // namespace autoware::localization_util
+
+#endif  // LOCALIZATION_UTIL__COVARIANCE_ELLIPSE_HPP_

--- a/localization/localization_util/src/covariance_ellipse.cpp
+++ b/localization/localization_util/src/covariance_ellipse.cpp
@@ -1,0 +1,90 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "localization_util/covariance_ellipse.hpp"
+
+#include <tf2/utils.h>
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
+namespace autoware::localization_util
+{
+
+Ellipse calculate_xy_ellipse(
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance, const double scale)
+{
+  // input geometry_msgs::PoseWithCovariance contain 6x6 matrix
+  Eigen::Matrix2d xy_covariance;
+  const auto cov = pose_with_covariance.covariance;
+  xy_covariance(0, 0) = cov[0 * 6 + 0];
+  xy_covariance(0, 1) = cov[0 * 6 + 1];
+  xy_covariance(1, 0) = cov[1 * 6 + 0];
+  xy_covariance(1, 1) = cov[1 * 6 + 1];
+
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix2d> eigensolver(xy_covariance);
+
+  Ellipse ellipse;
+
+  // eigen values and vectors are sorted in ascending order
+  ellipse.long_radius = scale * std::sqrt(eigensolver.eigenvalues()(1));
+  ellipse.short_radius = scale * std::sqrt(eigensolver.eigenvalues()(0));
+
+  // principal component vector
+  const Eigen::Vector2d pc_vector = eigensolver.eigenvectors().col(1);
+  ellipse.yaw = std::atan2(pc_vector.y(), pc_vector.x());
+
+  // ellipse size along lateral direction (body-frame)
+  ellipse.P = xy_covariance;
+  const double yaw_vehicle = tf2::getYaw(pose_with_covariance.pose.orientation);
+  const Eigen::Matrix2d & p_inv = ellipse.P.inverse();
+  Eigen::MatrixXd e(2, 1);
+  e(0, 0) = std::cos(yaw_vehicle);
+  e(1, 0) = std::sin(yaw_vehicle);
+  const double d = std::sqrt((e.transpose() * p_inv * e)(0, 0) / p_inv.determinant());
+  ellipse.size_lateral_direction = scale * d;
+
+  return ellipse;
+}
+
+visualization_msgs::msg::Marker create_ellipse_marker(
+  const Ellipse & ellipse, const std_msgs::msg::Header & header,
+  const geometry_msgs::msg::PoseWithCovariance & pose_with_covariance)
+{
+  tf2::Quaternion quat;
+  quat.setEuler(0, 0, ellipse.yaw);
+
+  const double ellipse_long_radius = std::min(ellipse.long_radius, 30.0);
+  const double ellipse_short_radius = std::min(ellipse.short_radius, 30.0);
+  visualization_msgs::msg::Marker marker;
+  marker.header = header;
+  marker.ns = "error_ellipse";
+  marker.id = 0;
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.pose = pose_with_covariance.pose;
+  marker.pose.orientation = tf2::toMsg(quat);
+  marker.scale.x = ellipse_long_radius * 2;
+  marker.scale.y = ellipse_short_radius * 2;
+  marker.scale.z = 0.01;
+  marker.color.a = 0.1;
+  marker.color.r = 0.0;
+  marker.color.g = 0.0;
+  marker.color.b = 1.0;
+  return marker;
+}
+
+}  // namespace autoware::localization_util


### PR DESCRIPTION
## Description

Since several modules, not only ekf, output pose_with_covariance, it would be a good idea to move the error ellipse struct and its visualization code into localization_util to make it common.

## Related links

None.

## How was this PR tested?

I have confirmed that logging_simulator works well.

To get a larger error ellipse, I ran the experiment with NDT turned off and confirmed that the correct error ellipse was visualized just as before.

![image](https://github.com/autowarefoundation/autoware.universe/assets/28504069/6ac81759-584c-436a-9de0-a588c7100da7)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
