### PR TITLE
feat(pid_longitudinal_controller): re-organize diff limit structure and fix state change condition

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -293,7 +293,7 @@ private:
    * @brief calculate control command in emergency state
    * @param [in] dt time between previous and current one
    */
-  Motion calcEmergencyCtrlCmd() const;
+  Motion calcEmergencyCtrlCmd(const double dt);
 
   /**
    * @brief update control state according to the current situation

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -192,6 +192,7 @@ private:
   {
     double vel;
     double acc;
+    double jerk;
   };
   EmergencyStateParams m_emergency_state_params;
 
@@ -203,7 +204,7 @@ private:
   double m_max_jerk;
   double m_min_jerk;
 
-  double m_max_pedal_pos_diff_rate;
+  double m_max_acc_cmd_diff_rate;
 
   // slope compensation
   enum class SlopeSource { RAW_PITCH = 0, TRAJECTORY_PITCH, TRAJECTORY_ADAPTIVE };

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -203,7 +203,6 @@ private:
   // jerk limit
   double m_max_jerk;
   double m_min_jerk;
-
   double m_max_acc_cmd_diff_rate;
 
   // slope compensation
@@ -228,8 +227,8 @@ private:
   Shift m_prev_shift{Shift::Forward};
 
   // diff limit
-  Motion m_prev_raw_ctrl_cmd{};  // without slope compensation
   Motion m_prev_ctrl_cmd{};      // with slope compensation
+  Motion m_prev_raw_ctrl_cmd{};  // without slope compensation
   std::vector<std::pair<rclcpp::Time, double>> m_vel_hist;
 
   // debug values

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -203,7 +203,7 @@ private:
   // jerk limit
   double m_max_jerk;
   double m_min_jerk;
-  double m_max_acc_cmd_diff_rate;
+  double m_max_acc_cmd_diff;
 
   // slope compensation
   enum class SlopeSource { RAW_PITCH = 0, TRAJECTORY_PITCH, TRAJECTORY_ADAPTIVE };

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -184,7 +184,6 @@ private:
   {
     double vel;
     double acc;
-    double jerk;
   };
   StoppedStateParams m_stopped_state_params;
 
@@ -193,7 +192,6 @@ private:
   {
     double vel;
     double acc;
-    double jerk;
   };
   EmergencyStateParams m_emergency_state_params;
 
@@ -204,6 +202,8 @@ private:
   // jerk limit
   double m_max_jerk;
   double m_min_jerk;
+
+  double m_max_pedal_pos_diff_rate;
 
   // slope compensation
   enum class SlopeSource { RAW_PITCH = 0, TRAJECTORY_PITCH, TRAJECTORY_ADAPTIVE };
@@ -227,8 +227,8 @@ private:
   Shift m_prev_shift{Shift::Forward};
 
   // diff limit
-  Motion m_prev_ctrl_cmd{};      // with slope compensation
   Motion m_prev_raw_ctrl_cmd{};  // without slope compensation
+  Motion m_prev_ctrl_cmd{};      // with slope compensation
   std::vector<std::pair<rclcpp::Time, double>> m_vel_hist;
 
   // debug values
@@ -292,7 +292,7 @@ private:
    * @brief calculate control command in emergency state
    * @param [in] dt time between previous and current one
    */
-  Motion calcEmergencyCtrlCmd(const double dt) const;
+  Motion calcEmergencyCtrlCmd() const;
 
   /**
    * @brief update control state according to the current situation

--- a/control/autoware_pid_longitudinal_controller/param/longitudinal_controller_defaults.param.yaml
+++ b/control/autoware_pid_longitudinal_controller/param/longitudinal_controller_defaults.param.yaml
@@ -53,12 +53,11 @@
 
     # stopped state
     stopped_vel: 0.0
-    stopped_acc: -3.4
-    stopped_jerk: -5.0
+    stopped_acc: -3.4 # denotes pedal position
 
     # emergency state
     emergency_vel: 0.0
-    emergency_acc: -5.0
+    emergency_acc: -5.0 # denotes acceleration
     emergency_jerk: -3.0
 
     # acceleration limit
@@ -68,6 +67,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
+    max_acc_cmd_diff: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -591,7 +591,6 @@ PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCm
 void PidLongitudinalController::updateControlState(const ControlData & control_data)
 {
   const double current_vel = control_data.current_motion.vel;
-  const double current_acc = control_data.current_motion.acc;
   const double stop_dist = control_data.stop_dist;
 
   // flags for state transition

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -169,9 +169,9 @@ PidLongitudinalController::PidLongitudinalController(
   m_min_acc = node.declare_parameter<double>("min_acc");  // [m/s^2]
 
   // parameters for jerk limit
-  m_max_jerk = node.declare_parameter<double>("max_jerk");                            // [m/s^3]
-  m_min_jerk = node.declare_parameter<double>("min_jerk");                            // [m/s^3]
-  m_max_acc_cmd_diff_rate = node.declare_parameter<double>("max_acc_cmd_diff_rate");  // [m/s^3]
+  m_max_jerk = node.declare_parameter<double>("max_jerk");                  // [m/s^3]
+  m_min_jerk = node.declare_parameter<double>("min_jerk");                  // [m/s^3]
+  m_max_acc_cmd_diff = node.declare_parameter<double>("max_acc_cmd_diff");  // [m/s^3]
 
   // parameters for slope compensation
   m_adaptive_trajectory_velocity_th =
@@ -371,7 +371,7 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
   // jerk limit
   update_param("max_jerk", m_max_jerk);
   update_param("min_jerk", m_min_jerk);
-  update_param("max_acc_cmd_diff_rate", m_max_acc_cmd_diff_rate);
+  update_param("max_acc_cmd_diff", m_max_acc_cmd_diff);
 
   // slope compensation
   update_param("max_pitch_rad", m_max_pitch_rad);
@@ -853,7 +853,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   storeAccelCmd(m_prev_raw_ctrl_cmd.acc);
 
   ctrl_cmd_as_pedal_pos.acc = longitudinal_utils::applyDiffLimitFilter(
-    ctrl_cmd_as_pedal_pos.acc, m_prev_ctrl_cmd.acc, control_data.dt, m_max_acc_cmd_diff_rate);
+    ctrl_cmd_as_pedal_pos.acc, m_prev_ctrl_cmd.acc, control_data.dt, m_max_acc_cmd_diff);
 
   // update debug visualization
   updateDebugVelAcc(control_data);

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -792,10 +792,10 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   if (m_control_state == ControlState::STOPPED) {
     const auto & p = m_stopped_state_params;
     ctrl_cmd_as_pedal_pos.vel = p.vel;
-    ctrl_cmd_as_pedal_pos.acc = p.acc;  // store brake pedal position corresponding value
+    ctrl_cmd_as_pedal_pos.acc = p.acc;
 
-    m_prev_raw_ctrl_cmd.vel = ctrl_cmd_as_pedal_pos.vel;
-    m_prev_raw_ctrl_cmd.acc = 0.0;  // store acceleration value
+    m_prev_raw_ctrl_cmd.vel = 0.0;
+    m_prev_raw_ctrl_cmd.acc = 0.0;
 
     m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, ctrl_cmd_as_pedal_pos.acc);
     m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, ctrl_cmd_as_pedal_pos.acc);

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -575,14 +575,15 @@ PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCm
 
   raw_ctrl_cmd.vel =
     longitudinal_utils::applyDiffLimitFilter(raw_ctrl_cmd.vel, m_prev_raw_ctrl_cmd.vel, dt, p.acc);
-  raw_ctrl_cmd.acc = std::clamp(raw_ctrl_cmd.acc, m_emergency_state_params.jerk, m_max_acc);
+  raw_ctrl_cmd.acc = std::clamp(raw_ctrl_cmd.acc, m_min_acc, m_max_acc);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, raw_ctrl_cmd.acc);
   raw_ctrl_cmd.acc =
     longitudinal_utils::applyDiffLimitFilter(raw_ctrl_cmd.acc, m_prev_raw_ctrl_cmd.acc, dt, p.jerk);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, raw_ctrl_cmd.acc);
 
   RCLCPP_ERROR_THROTTLE(
-    logger_, *clock_, 3000, "[Emergency stop] vel: %3.3f, acc: %3.3f", p.vel, p.acc);
+    logger_, *clock_, 3000, "[Emergency stop] vel: %3.3f, acc: %3.3f", raw_ctrl_cmd.vel,
+    raw_ctrl_cmd.acc);
 
   return raw_ctrl_cmd;
 }

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -152,17 +152,15 @@ PidLongitudinalController::PidLongitudinalController(
   // parameters for stop state
   {
     auto & p = m_stopped_state_params;
-    p.vel = node.declare_parameter<double>("stopped_vel");    // [m/s]
-    p.acc = node.declare_parameter<double>("stopped_acc");    // [m/s^2]
-    p.jerk = node.declare_parameter<double>("stopped_jerk");  // [m/s^3]
+    p.vel = node.declare_parameter<double>("stopped_vel");  // [m/s]
+    p.acc = node.declare_parameter<double>("stopped_acc");  // [m/s^2]
   }
 
   // parameters for emergency state
   {
     auto & p = m_emergency_state_params;
-    p.vel = node.declare_parameter<double>("emergency_vel");    // [m/s]
-    p.acc = node.declare_parameter<double>("emergency_acc");    // [m/s^2]
-    p.jerk = node.declare_parameter<double>("emergency_jerk");  // [m/s^3]
+    p.vel = node.declare_parameter<double>("emergency_vel");  // [m/s]
+    p.acc = node.declare_parameter<double>("emergency_acc");  // [m/s^2]
   }
 
   // parameters for acceleration limit
@@ -170,8 +168,9 @@ PidLongitudinalController::PidLongitudinalController(
   m_min_acc = node.declare_parameter<double>("min_acc");  // [m/s^2]
 
   // parameters for jerk limit
-  m_max_jerk = node.declare_parameter<double>("max_jerk");  // [m/s^3]
-  m_min_jerk = node.declare_parameter<double>("min_jerk");  // [m/s^3]
+  m_max_jerk = node.declare_parameter<double>("max_jerk");                                // [m/s^3]
+  m_min_jerk = node.declare_parameter<double>("min_jerk");                                // [m/s^3]
+  m_max_pedal_pos_diff_rate = node.declare_parameter<double>("max_pedal_pos_diff_rate");  // [m/s^3]
 
   // parameters for slope compensation
   m_adaptive_trajectory_velocity_th =
@@ -355,7 +354,6 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
     auto & p = m_stopped_state_params;
     update_param("stopped_vel", p.vel);
     update_param("stopped_acc", p.acc);
-    update_param("stopped_jerk", p.jerk);
   }
 
   // emergency state
@@ -363,7 +361,6 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
     auto & p = m_emergency_state_params;
     update_param("emergency_vel", p.vel);
     update_param("emergency_acc", p.acc);
-    update_param("emergency_jerk", p.jerk);
   }
 
   // acceleration limit
@@ -372,6 +369,7 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
   // jerk limit
   update_param("max_jerk", m_max_jerk);
   update_param("min_jerk", m_min_jerk);
+  update_param("max_pedal_pos_diff_rate", m_max_pedal_pos_diff_rate);
 
   // slope compensation
   update_param("max_pitch_rad", m_max_pitch_rad);
@@ -409,7 +407,7 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
     if (m_enable_large_tracking_error_emergency) {
       m_control_state = ControlState::EMERGENCY;  // update control state
     }
-    const Motion raw_ctrl_cmd = calcEmergencyCtrlCmd(control_data.dt);  // calculate control command
+    const Motion raw_ctrl_cmd = calcEmergencyCtrlCmd();  // calculate control command
     m_prev_raw_ctrl_cmd = raw_ctrl_cmd;
     const auto cmd_msg =
       createCtrlCmdMsg(raw_ctrl_cmd, control_data.current_motion.vel);  // create control command
@@ -567,20 +565,15 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   return control_data;
 }
 
-PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCmd(
-  const double dt) const
+PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCmd() const
 {
   // These accelerations are without slope compensation
   const auto & p = m_emergency_state_params;
-  const double vel =
-    longitudinal_utils::applyDiffLimitFilter(p.vel, m_prev_raw_ctrl_cmd.vel, dt, p.acc);
-  const double acc =
-    longitudinal_utils::applyDiffLimitFilter(p.acc, m_prev_raw_ctrl_cmd.acc, dt, p.jerk);
 
   RCLCPP_ERROR_THROTTLE(
-    logger_, *clock_, 3000, "[Emergency stop] vel: %3.3f, acc: %3.3f", vel, acc);
+    logger_, *clock_, 3000, "[Emergency stop] vel: %3.3f, acc: %3.3f", p.vel, p.acc);
 
-  return Motion{vel, acc};
+  return Motion{p.vel, p.acc};
 }
 
 void PidLongitudinalController::updateControlState(const ControlData & control_data)
@@ -601,8 +594,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
   const bool stopping_condition = stop_dist < p.stopping_state_stop_dist;
 
-  const bool is_stopped = std::abs(current_vel) < p.stopped_state_entry_vel &&
-                          std::abs(current_acc) < p.stopped_state_entry_acc;
+  const bool is_stopped =
+    std::abs(current_vel) < p.stopped_state_entry_vel && current_acc < p.stopped_state_entry_acc;
+  RCLCPP_DEBUG_STREAM(
+    logger_, "is_stopped: " << is_stopped << ", current_vel: " << current_vel
+                            << ", current_acc: " << current_acc);
   // Case where the ego slips in the opposite direction of the gear due to e.g. a slope is also
   // considered as a stop
   const bool is_not_running = [&]() {
@@ -703,7 +699,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
       m_pid_vel.reset();
       m_lpf_vel_error->reset(0.0);
       // prevent the car from taking a long time to start to move
-      m_prev_ctrl_cmd.acc = std::max(0.0, m_prev_ctrl_cmd.acc);
+      m_prev_ctrl_cmd.acc = std::max(0.0, m_prev_raw_ctrl_cmd.acc);
       return changeState(ControlState::DRIVE);
     }
     return;
@@ -749,8 +745,6 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
       m_pid_vel.reset();
       m_lpf_vel_error->reset(0.0);
-      // prevent the car from taking a long time to start to move
-      m_prev_ctrl_cmd.acc = std::max(0.0, m_prev_ctrl_cmd.acc);
       return changeState(ControlState::DRIVE);
     }
 
@@ -782,55 +776,79 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   const size_t target_idx = control_data.target_idx;
 
   // velocity and acceleration command
-  Motion raw_ctrl_cmd{
+  Motion ctrl_cmd_as_pedal_pos{
     control_data.interpolated_traj.points.at(target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(target_idx).acceleration_mps2};
 
-  if (m_control_state == ControlState::DRIVE) {
-    raw_ctrl_cmd.vel =
-      control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps;
-    raw_ctrl_cmd.acc = applyVelocityFeedback(control_data);
-    raw_ctrl_cmd = keepBrakeBeforeStop(control_data, raw_ctrl_cmd, target_idx);
-
-    RCLCPP_DEBUG(
-      logger_,
-      "[feedback control]  vel: %3.3f, acc: %3.3f, dt: %3.3f, v_curr: %3.3f, v_ref: %3.3f "
-      "feedback_ctrl_cmd.ac: %3.3f",
-      raw_ctrl_cmd.vel, raw_ctrl_cmd.acc, control_data.dt, control_data.current_motion.vel,
-      control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
-      raw_ctrl_cmd.acc);
-  } else if (m_control_state == ControlState::STOPPING) {
-    raw_ctrl_cmd.acc = m_smooth_stop.calculate(
-      control_data.stop_dist, control_data.current_motion.vel, control_data.current_motion.acc,
-      m_vel_hist, m_delay_compensation_time);
-    raw_ctrl_cmd.vel = m_stopped_state_params.vel;
-
-    RCLCPP_DEBUG(
-      logger_, "[smooth stop]: Smooth stopping. vel: %3.3f, acc: %3.3f", raw_ctrl_cmd.vel,
-      raw_ctrl_cmd.acc);
-  } else if (m_control_state == ControlState::STOPPED) {
-    // This acceleration is without slope compensation
+  if (m_control_state == ControlState::STOPPED) {
     const auto & p = m_stopped_state_params;
-    raw_ctrl_cmd.vel = p.vel;
-    raw_ctrl_cmd.acc = longitudinal_utils::applyDiffLimitFilter(
-      p.acc, m_prev_raw_ctrl_cmd.acc, control_data.dt, p.jerk);
+    ctrl_cmd_as_pedal_pos.vel = p.vel;
+    ctrl_cmd_as_pedal_pos.acc = p.acc;  // store brake pedal position corresponding value
 
-    RCLCPP_DEBUG(logger_, "[Stopped]. vel: %3.3f, acc: %3.3f", raw_ctrl_cmd.vel, raw_ctrl_cmd.acc);
-  } else if (m_control_state == ControlState::EMERGENCY) {
-    raw_ctrl_cmd = calcEmergencyCtrlCmd(control_data.dt);
+    m_prev_raw_ctrl_cmd.vel = ctrl_cmd_as_pedal_pos.vel;
+    m_prev_raw_ctrl_cmd.acc = 0.0;  // store acceleration value
+
+    RCLCPP_DEBUG(
+      logger_, "[Stopped]. vel: %3.3f, acc: %3.3f", ctrl_cmd_as_pedal_pos.vel,
+      ctrl_cmd_as_pedal_pos.acc);
+  } else {
+    Motion raw_ctrl_cmd{
+      control_data.interpolated_traj.points.at(target_idx).longitudinal_velocity_mps,
+      control_data.interpolated_traj.points.at(target_idx).acceleration_mps2};
+    if (m_control_state == ControlState::DRIVE) {
+      raw_ctrl_cmd.vel =
+        control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps;
+      raw_ctrl_cmd.acc = applyVelocityFeedback(control_data);
+      raw_ctrl_cmd = keepBrakeBeforeStop(control_data, raw_ctrl_cmd, target_idx);
+
+      RCLCPP_DEBUG(
+        logger_,
+        "[feedback control]  vel: %3.3f, acc: %3.3f, dt: %3.3f, v_curr: %3.3f, v_ref: %3.3f "
+        "feedback_ctrl_cmd.ac: %3.3f",
+        raw_ctrl_cmd.vel, raw_ctrl_cmd.acc, control_data.dt, control_data.current_motion.vel,
+        control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
+        raw_ctrl_cmd.acc);
+    } else if (m_control_state == ControlState::STOPPING) {
+      raw_ctrl_cmd.acc = m_smooth_stop.calculate(
+        control_data.stop_dist, control_data.current_motion.vel, control_data.current_motion.acc,
+        m_vel_hist, m_delay_compensation_time);
+      raw_ctrl_cmd.vel = m_stopped_state_params.vel;
+
+      RCLCPP_DEBUG(
+        logger_, "[smooth stop]: Smooth stopping. vel: %3.3f, acc: %3.3f", raw_ctrl_cmd.vel,
+        raw_ctrl_cmd.acc);
+    } else if (m_control_state == ControlState::EMERGENCY) {
+      raw_ctrl_cmd = calcEmergencyCtrlCmd();
+    }
+
+    raw_ctrl_cmd.acc = std::clamp(raw_ctrl_cmd.acc, m_min_acc, m_max_acc);
+    raw_ctrl_cmd.acc = longitudinal_utils::applyDiffLimitFilter(
+      raw_ctrl_cmd.acc, m_prev_raw_ctrl_cmd.acc, control_data.dt, m_max_jerk, m_min_jerk);
+
+    // store acceleration without slope compensation
+    m_prev_raw_ctrl_cmd = raw_ctrl_cmd;
+
+    ctrl_cmd_as_pedal_pos.acc =
+      applySlopeCompensation(raw_ctrl_cmd.acc, control_data.slope_angle, control_data.shift);
+    ctrl_cmd_as_pedal_pos.vel = raw_ctrl_cmd.vel;
   }
 
-  // store acceleration without slope compensation
-  m_prev_raw_ctrl_cmd = raw_ctrl_cmd;
+  m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, m_prev_raw_ctrl_cmd.acc);
+  storeAccelCmd(m_prev_raw_ctrl_cmd.acc);
 
-  // apply slope compensation and filter acceleration and jerk
-  const double filtered_acc_cmd = calcFilteredAcc(raw_ctrl_cmd.acc, control_data);
-  const Motion filtered_ctrl_cmd{raw_ctrl_cmd.vel, filtered_acc_cmd};
+  m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_SLOPE_APPLIED, ctrl_cmd_as_pedal_pos.acc);
+  ctrl_cmd_as_pedal_pos.acc = longitudinal_utils::applyDiffLimitFilter(
+    ctrl_cmd_as_pedal_pos.acc, m_prev_ctrl_cmd.acc, control_data.dt, m_max_pedal_pos_diff_rate);
+  m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, ctrl_cmd_as_pedal_pos.acc);
 
   // update debug visualization
   updateDebugVelAcc(control_data);
 
-  return filtered_ctrl_cmd;
+  RCLCPP_DEBUG(
+    logger_, "[final pedal output]: acc: %3.3f, vel: %3.3f", ctrl_cmd_as_pedal_pos.acc,
+    control_data.current_motion.vel);
+
+  return ctrl_cmd_as_pedal_pos;
 }
 
 // Do not use nearest_idx here
@@ -912,28 +930,6 @@ enum PidLongitudinalController::Shift PidLongitudinalController::getCurrentShift
   }
 
   return m_prev_shift;
-}
-
-double PidLongitudinalController::calcFilteredAcc(
-  const double raw_acc, const ControlData & control_data)
-{
-  const double acc_max_filtered = std::clamp(raw_acc, m_min_acc, m_max_acc);
-  m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, acc_max_filtered);
-
-  // store ctrl cmd without slope filter
-  storeAccelCmd(acc_max_filtered);
-
-  // apply slope compensation
-  const double acc_slope_filtered =
-    applySlopeCompensation(acc_max_filtered, control_data.slope_angle, control_data.shift);
-  m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_SLOPE_APPLIED, acc_slope_filtered);
-
-  // This jerk filter must be applied after slope compensation
-  const double acc_jerk_filtered = longitudinal_utils::applyDiffLimitFilter(
-    acc_slope_filtered, m_prev_ctrl_cmd.acc, control_data.dt, m_max_jerk, m_min_jerk);
-  m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, acc_jerk_filtered);
-
-  return acc_jerk_filtered;
 }
 
 void PidLongitudinalController::storeAccelCmd(const double accel)

--- a/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
@@ -58,6 +58,7 @@
     # emergency state
     emergency_vel: 0.0
     emergency_acc: -5.0 # denotes acceleration
+    emergency_jerk: -3.0
 
     # acceleration limit
     max_acc: 3.0
@@ -66,7 +67,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
-    max_pedal_pos_diff_rate: 50.0 # [m/s^2 * s^-1]
+    max_acc_cmd_diff_rate: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95

--- a/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
@@ -53,13 +53,11 @@
 
     # stopped state
     stopped_vel: 0.0
-    stopped_acc: -3.4
-    stopped_jerk: -5.0
+    stopped_acc: -3.4 # denotes pedal position
 
     # emergency state
     emergency_vel: 0.0
-    emergency_acc: -5.0
-    emergency_jerk: -3.0
+    emergency_acc: -5.0 # denotes acceleration
 
     # acceleration limit
     max_acc: 3.0
@@ -68,6 +66,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
+    max_pedal_pos_diff_rate: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95

--- a/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
@@ -67,7 +67,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
-    max_acc_cmd_diff_rate: 50.0 # [m/s^2 * s^-1]
+    max_acc_cmd_diff: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95


### PR DESCRIPTION
## Description
This PR re-organize diff limit structure to achieve proper handling of diff limit when the state is changed.
Creep down problems on slopes will be fixed by this PR and https://github.com/autowarefoundation/autoware.universe/pull/7720.

In the new structure raw_ctrl_cmd denotes acceleration and ctrl_cmd denotes pedal position.

Before
![before ](https://github.com/user-attachments/assets/41a4b530-d3cb-4ddd-966f-37b7c8100d40)

After
![after](https://github.com/user-attachments/assets/0dee2f43-aff8-4524-a291-5cc4c942514c)


## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1052

## How was this PR tested?
psim, tier4 internal tests and vehicle tests

## Notes for reviewers

None.

## Interface changes
some of parameters are newly defined and deleted

## Effects on system behavior

None.
