### PR TITLE
chore(ci): add problem matcher for cppcheck

### DIFF
--- a/.github/cppcheck-problem-matcher.json
+++ b/.github/cppcheck-problem-matcher.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher":
+  [
+    {
+      "owner": "cppcheck",
+      "pattern":
+      [
+        {
+          "regexp": "^([^:]+):(\\d+):(\\d*):\\s(style|performance|warning|error):\\s(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/cppcheck-problem-matcher.json
+++ b/.github/cppcheck-problem-matcher.json
@@ -1,10 +1,8 @@
 {
-  "problemMatcher":
-  [
+  "problemMatcher": [
     {
       "owner": "cppcheck",
-      "pattern":
-      [
+      "pattern": [
         {
           "regexp": "^([^:]+):(\\d+):(\\d*):\\s(style|performance|warning|error):\\s(.*)$",
           "file": 1,

--- a/.github/cppcheck-problem-matcher.json
+++ b/.github/cppcheck-problem-matcher.json
@@ -4,7 +4,7 @@
       "owner": "cppcheck",
       "pattern": [
         {
-          "regexp": "^([^:]+):(\\d+):(\\d*):\\s(style|performance|warning|error):\\s(.*)$",
+          "regexp": "^([^:]+):(\\d+):(\\d*):\\s(style|portability|performance|warning|error):\\s(.*)$",
           "file": 1,
           "line": 2,
           "column": 3,

--- a/.github/workflows/cppcheck-daily.yaml
+++ b/.github/workflows/cppcheck-daily.yaml
@@ -18,6 +18,9 @@ jobs:
         run: |
           sudo snap install cppcheck
 
+      - name: Setup problem matchers for cppcheck
+        run: echo "::add-matcher::.github/cppcheck-problem-matcher.json"
+
       - name: Run Cppcheck on all files
         continue-on-error: true
         id: cppcheck

--- a/.github/workflows/cppcheck-daily.yaml
+++ b/.github/workflows/cppcheck-daily.yaml
@@ -18,9 +18,6 @@ jobs:
         run: |
           sudo snap install cppcheck
 
-      - name: Setup problem matchers for cppcheck
-        run: echo "::add-matcher::.github/cppcheck-problem-matcher.json"
-
       # cspell: ignore suppr
       - name: Run Cppcheck on all files
         continue-on-error: true

--- a/.github/workflows/cppcheck-daily.yaml
+++ b/.github/workflows/cppcheck-daily.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup problem matchers for cppcheck
         run: echo "::add-matcher::.github/cppcheck-problem-matcher.json"
 
+      # cspell: ignore suppr
       - name: Run Cppcheck on all files
         continue-on-error: true
         id: cppcheck

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -53,6 +53,7 @@ jobs:
           done
           echo "full-paths=$paths" >> $GITHUB_OUTPUT
 
+      # cspell: ignore suppr
       - name: Run Cppcheck on modified packages
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         continue-on-error: true

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -62,6 +62,9 @@ jobs:
           cppcheck --enable=all --inconclusive --check-level=exhaustive --error-exitcode=1 --suppressions-list=.cppcheck_suppressions --inline-suppr ${{ steps.get-full-paths.outputs.full-paths }} 2> cppcheck-report.txt
         shell: bash
 
+      - name: Setup Problem Matchers for cppcheck
+        run: echo "::add-matcher::.github/cppcheck-problem-matcher.json"
+
       - name: Show cppcheck-report result
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         run: |

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -63,7 +63,6 @@ nav_msgs::msg::Odometry to_odometry(
     0.0, ego_pitch_angle, vehicle_model_ptr->getYaw());
   odometry.twist.twist.linear.x = vehicle_model_ptr->getVx();
   odometry.twist.twist.angular.z = vehicle_model_ptr->getWz();
-  int a;
 
   return odometry;
 }

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -63,6 +63,7 @@ nav_msgs::msg::Odometry to_odometry(
     0.0, ego_pitch_angle, vehicle_model_ptr->getYaw());
   odometry.twist.twist.linear.x = vehicle_model_ptr->getVx();
   odometry.twist.twist.angular.z = vehicle_model_ptr->getWz();
+  int a;
 
   return odometry;
 }


### PR DESCRIPTION
## Description

Add problem matcher for cppcheck messages to annotate in file diff view in GitHub.

![image](https://github.com/autowarefoundation/autoware.universe/assets/12395284/0a4cb83f-f7eb-4979-b0a3-0ba9ac53421c)


## Related links


## How was this PR tested?

Check the cppcheck error is matched well.
https://github.com/autowarefoundation/autoware.universe/actions/runs/9763078681/job/26948068884?pr=7794#step:12:7

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
