### PR TITLE
refactor(occupancy_grid_map_outlier_filter)!: fix namespace and directory structure

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -320,7 +320,7 @@ class GroundSegmentationPipeline:
         components.append(
             ComposableNode(
                 package="occupancy_grid_map_outlier_filter",
-                plugin="occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent",
+                plugin="autoware::occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent",
                 name="occupancy_grid_based_outlier_filter",
                 remappings=[
                     ("~/input/occupancy_grid_map", "/perception/occupancy_grid_map/map"),

--- a/perception/occupancy_grid_map_outlier_filter/CMakeLists.txt
+++ b/perception/occupancy_grid_map_outlier_filter/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
-find_package(pcl_conversions REQUIRED)
 find_package(OpenMP)
 ament_auto_find_build_dependencies()
 
@@ -22,26 +21,26 @@ include_directories(
   ${GRID_MAP_INCLUDE_DIR}
 )
 
-ament_auto_add_library(occupancy_grid_map_outlier_filter SHARED
-  src/occupancy_grid_map_outlier_filter_nodelet.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/occupancy_grid_map_outlier_filter_node.cpp
 )
 
-target_link_libraries(occupancy_grid_map_outlier_filter
+target_link_libraries(${PROJECT_NAME}
   ${Boost_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${PCL_LIBRARIES}
 )
 
 if(OPENMP_FOUND)
-  set_target_properties(occupancy_grid_map_outlier_filter PROPERTIES
+  set_target_properties(${PROJECT_NAME} PROPERTIES
     COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
     LINK_FLAGS ${OpenMP_CXX_FLAGS}
   )
 endif()
 
 # -- Occupancy Grid Map Outlier Filter --
-rclcpp_components_register_node(occupancy_grid_map_outlier_filter
-  PLUGIN "occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent"
   EXECUTABLE occupancy_grid_map_outlier_filter_node)
 
 ament_auto_package(INSTALL_TO_SHARE)

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -19,27 +19,18 @@
 
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_universe_utils</depend>
-  <depend>autoware_vehicle_msgs</depend>
-  <depend>diagnostic_updater</depend>
-  <depend>image_transport</depend>
-  <depend>libopencv-dev</depend>
   <depend>libpcl-all-dev</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
-  <depend>pcl_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>pointcloud_preprocessor</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tf2</depend>
   <depend>tf2_eigen</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
-  <depend>tier4_pcl_extensions</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp
+++ b/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "occupancy_grid_map_outlier_filter/occupancy_grid_map_outlier_filter_nodelet.hpp"
+#include "occupancy_grid_map_outlier_filter_node.hpp"
 
-#include <autoware/universe_utils/geometry/geometry.hpp>
-#include <autoware/universe_utils/ros/debug_publisher.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
+#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware/universe_utils/ros/debug_publisher.hpp"
+#include "autoware/universe_utils/system/stop_watch.hpp"
+
 #include <pcl_ros/transforms.hpp>
 
 #include <boost/optional.hpp>
@@ -101,7 +102,7 @@ boost::optional<char> getCost(
 
 }  // namespace
 
-namespace occupancy_grid_map_outlier_filter
+namespace autoware::occupancy_grid_map_outlier_filter
 {
 RadiusSearch2dFilter::RadiusSearch2dFilter(rclcpp::Node & node)
 {
@@ -489,8 +490,8 @@ void OccupancyGridMapOutlierFilterComponent::Debugger::transformToBaseLink(
   transformPointcloud(ros_input, *(node_.tf2_), node_.base_link_frame_, output);
 }
 
-}  // namespace occupancy_grid_map_outlier_filter
+}  // namespace autoware::occupancy_grid_map_outlier_filter
 
 #include <rclcpp_components/register_node_macro.hpp>
 RCLCPP_COMPONENTS_REGISTER_NODE(
-  occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent)
+  autoware::occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent)

--- a/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp
+++ b/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OCCUPANCY_GRID_MAP_OUTLIER_FILTER__OCCUPANCY_GRID_MAP_OUTLIER_FILTER_NODELET_HPP_
-#define OCCUPANCY_GRID_MAP_OUTLIER_FILTER__OCCUPANCY_GRID_MAP_OUTLIER_FILTER_NODELET_HPP_
+#ifndef OCCUPANCY_GRID_MAP_OUTLIER_FILTER_NODE_HPP_
+#define OCCUPANCY_GRID_MAP_OUTLIER_FILTER_NODE_HPP_
 
+#include "autoware/universe_utils/ros/published_time_publisher.hpp"
 #include "pointcloud_preprocessor/filter.hpp"
 
-#include <autoware/universe_utils/ros/published_time_publisher.hpp>
 #include <pcl/common/impl/common.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -40,7 +40,7 @@
 #include <memory>
 #include <string>
 
-namespace occupancy_grid_map_outlier_filter
+namespace autoware::occupancy_grid_map_outlier_filter
 {
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::OccupancyGrid;
@@ -129,6 +129,6 @@ private:
   std::string base_link_frame_;
   int cost_threshold_;
 };
-}  // namespace occupancy_grid_map_outlier_filter
+}  // namespace autoware::occupancy_grid_map_outlier_filter
 
-#endif  // OCCUPANCY_GRID_MAP_OUTLIER_FILTER__OCCUPANCY_GRID_MAP_OUTLIER_FILTER_NODELET_HPP_
+#endif  // OCCUPANCY_GRID_MAP_OUTLIER_FILTER_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)
2. [Clean unused dependencies](https://github.com/autowarefoundation/autoware/issues/3468)   [LIST](https://github.com/autowarefoundation/autoware.universe/pull/3606)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/dccc10d6-26a4-5389-9712-b821f000bdb1?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
