### PR TITLE
ci(codecov.yaml): make ci succeed regardless of coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,11 +1,15 @@
+# https://docs.codecov.com/docs/commit-status#project-status
+
 coverage:
   status:
     project:
       default:
-        target: auto
+        target: 0%  # Make CI always succeed
+        threshold: 100%   # Make CI always succeed
     patch:
       default:
-        target: auto
+        target: 0%  # Make CI always succeed
+        threshold: 100%  # Make CI always succeed
 
 comment:
   show_carryforward_flags: true

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -4,12 +4,12 @@ coverage:
   status:
     project:
       default:
-        target: 0%  # Make CI always succeed
-        threshold: 100%   # Make CI always succeed
+        target: 0% # Make CI always succeed
+        threshold: 100% # Make CI always succeed
     patch:
       default:
-        target: 0%  # Make CI always succeed
-        threshold: 100%  # Make CI always succeed
+        target: 0% # Make CI always succeed
+        threshold: 100% # Make CI always succeed
 
 comment:
   show_carryforward_flags: true


### PR DESCRIPTION
## Description

Since CodeCov configuration was fixed with:
- https://github.com/autowarefoundation/autoware.universe/pull/7767

We started having these checks as errors in CI.

Since we are not enforcing this check to pass, I'm reducing the thresholds to allow anything to pass these tests.

And we'll use it as an informative tool for the time being.

https://github.com/autowarefoundation/autoware.universe/commits/main/

![image](https://github.com/autowarefoundation/autoware.universe/assets/10751153/abac65c0-073b-49eb-b9ec-797bf533ddc3)

## Related links

- https://docs.codecov.com/docs/commit-status#project-status

**Partly Related Issue:**
- https://github.com/autowarefoundation/autoware.universe/issues/7769

## How was this PR tested?

Since this works with a GitHub App, I guess we can't test it unless we merge it :D

It's all well documented and change is minimal so it should be alright.

## Notes for reviewers

Here I am pasting the explanation of the values that I've changed.

In summary, I'm making the thresholds as inclusive as possible to make them pass regardless of the coverage change.

### target

https://docs.codecov.com/docs/commit-status#target

> `auto | <number>`
> Choose a minimum coverage ratio that the commit must meet to be considered a `success`.
> 
> `auto` will use the coverage from the base commit (pull request base or parent commit) coverage to compare against. This is the default.
> `<number>` you can specify a target of an exact coverage number such as `75%` or `100%` (`string, int, or float` accepted).

### threshold

https://docs.codecov.com/docs/commit-status#threshold

> `<number>`
> Allow the coverage to drop by `<number>%`, and posting a `success` status.

## Interface changes

None.

## Effects on system behavior

CI will pass 
