### PR TITLE
refactor(elevation_map_loader)!: fix namespace and directory structure

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -353,7 +353,7 @@ class GroundSegmentationPipeline:
         components.append(
             ComposableNode(
                 package="elevation_map_loader",
-                plugin="ElevationMapLoaderNode",
+                plugin="autoware::elevation_map_loader::ElevationMapLoaderNode",
                 name="elevation_map_loader",
                 namespace="elevation_map",
                 remappings=[

--- a/perception/elevation_map_loader/CMakeLists.txt
+++ b/perception/elevation_map_loader/CMakeLists.txt
@@ -6,22 +6,22 @@ autoware_package()
 
 find_package(PCL REQUIRED COMPONENTS io)
 
-ament_auto_add_library(elevation_map_loader_node SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/elevation_map_loader_node.cpp
 )
-target_link_libraries(elevation_map_loader_node ${PCL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
 
 # TODO(wep21): workaround for iron.
 # remove this block and update package.xml after iron.
 find_package(rosbag2_storage_sqlite3)
-target_include_directories(elevation_map_loader_node
+target_include_directories(${PROJECT_NAME}
   PRIVATE
     ${rosbag2_storage_sqlite3_INCLUDE_DIRS}
 )
 
-rclcpp_components_register_node(elevation_map_loader_node
-  PLUGIN "ElevationMapLoaderNode"
-  EXECUTABLE elevation_map_loader
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::elevation_map_loader::ElevationMapLoaderNode"
+  EXECUTABLE elevation_map_loader_node
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
+++ b/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
@@ -7,7 +7,7 @@
   <arg name="use_inpaint" default="true"/>
   <arg name="inpaint_radius" default="1.0"/>
 
-  <node pkg="elevation_map_loader" exec="elevation_map_loader" name="elevation_map_loader" output="screen">
+  <node pkg="elevation_map_loader" exec="elevation_map_loader_node" name="elevation_map_loader" output="screen">
     <remap from="output/elevation_map" to="/map/elevation_map"/>
     <remap from="input/pointcloud_map" to="/map/pointcloud_map"/>
     <remap from="input/pointcloud_map_metadata" to="/map/pointcloud_map_metadata"/>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -24,9 +24,9 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rosbag2_storage_default_plugins</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>tf2_ros</depend>
   <depend>tier4_external_api_msgs</depend>
+  <!-- <depend>tf2_geometry_msgs</depend> -->
+  <!-- <depend>tf2_ros</depend> -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -25,8 +25,6 @@
   <depend>rclcpp_components</depend>
   <depend>rosbag2_storage_default_plugins</depend>
   <depend>tier4_external_api_msgs</depend>
-  <!-- <depend>tf2_geometry_msgs</depend> -->
-  <!-- <depend>tf2_ros</depend> -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "elevation_map_loader/elevation_map_loader_node.hpp"
+#define EIGEN_MPL2_ONLY
 
-#include <autoware_grid_map_utils/polygon_iterator.hpp>
+#include "elevation_map_loader_node.hpp"
+
+#include "autoware_grid_map_utils/polygon_iterator.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <grid_map_core/GridMap.hpp>
@@ -45,15 +50,14 @@
 #include <utility>
 #include <vector>
 
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
 #if __has_include(<rosbag2_storage_sqlite3/sqlite_statement_wrapper.hpp>)
 #include <rosbag2_storage_sqlite3/sqlite_statement_wrapper.hpp>
 #else
 #include <rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp>
 #endif
+
+namespace autoware::elevation_map_loader
+{
 
 ElevationMapLoaderNode::ElevationMapLoaderNode(const rclcpp::NodeOptions & options)
 : Node("elevation_map_loader", options)
@@ -445,6 +449,7 @@ void ElevationMapLoaderNode::saveElevationMap()
   RCLCPP_INFO_STREAM(
     this->get_logger(), "Saving elevation map successful: " << std::boolalpha << saving_successful);
 }
+}  // namespace autoware::elevation_map_loader
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(ElevationMapLoaderNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::elevation_map_loader::ElevationMapLoaderNode)

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.hpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ELEVATION_MAP_LOADER__ELEVATION_MAP_LOADER_NODE_HPP_
-#define ELEVATION_MAP_LOADER__ELEVATION_MAP_LOADER_NODE_HPP_
+#ifndef ELEVATION_MAP_LOADER_NODE_HPP_
+#define ELEVATION_MAP_LOADER_NODE_HPP_
 
-#include <autoware/universe_utils/geometry/boost_geometry.hpp>
+#include "autoware/universe_utils/geometry/boost_geometry.hpp"
 #include <filters/filter_chain.hpp>
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_pcl/GridMapPclLoader.hpp>
@@ -36,6 +36,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace autoware::elevation_map_loader
+{
 
 class DataManager
 {
@@ -117,4 +120,5 @@ private:
   LaneFilter lane_filter_;
 };
 
-#endif  // ELEVATION_MAP_LOADER__ELEVATION_MAP_LOADER_NODE_HPP_
+}  // namespace autoware::elevation_map_loader
+#endif  // ELEVATION_MAP_LOADER_NODE_HPP_

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.hpp
@@ -16,6 +16,7 @@
 #define ELEVATION_MAP_LOADER_NODE_HPP_
 
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
+
 #include <filters/filter_chain.hpp>
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_pcl/GridMapPclLoader.hpp>


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)
2. [Clean unused dependencies](https://github.com/autowarefoundation/autoware/issues/3468)   [LIST](https://github.com/autowarefoundation/autoware.universe/pull/3606)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/dccc10d6-26a4-5389-9712-b821f000bdb1?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
