### PR TITLE
refactor(map_height_fitter): apply static analysis 

### DIFF
--- a/map/map_height_fitter/include/map_height_fitter/map_height_fitter.hpp
+++ b/map/map_height_fitter/include/map_height_fitter/map_height_fitter.hpp
@@ -33,10 +33,10 @@ class MapHeightFitter final
 public:
   explicit MapHeightFitter(rclcpp::Node * node);
   ~MapHeightFitter();
-  MapHeightFitter(const MapHeightFitter&) = delete;
-  MapHeightFitter& operator=(const MapHeightFitter&) = delete;
-  MapHeightFitter(MapHeightFitter&&) = delete;
-  MapHeightFitter& operator=(MapHeightFitter&&) = delete;
+  MapHeightFitter(const MapHeightFitter &) = delete;
+  MapHeightFitter & operator=(const MapHeightFitter &) = delete;
+  MapHeightFitter(MapHeightFitter &&) = delete;
+  MapHeightFitter & operator=(MapHeightFitter &&) = delete;
   std::optional<Point> fit(const Point & position, const std::string & frame);
 
 private:

--- a/map/map_height_fitter/include/map_height_fitter/map_height_fitter.hpp
+++ b/map/map_height_fitter/include/map_height_fitter/map_height_fitter.hpp
@@ -31,8 +31,12 @@ using geometry_msgs::msg::Point;
 class MapHeightFitter final
 {
 public:
-  MapHeightFitter(rclcpp::Node * node);
+  explicit MapHeightFitter(rclcpp::Node * node);
   ~MapHeightFitter();
+  MapHeightFitter(const MapHeightFitter&) = delete;
+  MapHeightFitter& operator=(const MapHeightFitter&) = delete;
+  MapHeightFitter(MapHeightFitter&&) = delete;
+  MapHeightFitter& operator=(MapHeightFitter&&) = delete;
   std::optional<Point> fit(const Point & position, const std::string & frame);
 
 private:

--- a/map/map_height_fitter/src/map_height_fitter.cpp
+++ b/map/map_height_fitter/src/map_height_fitter.cpp
@@ -14,7 +14,7 @@
 
 #include "map_height_fitter/map_height_fitter.hpp"
 
-#include "memory"
+#include <memory>
 
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>

--- a/map/map_height_fitter/src/map_height_fitter.cpp
+++ b/map/map_height_fitter/src/map_height_fitter.cpp
@@ -14,8 +14,6 @@
 
 #include "map_height_fitter/map_height_fitter.hpp"
 
-#include <memory>
-
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 
@@ -30,6 +28,8 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/transform_listener.h>
+
+#include <memory>
 
 namespace map_height_fitter
 {

--- a/map/map_height_fitter/src/map_height_fitter.cpp
+++ b/map/map_height_fitter/src/map_height_fitter.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "map_height_fitter/map_height_fitter.hpp"
+
 #include "memory"
 
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `map/map_height_fitter`.
Checked with clang-tidy and cppcheck.

Fixed:
- use explicit cast
- add or removed keyword from function/method which linter suggested
- add explicit delete for constructor
- fix use of std::make_shared with pcl::PointXYZ

not Fixed:
- safe access to members of unions by `boost::variant`
  - speed concern
 
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1)
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh map_height_fitter
...
13165 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/include/map_height_fitter/map_height_fitter.hpp:31:7: warning: class 'MapHeightFitter' defines a non-default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class MapHeightFitter final
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/include/map_height_fitter/map_height_fitter.hpp:34:3: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
  MapHeightFitter(rclcpp::Node * node);
  ^
  explicit 
Suppressed 13174 warnings (13163 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13774 warnings generated.
Suppressed 13785 warnings (13774 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
54003 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:110:16: warning: use std::make_shared instead [modernize-make-shared]
  map_cloud_ = pcl::PointCloud<pcl::PointXYZ>::Ptr(new pcl::PointCloud<pcl::PointXYZ>);
               ^~~~~~~~~~~~~~~                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               std::make_shared
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:128:24: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'autoware_map_msgs::msg::AreaInfo_::_center_x_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  req->area.center_x = point.x;
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:129:24: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'autoware_map_msgs::msg::AreaInfo_::_center_y_type' (aka 'float') [cppcoreguidelines-narrowing-conversions]
  req->area.center_y = point.y;
                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:160:16: warning: use std::make_shared instead [modernize-make-shared]
  map_cloud_ = pcl::PointCloud<pcl::PointXYZ>::Ptr(new pcl::PointCloud<pcl::PointXYZ>);
               ^~~~~~~~~~~~~~~                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               std::make_shared
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:185:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dx = x - p.x;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:186:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dy = y - p.y;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:195:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dx = x - p.x;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:196:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dy = y - p.y;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:199:57: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
        height = std::min(height, static_cast<double>(p.z));
                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:279:18: error: use '= default' to define a trivial destructor [modernize-use-equals-default,-warnings-as-errors]
MapHeightFitter::~MapHeightFitter()
                 ^
Suppressed 54168 warnings (53993 in non-user code, 175 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error

```
</details>

Check with cppcheck: (nothing to change)

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh map_height_fitter
...
13163 warnings generated.
Suppressed 13174 warnings (13163 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13772 warnings generated.
Suppressed 13783 warnings (13772 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
54008 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:186:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dx = x - p.x;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:187:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dy = y - p.y;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:196:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dx = x - p.x;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:197:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const double dy = y - p.y;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_height_fitter/src/map_height_fitter.cpp:200:57: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
        height = std::min(height, static_cast<double>(p.z));
                                                        ^
Suppressed 54178 warnings (54003 in non-user code, 175 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
