### PR TITLE
refactor(vehicle_cmd_gate)!: delete rate limit skipping function for vehicle departure

### DIFF
--- a/control/autoware_vehicle_cmd_gate/README.md
+++ b/control/autoware_vehicle_cmd_gate/README.md
@@ -78,6 +78,10 @@ The limitation values are calculated based on the 1D interpolation of the limita
 
 Notation: this filter is not designed to enhance ride comfort. Its main purpose is to detect and remove abnormal values in the control outputs during the final stages of Autoware. If this filter is frequently active, it implies the control module may need tuning. If you're aiming to smoothen the signal via a low-pass filter or similar techniques, that should be handled in the control module. When the filter is activated, the topic `~/is_filter_activated` is published.
 
+Notation 2: If you use vehicles in which the driving force is controlled by the accelerator/brake pedal, the jerk limit, denoting the pedal rate limit, must be sufficiently relaxed at low speeds.
+Otherwise, quick pedal changes at start/stop will not be possible, resulting in slow starts and creep down on hills.
+This functionality for starting/stopping was embedded in the source code but was removed because it was complex and could be achieved by parameters.
+
 ## Assumptions / Known limits
 
 The parameter `check_external_emergency_heartbeat` (true by default) enables an emergency stop request from external modules.

--- a/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
+++ b/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
@@ -16,14 +16,14 @@
     stop_check_duration: 1.0
     nominal:
       vel_lim: 25.0
-      reference_speed_points: [20.0, 30.0]
-      steer_lim: [1.0, 0.8]
-      steer_rate_lim: [1.0, 0.8]
-      lon_acc_lim: [5.0, 4.0]
-      lon_jerk_lim: [5.0, 4.0]
-      lat_acc_lim: [5.0, 4.0]
-      lat_jerk_lim: [7.0, 6.0]
-      actual_steer_diff_lim: [1.0, 0.8]
+      reference_speed_points: [0.1, 0.3, 20.0, 30.0]
+      steer_lim: [1.0, 1.0, 1.0, 0.8]
+      steer_rate_lim: [1.0, 1.0, 1.0, 0.8]
+      lon_acc_lim: [5.0, 5.0, 5.0, 4.0]
+      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting on a slope.
+      lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
+      lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
+      actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]
     on_transition:
       vel_lim: 50.0
       reference_speed_points: [20.0, 30.0]

--- a/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
+++ b/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
@@ -20,7 +20,7 @@
       steer_lim: [1.0, 1.0, 1.0, 0.8]
       steer_rate_lim: [1.0, 1.0, 1.0, 0.8]
       lon_acc_lim: [5.0, 5.0, 5.0, 4.0]
-      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting on a slope.
+      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting.
       lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
       lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
       actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -606,6 +606,7 @@ Control VehicleCmdGate::filterControlCommand(const Control & in)
   const double dt = getDt();
   const auto mode = current_operation_mode_;
   const auto current_status_cmd = getActualStatusAsCommand();
+  const auto ego_is_stopped = vehicle_stop_checker_->isVehicleStopped(stop_check_duration_);
 
   filter_.setCurrentSpeed(current_kinematics_.twist.twist.linear.x);
   filter_on_transition_.setCurrentSpeed(current_kinematics_.twist.twist.linear.x);

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -618,23 +618,6 @@ Control VehicleCmdGate::filterControlCommand(const Control & in)
   if (mode.is_in_transition) {
     filter_on_transition_.filterAll(dt, current_steer_, out, is_filter_activated);
   } else {
-    // When ego is stopped and the input command is not stopping,
-    // use the higher of actual vehicle longitudinal state
-    // and previous longitudinal command for the filtering
-    // this is to prevent the jerk limits being applied and causing
-    // a delay when restarting the vehicle.
-
-    if (ego_is_stopped && !input_cmd_is_stopping) {
-      auto prev_cmd = filter_.getPrevCmd();
-      prev_cmd.longitudinal.acceleration =
-        std::max(prev_cmd.longitudinal.acceleration, current_status_cmd.longitudinal.acceleration);
-      // consider reverse driving
-      prev_cmd.longitudinal.velocity = std::fabs(prev_cmd.longitudinal.velocity) >
-                                           std::fabs(current_status_cmd.longitudinal.velocity)
-                                         ? prev_cmd.longitudinal.velocity
-                                         : current_status_cmd.longitudinal.velocity;
-      filter_.setPrevCmd(prev_cmd);
-    }
     filter_.filterAll(dt, current_steer_, out, is_filter_activated);
   }
 

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -606,8 +606,6 @@ Control VehicleCmdGate::filterControlCommand(const Control & in)
   const double dt = getDt();
   const auto mode = current_operation_mode_;
   const auto current_status_cmd = getActualStatusAsCommand();
-  const auto ego_is_stopped = vehicle_stop_checker_->isVehicleStopped(stop_check_duration_);
-  const auto input_cmd_is_stopping = in.longitudinal.acceleration < 0.0;
 
   filter_.setCurrentSpeed(current_kinematics_.twist.twist.linear.x);
   filter_on_transition_.setCurrentSpeed(current_kinematics_.twist.twist.linear.x);


### PR DESCRIPTION
## Description
This PR delete rate limit skipping function which is activated when the vehicle departure.
More appropriate feature, including stopping, can be achieved by the parameter settings.

## Related links
https://github.com/autowarefoundation/autoware_launch/pull/1077

## How was this PR tested?
I have tested this change by two type of real vehicles.

## Notes for reviewers

None.

## Effects on system behavior

None.
