### PR TITLE
fix(autoware_freespace_planning_algorithms): fix syntaxError

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
+++ b/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
@@ -99,6 +99,7 @@ public:
 
 namespace py = pybind11;
 
+// cppcheck-suppress syntaxError
 PYBIND11_MODULE(autoware_freespace_planning_algorithms_pybind, p)
 {
   auto pyPlannerWaypointsVector =


### PR DESCRIPTION
## Description

This is just to avoid cppcheck `syntaxError` error

```
planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp:102:1: error: syntax error [syntaxError]
PYBIND11_MODULE(autoware_freespace_planning_algorithms_pybind, p)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
