### PR TITLE
fix(diagnostic_graph_aggregator): fix shadowFunction

### DIFF
--- a/system/diagnostic_graph_aggregator/src/common/graph/config.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.cpp
@@ -68,10 +68,10 @@ FileLoader::FileLoader(const PathConfig * path)
   }
 
   TreeData tree = TreeData::Load(path->resolved);
-  const auto paths = tree.optional("files").children("files");
+  const auto files = tree.optional("files").children("files");
   const auto edits = tree.optional("edits").children("edits");
   const auto units = tree.optional("units").children("units");
-  for (const auto & data : paths) create_path_config(data);
+  for (const auto & data : files) create_path_config(data);
   for (const auto & data : edits) create_edit_config(data);
   for (const auto & data : units) create_unit_config(data);
 }

--- a/system/diagnostic_graph_aggregator/src/common/graph/data.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/data.cpp
@@ -35,25 +35,25 @@ TreeData::TreeData(const YAML::Node & yaml, const TreePath & path) : path_(path)
 TreeData::Item TreeData::required(const std::string & name)
 {
   // TODO(Takagi, Isamu): check map type.
-  const auto path = path_.field(name);
+  const auto tree_path = path_.field(name);
   if (!yaml_[name]) {
-    throw FieldNotFound(path);
+    throw FieldNotFound(tree_path);
   }
   const auto data = yaml_[name];
   yaml_.remove(name);
-  return TreeData(data, path);
+  return TreeData(data, tree_path);
 }
 
 TreeData::Item TreeData::optional(const std::string & name)
 {
   // TODO(Takagi, Isamu): check map type.
-  const auto path = path_.field(name);
+  const auto tree_path = path_.field(name);
   if (!yaml_[name]) {
-    return TreeData(YAML::Node(YAML::NodeType::Undefined), path);
+    return TreeData(YAML::Node(YAML::NodeType::Undefined), tree_path);
   }
   const auto data = yaml_[name];
   yaml_.remove(name);
-  return TreeData(data, path);
+  return TreeData(data, tree_path);
 }
 
 bool TreeData::is_valid() const

--- a/system/diagnostic_graph_aggregator/src/common/graph/units.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/units.cpp
@@ -85,11 +85,10 @@ void NodeUnit::initialize_status()
 LeafUnit::LeafUnit(const UnitLoader & unit) : BaseUnit(unit)
 {
   const auto node = unit.data().required("node").text();
-  const auto name = unit.data().required("name").text();
   const auto sep = node.empty() ? "" : ": ";
 
   struct_.path = unit.path();
-  struct_.name = node + sep + name;
+  struct_.name = node + sep + unit.data().required("name").text();
   status_.level = DiagnosticStatus::STALE;
 }
 

--- a/system/diagnostic_graph_aggregator/src/common/graph/units.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/units.cpp
@@ -84,11 +84,12 @@ void NodeUnit::initialize_status()
 
 LeafUnit::LeafUnit(const UnitLoader & unit) : BaseUnit(unit)
 {
-  const auto node = unit.data().required("node").text();
-  const auto sep = node.empty() ? "" : ": ";
+  const auto diag_node = unit.data().required("node").text();
+  const auto diag_name = unit.data().required("name").text();
+  const auto sep = diag_node.empty() ? "" : ": ";
 
   struct_.path = unit.path();
-  struct_.name = node + sep + unit.data().required("name").text();
+  struct_.name = diag_node + sep + diag_name;
   status_.level = DiagnosticStatus::STALE;
 }
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `shadowFunction` warnings

```
system/diagnostic_graph_aggregator/src/common/graph/config.cpp:71:14: style: Local variable 'paths' shadows outer function [shadowFunction]
  const auto paths = tree.optional("files").children("files");
             ^
system/diagnostic_graph_aggregator/src/common/graph/config.hpp:73:16: note: Shadowed declaration
  const auto & paths() const { return paths_; }
               ^
system/diagnostic_graph_aggregator/src/common/graph/config.cpp:71:14: note: Shadow variable
  const auto paths = tree.optional("files").children("files");
             ^
```

```
system/diagnostic_graph_aggregator/src/common/graph/data.cpp:38:14: style: Local variable 'path' shadows outer function [shadowFunction]
  const auto path = path_.field(name);
             ^
system/diagnostic_graph_aggregator/src/common/graph/data.hpp:39:16: note: Shadowed declaration
  const auto & path() const { return path_; }
               ^
system/diagnostic_graph_aggregator/src/common/graph/data.cpp:38:14: note: Shadow variable
  const auto path = path_.field(name);
             ^
system/diagnostic_graph_aggregator/src/common/graph/data.cpp:50:14: style: Local variable 'path' shadows outer function [shadowFunction]
  const auto path = path_.field(name);
             ^
system/diagnostic_graph_aggregator/src/common/graph/data.hpp:39:16: note: Shadowed declaration
  const auto & path() const { return path_; }
               ^
system/diagnostic_graph_aggregator/src/common/graph/data.cpp:50:14: note: Shadow variable
  const auto path = path_.field(name);
             ^
```

```
system/diagnostic_graph_aggregator/src/common/graph/units.cpp:88:14: style: Local variable 'name' shadows outer function [shadowFunction]
  const auto name = unit.data().required("name").text();
             ^
system/diagnostic_graph_aggregator/src/common/graph/units.hpp:98:15: note: Shadowed declaration
  std::string name() const { return struct_.name; }
              ^
system/diagnostic_graph_aggregator/src/common/graph/units.cpp:88:14: note: Shadow variable
  const auto name = unit.data().required("name").text();
             ^
```

If you do not like the modified variable names, please fix them!

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
