### PR TITLE
fix(autoware_behavior_velocity_intersection_module): fix shadowFunction

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_lanelets.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_lanelets.cpp
@@ -48,11 +48,10 @@ void IntersectionLanelets::update(
     }
   }
   if (first_attention_lane_ && !second_attention_lane_ && !second_attention_lane_empty_) {
-    const auto first_attention_lane = first_attention_lane_.value();
     // remove first_attention_area_ and non-straight lanelets from attention_non_preceding
     lanelet::ConstLanelets attention_non_preceding_ex_first;
     lanelet::ConstLanelets sibling_first_attention_lanelets;
-    for (const auto & previous : routing_graph_ptr->previous(first_attention_lane)) {
+    for (const auto & previous : routing_graph_ptr->previous(first_attention_lane_.value())) {
       for (const auto & following : routing_graph_ptr->following(previous)) {
         sibling_first_attention_lanelets.push_back(following);
       }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp
@@ -137,8 +137,7 @@ bool ObjectInfo::can_stop_before_stopline(const double brake_deceleration) const
   if (!dist_to_stopline_opt) {
     return false;
   }
-  const double velocity =
-    predicted_object_.kinematics.initial_twist_with_covariance.twist.linear.x;
+  const double velocity = predicted_object_.kinematics.initial_twist_with_covariance.twist.linear.x;
   const double dist_to_stopline = dist_to_stopline_opt.value();
   const double braking_distance = (velocity * velocity) / (2.0 * brake_deceleration);
   return dist_to_stopline > braking_distance;
@@ -152,8 +151,7 @@ bool ObjectInfo::can_stop_before_ego_lane(
     return false;
   }
   const double dist_to_stopline = dist_to_stopline_opt.value();
-  const double velocity =
-    predicted_object_.kinematics.initial_twist_with_covariance.twist.linear.x;
+  const double velocity = predicted_object_.kinematics.initial_twist_with_covariance.twist.linear.x;
   const double braking_distance = (velocity * velocity) / (2.0 * brake_deceleration);
   if (dist_to_stopline > braking_distance) {
     return false;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp
@@ -137,11 +137,10 @@ bool ObjectInfo::can_stop_before_stopline(const double brake_deceleration) const
   if (!dist_to_stopline_opt) {
     return false;
   }
-  const double observed_velocity =
+  const double velocity =
     predicted_object_.kinematics.initial_twist_with_covariance.twist.linear.x;
   const double dist_to_stopline = dist_to_stopline_opt.value();
-  const double braking_distance =
-    (observed_velocity * observed_velocity) / (2.0 * brake_deceleration);
+  const double braking_distance = (velocity * velocity) / (2.0 * brake_deceleration);
   return dist_to_stopline > braking_distance;
 }
 
@@ -153,10 +152,9 @@ bool ObjectInfo::can_stop_before_ego_lane(
     return false;
   }
   const double dist_to_stopline = dist_to_stopline_opt.value();
-  const double observed_velocity =
+  const double velocity =
     predicted_object_.kinematics.initial_twist_with_covariance.twist.linear.x;
-  const double braking_distance =
-    (observed_velocity * observed_velocity) / (2.0 * brake_deceleration);
+  const double braking_distance = (velocity * velocity) / (2.0 * brake_deceleration);
   if (dist_to_stopline > braking_distance) {
     return false;
   }


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `shadowFunction` warnings

```
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_lanelets.cpp:51:16: style: Local variable 'first_attention_lane' shadows outer function [shadowFunction]
    const auto first_attention_lane = first_attention_lane_.value();
               ^
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_lanelets.hpp:86:48: note: Shadowed declaration
  const std::optional<lanelet::ConstLanelet> & first_attention_lane() const
                                               ^
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_lanelets.cpp:51:16: note: Shadow variable
    const auto first_attention_lane = first_attention_lane_.value();
               ^
```

```
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp:178:10: note: Shadowed declaration
  double observed_velocity() const
         ^
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:140:16: note: Shadow variable
  const double observed_velocity =
               ^
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:156:16: style: Local variable 'observed_velocity' shadows outer function [shadowFunction]
  const double observed_velocity =
               ^
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp:178:10: note: Shadowed declaration
  double observed_velocity() const
         ^
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:156:16: note: Shadow variable
  const double observed_velocity =
               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
