### PR TITLE
refactor(lane_change): move struct to lane change namespace

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -169,43 +169,45 @@
   />
   <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
-  <node pkg="autoware_behavior_path_planner" exec="autoware_behavior_path_planner_node" name="behavior_path_planner" namespace="" launch-prefix="xterm -e gdb -ex run --args">
-    <!-- topic remap -->
-    <remap from="~/input/route" to="$(var input_route_topic_name)"/>
-    <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
-    <remap from="~/input/perception" to="/perception/object_recognition/objects"/>
-    <remap from="~/input/occupancy_grid_map" to="/perception/occupancy_grid_map/map"/>
-    <remap from="~/input/costmap" to="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
-    <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
-    <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-    <remap from="~/input/accel" to="/localization/acceleration"/>
-    <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
-    <remap from="~/output/path" to="path_with_lane_id"/>
-    <remap from="~/output/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-    <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-    <remap from="~/output/modified_goal" to="/planning/scenario_planning/modified_goal"/>
-    <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
-    <!-- params -->
-    <param from="$(var common_param_path)"/>
-    <param from="$(var vehicle_param_file)"/>
-    <param from="$(var nearest_search_param_path)"/>
-    <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
-    <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
-    <param name="is_simulation" value="$(var is_simulation)"/>
-    <param from="$(var behavior_path_planner_side_shift_module_param_path)"/>
-    <param from="$(var behavior_path_planner_static_obstacle_avoidance_module_param_path)"/>
-    <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>
-    <param from="$(var behavior_path_planner_dynamic_obstacle_avoidance_module_param_path)"/>
-    <param from="$(var behavior_path_planner_lane_change_module_param_path)"/>
-    <param from="$(var behavior_path_planner_goal_planner_module_param_path)"/>
-    <param from="$(var behavior_path_planner_start_planner_module_param_path)"/>
-    <param from="$(var behavior_path_planner_sampling_planner_module_param_path)"/>
-    <param from="$(var behavior_path_planner_drivable_area_expansion_param_path)"/>
-    <param from="$(var behavior_path_planner_scene_module_manager_param_path)"/>
-    <param from="$(var behavior_path_planner_common_param_path)"/>
-  </node>
-
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="both">
+    <composable_node pkg="autoware_behavior_path_planner" plugin="autoware::behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
+      <!-- topic remap -->
+      <remap from="~/input/route" to="$(var input_route_topic_name)"/>
+      <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
+      <remap from="~/input/perception" to="/perception/object_recognition/objects"/>
+      <remap from="~/input/occupancy_grid_map" to="/perception/occupancy_grid_map/map"/>
+      <remap from="~/input/costmap" to="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
+      <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
+      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+      <remap from="~/input/accel" to="/localization/acceleration"/>
+      <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
+      <remap from="~/output/path" to="path_with_lane_id"/>
+      <remap from="~/output/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+      <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+      <remap from="~/output/modified_goal" to="/planning/scenario_planning/modified_goal"/>
+      <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
+      <!-- params -->
+      <param from="$(var common_param_path)"/>
+      <param from="$(var vehicle_param_file)"/>
+      <param from="$(var nearest_search_param_path)"/>
+      <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
+      <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
+      <param name="is_simulation" value="$(var is_simulation)"/>
+      <param from="$(var behavior_path_planner_side_shift_module_param_path)"/>
+      <param from="$(var behavior_path_planner_static_obstacle_avoidance_module_param_path)"/>
+      <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>
+      <param from="$(var behavior_path_planner_dynamic_obstacle_avoidance_module_param_path)"/>
+      <param from="$(var behavior_path_planner_lane_change_module_param_path)"/>
+      <param from="$(var behavior_path_planner_goal_planner_module_param_path)"/>
+      <param from="$(var behavior_path_planner_start_planner_module_param_path)"/>
+      <param from="$(var behavior_path_planner_sampling_planner_module_param_path)"/>
+      <param from="$(var behavior_path_planner_drivable_area_expansion_param_path)"/>
+      <param from="$(var behavior_path_planner_scene_module_manager_param_path)"/>
+      <param from="$(var behavior_path_planner_common_param_path)"/>
+      <!-- composable node config -->
+      <extra_arg name="use_intra_process_comms" value="false"/>
+    </composable_node>
+
     <composable_node pkg="autoware_behavior_velocity_planner" plugin="autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode" name="behavior_velocity_planner" namespace="">
       <!-- topic remap -->
       <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -169,45 +169,43 @@
   />
   <let name="behavior_velocity_planner_launch_modules" value="$(eval &quot;'$(var behavior_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
-  <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="both">
-    <composable_node pkg="autoware_behavior_path_planner" plugin="autoware::behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
-      <!-- topic remap -->
-      <remap from="~/input/route" to="$(var input_route_topic_name)"/>
-      <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
-      <remap from="~/input/perception" to="/perception/object_recognition/objects"/>
-      <remap from="~/input/occupancy_grid_map" to="/perception/occupancy_grid_map/map"/>
-      <remap from="~/input/costmap" to="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
-      <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
-      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-      <remap from="~/input/accel" to="/localization/acceleration"/>
-      <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
-      <remap from="~/output/path" to="path_with_lane_id"/>
-      <remap from="~/output/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-      <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-      <remap from="~/output/modified_goal" to="/planning/scenario_planning/modified_goal"/>
-      <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
-      <!-- params -->
-      <param from="$(var common_param_path)"/>
-      <param from="$(var vehicle_param_file)"/>
-      <param from="$(var nearest_search_param_path)"/>
-      <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
-      <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
-      <param name="is_simulation" value="$(var is_simulation)"/>
-      <param from="$(var behavior_path_planner_side_shift_module_param_path)"/>
-      <param from="$(var behavior_path_planner_static_obstacle_avoidance_module_param_path)"/>
-      <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>
-      <param from="$(var behavior_path_planner_dynamic_obstacle_avoidance_module_param_path)"/>
-      <param from="$(var behavior_path_planner_lane_change_module_param_path)"/>
-      <param from="$(var behavior_path_planner_goal_planner_module_param_path)"/>
-      <param from="$(var behavior_path_planner_start_planner_module_param_path)"/>
-      <param from="$(var behavior_path_planner_sampling_planner_module_param_path)"/>
-      <param from="$(var behavior_path_planner_drivable_area_expansion_param_path)"/>
-      <param from="$(var behavior_path_planner_scene_module_manager_param_path)"/>
-      <param from="$(var behavior_path_planner_common_param_path)"/>
-      <!-- composable node config -->
-      <extra_arg name="use_intra_process_comms" value="false"/>
-    </composable_node>
+  <node pkg="autoware_behavior_path_planner" exec="autoware_behavior_path_planner_node" name="behavior_path_planner" namespace="" launch-prefix="xterm -e gdb -ex run --args">
+    <!-- topic remap -->
+    <remap from="~/input/route" to="$(var input_route_topic_name)"/>
+    <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
+    <remap from="~/input/perception" to="/perception/object_recognition/objects"/>
+    <remap from="~/input/occupancy_grid_map" to="/perception/occupancy_grid_map/map"/>
+    <remap from="~/input/costmap" to="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
+    <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
+    <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+    <remap from="~/input/accel" to="/localization/acceleration"/>
+    <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
+    <remap from="~/output/path" to="path_with_lane_id"/>
+    <remap from="~/output/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+    <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+    <remap from="~/output/modified_goal" to="/planning/scenario_planning/modified_goal"/>
+    <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
+    <!-- params -->
+    <param from="$(var common_param_path)"/>
+    <param from="$(var vehicle_param_file)"/>
+    <param from="$(var nearest_search_param_path)"/>
+    <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
+    <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
+    <param name="is_simulation" value="$(var is_simulation)"/>
+    <param from="$(var behavior_path_planner_side_shift_module_param_path)"/>
+    <param from="$(var behavior_path_planner_static_obstacle_avoidance_module_param_path)"/>
+    <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>
+    <param from="$(var behavior_path_planner_dynamic_obstacle_avoidance_module_param_path)"/>
+    <param from="$(var behavior_path_planner_lane_change_module_param_path)"/>
+    <param from="$(var behavior_path_planner_goal_planner_module_param_path)"/>
+    <param from="$(var behavior_path_planner_start_planner_module_param_path)"/>
+    <param from="$(var behavior_path_planner_sampling_planner_module_param_path)"/>
+    <param from="$(var behavior_path_planner_drivable_area_expansion_param_path)"/>
+    <param from="$(var behavior_path_planner_scene_module_manager_param_path)"/>
+    <param from="$(var behavior_path_planner_common_param_path)"/>
+  </node>
 
+  <node_container pkg="rclcpp_components" exec="$(var container_type)" name="behavior_planning_container" namespace="" args="" output="both">
     <composable_node pkg="autoware_behavior_velocity_planner" plugin="autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode" name="behavior_velocity_planner" namespace="">
       <!-- topic remap -->
       <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -50,7 +50,10 @@ public:
   LaneChangeBase(
     std::shared_ptr<LaneChangeParameters> parameters, LaneChangeModuleType type,
     Direction direction)
-  : lane_change_parameters_{std::move(parameters)}, direction_{direction}, type_{type}
+  : lane_change_parameters_{std::move(parameters)},
+    common_data_ptr_{std::make_shared<lane_change::CommonData>()},
+    direction_{direction},
+    type_{type}
   {
   }
 
@@ -151,7 +154,18 @@ public:
 
   bool isValidPath() const { return status_.is_valid_path; }
 
-  void setData(const std::shared_ptr<const PlannerData> & data) { planner_data_ = data; }
+  void setData(const std::shared_ptr<const PlannerData> & data)
+  {
+    planner_data_ = data;
+    if (!common_data_ptr_->bpp_param_ptr) {
+      common_data_ptr_->bpp_param_ptr =
+        std::make_shared<BehaviorPathPlannerParameters>(data->parameters);
+    }
+    common_data_ptr_->self_odometry_ptr = data->self_odometry;
+    common_data_ptr_->route_handler_ptr = data->route_handler;
+    common_data_ptr_->lc_param_ptr = lane_change_parameters_;
+    common_data_ptr_->direction = direction_;
+  }
 
   void toNormalState() { current_lane_change_state_ = LaneChangeStates::Normal; }
 
@@ -219,6 +233,7 @@ protected:
   std::shared_ptr<LaneChangeParameters> lane_change_parameters_{};
   std::shared_ptr<LaneChangePath> abort_path_{};
   std::shared_ptr<const PlannerData> planner_data_{};
+  lane_change::CommonDataPtr common_data_ptr_{};
   BehaviorModuleOutput prev_module_output_{};
   std::optional<Pose> lane_change_stop_pose_{std::nullopt};
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
@@ -31,8 +31,8 @@ struct LaneChangePath
 {
   PathWithLaneId path{};
   ShiftedPath shifted_path{};
-  PathWithLaneId prev_path{};
-  LaneChangeInfo info{};
+  LaneChangeInfo info;
+  bool is_safe{false};
 };
 using LaneChangePaths = std::vector<LaneChangePath>;
 


### PR DESCRIPTION
## Description

Move lane change data structs to lane change namespace to avoid LaneChangeXXXXX naming.
Also added common data which will be use for further refactoring or development.

## Related links

None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Build success

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
