### PR TITLE
feat(freespace_planning_algorithms): add is_back flag into the return of A* python wrapper

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/autoware_freespace_planning_algorithms/astar_search.py
+++ b/planning/autoware_freespace_planning_algorithms/autoware_freespace_planning_algorithms/astar_search.py
@@ -24,6 +24,12 @@ VehicleShape = _fp.VehicleShape
 AstarParam = _fp.AstarParam
 
 
+class PlannerWaypoint:
+    def __init__(self, pose, is_back):
+        self.pose = pose
+        self.is_back = is_back
+
+
 class PlannerWaypoints:
     def __init__(self):
         self.waypoints = []
@@ -59,6 +65,9 @@ class AstarSearch:
         for waypoint in waypoints_vector.waypoints:
             pos = Point(x=waypoint[0], y=waypoint[1], z=waypoint[2])
             quat = Quaternion(x=waypoint[3], y=waypoint[4], z=waypoint[5], w=waypoint[6])
-            waypoints.waypoints.append(Pose(position=pos, orientation=quat))
+            is_bask = bool(waypoint[7])
+            waypoints.waypoints.append(
+                PlannerWaypoint(Pose(position=pos, orientation=quat), is_bask)
+            )
 
         return waypoints

--- a/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
+++ b/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
@@ -89,8 +89,9 @@ public:
       // python-side. So this function returns [*position, *quaternion] as double array
       const auto & xyz = waypoint.pose.pose.position;
       const auto & quat = waypoint.pose.pose.orientation;
+      const double & is_back = waypoint.is_back;
       waypoints_vector.waypoints.push_back(
-        std::vector<double>({xyz.x, xyz.y, xyz.z, quat.x, quat.y, quat.z, quat.w}));
+        std::vector<double>({xyz.x, xyz.y, xyz.z, quat.x, quat.y, quat.z, quat.w, is_back}));
     }
     waypoints_vector.length = waypoints.compute_length();
     return waypoints_vector;


### PR DESCRIPTION
## Description

This is an updated version of the [A* python wrapper](https://github.com/autowarefoundation/autoware.universe/pull/6398)

The previous version does not have [is_back](https://github.com/autowarefoundation/autoware.universe/blob/7a6bf3983bdc602856ab6accefa5a04cb1d3f748/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/abstract_algorithm.hpp#L105) in the result return of A* search. I append it with this PR.

<!-- Write a brief description of this PR. -->

## Related links
[#6398](https://github.com/autowarefoundation/autoware.universe/pull/6398)
Evaluator: https://evaluation.tier4.jp/evaluation/reports/54647b99-62d4-5849-b6f8-d7d78de25c8c?project_id=prd_jt

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes
N/A
<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes
N/A
<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior
This feature is independent of the main autoware features. There are no effects.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.


[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
