### PR TITLE
feat(control_validator)!: add velocity check

### DIFF
--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -6,16 +6,16 @@ The `control_validator` is a module that checks the validity of the output of th
 
 ## Supported features
 
-The following features are supported for the validation and can have thresholds set by parameters:
+The following features are supported for the validation and can have thresholds set by parameters.
+The listed features below does not always correspond to the latest implementation.
+| Description | Arguments | Diagnostic equation | Implemented function name |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | :--------------------------------: | ------------------------------- |
+| Inverse velocity: Measured velocity has a different sign from the target velocity. | measured velocity $v$, target velocity $\hat{v}$, and threshold velocity parameter $k$ | $v\hat{v}<0,~\|v\|>k $       | `checkValidVelocityDeviation()` |
+| Overspeed: Measured speed exceeds target speed significantly.                      | measured velocity $v$, target velocity $\hat{v}$, and threshold ratio parameter $r$ | $\| v \| > (1 + r) \| \hat{v} \| $ | `checkValidVelocityDeviation()` |
 
 - **Deviation check between reference trajectory and predicted trajectory** : invalid when the largest deviation between the predicted trajectory and reference trajectory is greater than the given threshold.
 
 ![trajectory_deviation](./image/trajectory_deviation.drawio.svg)
-
-| Description                                                                        | Arguments                                                                              |        Diagnostic equation         | Implemented function name       |
-| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | :--------------------------------: | ------------------------------- |
-| Inverse velocity: Measured velocity has a different sign from the target velocity. | measured velocity $v$, target velocity $\hat{v}$, and threshold velocity parameter $k$ |       $v\hat{v}<0,~\|v\|>k $       | `checkValidVelocityDeviation()` |
-| Overspeed: Measured speed exceeds target speed significantly.                      | measured velocity $v$, target velocity $\hat{v}$, and threshold ratio parameter $r$    | $\| v \| > (1 + r) \| \hat{v} \| $ | `checkValidVelocityDeviation()` |
 
 ## Inputs/Outputs
 

--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -12,7 +12,10 @@ The following features are supported for the validation and can have thresholds 
 
 ![trajectory_deviation](./image/trajectory_deviation.drawio.svg)
 
-Other features are to be implemented.
+| Description                                                                        | Arguments                                                                              |        Diagnostic equation         | Implemented function name       |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | :--------------------------------: | ------------------------------- |
+| Inverse velocity: Measured velocity has a different sign from the target velocity. | measured velocity $v$, target velocity $\hat{v}$, and threshold velocity parameter $k$ |       $v\hat{v}<0,~\|v\|>k $       | `checkValidVelocityDeviation()` |
+| Overspeed: Measured speed exceeds target speed significantly.                      | measured velocity $v$, target velocity $\hat{v}$, and threshold ratio parameter $r$    | $\| v \| > (1 + r) \| \hat{v} \| $ | `checkValidVelocityDeviation()` |
 
 ## Inputs/Outputs
 
@@ -53,6 +56,8 @@ The following parameters can be set for the `control_validator`:
 
 The input trajectory is detected as invalid if the index exceeds the following thresholds.
 
-| Name                                | Type   | Description                                                                                                 | Default value |
-| :---------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
-| `thresholds.max_distance_deviation` | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
+| Name                                 | Type   | Description                                                                                                 | Default value |
+| :----------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
+| `thresholds.max_distance_deviation`  | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
+| `thresholds.max_reverse_velocity`    | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | WIP           |
+| `thresholds.max_over_velocity_ratio` | double | threshold ratio to valid the vehicle velocity [*]                                                           | WIP           |

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -1,6 +1,5 @@
 /**:
   ros__parameters:
-
     # If the number of consecutive invalid trajectory exceeds this threshold, the Diag will be set to ERROR.
     # (For example, threshold = 1 means, even if the trajectory is invalid, Diag will not be ERROR if
     #  the next trajectory is valid.)
@@ -10,3 +9,5 @@
 
     thresholds:
       max_distance_deviation: 1.0
+      max_reverse_velocity: 0.2
+      max_over_velocity_ratio: 0.1

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -52,6 +52,7 @@ public:
   void onPredictedTrajectory(const Trajectory::ConstSharedPtr msg);
 
   bool checkValidMaxDistanceDeviation(const Trajectory & predicted_trajectory);
+  bool checkValidVelocityDeviation(const Trajectory & reference_trajectory, const Odometry & kinematics);
 
 private:
   void setupDiag();
@@ -60,7 +61,9 @@ private:
 
   bool isDataReady();
 
-  void validate(const Trajectory & trajectory);
+  void validate(
+    const Trajectory & predicted_trajectory, const Trajectory & reference_trajectory,
+    const Odometry & kinematics);
 
   void publishPredictedTrajectory();
   void publishDebugInfo();
@@ -84,6 +87,10 @@ private:
 
   ControlValidatorStatus validation_status_;
   ValidationParams validation_params_;  // for thresholds
+
+  // ego nearest index search
+  double ego_nearest_dist_threshold_;
+  double ego_nearest_yaw_threshold_;
 
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -54,7 +54,8 @@ public:
   void onPredictedTrajectory(const Trajectory::ConstSharedPtr msg);
 
   bool checkValidMaxDistanceDeviation(const Trajectory & predicted_trajectory);
-  bool checkValidVelocityDeviation(const Trajectory & reference_trajectory, const Odometry & kinematics);
+  bool checkValidVelocityDeviation(
+    const Trajectory & reference_trajectory, const Odometry & kinematics);
 
 private:
   void setupDiag();

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -42,6 +42,8 @@ using nav_msgs::msg::Odometry;
 struct ValidationParams
 {
   double max_distance_deviation_threshold;
+  double max_reverse_velocity_threshold;
+  double max_over_velocity_ratio_threshold;
 };
 
 class ControlValidator : public rclcpp::Node

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -2,8 +2,11 @@ builtin_interfaces/Time stamp
 
 # states
 bool is_valid_max_distance_deviation
+bool is_valid_velocity_deviation
 
 # values
 float64 max_distance_deviation
+float64 desired_velocity
+float64 current_velocity
 
 int64 invalid_count

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -185,14 +185,14 @@ bool ControlValidator::checkValidMaxDistanceDeviation(const Trajectory & predict
 bool ControlValidator::checkValidVelocityDeviation(
   const Trajectory & reference_trajectory, const Odometry & kinematics)
 {
-  // get current vel
   const double current_vel = kinematics.twist.twist.linear.x;
-
-  // get desired vel
   if (reference_trajectory.points.size() < 2) return true;
   const double desired_vel =
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps;
+
+  validation_status_.current_velocity = current_vel;
+  validation_status_.desired_velocity = desired_vel;
 
   const bool is_over_velocity =
     std::abs(current_vel) >

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -95,7 +95,7 @@ void ControlValidator::setupDiag()
   d.add(ns + "velocity_deviation", [&](auto & stat) {
     setStatus(
       stat, validation_status_.is_valid_velocity_deviation,
-      "currnet velocity is deviated from the desired velocity");
+      "current velocity is deviated from the desired velocity");
   });
 }
 
@@ -194,7 +194,7 @@ bool ControlValidator::checkValidVelocityDeviation(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps;
 
-  const bool is_over_velociay =
+  const bool is_over_velocity =
     std::abs(current_vel) >
     std::abs(desired_vel) * (1.0 + validation_params_.max_over_velocity_ratio_threshold) +
       validation_params_.max_reverse_velocity_threshold;
@@ -202,7 +202,7 @@ bool ControlValidator::checkValidVelocityDeviation(
     std::signbit(current_vel * desired_vel) &&
     std::abs(current_vel) > validation_params_.max_reverse_velocity_threshold;
 
-  return !(is_over_velociay || is_reverse_velocity);
+  return !(is_over_velocity || is_reverse_velocity);
 }
 
 bool ControlValidator::isAllValid(const ControlValidatorStatus & s)


### PR DESCRIPTION
## Description
This PR  add velocity check function to validate vehicle velocity controllers.

If the current velocity has over velocity or reversed velocity against the target velocity for the velocity controller, control_validator will publish diagnostic msg.


## Related links
https://github.com/autowarefoundation/autoware_launch/pull/1050

- Link

## How was this PR tested?
psim and teir4 internal tests


## Effects on system behavior

None.
