### PR TITLE
ci(codecov.yaml): make it pass regardless of coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -20,7 +20,9 @@ flag_management:
     statuses:
       - name_prefix: project-
         type: project
-        target: auto
+        target: 0% # Make CI always succeed
+        threshold: 100% # Make CI always succeed
       - name_prefix: patch-
         type: patch
-        target: auto
+        target: 0% # Make CI always succeed
+        threshold: 100% # Make CI always succeed


### PR DESCRIPTION
## Description

![image](https://github.com/autowarefoundation/autoware.universe/assets/10751153/15e286a6-89d6-4f98-92d9-172695e353f6)

I think I should have updated these lines too.

It got better, only 2 are failing now. With these too, all should pass.

## Related links

**Continuation from:**

- https://github.com/autowarefoundation/autoware.universe/pull/7793

## How was this PR tested?

## Notes for reviewers

The targets for these were changed [in the previous PR](https://github.com/autowarefoundation/autoware.universe/pull/7793):
![image](https://github.com/autowarefoundation/autoware.universe/assets/10751153/b1cc5940-fe84-4de1-936b-afe536e4c679)

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
