### PR TITLE
refactor(control_evaluator): use class naming standard and use remapped param name

### DIFF
--- a/evaluator/autoware_control_evaluator/CMakeLists.txt
+++ b/evaluator/autoware_control_evaluator/CMakeLists.txt
@@ -12,7 +12,7 @@ ament_auto_add_library(control_evaluator_node SHARED
 )
 
 rclcpp_components_register_node(control_evaluator_node
-  PLUGIN "control_diagnostics::controlEvaluatorNode"
+  PLUGIN "control_diagnostics::ControlEvaluatorNode"
   EXECUTABLE control_evaluator
 )
 

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -48,10 +48,10 @@ using geometry_msgs::msg::AccelWithCovarianceStamped;
 /**
  * @brief Node for control evaluation
  */
-class controlEvaluatorNode : public rclcpp::Node
+class ControlEvaluatorNode : public rclcpp::Node
 {
 public:
-  explicit controlEvaluatorNode(const rclcpp::NodeOptions & node_options);
+  explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
   void removeOldDiagnostics(const rclcpp::Time & stamp);
   void removeDiagnosticsByName(const std::string & name);
   void addDiagnostic(const DiagnosticStatus & diag, const rclcpp::Time & stamp);
@@ -83,7 +83,7 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<Odometry> odometry_sub_{
     this, "~/input/odometry"};
   autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
-    this, "/localization/acceleration"};
+    this, "~/input/acceleration"};
   autoware::universe_utils::InterProcessPollingSubscriber<Trajectory> traj_sub_{
     this, "~/input/trajectory"};
   autoware::universe_utils::InterProcessPollingSubscriber<LaneletRoute> route_subscriber_{

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -25,12 +25,12 @@
 
 namespace control_diagnostics
 {
-controlEvaluatorNode::controlEvaluatorNode(const rclcpp::NodeOptions & node_options)
+ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_options)
 : Node("control_evaluator", node_options)
 {
   using std::placeholders::_1;
   control_diag_sub_ = create_subscription<DiagnosticArray>(
-    "~/input/diagnostics", 1, std::bind(&controlEvaluatorNode::onDiagnostics, this, _1));
+    "~/input/diagnostics", 1, std::bind(&ControlEvaluatorNode::onDiagnostics, this, _1));
 
   // Publisher
   metrics_pub_ = create_publisher<DiagnosticArray>("~/metrics", 1);
@@ -38,10 +38,10 @@ controlEvaluatorNode::controlEvaluatorNode(const rclcpp::NodeOptions & node_opti
   // Timer callback to publish evaluator diagnostics
   using namespace std::literals::chrono_literals;
   timer_ =
-    rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&controlEvaluatorNode::onTimer, this));
+    rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&ControlEvaluatorNode::onTimer, this));
 }
 
-void controlEvaluatorNode::getRouteData()
+void ControlEvaluatorNode::getRouteData()
 {
   // route
   {
@@ -64,7 +64,7 @@ void controlEvaluatorNode::getRouteData()
   }
 }
 
-void controlEvaluatorNode::removeOldDiagnostics(const rclcpp::Time & stamp)
+void ControlEvaluatorNode::removeOldDiagnostics(const rclcpp::Time & stamp)
 {
   constexpr double KEEP_TIME = 1.0;
   diag_queue_.erase(
@@ -76,7 +76,7 @@ void controlEvaluatorNode::removeOldDiagnostics(const rclcpp::Time & stamp)
     diag_queue_.end());
 }
 
-void controlEvaluatorNode::removeDiagnosticsByName(const std::string & name)
+void ControlEvaluatorNode::removeDiagnosticsByName(const std::string & name)
 {
   diag_queue_.erase(
     std::remove_if(
@@ -87,13 +87,13 @@ void controlEvaluatorNode::removeDiagnosticsByName(const std::string & name)
     diag_queue_.end());
 }
 
-void controlEvaluatorNode::addDiagnostic(
+void ControlEvaluatorNode::addDiagnostic(
   const diagnostic_msgs::msg::DiagnosticStatus & diag, const rclcpp::Time & stamp)
 {
   diag_queue_.push_back(std::make_pair(diag, stamp));
 }
 
-void controlEvaluatorNode::updateDiagnosticQueue(
+void ControlEvaluatorNode::updateDiagnosticQueue(
   const DiagnosticArray & input_diagnostics, const std::string & function,
   const rclcpp::Time & stamp)
 {
@@ -110,7 +110,7 @@ void controlEvaluatorNode::updateDiagnosticQueue(
   removeOldDiagnostics(stamp);
 }
 
-void controlEvaluatorNode::onDiagnostics(const DiagnosticArray::ConstSharedPtr diag_msg)
+void ControlEvaluatorNode::onDiagnostics(const DiagnosticArray::ConstSharedPtr diag_msg)
 {
   // add target diagnostics to the queue and remove old ones
   for (const auto & function : target_functions_) {
@@ -118,7 +118,7 @@ void controlEvaluatorNode::onDiagnostics(const DiagnosticArray::ConstSharedPtr d
   }
 }
 
-DiagnosticStatus controlEvaluatorNode::generateAEBDiagnosticStatus(const DiagnosticStatus & diag)
+DiagnosticStatus ControlEvaluatorNode::generateAEBDiagnosticStatus(const DiagnosticStatus & diag)
 {
   DiagnosticStatus status;
   status.level = status.OK;
@@ -131,7 +131,7 @@ DiagnosticStatus controlEvaluatorNode::generateAEBDiagnosticStatus(const Diagnos
   return status;
 }
 
-DiagnosticStatus controlEvaluatorNode::generateLaneletDiagnosticStatus(const Pose & ego_pose) const
+DiagnosticStatus ControlEvaluatorNode::generateLaneletDiagnosticStatus(const Pose & ego_pose) const
 {
   const auto current_lanelets = [&]() {
     lanelet::ConstLanelet closest_route_lanelet;
@@ -162,7 +162,7 @@ DiagnosticStatus controlEvaluatorNode::generateLaneletDiagnosticStatus(const Pos
   return status;
 }
 
-DiagnosticStatus controlEvaluatorNode::generateKinematicStateDiagnosticStatus(
+DiagnosticStatus ControlEvaluatorNode::generateKinematicStateDiagnosticStatus(
   const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped)
 {
   DiagnosticStatus status;
@@ -198,7 +198,7 @@ DiagnosticStatus controlEvaluatorNode::generateKinematicStateDiagnosticStatus(
   return status;
 }
 
-DiagnosticStatus controlEvaluatorNode::generateLateralDeviationDiagnosticStatus(
+DiagnosticStatus ControlEvaluatorNode::generateLateralDeviationDiagnosticStatus(
   const Trajectory & traj, const Point & ego_point)
 {
   const double lateral_deviation = metrics::calcLateralDeviation(traj, ego_point);
@@ -214,7 +214,7 @@ DiagnosticStatus controlEvaluatorNode::generateLateralDeviationDiagnosticStatus(
   return status;
 }
 
-DiagnosticStatus controlEvaluatorNode::generateYawDeviationDiagnosticStatus(
+DiagnosticStatus ControlEvaluatorNode::generateYawDeviationDiagnosticStatus(
   const Trajectory & traj, const Pose & ego_pose)
 {
   const double yaw_deviation = metrics::calcYawDeviation(traj, ego_pose);
@@ -230,7 +230,7 @@ DiagnosticStatus controlEvaluatorNode::generateYawDeviationDiagnosticStatus(
   return status;
 }
 
-void controlEvaluatorNode::onTimer()
+void ControlEvaluatorNode::onTimer()
 {
   DiagnosticArray metrics_msg;
   const auto traj = traj_sub_.takeData();
@@ -278,4 +278,4 @@ void controlEvaluatorNode::onTimer()
 }  // namespace control_diagnostics
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(control_diagnostics::controlEvaluatorNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(control_diagnostics::ControlEvaluatorNode)

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -376,7 +376,7 @@ def launch_setup(context, *args, **kwargs):
     # control evaluator
     control_evaluator_component = ComposableNode(
         package="autoware_control_evaluator",
-        plugin="control_diagnostics::controlEvaluatorNode",
+        plugin="control_diagnostics::ControlEvaluatorNode",
         name="control_evaluator",
         remappings=[
             ("~/input/diagnostics", "/diagnostics"),


### PR DESCRIPTION
## Description
Change class name and use the remapped topic name for consistency.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim


https://github.com/autowarefoundation/autoware.universe/assets/25967964/01b8833f-b32e-46ec-84e9-f38ffd2b2489


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
