### PR TITLE
ci: run on gpu

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-test-daily:
-    runs-on: [self-hosted, linux, X64]
+    runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false
@@ -19,8 +19,15 @@ jobs:
           - -cuda
         include:
           - rosdistro: humble
+            container-suffix: ""
             container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
             build-depends-repos: build_depends.repos
+            runs-on: [self-hosted, linux, X64]
+          - rosdistro: humble
+            container-suffix: -cuda
+            container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
+            build-depends-repos: build_depends.repos
+            runs-on: [self-hosted, linux, X64, gpu]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,8 +12,10 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, linux, X64]
-    container: ${{ matrix.container }}${{ matrix.container-suffix }}
+    runs-on: [self-hosted, linux, X64, gpu]
+    container:
+      image: ${{ matrix.container }}${{ matrix.container-suffix }}
+      options: --gpus all
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

This is a test PR to see if gpu dependent cuda tests will pass on a machine with an nvidia gpu.

## Related links

**Parent Issues:**

- https://github.com/autowarefoundation/autoware.universe/issues/7668
- https://github.com/autowarefoundation/autoware.universe/issues/7724

## How was this PR tested?

It has passed:
- https://github.com/autowarefoundation/autoware.universe/actions/runs/9693666201/job/26749627081

## Notes for reviewers

This is not meant to be merged.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
