### PR TITLE
fix(probabilistic_occupancy_grid_map): fix noExplicitConstructor

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/src/fusion/single_frame_fusion_policy.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/fusion/single_frame_fusion_policy.cpp
@@ -171,7 +171,7 @@ struct dempsterShaferOccupancy
   }
 
   // initialize with probability
-  dempsterShaferOccupancy(double occupied_probability)
+  explicit dempsterShaferOccupancy(double occupied_probability)
   {
     // confine to [0, 1]
     double p = std::max(0.0, std::min(1.0, occupied_probability));

--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp
@@ -75,7 +75,7 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
   // Create angle bins and sort points by range
   struct BinInfo3D
   {
-    BinInfo3D(
+    explicit BinInfo3D(
       const double _range = 0.0, const double _wx = 0.0, const double _wy = 0.0,
       const double _wz = 0.0, const double _projection_length = 0.0,
       const double _projected_wx = 0.0, const double _projected_wy = 0.0)


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `noExplicitConstructor` warnings

```
perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map_projective.cpp:78:5: style: Struct 'BinInfo3D' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
    BinInfo3D(
    ^

perception/probabilistic_occupancy_grid_map/src/fusion/single_frame_fusion_policy.cpp:174:3: style: Struct 'dempsterShaferOccupancy' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
  dempsterShaferOccupancy(double occupied_probability)
  ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
