### PR TITLE
feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -151,8 +151,8 @@ void AvoidanceByLaneChange::fillAvoidanceTargetObjects(
   const auto [object_within_target_lane, object_outside_target_lane] =
     utils::path_safety_checker::separateObjectsByLanelets(
       *planner_data_->dynamic_object, data.current_lanelets,
-      [](const auto & obj, const auto & lane) {
-        return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lane);
+      [](const auto & obj, const auto & lane, const auto yaw_threshold) {
+        return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lane, yaw_threshold);
       });
 
   // Assume that the maximum allocation for data.other object is the sum of

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -145,8 +145,8 @@ PredictedObjects extractObjectsInExpandedPullOverLanes(
     route_handler, left_side, backward_distance, forward_distance, bound_offset);
 
   const auto [objects_in_lanes, others] = utils::path_safety_checker::separateObjectsByLanelets(
-    objects, lanes, [](const auto & obj, const auto & lanelet) {
-      return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lanelet);
+    objects, lanes, [](const auto & obj, const auto & lanelet, const auto yaw_threshold) {
+      return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lanelet, yaw_threshold);
     });
 
   return objects_in_lanes;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
@@ -56,6 +56,7 @@ using tier4_planning_msgs::msg::PathPointWithLaneId;
  *
  * @param objects The predicted objects to filter.
  * @param lanelet
+ * @param yaw_threshold
  * @return result.
  */
 bool isCentroidWithinLanelet(
@@ -67,6 +68,7 @@ bool isCentroidWithinLanelet(
  *
  * @param objects The predicted objects to filter.
  * @param lanelet
+ * @param yaw_threshold
  * @return result.
  */
 bool isPolygonOverlapLanelet(
@@ -174,7 +176,7 @@ std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanel
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets,
   const std::function<bool(const PredictedObject, const lanelet::ConstLanelet, const double)> &
     condition,
-  const double yaw_threshold = M_PI_2);
+  const double yaw_threshold = M_PI);
 
 /**
  * @brief Separate the objects into two part based on whether the object is within lanelet.
@@ -184,7 +186,7 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets,
   const std::function<bool(const PredictedObject, const lanelet::ConstLanelet, const double)> &
     condition,
-  const double yaw_threshold = M_PI_2);
+  const double yaw_threshold = M_PI);
 
 /**
  * @brief Get the predicted path from an object.

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
@@ -58,7 +58,9 @@ using tier4_planning_msgs::msg::PathPointWithLaneId;
  * @param lanelet
  * @return result.
  */
-bool isCentroidWithinLanelet(const PredictedObject & object, const lanelet::ConstLanelet & lanelet);
+bool isCentroidWithinLanelet(
+  const PredictedObject & object, const lanelet::ConstLanelet & lanelet,
+  const double yaw_threshold);
 
 /**
  * @brief Filters objects based on object polygon overlapping with lanelet.
@@ -67,7 +69,9 @@ bool isCentroidWithinLanelet(const PredictedObject & object, const lanelet::Cons
  * @param lanelet
  * @return result.
  */
-bool isPolygonOverlapLanelet(const PredictedObject & object, const lanelet::ConstLanelet & lanelet);
+bool isPolygonOverlapLanelet(
+  const PredictedObject & object, const lanelet::ConstLanelet & lanelet,
+  const double yaw_threshold);
 
 bool isPolygonOverlapLanelet(
   const PredictedObject & object, const autoware::universe_utils::Polygon2d & lanelet_polygon);
@@ -168,7 +172,9 @@ void filterObjectsByClass(
  */
 std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets,
-  const std::function<bool(const PredictedObject, const lanelet::ConstLanelet)> & condition);
+  const std::function<bool(const PredictedObject, const lanelet::ConstLanelet, const double)> &
+    condition,
+  const double yaw_threshold = M_PI_2);
 
 /**
  * @brief Separate the objects into two part based on whether the object is within lanelet.
@@ -176,7 +182,9 @@ std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanel
  */
 std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets,
-  const std::function<bool(const PredictedObject, const lanelet::ConstLanelet)> & condition);
+  const std::function<bool(const PredictedObject, const lanelet::ConstLanelet, const double)> &
+    condition,
+  const double yaw_threshold = M_PI_2);
 
 /**
  * @brief Get the predicted path from an object.

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -74,8 +74,9 @@ protected:
       *dynamic_objects, parameters_.th_moving_object_velocity);
     auto [pull_out_lane_stop_objects, others] =
       utils::path_safety_checker::separateObjectsByLanelets(
-        stop_objects, pull_out_lanes, [](const auto & obj, const auto & lane) {
-          return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lane);
+        stop_objects, pull_out_lanes,
+        [](const auto & obj, const auto & lane, const auto yaw_threshold) {
+          return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lane, yaw_threshold);
         });
     utils::path_safety_checker::filterObjectsByClass(
       pull_out_lane_stop_objects, parameters_.object_types_to_check_for_path_generation);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1217,8 +1217,9 @@ PredictedObjects StartPlannerModule::filterStopObjectsInPullOutLanes(
   // filter for objects located in pull out lanes and moving at a speed below the threshold
   auto [stop_objects_in_pull_out_lanes, others] =
     utils::path_safety_checker::separateObjectsByLanelets(
-      stop_objects, pull_out_lanes, [](const auto & obj, const auto & lane) {
-        return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lane);
+      stop_objects, pull_out_lanes,
+      [](const auto & obj, const auto & lane, const auto yaw_threshold) {
+        return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lane, yaw_threshold);
       });
 
   const auto path = planner_data_->route_handler->getCenterLinePath(


### PR DESCRIPTION
## Description

Sometimes, the safety check caused false positive because it couldn't judge which lane the object belonged to properly.

**Example**: the red lanes mean safety check target lane for avoidance maneuver in following movie and a vehicle is trying to merge ego lane. Basically, the avoidance module only check objects which are on shift side adjacent lane, so the ego don't have to revert avoidance path due to the object in this case. But the object becomes safety check target when it's on safety check target lane even though the direction is different from the lane direction.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/2b276be3-a8b3-4356-a4c3-1bb8261c392e

---

After this PR, we're going to be able to set yaw deviation threshold and ignore the object whose pose is not along with the lane. Additionally, the avoidance module set the threshold to `PI/2` by default.As a result, the object won't be a safety check target even though it's on safety target lane (red lane) in following scene.

:warning: But the avoidance module filters objects by yaw deviation only when the object is moving because the head direction is not reliable while object is stopping.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/bfbeb69a-aa1f-4620-8bb2-815069f7b8ff

On the other hand, if the yaw deviation is less than threshold, the safety check module reacts the object in the same way as original.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/5022efd2-1352-44c4-a5a7-ecf9f3383003

## Related links

**Parent Issue:**

- [TIER IV INTERNAL LINK](https://docs.google.com/presentation/d/1SFzKrDvpwxCm1naLeda-oqcpvzIQkKPURID-qRJCQe4/edit#slide=id.g272e7af22cd_4_63)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x]  [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/ea3701dc-6b2b-5024-aa54-35d4e0ae6e1b?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
