### PR TITLE
refactor(detected_object_feature_remover)!: fix namespace and directory structure

### DIFF
--- a/perception/detected_object_feature_remover/CMakeLists.txt
+++ b/perception/detected_object_feature_remover/CMakeLists.txt
@@ -4,13 +4,13 @@ project(detected_object_feature_remover)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-ament_auto_add_library(detected_object_feature_remover_node SHARED
-  src/detected_object_feature_remover.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/detected_object_feature_remover_node.cpp
 )
 
-rclcpp_components_register_node(detected_object_feature_remover_node
-  PLUGIN "detected_object_feature_remover::DetectedObjectFeatureRemover"
-  EXECUTABLE detected_object_feature_remover
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::detected_object_feature_remover::DetectedObjectFeatureRemover"
+  EXECUTABLE detected_object_feature_remover_node
 )
 
 ament_auto_package(

--- a/perception/detected_object_feature_remover/launch/detected_object_feature_remover.launch.xml
+++ b/perception/detected_object_feature_remover/launch/detected_object_feature_remover.launch.xml
@@ -3,7 +3,7 @@
   <arg name="output"/>
   <arg name="node_name" default="detected_object_feature_remover"/>
 
-  <node pkg="detected_object_feature_remover" exec="detected_object_feature_remover" name="$(var node_name)" output="screen">
+  <node pkg="detected_object_feature_remover" exec="detected_object_feature_remover_node" name="$(var node_name)" output="screen">
     <remap from="~/input" to="$(var input)"/>
     <remap from="~/output" to="$(var output)"/>
   </node>

--- a/perception/detected_object_feature_remover/src/detected_object_feature_remover_node.cpp
+++ b/perception/detected_object_feature_remover/src/detected_object_feature_remover_node.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <detected_object_feature_remover/detected_object_feature_remover.hpp>
+#include "detected_object_feature_remover_node.hpp"
 
-namespace detected_object_feature_remover
+namespace autoware::detected_object_feature_remover
 {
 DetectedObjectFeatureRemover::DetectedObjectFeatureRemover(const rclcpp::NodeOptions & node_options)
 : Node("detected_object_feature_remover", node_options)
@@ -45,7 +45,8 @@ void DetectedObjectFeatureRemover::convert(
   }
 }
 
-}  // namespace detected_object_feature_remover
+}  // namespace autoware::detected_object_feature_remover
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(detected_object_feature_remover::DetectedObjectFeatureRemover)
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::detected_object_feature_remover::DetectedObjectFeatureRemover)

--- a/perception/detected_object_feature_remover/src/detected_object_feature_remover_node.hpp
+++ b/perception/detected_object_feature_remover/src/detected_object_feature_remover_node.hpp
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DETECTED_OBJECT_FEATURE_REMOVER__DETECTED_OBJECT_FEATURE_REMOVER_HPP_
-#define DETECTED_OBJECT_FEATURE_REMOVER__DETECTED_OBJECT_FEATURE_REMOVER_HPP_
+#ifndef DETECTED_OBJECT_FEATURE_REMOVER_NODE_HPP_
+#define DETECTED_OBJECT_FEATURE_REMOVER_NODE_HPP_
 
-#include <autoware/universe_utils/ros/published_time_publisher.hpp>
+#include "autoware/universe_utils/ros/published_time_publisher.hpp"
+
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/msg/detected_objects.hpp>
-#include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
+#include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
 
 #include <memory>
 
-namespace detected_object_feature_remover
+namespace autoware::detected_object_feature_remover
 {
 using autoware_perception_msgs::msg::DetectedObjects;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
@@ -41,6 +42,6 @@ private:
   void convert(const DetectedObjectsWithFeature & objs_with_feature, DetectedObjects & objs);
 };
 
-}  // namespace detected_object_feature_remover
+}  // namespace autoware::detected_object_feature_remover
 
-#endif  // DETECTED_OBJECT_FEATURE_REMOVER__DETECTED_OBJECT_FEATURE_REMOVER_HPP_
+#endif  // DETECTED_OBJECT_FEATURE_REMOVER_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/dccc10d6-26a4-5389-9712-b821f000bdb1?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
