### PR TITLE
fix(autoware_planning_validator): fix knownConditionTrueFalse

### DIFF
--- a/planning/autoware_planning_validator/src/invalid_trajectory_publisher/invalid_trajectory_publisher.cpp
+++ b/planning/autoware_planning_validator/src/invalid_trajectory_publisher/invalid_trajectory_publisher.cpp
@@ -59,11 +59,6 @@ void InvalidTrajectoryPublisherNode::onTimer()
   traj_pub_->publish(output);
 
   RCLCPP_INFO(this->get_logger(), "invalid trajectory is published.");
-
-  bool EXIT_AFTER_PUBLISH = false;
-  if (EXIT_AFTER_PUBLISH) {
-    exit(0);
-  }
 }
 
 void InvalidTrajectoryPublisherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr msg)


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `knownConditionTrueFalse` warning

```
planning/autoware_planning_validator/src/invalid_trajectory_publisher/invalid_trajectory_publisher.cpp:64:7: style: Condition 'EXIT_AFTER_PUBLISH' is always false [knownConditionTrueFalse]
  if (EXIT_AFTER_PUBLISH) {
      ^
planning/autoware_planning_validator/src/invalid_trajectory_publisher/invalid_trajectory_publisher.cpp:63:29: note: Assignment 'EXIT_AFTER_PUBLISH=false', assigned value is 0
  bool EXIT_AFTER_PUBLISH = false;
                            ^
planning/autoware_planning_validator/src/invalid_trajectory_publisher/invalid_trajectory_publisher.cpp:64:7: note: Condition 'EXIT_AFTER_PUBLISH' is always false
  if (EXIT_AFTER_PUBLISH) {
      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
