### PR TITLE
fix(autonomous_emergency_braking): aeb strange mpc polygon

### DIFF
--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -588,11 +588,11 @@ std::optional<Path> AEB::generateEgoPath(const Trajectory & predicted_traj)
 
   // create path
   Path path;
-  path.resize(predicted_traj.points.size());
+  path.reserve(predicted_traj.points.size());
   for (size_t i = 0; i < predicted_traj.points.size(); ++i) {
     geometry_msgs::msg::Pose map_pose;
     tf2::doTransform(predicted_traj.points.at(i).pose, map_pose, transform_stamped);
-    path.at(i) = map_pose;
+    path.push_back(map_pose);
 
     if (i * mpc_prediction_time_interval_ > mpc_prediction_time_horizon_) {
       break;


### PR DESCRIPTION
## Description
Due to the use of resize() the path vector generates a vector full of path points with position x:0 y:0 z:0 . This causes the AEB module to generate a wrong polygon path (because the last path poses are located at the base link). 

This PR fixes the issue by doing reserve() instead, which seems like the original intention of the original commit. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Before: 
![cap- 2024-06-28-13-52-30](https://github.com/autowarefoundation/autoware.universe/assets/25967964/4d81ccde-02ed-430f-9392-342c3dc43f4d)
The polygon is disjointed and an NPC is wrongly detected as an obstacle.

After: 
![cap- 2024-06-28-13-50-29](https://github.com/autowarefoundation/autoware.universe/assets/25967964/561324bc-b508-4880-9561-3586b9bd5224)
The polygons are correct and no collision is detected!

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
