### PR TITLE
fix(faster_voxel_grid_downsample_filter): typo in if statement in get_min_max_voxel()

### DIFF
--- a/sensing/pointcloud_preprocessor/src/downsample_filter/faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/pointcloud_preprocessor/src/downsample_filter/faster_voxel_grid_downsample_filter.cpp
@@ -107,7 +107,7 @@ bool FasterVoxelGridDownsampleFilter::get_min_max_voxel(
   for (size_t global_offset = 0; global_offset + input->point_step <= input->data.size();
        global_offset += input->point_step) {
     Eigen::Vector4f point = get_point_from_global_offset(input, global_offset);
-    if (std::isfinite(point[0]) && std::isfinite(point[1]), std::isfinite(point[2])) {
+    if (std::isfinite(point[0]) && std::isfinite(point[1]) && std::isfinite(point[2])) {
       min_point = min_point.cwiseMin(point.head<3>());
       max_point = max_point.cwiseMax(point.head<3>());
     }


### PR DESCRIPTION
## Description

This PR fixes a typo in the if statement in the `get_min_max_voxel` function in faster_voxel_grid_downsample_filter.cpp.

## Related links

[Discussion in Slack](https://star4.slack.com/archives/CEV8XMJBV/p1719965385138959?thread_ts=1719796541.332269&cid=CEV8XMJBV) (TIER IV internal)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

None.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
