### PR TITLE
feat(planning_evaluator): add lanelet info to the planning evaluator

### DIFF
--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -21,12 +21,17 @@
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
+#include <autoware/route_handler/route_handler.hpp>
+#include <autoware/universe_utils/ros/polling_subscriber.hpp>
+
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <array>
 #include <deque>
@@ -43,6 +48,9 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using diagnostic_msgs::msg::DiagnosticArray;
 using diagnostic_msgs::msg::DiagnosticStatus;
 using nav_msgs::msg::Odometry;
+using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
+using autoware_planning_msgs::msg::LaneletRoute;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
 /**
  * @brief Node for planning evaluation
  */
@@ -88,9 +96,22 @@ public:
   DiagnosticStatus generateDiagnosticStatus(
     const Metric & metric, const Stat<double> & metric_stat) const;
 
+  /**
+   * @brief publish current ego lane info
+   */
+  DiagnosticStatus generateLaneletDiagnosticStatus();
+
+  /**
+   * @brief publish current ego kinematic state
+   */
+  DiagnosticStatus generateKinematicStateDiagnosticStatus(
+    const AccelWithCovarianceStamped & accel_stamped);
+
 private:
   static bool isFinite(const TrajectoryPoint & p);
   void publishModifiedGoalDeviationMetrics();
+  // update Route Handler
+  void getRouteData();
 
   // ROS
   rclcpp::Subscription<Trajectory>::SharedPtr traj_sub_;
@@ -98,10 +119,17 @@ private:
   rclcpp::Subscription<PredictedObjects>::SharedPtr objects_sub_;
   rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr modified_goal_sub_;
   rclcpp::Subscription<Odometry>::SharedPtr odom_sub_;
+  autoware::universe_utils::InterProcessPollingSubscriber<LaneletRoute> route_subscriber_{
+    this, "~/input/route", rclcpp::QoS{1}.transient_local()};
+  autoware::universe_utils::InterProcessPollingSubscriber<LaneletMapBin> vector_map_subscriber_{
+    this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
+  autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
+    this, "~/input/acceleration"};
 
   rclcpp::Publisher<DiagnosticArray>::SharedPtr metrics_pub_;
   std::shared_ptr<tf2_ros::TransformListener> transform_listener_{nullptr};
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  autoware::route_handler::RouteHandler route_handler_;
 
   // Parameters
   std::string output_file_str_;
@@ -116,6 +144,7 @@ private:
 
   Odometry::ConstSharedPtr ego_state_ptr_;
   PoseWithUuidStamped::ConstSharedPtr modified_goal_ptr_;
+  std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
 };
 }  // namespace planning_diagnostics
 

--- a/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
@@ -1,19 +1,25 @@
 <launch>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
+  <arg name="input/acceleration" default="/localization/acceleration"/>
   <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
   <arg name="input/reference_trajectory" default="/planning/scenario_planning/lane_driving/motion_planning/path_optimizer/trajectory"/>
   <arg name="input/objects" default="/perception/object_recognition/objects"/>
   <arg name="input/modified_goal" default="/planning/scenario_planning/modified_goal"/>
+  <arg name="input/map_topic" default="/map/vector_map"/>
+  <arg name="input/route_topic" default="/planning/mission_planning/route"/>
 
   <!-- planning evaluator -->
   <group>
     <node name="planning_evaluator" exec="planning_evaluator" pkg="autoware_planning_evaluator">
       <param from="$(find-pkg-share autoware_planning_evaluator)/param/planning_evaluator.defaults.yaml"/>
       <remap from="~/input/odometry" to="$(var input/odometry)"/>
+      <remap from="~/input/acceleration" to="$(var input/acceleration)"/>
       <remap from="~/input/trajectory" to="$(var input/trajectory)"/>
       <remap from="~/input/reference_trajectory" to="$(var input/reference_trajectory)"/>
       <remap from="~/input/objects" to="$(var input/objects)"/>
       <remap from="~/input/modified_goal" to="$(var input/modified_goal)"/>
+      <remap from="~/input/route" to="$(var input/route_topic)"/>
+      <remap from="~/input/vector_map" to="$(var input/map_topic)"/>
       <remap from="~/metrics" to="/diagnostic/planning_evaluator/metrics"/>
     </node>
   </group>

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_route_handler</depend>
   <depend>autoware_universe_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>


### PR DESCRIPTION
## Description
Add kinematic state and lanelet info to the planning evaluator for DLR purposes. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim


https://github.com/autowarefoundation/autoware.universe/assets/25967964/e639f63f-67b9-4ffb-b861-c35db7b13db4


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
