### PR TITLE
fix(traffic_light_occlusion_predictor): fix cppcheck warnings

### DIFF
--- a/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
+++ b/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
@@ -129,10 +129,10 @@ void TrafficLightOcclusionPredictorNodelet::syncCallback(
   const uint8_t traffic_light_type)
 {
   std::vector<int> occlusion_ratios;
-  size_t not_detected_roi = 0;
   if (in_cloud_msg == nullptr || in_cam_info_msg == nullptr || in_roi_msg == nullptr) {
     occlusion_ratios.resize(in_signal_msg->signals.size(), 0);
   } else {
+    size_t not_detected_roi = 0;
     tier4_perception_msgs::msg::TrafficLightRoiArray selected_roi_msg;
     selected_roi_msg.rois.reserve(in_roi_msg->rois.size());
     for (size_t i = 0; i < in_roi_msg->rois.size(); ++i) {

--- a/perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp
+++ b/perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp
@@ -211,7 +211,9 @@ uint32_t CloudOcclusionPredictor::predict(
 {
   const uint32_t horizontal_sample_num = 20;
   const uint32_t vertical_sample_num = 20;
-  static_assert(horizontal_sample_num > 1 && vertical_sample_num > 1);
+  static_assert(horizontal_sample_num > 1);
+  static_assert(vertical_sample_num > 1);
+
   const float min_dist_from_occlusion_to_tl = 5.0f;
 
   pcl::PointCloud<pcl::PointXYZ> tl_sample_cloud;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warnings

```
perception/traffic_light_occlusion_predictor/src/nodelet.cpp:132:10: style: The scope of the variable 'not_detected_roi' can be reduced. [variableScope]
  size_t not_detected_roi = 0;
         ^
```

`static_assert` is splited just to avoid cppcheck warnings.
```
perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp:214:43: style: Same expression on both sides of '&&' because 'horizontal_sample_num>1' and 'vertical_sample_num>1' represent the same value. [knownConditionTrueFalse]
  static_assert(horizontal_sample_num > 1 && vertical_sample_num > 1);
                                          ^
perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp:212:42: note: 'horizontal_sample_num' is assigned value '20' here.
  const uint32_t horizontal_sample_num = 20;
                                         ^
perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp:213:40: note: 'vertical_sample_num' is assigned value '20' here.
  const uint32_t vertical_sample_num = 20;
                                       ^
perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp:214:43: note: Same expression on both sides of '&&' because 'horizontal_sample_num>1' and 'vertical_sample_num>1' represent the same value.
  static_assert(horizontal_sample_num > 1 && vertical_sample_num > 1);
                                          ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
