### PR TITLE
refactor(yabloc_pose_initializer): apply static analysis

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp
+++ b/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp
@@ -65,9 +65,9 @@ private:
 
   void on_map(const LaneletMapBin & msg);
   void on_service(
-    const RequestPoseAlignment::Request::SharedPtr,
-    RequestPoseAlignment::Response::SharedPtr request);
-  PoseCovStamped create_rectified_initial_pose(
+    const RequestPoseAlignment::Request::SharedPtr request,
+    RequestPoseAlignment::Response::SharedPtr response);
+  static PoseCovStamped create_rectified_initial_pose(
     const Eigen::Vector3f & pos, double yaw_angle_rad, const PoseCovStamped & src_msg);
 
   std::optional<double> estimate_pose(

--- a/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/semantic_segmentation.hpp
+++ b/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/semantic_segmentation.hpp
@@ -31,13 +31,13 @@ public:
   static void print_error_message(const rclcpp::Logger & logger);
 
 private:
-  cv::Mat make_blob(const cv::Mat & image);
+  static cv::Mat make_blob(const cv::Mat & image);
 
-  cv::Mat convert_blob_to_image(const cv::Mat & blob);
+  static cv::Mat convert_blob_to_image(const cv::Mat & blob);
 
-  cv::Mat normalize(const cv::Mat & mask, double score_threshold = 0.5);
+  static cv::Mat normalize(const cv::Mat & mask, double score_threshold = 0.5);
 
-  cv::Mat draw_overlay(const cv::Mat & image, const cv::Mat & segmentation);
+  static cv::Mat draw_overlay(const cv::Mat & image, const cv::Mat & segmentation);
 
   struct Impl;
   std::shared_ptr<Impl> impl_{nullptr};

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp
@@ -27,22 +27,22 @@ namespace yabloc
 {
 namespace bg = boost::geometry;
 
-typedef bg::model::d2::point_xy<double> point_t;
-typedef bg::model::box<point_t> box_t;
-typedef bg::model::polygon<point_t> polygon_t;
+using point_t = bg::model::d2::point_xy<double>;
+using box_t = bg::model::box<point_t>;
+using polygon_t = bg::model::polygon<point_t>;
 
-LaneImage::LaneImage(lanelet::LaneletMapPtr map) : map_(map)
+LaneImage::LaneImage(lanelet::LaneletMapPtr map) : map_(std::move(map))
 {
 }
 
 cv::Point2i to_cv_point(const Eigen::Vector3f & v)
 {
-  const float image_size_ = 800;
-  const float max_range_ = 30;
+  const float image_size = 800;
+  const float max_range = 30;
 
   cv::Point pt;
-  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
-  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
+  pt.x = static_cast<int>(-v.y() / max_range * image_size * 0.5f + image_size / 2.f);
+  pt.y = static_cast<int>(-v.x() / max_range * image_size * 0.5f + image_size / 2.f);
   return pt;
 }
 
@@ -59,7 +59,8 @@ void draw_lane(cv::Mat & image, const polygon_t & polygon)
 {
   std::vector<cv::Point> contour;
   for (auto p : polygon.outer()) {
-    cv::Point2i pt = to_cv_point(Eigen::Vector3f(p.x(), p.y(), 0));
+    cv::Point2i pt = to_cv_point(
+      Eigen::Vector3f(static_cast<float>(p.x()), static_cast<float>(p.y()), 0));
     contour.push_back(pt);
   }
 
@@ -71,8 +72,9 @@ void draw_lane(cv::Mat & image, const polygon_t & polygon)
 void draw_line(cv::Mat & image, const lanelet::LineString2d & line, geometry_msgs::msg::Point xyz)
 {
   std::vector<cv::Point> contour;
-  for (auto p : line) {
-    cv::Point2i pt = to_cv_point(Eigen::Vector3f(p.x() - xyz.x, p.y() - xyz.y, 0));
+  for (const auto & p : line) {
+    cv::Point2i pt = to_cv_point(
+      Eigen::Vector3f(static_cast<float>(p.x() - xyz.x), static_cast<float>(p.y() - xyz.y), 0));
     contour.push_back(pt);
   }
   cv::polylines(image, contour, false, cv::Scalar(0, 0, 255), 2);
@@ -83,7 +85,9 @@ cv::Mat LaneImage::get_image(const Pose & pose)
   const auto xyz = pose.position;
   box_t box(point_t(-20, -20), point_t(20, 20));
 
-  cv::Mat image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3);
+  cv::Mat image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3); // NOLINT
+                                                               // suppress hicpp-signed-bitwise
+                                                               // from OpenCV
 
   std::vector<lanelet::Lanelet> joint_lanes;
   for (auto lanelet : map_->laneletLayer) {
@@ -91,7 +95,7 @@ cv::Mat LaneImage::get_image(const Pose & pose)
     for (auto right : lanelet.rightBound2d()) {
       polygon.outer().push_back(point_t(right.x() - xyz.x, right.y() - xyz.y));
     }
-    for (auto left : boost::adaptors::reverse(lanelet.leftBound2d())) {
+    for (const  auto & left : boost::adaptors::reverse(lanelet.leftBound2d())) {
       polygon.outer().push_back(point_t(left.x() - xyz.x, left.y() - xyz.y));
     }
 

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp
@@ -59,8 +59,8 @@ void draw_lane(cv::Mat & image, const polygon_t & polygon)
 {
   std::vector<cv::Point> contour;
   for (auto p : polygon.outer()) {
-    cv::Point2i pt = to_cv_point(
-      Eigen::Vector3f(static_cast<float>(p.x()), static_cast<float>(p.y()), 0));
+    cv::Point2i pt =
+      to_cv_point(Eigen::Vector3f(static_cast<float>(p.x()), static_cast<float>(p.y()), 0));
     contour.push_back(pt);
   }
 
@@ -85,9 +85,9 @@ cv::Mat LaneImage::get_image(const Pose & pose)
   const auto xyz = pose.position;
   box_t box(point_t(-20, -20), point_t(20, 20));
 
-  cv::Mat image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3); // NOLINT
-                                                               // suppress hicpp-signed-bitwise
-                                                               // from OpenCV
+  cv::Mat image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3);  // NOLINT
+                                                                // suppress hicpp-signed-bitwise
+                                                                // from OpenCV
 
   std::vector<lanelet::Lanelet> joint_lanes;
   for (auto lanelet : map_->laneletLayer) {
@@ -95,7 +95,7 @@ cv::Mat LaneImage::get_image(const Pose & pose)
     for (auto right : lanelet.rightBound2d()) {
       polygon.outer().push_back(point_t(right.x() - xyz.x, right.y() - xyz.y));
     }
-    for (const  auto & left : boost::adaptors::reverse(lanelet.leftBound2d())) {
+    for (const auto & left : boost::adaptors::reverse(lanelet.leftBound2d())) {
       polygon.outer().push_back(point_t(left.x() - xyz.x, left.y() - xyz.y));
     }
 

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp
@@ -42,9 +42,8 @@ void MarkerModule::publish_marker(
     marker.type = Marker::ARROW;
     marker.id = i;
     marker.ns = "arrow";
-    marker.color =
-      static_cast<std_msgs::msg::ColorRGBA>(common::color_scale::rainbow(
-        normalize(static_cast<int>(scores.at(i)))));
+    marker.color = static_cast<std_msgs::msg::ColorRGBA>(
+      common::color_scale::rainbow(normalize(static_cast<int>(scores.at(i)))));
     marker.color.a = 0.5;
 
     marker.pose.position.x = position.x();

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp
@@ -28,22 +28,23 @@ void MarkerModule::publish_marker(
   const std::vector<float> & scores, const std::vector<float> & angles,
   const Eigen::Vector3f & position)
 {
-  const int N = scores.size();
+  const int n = static_cast<int>(scores.size());
   auto minmax = std::minmax_element(scores.begin(), scores.end());
   auto normalize = [minmax](int score) -> float {
-    return static_cast<float>(score - *minmax.first) /
+    return static_cast<float>(static_cast<float>(score) - *minmax.first) /
            std::max(1e-4f, static_cast<float>(*minmax.second - *minmax.first));
   };
 
   MarkerArray array;
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < n; i++) {
     Marker marker;
     marker.header.frame_id = "map";
     marker.type = Marker::ARROW;
     marker.id = i;
     marker.ns = "arrow";
     marker.color =
-      static_cast<std_msgs::msg::ColorRGBA>(common::color_scale::rainbow(normalize(scores.at(i))));
+      static_cast<std_msgs::msg::ColorRGBA>(common::color_scale::rainbow(
+        normalize(static_cast<int>(scores.at(i)))));
     marker.color.a = 0.5;
 
     marker.pose.position.x = position.x();

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp
@@ -27,12 +27,12 @@ ProjectorModule::ProjectorModule(rclcpp::Node * node)
 
 cv::Point2i to_cv_point(const Eigen::Vector3f & v)
 {
-  const float image_size_ = 800;
-  const float max_range_ = 30;
+  const float image_size = 800;
+  const float max_range = 30;
 
   cv::Point pt;
-  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
-  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
+  pt.x = static_cast<int>(-v.y() / max_range * image_size * 0.5f + image_size / 2.f);
+  pt.y = static_cast<int>(-v.x() / max_range * image_size * 0.5f + image_size / 2.f);
   return pt;
 }
 
@@ -44,7 +44,9 @@ cv::Mat ProjectorModule::project_image(const cv::Mat & mask_image)
   std::vector<cv::Scalar> colors = {
     cv::Scalar(255, 0, 0), cv::Scalar(0, 255, 0), cv::Scalar(0, 0, 255)};
 
-  cv::Mat projected_image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3);
+  cv::Mat projected_image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3); // NOLINT
+                                                                  // suppress hicpp-signed-bitwise
+                                                                  // from OpenCV
   for (int i = 0; i < 3; i++) {
     std::vector<std::vector<cv::Point> > contours;
     cv::findContours(masks[i], contours, cv::RETR_LIST, cv::CHAIN_APPROX_NONE);
@@ -90,7 +92,7 @@ bool ProjectorModule::define_project_func()
 
   // TODO(KYabuuchi) This will take into account ground tilt and camera vibration someday.
   project_func_ = [intrinsic_inv, q, t](const cv::Point & u) -> std::optional<Eigen::Vector3f> {
-    Eigen::Vector3f u3(u.x, u.y, 1);
+    Eigen::Vector3f u3(static_cast<float>(u.x), static_cast<float>(u.y), 1);
     Eigen::Vector3f u_bearing = (q * intrinsic_inv * u3).normalized();
     if (u_bearing.z() > -0.01) return std::nullopt;
     float u_distance = -t.z() / u_bearing.z();

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp
@@ -44,9 +44,10 @@ cv::Mat ProjectorModule::project_image(const cv::Mat & mask_image)
   std::vector<cv::Scalar> colors = {
     cv::Scalar(255, 0, 0), cv::Scalar(0, 255, 0), cv::Scalar(0, 0, 255)};
 
-  cv::Mat projected_image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3); // NOLINT
-                                                                  // suppress hicpp-signed-bitwise
-                                                                  // from OpenCV
+  cv::Mat projected_image =
+    cv::Mat::zeros(cv::Size(800, 800), CV_8UC3);  // NOLINT
+                                                  // suppress hicpp-signed-bitwise
+                                                  // from OpenCV
   for (int i = 0; i < 3; i++) {
     std::vector<std::vector<cv::Point> > contours;
     cv::findContours(masks[i], contours, cv::RETR_LIST, cv::CHAIN_APPROX_NONE);

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
@@ -53,7 +53,8 @@ cv::Mat SemanticSegmentation::convert_blob_to_image(const cv::Mat & blob)
   const int channels = blob.size[1];
   const int height = blob.size[2];
   const int width = blob.size[3];
-  cv::Mat image = cv::Mat(height, width, CV_32FC4);
+  cv::Mat image = cv::Mat(height, width, CV_32FC4); // NOLINT
+                                                    // suppress hicpp-signed-bitwise from OpenCV
 
   for (int h = 0; h < height; ++h) {
     for (int w = 0; w < width; ++w) {
@@ -92,7 +93,8 @@ cv::Mat SemanticSegmentation::normalize(const cv::Mat & mask, double score_thres
   for (size_t i = 1; i < masks.size(); ++i) {
     cv::Mat bin_mask;
     cv::threshold(masks[i], bin_mask, score_threshold, 255, cv::THRESH_BINARY_INV);
-    bin_mask.convertTo(bin_mask, CV_8UC1);
+    bin_mask.convertTo(bin_mask, CV_8UC1); // NOLINT
+                                           // suppress hicpp-signed-bitwise from OpenCV
     bin_masks.push_back(255 - bin_mask);
   }
 
@@ -109,11 +111,11 @@ cv::Mat SemanticSegmentation::draw_overlay(const cv::Mat & image, const cv::Mat 
 
 void SemanticSegmentation::print_error_message(const rclcpp::Logger & logger)
 {
-  const std::string ERROR_MESSAGE =
+  const std::string error_message =
     R"(The yabloc_pose_initializer is not working correctly because the DNN model has not been downloaded correctly.
 Please check the README of yabloc_pose_initializer to know how download models.)";
 
-  std::istringstream stream(ERROR_MESSAGE);
+  std::istringstream stream(error_message);
   std::string line;
   while (std::getline(stream, line)) {
     RCLCPP_ERROR_STREAM(logger, line);

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
@@ -53,8 +53,8 @@ cv::Mat SemanticSegmentation::convert_blob_to_image(const cv::Mat & blob)
   const int channels = blob.size[1];
   const int height = blob.size[2];
   const int width = blob.size[3];
-  cv::Mat image = cv::Mat(height, width, CV_32FC4); // NOLINT
-                                                    // suppress hicpp-signed-bitwise from OpenCV
+  cv::Mat image = cv::Mat(height, width, CV_32FC4);  // NOLINT
+                                                     // suppress hicpp-signed-bitwise from OpenCV
 
   for (int h = 0; h < height; ++h) {
     for (int w = 0; w < width; ++w) {
@@ -93,8 +93,8 @@ cv::Mat SemanticSegmentation::normalize(const cv::Mat & mask, double score_thres
   for (size_t i = 1; i < masks.size(); ++i) {
     cv::Mat bin_mask;
     cv::threshold(masks[i], bin_mask, score_threshold, 255, cv::THRESH_BINARY_INV);
-    bin_mask.convertTo(bin_mask, CV_8UC1); // NOLINT
-                                           // suppress hicpp-signed-bitwise from OpenCV
+    bin_mask.convertTo(bin_mask, CV_8UC1);  // NOLINT
+                                            // suppress hicpp-signed-bitwise from OpenCV
     bin_masks.push_back(255 - bin_mask);
   }
 


### PR DESCRIPTION
## Description
This PR applies some suggestions from the linter to `localization/yabloc/yabloc_pose_initializer`.
Checked with clang-tidy and cppcheck.

Fixed:
- use explicit cast
- change variable names
  - camelCase to snake_case for variable
  - remove `_` from non-private variable
  - align variable name in header's definition and the implementation
  - LOCAL_VAR to local_var
- add or removed keyword from function/method which linter suggested


not Fixed:
- [hicpp-signed-bitwise](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp-signed-bitwise.html)
  - this occurs from bit shift operation in OpenCV, so currently it is marked as `NOLINT`
- C11 extension error [clang-diagnostic-c11-extensions]
  - like `error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions] CV_XADD(&this->hdr->refcount, 1);`
  - possibly suppressible with `-checks=-clang-diagnostic-c11-extensions` (didn't work with the following script)

We might need to change the clang-tidy's configuration to suppress this errors which occurs from OpenCV header.
- on going investigation: https://github.com/orgs/autowarefoundation/discussions/4876#discussioncomment-9900497
 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>output from above commands</summary>

```Text
$ ./check_linter.sh yabloc_pose_initializer
...
8182 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/semantic_segmentation.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 8182 warnings (8182 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
14785 warnings and 5 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:38:31: warning: method 'make_blob' can be made static [readability-convert-member-functions-to-static]
cv::Mat SemanticSegmentation::make_blob(const cv::Mat & image)
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:48:31: warning: method 'convert_blob_to_image' can be made static [readability-convert-member-functions-to-static]
cv::Mat SemanticSegmentation::convert_blob_to_image(const cv::Mat & blob)
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:56:42: warning: use of a signed integer operand with a binary bitwise operator [hicpp-signed-bitwise]
  cv::Mat image = cv::Mat(height, width, CV_32FC4);
                                         ^
/usr/include/opencv4/opencv2/core/hal/interface.h:121:18: note: expanded from macro 'CV_32FC4'
#define CV_32FC4 CV_MAKETYPE(CV_32F,4)
                 ^~~~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:85:32: note: expanded from macro 'CV_MAKETYPE'
#define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
                               ^~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:83:34: note: expanded from macro 'CV_MAT_DEPTH'
#define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
                                 ^~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:86:31: warning: method 'normalize' can be made static [readability-convert-member-functions-to-static]
cv::Mat SemanticSegmentation::normalize(const cv::Mat & mask, double score_threshold)
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:95:34: warning: use of a signed integer operand with a binary bitwise operator [hicpp-signed-bitwise]
    bin_mask.convertTo(bin_mask, CV_8UC1);
                                 ^
/usr/include/opencv4/opencv2/core/hal/interface.h:88:17: note: expanded from macro 'CV_8UC1'
#define CV_8UC1 CV_MAKETYPE(CV_8U,1)
                ^~~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:85:32: note: expanded from macro 'CV_MAKETYPE'
#define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
                               ^~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:83:34: note: expanded from macro 'CV_MAT_DEPTH'
#define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
                                 ^~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:104:31: warning: method 'draw_overlay' can be made static [readability-convert-member-functions-to-static]
cv::Mat SemanticSegmentation::draw_overlay(const cv::Mat & image, const cv::Mat & segmentation)
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp:112:21: warning: invalid case style for variable 'ERROR_MESSAGE' [readability-identifier-naming]
  const std::string ERROR_MESSAGE =
                    ^~~~~~~~~~~~~
                    error_message
/usr/include/opencv4/opencv2/core/cuda.inl.hpp:105:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/cuda.inl.hpp:487:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/flann/index_testing.h:249:11: error: variable 'p1' set but not used [clang-diagnostic-unused-but-set-variable]
    float p1;
          ^
Suppressed 14774 warnings (14774 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
29292 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/lane_image.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 29341 warnings (29292 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
18078 warnings generated.
Suppressed 18091 warnings (18078 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21149 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp:31:13: warning: invalid case style for variable 'N' [readability-identifier-naming]
  const int N = scores.size();
            ^
            n
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp:31:17: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  const int N = scores.size();
                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp:34:31: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
    return static_cast<float>(score - *minmax.first) /
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/marker_module.cpp:46:84: warning: narrowing conversion from '__gnu_cxx::__alloc_traits<std::allocator<float>, float>::value_type' (aka 'float') to 'int' [cppcoreguidelines-narrowing-conversions]
      static_cast<std_msgs::msg::ColorRGBA>(common::color_scale::rainbow(normalize(scores.at(i))));
                                                                                   ^
Suppressed 21158 warnings (21145 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
44605 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:30:1: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
typedef bg::model::d2::point_xy<double> point_t;
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
using point_t = bg::model::d2::point_xy<double>
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:31:1: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
typedef bg::model::box<point_t> box_t;
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
using box_t = bg::model::box<point_t>
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:32:1: error: use 'using' instead of 'typedef' [modernize-use-using,-warnings-as-errors]
typedef bg::model::polygon<point_t> polygon_t;
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
using polygon_t = bg::model::polygon<point_t>
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:34:22: warning: pass by value and use std::move [modernize-pass-by-value]
LaneImage::LaneImage(lanelet::LaneletMapPtr map) : map_(map)
                     ^
                                                        std::move( )
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:40:15: warning: invalid case style for variable 'image_size_' [readability-identifier-naming]
  const float image_size_ = 800;
              ^~~~~~~~~~~
              image_size
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:41:15: warning: invalid case style for variable 'max_range_' [readability-identifier-naming]
  const float max_range_ = 30;
              ^~~~~~~~~~
              max_range
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:44:10: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:45:10: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:62:50: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    cv::Point2i pt = to_cv_point(Eigen::Vector3f(p.x(), p.y(), 0));
                                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:62:57: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    cv::Point2i pt = to_cv_point(Eigen::Vector3f(p.x(), p.y(), 0));
                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:74:13: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
  for (auto p : line) {
            ^
       const  &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:75:50: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    cv::Point2i pt = to_cv_point(Eigen::Vector3f(p.x() - xyz.x, p.y() - xyz.y, 0));
                                                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:75:65: warning: narrowing conversion from 'double' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    cv::Point2i pt = to_cv_point(Eigen::Vector3f(p.x() - xyz.x, p.y() - xyz.y, 0));
                                                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:86:54: warning: use of a signed integer operand with a binary bitwise operator [hicpp-signed-bitwise]
  cv::Mat image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3);
                                                     ^
/usr/include/opencv4/opencv2/core/hal/interface.h:90:17: note: expanded from macro 'CV_8UC3'
#define CV_8UC3 CV_MAKETYPE(CV_8U,3)
                ^~~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:85:32: note: expanded from macro 'CV_MAKETYPE'
#define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
                               ^~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:83:34: note: expanded from macro 'CV_MAT_DEPTH'
#define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
                                 ^~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp:94:15: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
    for (auto left : boost::adaptors::reverse(lanelet.leftBound2d())) {
              ^
         const  &
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 44637 warnings (44588 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
3 warnings treated as errors
23928 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/projector_module.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 23941 warnings (23928 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
31949 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:30:15: warning: invalid case style for variable 'image_size_' [readability-identifier-naming]
  const float image_size_ = 800;
              ^~~~~~~~~~~
              image_size
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:31:15: warning: invalid case style for variable 'max_range_' [readability-identifier-naming]
  const float max_range_ = 30;
              ^~~~~~~~~~
              max_range
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:34:10: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  pt.x = -v.y() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:35:10: warning: narrowing conversion from 'float' to 'int' [cppcoreguidelines-narrowing-conversions]
  pt.y = -v.x() / max_range_ * image_size_ * 0.5f + image_size_ / 2.f;
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:47:64: warning: use of a signed integer operand with a binary bitwise operator [hicpp-signed-bitwise]
  cv::Mat projected_image = cv::Mat::zeros(cv::Size(800, 800), CV_8UC3);
                                                               ^
/usr/include/opencv4/opencv2/core/hal/interface.h:90:17: note: expanded from macro 'CV_8UC3'
#define CV_8UC3 CV_MAKETYPE(CV_8U,3)
                ^~~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:85:32: note: expanded from macro 'CV_MAKETYPE'
#define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
                               ^~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:83:34: note: expanded from macro 'CV_MAT_DEPTH'
#define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
                                 ^~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:93:24: warning: narrowing conversion from 'int' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    Eigen::Vector3f u3(u.x, u.y, 1);
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp:93:29: warning: narrowing conversion from 'int' to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    Eigen::Vector3f u3(u.x, u.y, 1);
                            ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 31953 warnings (31940 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
38390 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 38450 warnings (38390 in non-user code, 60 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
45502 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp:67:8: warning: function 'yabloc::CameraPoseInitializer::on_service' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]
  void on_service(
       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:184:29: note: the definition seen here
void CameraPoseInitializer::on_service(
                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp:67:8: note: differing parameters are named here: ('request'), in definition: ('response')
  void on_service(
       ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:35:21: warning: narrowing conversion from 'long' to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  angle_resolution_(declare_parameter<int>("angle_resolution"))
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:65:39: warning: the const qualified parameter 'src1' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
cv::Mat bitwise_and_3ch(const cv::Mat src1, const cv::Mat src2)
                                      ^
                                     &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:65:59: warning: the const qualified parameter 'src2' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
cv::Mat bitwise_and_3ch(const cv::Mat src1, const cv::Mat src2)
                                                          ^
                                                         &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:82:28: warning: the parameter 'image_3ch' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
int count_non_zero(cv::Mat image_3ch)
                           ^
                   const  &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:156:14: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      gain = 2 + std::cos((lane_angle_rad.value() - angle_rad) / 2.0);
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:159:32: warning: narrowing conversion from 'int' to 'float' [cppcoreguidelines-narrowing-conversions]
    const float score = gain * (1 + count_non_zero(dst));
                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:162:26: warning: narrowing conversion from 'double' to 'std::vector<float>::value_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    angles_rad.push_back(angle_rad);
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:179:13: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
  for (auto l : lanelet_map->laneletLayer) {
            ^
       const  &
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:194:35: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  const Eigen::Vector3f pos_vec3f(query_pos.x, query_pos.y, query_pos.z);
                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:194:48: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  const Eigen::Vector3f pos_vec3f(query_pos.x, query_pos.y, query_pos.z);
                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:194:61: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'Eigen::Matrix<float, 3, 1, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  const Eigen::Vector3f pos_vec3f(query_pos.x, query_pos.y, query_pos.z);
                                                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp:209:62: warning: method 'create_rectified_initial_pose' can be made static [readability-convert-member-functions-to-static]
CameraPoseInitializer::PoseCovStamped CameraPoseInitializer::create_rectified_initial_pose(
                                                             ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 45688 warnings (45489 in non-user code, 199 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
```
</details>

Check with cppcheck : (nothing to be changed)

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh yabloc_pose_initializer
...
8182 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/semantic_segmentation.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 8182 warnings (8182 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
14774 warnings and 5 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp.
/usr/include/opencv4/opencv2/core/cuda.inl.hpp:105:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/cuda.inl.hpp:487:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/flann/index_testing.h:249:11: error: variable 'p1' set but not used [clang-diagnostic-unused-but-set-variable]
    float p1;
          ^
Suppressed 14780 warnings (14774 in non-user code, 6 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
29292 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/lane_image.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 29341 warnings (29292 in non-user code, 49 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
18078 warnings generated.
Suppressed 18091 warnings (18078 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
21145 warnings generated.
Suppressed 21158 warnings (21145 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
44588 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/lane_image.cpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 44640 warnings (44588 in non-user code, 52 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
23928 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/projector_module.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 23941 warnings (23928 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
31940 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/projector_module.cpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 31956 warnings (31940 in non-user code, 16 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
38390 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 38450 warnings (38390 in non-user code, 60 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
45489 warnings and 2 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp.
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
Suppressed 45688 warnings (45489 in non-user code, 199 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).

```
</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
