### PR TITLE
refactor(velocity_smoother): change method to take data for external velocity

### DIFF
--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -422,7 +422,7 @@ void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr 
   // receive data
   current_odometry_ptr_ = sub_current_odometry_.takeData();
   current_acceleration_ptr_ = sub_current_acceleration_.takeData();
-  external_velocity_limit_ptr_ = sub_external_velocity_limit_.takeData();
+  external_velocity_limit_ptr_ = sub_external_velocity_limit_.takeNewData();
   const auto operation_mode_ptr = sub_operation_mode_.takeData();
   if (operation_mode_ptr) {
     operation_mode_ = *operation_mode_ptr;
@@ -454,9 +454,6 @@ void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr 
   // calculate distance to insert external velocity limit
   calcExternalVelocityLimit();
   updateDataForExternalVelocityLimit();
-
-  // ignore current external velocity limit next time
-  external_velocity_limit_ptr_ = nullptr;
 
   // For negative velocity handling, multiple -1 to velocity if it is for reverse.
   // NOTE: this process must be in the beginning of the process


### PR DESCRIPTION
## Description
[Before using the polling subscriber ](https://github.com/autowarefoundation/autoware.universe/pull/7216) the member variable `external_velocity_limit_ptr_` was set to `nullptr` once it was used. However by using `takeData()` the latest msg would be used continuously.  This PR solves the problem by utilizing `takeNewData()` instead of `takeData()`.

## Related links
None

## How was this PR tested?
[TIER IV internal simulator](https://evaluation.tier4.jp/evaluation/reports/f87b4ca1-b5db-53c7-ba1e-a97b5217e34f?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
