### PR TITLE
refactor(cluster_merger)!: fix namespace and directory structure

### DIFF
--- a/perception/cluster_merger/CMakeLists.txt
+++ b/perception/cluster_merger/CMakeLists.txt
@@ -6,12 +6,12 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 # Targets
-ament_auto_add_library(cluster_merger_node_component SHARED
-  src/cluster_merger/node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/cluster_merger_node.cpp
 )
 
-rclcpp_components_register_node(cluster_merger_node_component
-  PLUGIN "cluster_merger::ClusterMergerNode"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::cluster_merger::ClusterMergerNode"
   EXECUTABLE cluster_merger_node)
 
 

--- a/perception/cluster_merger/src/cluster_merger_node.cpp
+++ b/perception/cluster_merger/src/cluster_merger_node.cpp
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cluster_merger/node.hpp"
+#include "cluster_merger_node.hpp"
 
 #include "object_recognition_utils/object_recognition_utils.hpp"
 
 #include <memory>
 #include <string>
 #include <vector>
-namespace cluster_merger
+
+namespace autoware::cluster_merger
 {
 
 ClusterMergerNode::ClusterMergerNode(const rclcpp::NodeOptions & node_options)
@@ -67,7 +68,7 @@ void ClusterMergerNode::objectsCallback(
     transformed_objects1.feature_objects.end());
   pub_objects_->publish(output_objects);
 }
-}  // namespace cluster_merger
+}  // namespace autoware::cluster_merger
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(cluster_merger::ClusterMergerNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::cluster_merger::ClusterMergerNode)

--- a/perception/cluster_merger/src/cluster_merger_node.hpp
+++ b/perception/cluster_merger/src/cluster_merger_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef CLUSTER_MERGER__NODE_HPP_
-#define CLUSTER_MERGER__NODE_HPP_
+#ifndef CLUSTER_MERGER_NODE_HPP_
+#define CLUSTER_MERGER_NODE_HPP_
 
 #include "autoware/universe_utils/ros/transform_listener.hpp"
 #include "message_filters/subscriber.h"
@@ -31,7 +31,7 @@
 #include <string>
 #include <vector>
 
-namespace cluster_merger
+namespace autoware::cluster_merger
 {
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using tier4_perception_msgs::msg::DetectedObjectWithFeature;
@@ -68,6 +68,6 @@ private:
   rclcpp::Publisher<DetectedObjectsWithFeature>::SharedPtr pub_objects_;
 };
 
-}  // namespace cluster_merger
+}  // namespace autoware::cluster_merger
 
-#endif  // CLUSTER_MERGER__NODE_HPP_
+#endif  // CLUSTER_MERGER_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
In a local recompute environment, TIER IV Cloud enviornment.
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/dccc10d6-26a4-5389-9712-b821f000bdb1?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
