### PR TITLE
feat(mrm_handler): operate mrm only when autonomous operation mode

### DIFF
--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -149,6 +149,7 @@ private:
   bool isDrivingBackwards();
   bool isEmergency() const;
   bool isAutonomous();
+  bool isOperationModeAutonomous();
   bool isPullOverStatusAvailable();
   bool isComfortableStopStatusAvailable();
   bool isEmergencyStopStatusAvailable();

--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -148,7 +148,7 @@ private:
   bool isStopped();
   bool isDrivingBackwards();
   bool isEmergency() const;
-  bool isAutonomous();
+  bool isControlModeAutonomous();
   bool isOperationModeAutonomous();
   bool isPullOverStatusAvailable();
   bool isComfortableStopStatusAvailable();

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -538,7 +538,7 @@ bool MrmHandler::isEmergency() const
          is_operation_mode_availability_timeout;
 }
 
-bool MrmHandler::isAutonomous()
+bool MrmHandler::isControlModeAutonomous()
 {
   using autoware_vehicle_msgs::msg::ControlModeReport;
   auto mode = sub_control_mode_.takeData();

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -396,13 +396,13 @@ void MrmHandler::updateMrmState()
   }
 
   // Get mode
-  const bool is_auto_mode = isAutonomous();
-  const bool is_operation_mode_auto_mode = isOperationModeAutonomous();
+  const bool is_control_mode_autonomous = isControlModeAutonomous();
+  const bool is_operation_mode_autonomous = isOperationModeAutonomous();
 
   // State Machine
   switch (mrm_state_.state) {
     case MrmState::NORMAL:
-      if (is_auto_mode && is_operation_mode_auto_mode) {
+      if (is_control_mode_autonomous && is_operation_mode_autonomous) {
         transitionTo(MrmState::MRM_OPERATING);
       }
       return;

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -397,11 +397,12 @@ void MrmHandler::updateMrmState()
 
   // Get mode
   const bool is_auto_mode = isAutonomous();
+  const bool is_operation_mode_auto_mode = isOperationModeAutonomous();
 
   // State Machine
   switch (mrm_state_.state) {
     case MrmState::NORMAL:
-      if (is_auto_mode) {
+      if (is_auto_mode && is_operation_mode_auto_mode) {
         transitionTo(MrmState::MRM_OPERATING);
       }
       return;
@@ -543,6 +544,14 @@ bool MrmHandler::isAutonomous()
   auto mode = sub_control_mode_.takeData();
   if (mode == nullptr) return false;
   return mode->mode == ControlModeReport::AUTONOMOUS;
+}
+
+bool MrmHandler::isOperationModeAutonomous()
+{
+  using autoware_adapi_v1_msgs::msg::OperationModeState;
+  auto state = sub_operation_mode_state_.takeData();
+  if (state == nullptr) return false;
+  return state->mode == OperationModeState::AUTONOMOUS;
 }
 
 bool MrmHandler::isPullOverStatusAvailable()


### PR DESCRIPTION
## Description

By switching to the diagnostics graph in the [PR](https://github.com/autowarefoundation/autoware_launch/pull/1043), a problem arose where the state becomes emergency when scenario_simulator_v2 starts up, causing the simulation to fail.

This change fixes the above problem by operating MRM only during autonomous operation mode.

## How was this PR tested?

- [x] run psim
- [x] run simualtion in local environment

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
