### PR TITLE
refactor(static_avoidance): modify getAdjacentLane function

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1987,6 +1987,17 @@ lanelet::ConstLanelets getAdjacentLane(
       lanes.push_back(opt_right_lane.value());
     }
 
+    const auto left_opposite_lanes = rh->getLeftOppositeLanelets(lane);
+    if (!is_right_shift && !left_opposite_lanes.empty()) {
+      lanes.push_back(left_opposite_lanes.front());
+
+      for (const auto & prev_lane : rh->getPreviousLanelets(left_opposite_lanes.front())) {
+        if (!exist(prev_lane.id())) {
+          lanes.push_back(prev_lane);
+        }
+      }
+    }
+
     const auto right_opposite_lanes = rh->getRightOppositeLanelets(lane);
     if (is_right_shift && !right_opposite_lanes.empty()) {
       lanes.push_back(right_opposite_lanes.front());


### PR DESCRIPTION
## Description
Left opposite lanes were not considered in the getAdjacentLane function. This PR adds the left opposite lanes inside the function.

## Related links
None

## How was this PR tested?
[Internal test](https://evaluation.tier4.jp/evaluation/reports/2231c1a3-cf06-55fd-b04e-e251873acdc3?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
Static obstacle avoidance should cover wider scenes.
