### PR TITLE
fix(tvm_utility): add virtual destructor to tvm_utility

### DIFF
--- a/common/tvm_utility/include/tvm_utility/pipeline.hpp
+++ b/common/tvm_utility/include/tvm_utility/pipeline.hpp
@@ -300,7 +300,7 @@ public:
     }
   }
 
-  TVMArrayContainerVector schedule(const TVMArrayContainerVector & input)
+  TVMArrayContainerVector schedule(const TVMArrayContainerVector & input) override
   {
     // Set input(s)
     for (uint32_t index = 0; index < input.size(); ++index) {

--- a/common/tvm_utility/include/tvm_utility/pipeline.hpp
+++ b/common/tvm_utility/include/tvm_utility/pipeline.hpp
@@ -93,6 +93,7 @@ public:
    * @return The output of the pipeline
    */
   virtual OutputType schedule(const InputType & input) = 0;
+  virtual ~PipelineStage() {}
   InputType input_type_indicator_;
   OutputType output_type_indicator_;
 };


### PR DESCRIPTION
## Description

Because a virtual class requires a virtual destructor, it has been added.

## Related links

https://stackoverflow.com/questions/461203/when-to-use-virtual-destructors

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
