### PR TITLE
fix(static_centerline_generator): save_map only once

### DIFF
--- a/planning/autoware_static_centerline_generator/scripts/centerline_updater_helper.py
+++ b/planning/autoware_static_centerline_generator/scripts/centerline_updater_helper.py
@@ -162,6 +162,13 @@ class CenterlineUpdaterHelper(Node):
         msg = Empty()
         self.pub_save_map.publish(msg)
 
+        # NOTE: After saving the map, the generated centerline is written
+        # in original_map_ptr_ in static_centerline_generator_node.
+        # When saving the map again, another centerline is written without
+        # removing the previous centerline.
+        # Therefore, saving the map can be called only once.
+        self.widget.save_map_button.setEnabled(False)
+
     def onValidateButtonPushed(self, event):
         msg = Empty()
         self.pub_validate.publish(msg)


### PR DESCRIPTION
## Description

Saving the map twice by centerline_updater_helper.py did not work well as written in the comment of the changes.
This PR suppress the usage.
## Related links


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit test passed.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
