### PR TITLE
fix(radar_fusion_to_detected_object): fix knownConditionTrueFalse

### DIFF
--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -95,7 +95,7 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
     for (auto & split_object : split_objects) {
       // set radars within objects
       std::shared_ptr<std::vector<RadarInput>> radars_within_split_object;
-      if (split_objects.size() == 1) {
+      if (split_object.size() == 1) {
         // If object is not split, radar data within object is same
         radars_within_split_object = radars_within_object;
       } else {

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -95,7 +95,9 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
     for (auto & split_object : split_objects) {
       // set radars within objects
       std::shared_ptr<std::vector<RadarInput>> radars_within_split_object;
-      if (split_object.size() == 1) {
+
+      // cppcheck-suppress knownConditionTrueFalse
+      if (split_objects.size() == 1) {
         // If object is not split, radar data within object is same
         radars_within_split_object = radars_within_object;
       } else {


### PR DESCRIPTION
## Description

This is a cppcheck warning

```
perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp:98:32: style: Condition 'split_objects.size()==1' is always true [knownConditionTrueFalse]
      if (split_objects.size() == 1) {
                               ^
```

What did you mean here?
Maybe my modification `split_object.size() == 1` is incorrect.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
