### PR TITLE
refactor(detection_by_tracker)!: fix namespace and directory structure

### DIFF
--- a/perception/detection_by_tracker/CMakeLists.txt
+++ b/perception/detection_by_tracker/CMakeLists.txt
@@ -26,22 +26,22 @@ include_directories(
 
 # Generate exe file
 set(DETECTION_BY_TRACKER_SRC
-  src/detection_by_tracker_core.cpp
-  src/utils.cpp
+  src/detection_by_tracker_node.cpp
+  src/utils/utils.cpp
 )
 
-ament_auto_add_library(detection_by_tracker_node SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   ${DETECTION_BY_TRACKER_SRC}
 )
 
-target_link_libraries(detection_by_tracker_node
+target_link_libraries(${PROJECT_NAME}
   Eigen3::Eigen
   ${PCL_LIBRARIES}
 )
 
-rclcpp_components_register_node(detection_by_tracker_node
-  PLUGIN "DetectionByTracker"
-  EXECUTABLE detection_by_tracker
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::detection_by_tracker::DetectionByTracker"
+  EXECUTABLE detection_by_tracker_node
 )
 
 ament_auto_package(

--- a/perception/detection_by_tracker/launch/detection_by_tracker.launch.xml
+++ b/perception/detection_by_tracker/launch/detection_by_tracker.launch.xml
@@ -4,7 +4,7 @@
   <arg name="input/initial_objects" default="/perception/object_recognition/detection/clustering/objects_with_feature"/>
   <arg name="output" default="objects"/>
   <arg name="detection_by_tracker_param_path" default="$(find-pkg-share detection_by_tracker)/config/detection_by_tracker.param.yaml"/>
-  <node pkg="detection_by_tracker" exec="detection_by_tracker" name="detection_by_tracker_node" output="screen">
+  <node pkg="detection_by_tracker" exec="detection_by_tracker_node" name="detection_by_tracker_node" output="screen">
     <remap from="~/input/tracked_objects" to="$(var input/tracked_objects)"/>
     <remap from="~/input/initial_objects" to="$(var input/initial_objects)"/>
     <remap from="~/output" to="$(var output)"/>

--- a/perception/detection_by_tracker/package.xml
+++ b/perception/detection_by_tracker/package.xml
@@ -16,9 +16,7 @@
   <depend>autoware_universe_utils</depend>
   <depend>eigen</depend>
   <depend>euclidean_cluster</depend>
-  <depend>libpcl-all-dev</depend>
   <depend>object_recognition_utils</depend>
-  <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>shape_estimation</depend>

--- a/perception/detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/detection_by_tracker/src/debugger/debugger.hpp
@@ -12,22 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DETECTION_BY_TRACKER__DEBUGGER_HPP_
-#define DETECTION_BY_TRACKER__DEBUGGER_HPP_
+#ifndef DEBUGGER__DEBUGGER_HPP_
+#define DEBUGGER__DEBUGGER_HPP_
 
-#include <autoware/universe_utils/ros/debug_publisher.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
-#include <euclidean_cluster/euclidean_cluster.hpp>
-#include <euclidean_cluster/utils.hpp>
-#include <euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp>
+#include "autoware/universe_utils/ros/debug_publisher.hpp"
+#include "autoware/universe_utils/system/stop_watch.hpp"
+#include "euclidean_cluster/euclidean_cluster.hpp"
+#include "euclidean_cluster/utils.hpp"
+#include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "shape_estimation/shape_estimator.hpp"
+
 #include <rclcpp/rclcpp.hpp>
-#include <shape_estimation/shape_estimator.hpp>
 
-#include <autoware_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_perception_msgs/msg/tracked_objects.hpp>
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/tracked_objects.hpp"
+#include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
@@ -46,6 +47,8 @@
 #include <memory>
 #include <vector>
 
+namespace autoware::detection_by_tracker
+{
 class Debugger
 {
 public:
@@ -117,5 +120,6 @@ private:
     return objects;
   }
 };
+}  // namespace autoware::detection_by_tracker
 
-#endif  // DETECTION_BY_TRACKER__DEBUGGER_HPP_
+#endif  // DEBUGGER__DEBUGGER_HPP_

--- a/perception/detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "detection_by_tracker/detection_by_tracker_core.hpp"
+#define EIGEN_MPL2_ONLY
 
+#include "detection_by_tracker_node.hpp"
+
+#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware/universe_utils/math/unit_conversion.hpp"
 #include "object_recognition_utils/object_recognition_utils.hpp"
 
-#include <autoware/universe_utils/geometry/geometry.hpp>
-#include <autoware/universe_utils/math/unit_conversion.hpp>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 
 using Label = autoware_perception_msgs::msg::ObjectClassification;
 namespace
@@ -79,6 +79,9 @@ boost::optional<ReferenceShapeSizeInfo> getReferenceShapeSizeInfo(
   }
 }
 }  // namespace
+
+namespace autoware::detection_by_tracker
+{
 
 void TrackerHandler::onTrackedObjects(
   const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr msg)
@@ -466,5 +469,7 @@ void DetectionByTracker::mergeOverSegmentedObjects(
   }
 }
 
+}  // namespace autoware::detection_by_tracker
+
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(DetectionByTracker)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::detection_by_tracker::DetectionByTracker)

--- a/perception/detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DETECTION_BY_TRACKER__DETECTION_BY_TRACKER_CORE_HPP_
-#define DETECTION_BY_TRACKER__DETECTION_BY_TRACKER_CORE_HPP_
+#ifndef DETECTION_BY_TRACKER_NODE_HPP_
+#define DETECTION_BY_TRACKER_NODE_HPP_
 
-#include "detection_by_tracker/debugger.hpp"
-#include "detection_by_tracker/utils.hpp"
+#include "autoware/universe_utils/ros/published_time_publisher.hpp"
+#include "debugger/debugger.hpp"
+#include "euclidean_cluster/euclidean_cluster.hpp"
+#include "euclidean_cluster/utils.hpp"
+#include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "shape_estimation/shape_estimator.hpp"
+#include "utils/utils.hpp"
 
-#include <autoware/universe_utils/ros/published_time_publisher.hpp>
-#include <euclidean_cluster/euclidean_cluster.hpp>
-#include <euclidean_cluster/utils.hpp>
-#include <euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <shape_estimation/shape_estimator.hpp>
 
-#include <autoware_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_perception_msgs/msg/tracked_objects.hpp>
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_perception_msgs/msg/tracked_objects.hpp"
+#include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
@@ -48,6 +48,10 @@
 #include <map>
 #include <memory>
 #include <vector>
+
+namespace autoware::detection_by_tracker
+{
+
 class TrackerHandler
 {
 private:
@@ -82,7 +86,7 @@ private:
   std::map<uint8_t, int> max_search_distance_for_merger_;
   std::map<uint8_t, int> max_search_distance_for_divider_;
 
-  detection_by_tracker::utils::TrackerIgnoreLabel tracker_ignore_;
+  utils::TrackerIgnoreLabel tracker_ignore_;
 
   std::unique_ptr<autoware::universe_utils::PublishedTimePublisher> published_time_publisher_;
 
@@ -109,4 +113,6 @@ private:
     tier4_perception_msgs::msg::DetectedObjectsWithFeature & out_objects);
 };
 
-#endif  // DETECTION_BY_TRACKER__DETECTION_BY_TRACKER_CORE_HPP_
+}  // namespace autoware::detection_by_tracker
+
+#endif  // DETECTION_BY_TRACKER_NODE_HPP_

--- a/perception/detection_by_tracker/src/utils/utils.cpp
+++ b/perception/detection_by_tracker/src/utils/utils.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "detection_by_tracker/utils.hpp"
+#include "utils.hpp"
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 
-namespace detection_by_tracker
+namespace autoware::detection_by_tracker
 {
 namespace utils
 {
@@ -30,4 +30,4 @@ bool TrackerIgnoreLabel::isIgnore(const uint8_t label) const
          (label == Label::BICYCLE && BICYCLE) || (label == Label::PEDESTRIAN && PEDESTRIAN);
 }
 }  // namespace utils
-}  // namespace detection_by_tracker
+}  // namespace autoware::detection_by_tracker

--- a/perception/detection_by_tracker/src/utils/utils.hpp
+++ b/perception/detection_by_tracker/src/utils/utils.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DETECTION_BY_TRACKER__UTILS_HPP_
-#define DETECTION_BY_TRACKER__UTILS_HPP_
+#ifndef UTILS__UTILS_HPP_
+#define UTILS__UTILS_HPP_
 
 #include <cstdint>
 
-namespace detection_by_tracker
+namespace autoware::detection_by_tracker
 {
 namespace utils
 {
@@ -34,6 +34,6 @@ struct TrackerIgnoreLabel
   bool isIgnore(const uint8_t label) const;
 };  // struct TrackerIgnoreLabel
 }  // namespace utils
-}  // namespace detection_by_tracker
+}  // namespace autoware::detection_by_tracker
 
-#endif  // DETECTION_BY_TRACKER__UTILS_HPP_
+#endif  // UTILS__UTILS_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)
2. [Clean unused dependencies](https://github.com/autowarefoundation/autoware/issues/3468)   [LIST](https://github.com/autowarefoundation/autoware.universe/pull/3606)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/dccc10d6-26a4-5389-9712-b821f000bdb1?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
