### PR TITLE
fix(autoware_joy_controller): add virtual destructor to autoware_joy_controller

### DIFF
--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
@@ -33,7 +33,6 @@
 #include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_external_api_msgs/srv/set_emergency.hpp>
 
-#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -110,7 +109,6 @@ private:
   autoware_control_msgs::msg::Control prev_control_command_;
   tier4_external_api_msgs::msg::ControlCommand prev_external_control_command_;
   GearShiftType prev_shift_ = tier4_external_api_msgs::msg::GearShift::NONE;
-  TurnSignalType prev_turn_signal_ = tier4_external_api_msgs::msg::TurnSignal::NONE;
   GateModeType prev_gate_mode_ = tier4_control_msgs::msg::GateMode::AUTO;
 
   // Timer

--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_converter/g29_joy_converter.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_converter/g29_joy_converter.hpp
@@ -17,6 +17,8 @@
 
 #include "autoware/joy_controller/joy_converter/joy_converter_base.hpp"
 
+#include <cstdlib>
+
 namespace autoware::joy_controller
 {
 class G29JoyConverter : public JoyConverterBase
@@ -27,7 +29,7 @@ public:
   float accel() const
   {
     constexpr float eps = 0.0000001;
-    if (std::fabs(AccelPedal()) < eps) {
+    if (std::abs(AccelPedal()) < eps) {
       return 0.0f;
     }
     return (AccelPedal() + 1.0f) / 2;
@@ -36,7 +38,7 @@ public:
   float brake() const
   {
     constexpr float eps = 0.0000001;
-    if (std::fabs(BrakePedal()) < eps) {
+    if (std::abs(BrakePedal()) < eps) {
       return 0.0f;
     }
     return (BrakePedal() + 1.0f) / 2;

--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_converter/joy_converter_base.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_converter/joy_converter_base.hpp
@@ -17,8 +17,6 @@
 
 #include <sensor_msgs/msg/joy.hpp>
 
-#include <algorithm>
-
 namespace autoware::joy_controller
 {
 class JoyConverterBase
@@ -49,6 +47,8 @@ public:
 
   virtual bool vehicle_engage() const = 0;
   virtual bool vehicle_disengage() const = 0;
+
+  virtual ~JoyConverterBase() = default;
 };
 }  // namespace autoware::joy_controller
 

--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <utility>
 
 namespace
 {
@@ -404,8 +403,8 @@ void AutowareJoyControllerNode::sendEmergencyRequest(bool emergency)
   request->emergency = emergency;
 
   client_emergency_stop_->async_send_request(
-    request, [this, emergency](
-               rclcpp::Client<tier4_external_api_msgs::srv::SetEmergency>::SharedFuture result) {
+    request,
+    [this](rclcpp::Client<tier4_external_api_msgs::srv::SetEmergency>::SharedFuture result) {
       auto response = result.get();
       if (tier4_api_utils::is_success(response->status)) {
         RCLCPP_INFO(get_logger(), "service succeeded");


### PR DESCRIPTION
## Description

- Because a virtual class requires a virtual destructor, it has been added.
- Some refactorings

## Related links

https://stackoverflow.com/questions/461203/when-to-use-virtual-destructors

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
