### PR TITLE
refactor(map_loader): apply static analysis

### DIFF
--- a/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
+++ b/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
@@ -27,7 +27,6 @@
 #include <memory>
 #include <string>
 
-
 class Lanelet2MapLoaderNode : public rclcpp::Node
 {
 public:

--- a/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
+++ b/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
@@ -27,8 +27,6 @@
 #include <memory>
 #include <string>
 
-using autoware_map_msgs::msg::LaneletMapBin;
-using tier4_map_msgs::msg::MapProjectorInfo;
 
 class Lanelet2MapLoaderNode : public rclcpp::Node
 {
@@ -38,7 +36,7 @@ public:
   static lanelet::LaneletMapPtr load_map(
     const std::string & lanelet2_filename,
     const tier4_map_msgs::msg::MapProjectorInfo & projector_info);
-  static LaneletMapBin create_map_bin_msg(
+  static autoware_map_msgs::msg::LaneletMapBin create_map_bin_msg(
     const lanelet::LaneletMapPtr map, const std::string & lanelet2_filename,
     const rclcpp::Time & now);
 
@@ -48,7 +46,7 @@ private:
   void on_map_projector_info(const MapProjectorInfo::Message::ConstSharedPtr msg);
 
   component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
-  rclcpp::Publisher<LaneletMapBin>::SharedPtr pub_map_bin_;
+  rclcpp::Publisher<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr pub_map_bin_;
 };
 
 #endif  // MAP_LOADER__LANELET2_MAP_LOADER_NODE_HPP_

--- a/map/map_loader/include/map_loader/lanelet2_map_visualization_node.hpp
+++ b/map/map_loader/include/map_loader/lanelet2_map_visualization_node.hpp
@@ -34,7 +34,7 @@ private:
 
   bool viz_lanelets_centerline_;
 
-  void onMapBin(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
+  void on_map_bin(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
 };
 
 #endif  // MAP_LOADER__LANELET2_MAP_VISUALIZATION_NODE_HPP_

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp
@@ -30,7 +30,7 @@ public:
     return BasicPoint3d{0.0, 0.0, gps.ele};
   }
 
-  GPSPoint reverse(const BasicPoint3d & point) const override
+  [[nodiscard]] GPSPoint reverse(const BasicPoint3d & point) const override
   {
     return GPSPoint{0.0, 0.0, point.z()};
   }

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -51,6 +51,9 @@
 
 #include <string>
 
+using autoware_map_msgs::msg::LaneletMapBin;
+using tier4_map_msgs::msg::MapProjectorInfo;
+
 Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options)
 : Node("lanelet2_map_loader", options)
 {
@@ -105,13 +108,13 @@ lanelet::LaneletMapPtr Lanelet2MapLoaderNode::load_map(
   if (projector_info.projector_type != tier4_map_msgs::msg::MapProjectorInfo::LOCAL) {
     std::unique_ptr<lanelet::Projector> projector =
       geography_utils::get_lanelet2_projector(projector_info);
-    const lanelet::LaneletMapPtr map = lanelet::load(lanelet2_filename, *projector, &errors);
+    lanelet::LaneletMapPtr map = lanelet::load(lanelet2_filename, *projector, &errors);
     if (errors.empty()) {
       return map;
     }
   } else {
     const lanelet::projection::LocalProjector projector;
-    const lanelet::LaneletMapPtr map = lanelet::load(lanelet2_filename, projector, &errors);
+    lanelet::LaneletMapPtr map = lanelet::load(lanelet2_filename, projector, &errors);
 
     if (!errors.empty()) {
       for (const auto & error : errors) {
@@ -150,7 +153,8 @@ lanelet::LaneletMapPtr Lanelet2MapLoaderNode::load_map(
 LaneletMapBin Lanelet2MapLoaderNode::create_map_bin_msg(
   const lanelet::LaneletMapPtr map, const std::string & lanelet2_filename, const rclcpp::Time & now)
 {
-  std::string format_version{}, map_version{};
+  std::string format_version{};
+  std::string map_version{};
   lanelet::io_handlers::AutowareOsmParser::parseVersions(
     lanelet2_filename, &format_version, &map_version);
 

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -51,18 +51,18 @@
 
 namespace
 {
-void insertMarkerArray(
+void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2)
 {
   a1->markers.insert(a1->markers.end(), a2.markers.begin(), a2.markers.end());
 }
 
-void setColor(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a)
+void set_color(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a)
 {
-  cl->r = r;
-  cl->g = g;
-  cl->b = b;
-  cl->a = a;
+  cl->r = static_cast<float>(r);
+  cl->g = static_cast<float>(g);
+  cl->b = static_cast<float>(b);
+  cl->a = static_cast<float>(a);
 }
 }  // namespace
 
@@ -75,13 +75,13 @@ Lanelet2MapVisualizationNode::Lanelet2MapVisualizationNode(const rclcpp::NodeOpt
 
   sub_map_bin_ = this->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&Lanelet2MapVisualizationNode::onMapBin, this, _1));
+    std::bind(&Lanelet2MapVisualizationNode::on_map_bin, this, _1));
 
   pub_marker_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "output/lanelet2_map_marker", rclcpp::QoS{1}.transient_local());
 }
 
-void Lanelet2MapVisualizationNode::onMapBin(
+void Lanelet2MapVisualizationNode::on_map_bin(
   const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg)
 {
   lanelet::LaneletMapPtr viz_lanelet_map(new lanelet::LaneletMap);
@@ -103,8 +103,6 @@ void Lanelet2MapVisualizationNode::onMapBin(
   lanelet::ConstLanelets walkway_lanelets = lanelet::utils::query::walkwayLanelets(all_lanelets);
   std::vector<lanelet::ConstLineString3d> stop_lines =
     lanelet::utils::query::stopLinesLanelets(road_lanelets);
-  std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems =
-    lanelet::utils::query::trafficLights(all_lanelets);
   std::vector<lanelet::AutowareTrafficLightConstPtr> aw_tl_reg_elems =
     lanelet::utils::query::autowareTrafficLights(all_lanelets);
   std::vector<lanelet::DetectionAreaConstPtr> da_reg_elems =
@@ -133,140 +131,158 @@ void Lanelet2MapVisualizationNode::onMapBin(
     lanelet::utils::query::noParkingAreas(all_lanelets);
   lanelet::ConstLineStrings3d curbstones = lanelet::utils::query::curbstones(viz_lanelet_map);
 
-  std_msgs::msg::ColorRGBA cl_road, cl_shoulder, cl_cross, cl_partitions, cl_pedestrian_markings,
-    cl_ll_borders, cl_shoulder_borders, cl_stoplines, cl_trafficlights, cl_detection_areas,
-    cl_speed_bumps, cl_crosswalks, cl_parking_lots, cl_parking_spaces, cl_lanelet_id,
-    cl_obstacle_polygons, cl_no_stopping_areas, cl_no_obstacle_segmentation_area,
-    cl_no_obstacle_segmentation_area_for_run_out, cl_hatched_road_markings_area,
-    cl_hatched_road_markings_line, cl_no_parking_areas, cl_curbstones, cl_intersection_area;
-  setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
-  setColor(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
-  setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
-  setColor(&cl_partitions, 0.25, 0.25, 0.25, 0.999);
-  setColor(&cl_pedestrian_markings, 0.5, 0.5, 0.5, 0.999);
-  setColor(&cl_ll_borders, 0.5, 0.5, 0.5, 0.999);
-  setColor(&cl_shoulder_borders, 0.2, 0.2, 0.2, 0.999);
-  setColor(&cl_stoplines, 0.5, 0.5, 0.5, 0.999);
-  setColor(&cl_trafficlights, 0.5, 0.5, 0.5, 0.8);
-  setColor(&cl_detection_areas, 0.27, 0.27, 0.37, 0.5);
-  setColor(&cl_no_stopping_areas, 0.37, 0.37, 0.37, 0.5);
-  setColor(&cl_speed_bumps, 0.56, 0.40, 0.27, 0.5);
-  setColor(&cl_crosswalks, 0.80, 0.80, 0.0, 0.5);
-  setColor(&cl_obstacle_polygons, 0.4, 0.27, 0.27, 0.5);
-  setColor(&cl_parking_lots, 1.0, 1.0, 1.0, 0.2);
-  setColor(&cl_parking_spaces, 1.0, 1.0, 1.0, 0.3);
-  setColor(&cl_lanelet_id, 0.5, 0.5, 0.5, 0.999);
-  setColor(&cl_no_obstacle_segmentation_area, 0.37, 0.37, 0.27, 0.5);
-  setColor(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
-  setColor(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
-  setColor(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
-  setColor(&cl_no_parking_areas, 0.42, 0.42, 0.42, 0.5);
-  setColor(&cl_curbstones, 0.1, 0.1, 0.2, 0.999);
-  setColor(&cl_intersection_area, 0.16, 1.0, 0.69, 0.5);
+  std_msgs::msg::ColorRGBA cl_road;
+  std_msgs::msg::ColorRGBA cl_shoulder;
+  std_msgs::msg::ColorRGBA cl_cross;
+  std_msgs::msg::ColorRGBA cl_partitions;
+  std_msgs::msg::ColorRGBA cl_pedestrian_markings;
+  std_msgs::msg::ColorRGBA cl_ll_borders;
+  std_msgs::msg::ColorRGBA cl_shoulder_borders;
+  std_msgs::msg::ColorRGBA cl_stoplines;
+  std_msgs::msg::ColorRGBA cl_trafficlights;
+  std_msgs::msg::ColorRGBA cl_detection_areas;
+  std_msgs::msg::ColorRGBA cl_speed_bumps;
+  std_msgs::msg::ColorRGBA cl_crosswalks;
+  std_msgs::msg::ColorRGBA cl_parking_lots;
+  std_msgs::msg::ColorRGBA cl_parking_spaces;
+  std_msgs::msg::ColorRGBA cl_lanelet_id;
+  std_msgs::msg::ColorRGBA cl_obstacle_polygons;
+  std_msgs::msg::ColorRGBA cl_no_stopping_areas;
+  std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area;
+  std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area_for_run_out;
+  std_msgs::msg::ColorRGBA cl_hatched_road_markings_area;
+  std_msgs::msg::ColorRGBA cl_hatched_road_markings_line;
+  std_msgs::msg::ColorRGBA cl_no_parking_areas;
+  std_msgs::msg::ColorRGBA cl_curbstones;
+  std_msgs::msg::ColorRGBA cl_intersection_area;
+  set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
+  set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
+  set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
+  set_color(&cl_partitions, 0.25, 0.25, 0.25, 0.999);
+  set_color(&cl_pedestrian_markings, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_ll_borders, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_shoulder_borders, 0.2, 0.2, 0.2, 0.999);
+  set_color(&cl_stoplines, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_trafficlights, 0.5, 0.5, 0.5, 0.8);
+  set_color(&cl_detection_areas, 0.27, 0.27, 0.37, 0.5);
+  set_color(&cl_no_stopping_areas, 0.37, 0.37, 0.37, 0.5);
+  set_color(&cl_speed_bumps, 0.56, 0.40, 0.27, 0.5);
+  set_color(&cl_crosswalks, 0.80, 0.80, 0.0, 0.5);
+  set_color(&cl_obstacle_polygons, 0.4, 0.27, 0.27, 0.5);
+  set_color(&cl_parking_lots, 1.0, 1.0, 1.0, 0.2);
+  set_color(&cl_parking_spaces, 1.0, 1.0, 1.0, 0.3);
+  set_color(&cl_lanelet_id, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_no_obstacle_segmentation_area, 0.37, 0.37, 0.27, 0.5);
+  set_color(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
+  set_color(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
+  set_color(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_no_parking_areas, 0.42, 0.42, 0.42, 0.5);
+  set_color(&cl_curbstones, 0.1, 0.1, 0.2, 0.999);
+  set_color(&cl_intersection_area, 0.16, 1.0, 0.69, 0.5);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::lineStringsAsMarkerArray(stop_lines, "stop_lines", cl_stoplines, 0.5));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::lineStringsAsMarkerArray(partitions, "partitions", cl_partitions, 0.1));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::laneletDirectionAsMarkerArray(shoulder_lanelets, "shoulder_"));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::laneletDirectionAsMarkerArray(road_lanelets));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
                          "crosswalk_lanelets", crosswalk_lanelets, cl_cross));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::pedestrianPolygonMarkingsAsMarkerArray(
                          pedestrian_polygon_markings, cl_pedestrian_markings));
 
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::pedestrianLineMarkingsAsMarkerArray(
                          pedestrian_line_markings, cl_pedestrian_markings));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
                          "walkway_lanelets", walkway_lanelets, cl_cross));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::obstaclePolygonsAsMarkerArray(obstacle_polygons, cl_obstacle_polygons));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::detectionAreasAsMarkerArray(da_reg_elems, cl_detection_areas));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::noStoppingAreasAsMarkerArray(no_reg_elems, cl_no_stopping_areas));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::speedBumpsAsMarkerArray(sb_reg_elems, cl_speed_bumps));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::crosswalkAreasAsMarkerArray(cw_reg_elems, cl_crosswalks));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::parkingLotsAsMarkerArray(parking_lots, cl_parking_lots));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::parkingSpacesAsMarkerArray(parking_spaces, cl_parking_spaces));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::laneletsBoundaryAsMarkerArray(
       shoulder_lanelets, cl_shoulder_borders, viz_lanelets_centerline_, "shoulder_"));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::laneletsBoundaryAsMarkerArray(
                          road_lanelets, cl_ll_borders, viz_lanelets_centerline_));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::autowareTrafficLightsAsMarkerArray(aw_tl_reg_elems, cl_trafficlights));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
                          road_lanelets, cl_trafficlights));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
                          crosswalk_lanelets, cl_trafficlights));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::generateTrafficLightIdMaker(aw_tl_reg_elems, cl_trafficlights));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::generateLaneletIdMarker(shoulder_lanelets, cl_lanelet_id));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::generateLaneletIdMarker(road_lanelets, cl_lanelet_id));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::generateLaneletIdMarker(
                          crosswalk_lanelets, cl_lanelet_id, "crosswalk_lanelet_id"));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
                          "shoulder_road_lanelets", shoulder_lanelets, cl_shoulder));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::laneletsAsTriangleMarkerArray("road_lanelets", road_lanelets, cl_road));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::noObstacleSegmentationAreaAsMarkerArray(
                          no_obstacle_segmentation_area, cl_no_obstacle_segmentation_area));
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
       no_obstacle_segmentation_area_for_run_out, cl_no_obstacle_segmentation_area_for_run_out));
 
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
       hatched_road_markings_area, cl_hatched_road_markings_area, cl_hatched_road_markings_line));
 
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::noParkingAreasAsMarkerArray(no_parking_reg_elems, cl_no_parking_areas));
 
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array,
     lanelet::visualization::lineStringsAsMarkerArray(curbstones, "curbstone", cl_curbstones, 0.2));
 
-  insertMarkerArray(
+  insert_marker_array(
     &map_marker_array, lanelet::visualization::intersectionAreaAsMarkerArray(
                          intersection_areas, cl_intersection_area));
 

--- a/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp
@@ -14,20 +14,22 @@
 
 #include "differential_map_loader_module.hpp"
 
+#include <utility>
+
 DifferentialMapLoaderModule::DifferentialMapLoaderModule(
-  rclcpp::Node * node, const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict)
-: logger_(node->get_logger()), all_pcd_file_metadata_dict_(pcd_file_metadata_dict)
+  rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict)
+: logger_(node->get_logger()), all_pcd_file_metadata_dict_(std::move(pcd_file_metadata_dict))
 {
   get_differential_pcd_maps_service_ = node->create_service<GetDifferentialPointCloudMap>(
     "service/get_differential_pcd_map",
     std::bind(
-      &DifferentialMapLoaderModule::onServiceGetDifferentialPointCloudMap, this,
+      &DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map, this,
       std::placeholders::_1, std::placeholders::_2));
 }
 
-void DifferentialMapLoaderModule::differentialAreaLoad(
-  const autoware_map_msgs::msg::AreaInfo & area, const std::vector<std::string> & cached_ids,
-  GetDifferentialPointCloudMap::Response::SharedPtr & response) const
+void DifferentialMapLoaderModule::differential_area_load(
+  const autoware_map_msgs::msg::AreaInfo & area_info, const std::vector<std::string> & cached_ids,
+  const GetDifferentialPointCloudMap::Response::SharedPtr & response) const
 {
   // iterate over all the available pcd map grids
   std::vector<bool> should_remove(static_cast<int>(cached_ids.size()), true);
@@ -36,18 +38,18 @@ void DifferentialMapLoaderModule::differentialAreaLoad(
     PCDFileMetadata metadata = ele.second;
 
     // assume that the map ID = map path (for now)
-    std::string map_id = path;
+    const std::string& map_id = path;
 
     // skip if the pcd file is not within the queried area
-    if (!isGridWithinQueriedArea(area, metadata)) continue;
+    if (!is_grid_within_queried_area(area_info, metadata)) continue;
 
     auto id_in_cached_list = std::find(cached_ids.begin(), cached_ids.end(), map_id);
     if (id_in_cached_list != cached_ids.end()) {
-      int index = id_in_cached_list - cached_ids.begin();
+      int index = static_cast<int>(id_in_cached_list - cached_ids.begin());
       should_remove[index] = false;
     } else {
       autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =
-        loadPointCloudMapCellWithID(path, map_id);
+        load_point_cloud_map_cell_with_id(path, map_id);
       pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
       pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
       pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
@@ -63,19 +65,19 @@ void DifferentialMapLoaderModule::differentialAreaLoad(
   }
 }
 
-bool DifferentialMapLoaderModule::onServiceGetDifferentialPointCloudMap(
+bool DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map(
   GetDifferentialPointCloudMap::Request::SharedPtr req,
-  GetDifferentialPointCloudMap::Response::SharedPtr res)
+  GetDifferentialPointCloudMap::Response::SharedPtr res) const
 {
   auto area = req->area;
   std::vector<std::string> cached_ids = req->cached_ids;
-  differentialAreaLoad(area, cached_ids, res);
+  differential_area_load(area, cached_ids, res);
   res->header.frame_id = "map";
   return true;
 }
 
 autoware_map_msgs::msg::PointCloudMapCellWithID
-DifferentialMapLoaderModule::loadPointCloudMapCellWithID(
+DifferentialMapLoaderModule::load_point_cloud_map_cell_with_id(
   const std::string & path, const std::string & map_id) const
 {
   sensor_msgs::msg::PointCloud2 pcd;

--- a/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 
 DifferentialMapLoaderModule::DifferentialMapLoaderModule(
-  rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict)
+  rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict)
 : logger_(node->get_logger()), all_pcd_file_metadata_dict_(std::move(pcd_file_metadata_dict))
 {
   get_differential_pcd_maps_service_ = node->create_service<GetDifferentialPointCloudMap>(
@@ -38,7 +38,7 @@ void DifferentialMapLoaderModule::differential_area_load(
     PCDFileMetadata metadata = ele.second;
 
     // assume that the map ID = map path (for now)
-    const std::string& map_id = path;
+    const std::string & map_id = path;
 
     // skip if the pcd file is not within the queried area
     if (!is_grid_within_queried_area(area_info, metadata)) continue;

--- a/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.hpp
@@ -38,7 +38,7 @@ class DifferentialMapLoaderModule
 
 public:
   explicit DifferentialMapLoaderModule(
-    rclcpp::Node * node, const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict);
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict);
 
 private:
   rclcpp::Logger logger_;
@@ -46,13 +46,13 @@ private:
   std::map<std::string, PCDFileMetadata> all_pcd_file_metadata_dict_;
   rclcpp::Service<GetDifferentialPointCloudMap>::SharedPtr get_differential_pcd_maps_service_;
 
-  bool onServiceGetDifferentialPointCloudMap(
+  [[nodiscard]] bool on_service_get_differential_point_cloud_map(
     GetDifferentialPointCloudMap::Request::SharedPtr req,
-    GetDifferentialPointCloudMap::Response::SharedPtr res);
-  void differentialAreaLoad(
+    GetDifferentialPointCloudMap::Response::SharedPtr res) const;
+  void differential_area_load(
     const autoware_map_msgs::msg::AreaInfo & area_info, const std::vector<std::string> & cached_ids,
-    GetDifferentialPointCloudMap::Response::SharedPtr & response) const;
-  autoware_map_msgs::msg::PointCloudMapCellWithID loadPointCloudMapCellWithID(
+    const GetDifferentialPointCloudMap::Response::SharedPtr & response) const;
+  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
     const std::string & path, const std::string & map_id) const;
 };
 

--- a/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.hpp
@@ -38,7 +38,7 @@ class DifferentialMapLoaderModule
 
 public:
   explicit DifferentialMapLoaderModule(
-    rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict);
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict);
 
 private:
   rclcpp::Logger logger_;

--- a/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.cpp
@@ -17,13 +17,14 @@
 #include <utility>
 
 PartialMapLoaderModule::PartialMapLoaderModule(
-  rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict)
+  rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict)
 : logger_(node->get_logger()), all_pcd_file_metadata_dict_(std::move(pcd_file_metadata_dict))
 {
   get_partial_pcd_maps_service_ = node->create_service<GetPartialPointCloudMap>(
     "service/get_partial_pcd_map",
-    std::bind(&PartialMapLoaderModule::on_service_get_partial_point_cloud_map,
-      this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &PartialMapLoaderModule::on_service_get_partial_point_cloud_map, this, std::placeholders::_1,
+      std::placeholders::_2));
 }
 
 void PartialMapLoaderModule::partial_area_load(
@@ -36,7 +37,7 @@ void PartialMapLoaderModule::partial_area_load(
     PCDFileMetadata metadata = ele.second;
 
     // assume that the map ID = map path (for now)
-    const std::string& map_id = path;
+    const std::string & map_id = path;
 
     // skip if the pcd file is not within the queried area
     if (!is_grid_within_queried_area(area, metadata)) continue;
@@ -63,7 +64,7 @@ bool PartialMapLoaderModule::on_service_get_partial_point_cloud_map(
 }
 
 autoware_map_msgs::msg::PointCloudMapCellWithID
-  PartialMapLoaderModule::load_point_cloud_map_cell_with_id(
+PartialMapLoaderModule::load_point_cloud_map_cell_with_id(
   const std::string & path, const std::string & map_id) const
 {
   sensor_msgs::msg::PointCloud2 pcd;

--- a/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.cpp
@@ -14,19 +14,21 @@
 
 #include "partial_map_loader_module.hpp"
 
+#include <utility>
+
 PartialMapLoaderModule::PartialMapLoaderModule(
-  rclcpp::Node * node, const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict)
-: logger_(node->get_logger()), all_pcd_file_metadata_dict_(pcd_file_metadata_dict)
+  rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict)
+: logger_(node->get_logger()), all_pcd_file_metadata_dict_(std::move(pcd_file_metadata_dict))
 {
   get_partial_pcd_maps_service_ = node->create_service<GetPartialPointCloudMap>(
-    "service/get_partial_pcd_map", std::bind(
-                                     &PartialMapLoaderModule::onServiceGetPartialPointCloudMap,
-                                     this, std::placeholders::_1, std::placeholders::_2));
+    "service/get_partial_pcd_map",
+    std::bind(&PartialMapLoaderModule::on_service_get_partial_point_cloud_map,
+      this, std::placeholders::_1, std::placeholders::_2));
 }
 
-void PartialMapLoaderModule::partialAreaLoad(
+void PartialMapLoaderModule::partial_area_load(
   const autoware_map_msgs::msg::AreaInfo & area,
-  GetPartialPointCloudMap::Response::SharedPtr & response) const
+  const GetPartialPointCloudMap::Response::SharedPtr & response) const
 {
   // iterate over all the available pcd map grids
   for (const auto & ele : all_pcd_file_metadata_dict_) {
@@ -34,13 +36,13 @@ void PartialMapLoaderModule::partialAreaLoad(
     PCDFileMetadata metadata = ele.second;
 
     // assume that the map ID = map path (for now)
-    std::string map_id = path;
+    const std::string& map_id = path;
 
     // skip if the pcd file is not within the queried area
-    if (!isGridWithinQueriedArea(area, metadata)) continue;
+    if (!is_grid_within_queried_area(area, metadata)) continue;
 
     autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =
-      loadPointCloudMapCellWithID(path, map_id);
+      load_point_cloud_map_cell_with_id(path, map_id);
     pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
     pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
     pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
@@ -50,16 +52,18 @@ void PartialMapLoaderModule::partialAreaLoad(
   }
 }
 
-bool PartialMapLoaderModule::onServiceGetPartialPointCloudMap(
-  GetPartialPointCloudMap::Request::SharedPtr req, GetPartialPointCloudMap::Response::SharedPtr res)
+bool PartialMapLoaderModule::on_service_get_partial_point_cloud_map(
+  GetPartialPointCloudMap::Request::SharedPtr req,
+  GetPartialPointCloudMap::Response::SharedPtr res) const
 {
   auto area = req->area;
-  partialAreaLoad(area, res);
+  partial_area_load(area, res);
   res->header.frame_id = "map";
   return true;
 }
 
-autoware_map_msgs::msg::PointCloudMapCellWithID PartialMapLoaderModule::loadPointCloudMapCellWithID(
+autoware_map_msgs::msg::PointCloudMapCellWithID
+  PartialMapLoaderModule::load_point_cloud_map_cell_with_id(
   const std::string & path, const std::string & map_id) const
 {
   sensor_msgs::msg::PointCloud2 pcd;

--- a/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.hpp
@@ -38,7 +38,7 @@ class PartialMapLoaderModule
 
 public:
   explicit PartialMapLoaderModule(
-    rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict);
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict);
 
 private:
   rclcpp::Logger logger_;

--- a/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/partial_map_loader_module.hpp
@@ -38,7 +38,7 @@ class PartialMapLoaderModule
 
 public:
   explicit PartialMapLoaderModule(
-    rclcpp::Node * node, const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict);
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict);
 
 private:
   rclcpp::Logger logger_;
@@ -46,13 +46,13 @@ private:
   std::map<std::string, PCDFileMetadata> all_pcd_file_metadata_dict_;
   rclcpp::Service<GetPartialPointCloudMap>::SharedPtr get_partial_pcd_maps_service_;
 
-  bool onServiceGetPartialPointCloudMap(
+  [[nodiscard]] bool on_service_get_partial_point_cloud_map(
     GetPartialPointCloudMap::Request::SharedPtr req,
-    GetPartialPointCloudMap::Response::SharedPtr res);
-  void partialAreaLoad(
+    GetPartialPointCloudMap::Response::SharedPtr res) const;
+  void partial_area_load(
     const autoware_map_msgs::msg::AreaInfo & area,
-    GetPartialPointCloudMap::Response::SharedPtr & response) const;
-  autoware_map_msgs::msg::PointCloudMapCellWithID loadPointCloudMapCellWithID(
+    const GetPartialPointCloudMap::Response::SharedPtr & response) const;
+  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
     const std::string & path, const std::string & map_id) const;
 };
 

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
@@ -50,10 +50,10 @@ PointcloudMapLoaderModule::PointcloudMapLoaderModule(
 
   sensor_msgs::msg::PointCloud2 pcd;
   if (use_downsample) {
-    const float leaf_size = node->declare_parameter<float>("leaf_size");
-    pcd = loadPCDFiles(pcd_paths, leaf_size);
+    const float leaf_size = static_cast<float>(node->declare_parameter<float>("leaf_size"));
+    pcd = load_pcd_files(pcd_paths, leaf_size);
   } else {
-    pcd = loadPCDFiles(pcd_paths, boost::none);
+    pcd = load_pcd_files(pcd_paths, boost::none);
   }
 
   if (pcd.width == 0) {
@@ -65,7 +65,7 @@ PointcloudMapLoaderModule::PointcloudMapLoaderModule(
   pub_pointcloud_map_->publish(pcd);
 }
 
-sensor_msgs::msg::PointCloud2 PointcloudMapLoaderModule::loadPCDFiles(
+sensor_msgs::msg::PointCloud2 PointcloudMapLoaderModule::load_pcd_files(
   const std::vector<std::string> & pcd_paths, const boost::optional<float> leaf_size) const
 {
   sensor_msgs::msg::PointCloud2 whole_pcd;

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.hpp
@@ -39,7 +39,7 @@ private:
   rclcpp::Logger logger_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_pointcloud_map_;
 
-  sensor_msgs::msg::PointCloud2 loadPCDFiles(
+  [[nodiscard]] sensor_msgs::msg::PointCloud2 load_pcd_files(
     const std::vector<std::string> & pcd_paths, const boost::optional<float> leaf_size) const;
 };
 

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
@@ -45,9 +45,9 @@ private:
   std::unique_ptr<DifferentialMapLoaderModule> differential_map_loader_;
   std::unique_ptr<SelectedMapLoaderModule> selected_map_loader_;
 
-  std::vector<std::string> getPcdPaths(
+  std::vector<std::string> get_pcd_paths(
     const std::vector<std::string> & pcd_paths_or_directory) const;
-  std::map<std::string, PCDFileMetadata> getPCDMetadata(
+  std::map<std::string, PCDFileMetadata> get_pcd_metadata(
     const std::string & pcd_metadata_path, const std::vector<std::string> & pcd_paths) const;
 };
 

--- a/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include "selected_map_loader_module.hpp"
+
+#include <utility>
 namespace
 {
-autoware_map_msgs::msg::PointCloudMapMetaData createMetadata(
+autoware_map_msgs::msg::PointCloudMapMetaData create_metadata(
   const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict)
 {
   autoware_map_msgs::msg::PointCloudMapMetaData metadata_msg;
@@ -23,11 +25,10 @@ autoware_map_msgs::msg::PointCloudMapMetaData createMetadata(
   metadata_msg.header.stamp = rclcpp::Clock().now();
 
   for (const auto & ele : pcd_file_metadata_dict) {
-    std::string path = ele.first;
     PCDFileMetadata metadata = ele.second;
 
     // assume that the map ID = map path (for now)
-    std::string map_id = path;
+    const std::string& map_id = ele.first;
 
     autoware_map_msgs::msg::PointCloudMapCellMetaDataWithID cell_metadata_with_id;
     cell_metadata_with_id.cell_id = map_id;
@@ -44,23 +45,23 @@ autoware_map_msgs::msg::PointCloudMapMetaData createMetadata(
 }  // namespace
 
 SelectedMapLoaderModule::SelectedMapLoaderModule(
-  rclcpp::Node * node, const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict)
-: logger_(node->get_logger()), all_pcd_file_metadata_dict_(pcd_file_metadata_dict)
+  rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict)
+: logger_(node->get_logger()), all_pcd_file_metadata_dict_(std::move(pcd_file_metadata_dict))
 {
   get_selected_pcd_maps_service_ = node->create_service<GetSelectedPointCloudMap>(
-    "service/get_selected_pcd_map", std::bind(
-                                      &SelectedMapLoaderModule::onServiceGetSelectedPointCloudMap,
-                                      this, std::placeholders::_1, std::placeholders::_2));
+    "service/get_selected_pcd_map",
+    std::bind(&SelectedMapLoaderModule::on_service_get_selected_point_cloud_map, this,
+      std::placeholders::_1, std::placeholders::_2));
 
   // publish the map metadata
   rclcpp::QoS durable_qos{1};
   durable_qos.transient_local();
   pub_metadata_ = node->create_publisher<autoware_map_msgs::msg::PointCloudMapMetaData>(
     "output/pointcloud_map_metadata", durable_qos);
-  pub_metadata_->publish(createMetadata(all_pcd_file_metadata_dict_));
+  pub_metadata_->publish(create_metadata(all_pcd_file_metadata_dict_));
 }
 
-bool SelectedMapLoaderModule::onServiceGetSelectedPointCloudMap(
+bool SelectedMapLoaderModule::on_service_get_selected_point_cloud_map(
   GetSelectedPointCloudMap::Request::SharedPtr req,
   GetSelectedPointCloudMap::Response::SharedPtr res) const
 {
@@ -76,11 +77,11 @@ bool SelectedMapLoaderModule::onServiceGetSelectedPointCloudMap(
 
     const std::string path = requested_selected_map_iterator->first;
     // assume that the map ID = map path (for now)
-    const std::string map_id = path;
+    const std::string& map_id = path;
     PCDFileMetadata metadata = requested_selected_map_iterator->second;
 
     autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =
-      loadPointCloudMapCellWithID(path, map_id);
+      load_point_cloud_map_cell_with_id(path, map_id);
     pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
     pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
     pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
@@ -93,7 +94,7 @@ bool SelectedMapLoaderModule::onServiceGetSelectedPointCloudMap(
 }
 
 autoware_map_msgs::msg::PointCloudMapCellWithID
-SelectedMapLoaderModule::loadPointCloudMapCellWithID(
+SelectedMapLoaderModule::load_point_cloud_map_cell_with_id(
   const std::string & path, const std::string & map_id) const
 {
   sensor_msgs::msg::PointCloud2 pcd;

--- a/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
@@ -28,7 +28,7 @@ autoware_map_msgs::msg::PointCloudMapMetaData create_metadata(
     PCDFileMetadata metadata = ele.second;
 
     // assume that the map ID = map path (for now)
-    const std::string& map_id = ele.first;
+    const std::string & map_id = ele.first;
 
     autoware_map_msgs::msg::PointCloudMapCellMetaDataWithID cell_metadata_with_id;
     cell_metadata_with_id.cell_id = map_id;
@@ -45,12 +45,13 @@ autoware_map_msgs::msg::PointCloudMapMetaData create_metadata(
 }  // namespace
 
 SelectedMapLoaderModule::SelectedMapLoaderModule(
-  rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict)
+  rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict)
 : logger_(node->get_logger()), all_pcd_file_metadata_dict_(std::move(pcd_file_metadata_dict))
 {
   get_selected_pcd_maps_service_ = node->create_service<GetSelectedPointCloudMap>(
     "service/get_selected_pcd_map",
-    std::bind(&SelectedMapLoaderModule::on_service_get_selected_point_cloud_map, this,
+    std::bind(
+      &SelectedMapLoaderModule::on_service_get_selected_point_cloud_map, this,
       std::placeholders::_1, std::placeholders::_2));
 
   // publish the map metadata
@@ -77,7 +78,7 @@ bool SelectedMapLoaderModule::on_service_get_selected_point_cloud_map(
 
     const std::string path = requested_selected_map_iterator->first;
     // assume that the map ID = map path (for now)
-    const std::string& map_id = path;
+    const std::string & map_id = path;
     PCDFileMetadata metadata = requested_selected_map_iterator->second;
 
     autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =

--- a/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
@@ -39,7 +39,7 @@ class SelectedMapLoaderModule
 
 public:
   explicit SelectedMapLoaderModule(
-    rclcpp::Node * node, const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict);
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict);
 
 private:
   rclcpp::Logger logger_;
@@ -49,10 +49,10 @@ private:
 
   rclcpp::Publisher<autoware_map_msgs::msg::PointCloudMapMetaData>::SharedPtr pub_metadata_;
 
-  bool onServiceGetSelectedPointCloudMap(
+  [[nodiscard]] bool on_service_get_selected_point_cloud_map(
     GetSelectedPointCloudMap::Request::SharedPtr req,
     GetSelectedPointCloudMap::Response::SharedPtr res) const;
-  autoware_map_msgs::msg::PointCloudMapCellWithID loadPointCloudMapCellWithID(
+  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
     const std::string & path, const std::string & map_id) const;
 };
 

--- a/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
@@ -39,7 +39,7 @@ class SelectedMapLoaderModule
 
 public:
   explicit SelectedMapLoaderModule(
-    rclcpp::Node * node, std::map<std::string, PCDFileMetadata>  pcd_file_metadata_dict);
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict);
 
 private:
   rclcpp::Logger logger_;

--- a/map/map_loader/src/pointcloud_map_loader/utils.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/utils.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-std::map<std::string, PCDFileMetadata> loadPCDMetadata(const std::string & pcd_metadata_path)
+std::map<std::string, PCDFileMetadata> load_pcd_metadata(const std::string & pcd_metadata_path)
 {
   YAML::Node config = YAML::LoadFile(pcd_metadata_path);
 
@@ -33,22 +33,22 @@ std::map<std::string, PCDFileMetadata> loadPCDMetadata(const std::string & pcd_m
       continue;
     }
 
-    std::string key = node.first.as<std::string>();
-    std::vector<int> values = node.second.as<std::vector<int>>();
+    auto key = node.first.as<std::string>();
+    auto values = node.second.as<std::vector<int>>();
 
-    PCDFileMetadata fileMetadata;
-    fileMetadata.min.x = values[0];
-    fileMetadata.min.y = values[1];
-    fileMetadata.max.x = values[0] + config["x_resolution"].as<float>();
-    fileMetadata.max.y = values[1] + config["y_resolution"].as<float>();
+    PCDFileMetadata file_metadata;
+    file_metadata.min.x = static_cast<float>(values[0]);
+    file_metadata.min.y = static_cast<float>(values[1]);
+    file_metadata.max.x = static_cast<float>(values[0]) + config["x_resolution"].as<float>();
+    file_metadata.max.y = static_cast<float>(values[1]) + config["y_resolution"].as<float>();
 
-    metadata[key] = fileMetadata;
+    metadata[key] = file_metadata;
   }
 
   return metadata;
 }
 
-std::map<std::string, PCDFileMetadata> replaceWithAbsolutePath(
+std::map<std::string, PCDFileMetadata> replace_with_absolute_path(
   const std::map<std::string, PCDFileMetadata> & pcd_metadata_path,
   const std::vector<std::string> & pcd_paths, std::set<std::string> & missing_pcd_names)
 {
@@ -75,7 +75,7 @@ std::map<std::string, PCDFileMetadata> replaceWithAbsolutePath(
   return absolute_path_map;
 }
 
-bool cylinderAndBoxOverlapExists(
+bool cylinder_and_box_overlap_exists(
   const double center_x, const double center_y, const double radius,
   const pcl::PointXYZ box_min_point, const pcl::PointXYZ box_max_point)
 {
@@ -92,22 +92,18 @@ bool cylinderAndBoxOverlapExists(
   const double dy0 = center_y - box_min_point.y;
   const double dy1 = center_y - box_max_point.y;
 
-  if (
-    std::hypot(dx0, dy0) <= radius || std::hypot(dx1, dy0) <= radius ||
-    std::hypot(dx0, dy1) <= radius || std::hypot(dx1, dy1) <= radius) {
-    return true;
-  }
-
-  return false;
+  return std::hypot(dx0, dy0) <= radius || std::hypot(dx1, dy0) <= radius ||
+    std::hypot(dx0, dy1) <= radius || std::hypot(dx1, dy1) <= radius;
 }
 
-bool isGridWithinQueriedArea(
+bool is_grid_within_queried_area(
   const autoware_map_msgs::msg::AreaInfo area, const PCDFileMetadata metadata)
 {
   // Currently, the area load only supports cylindrical area
   double center_x = area.center_x;
   double center_y = area.center_y;
   double radius = area.radius;
-  bool res = cylinderAndBoxOverlapExists(center_x, center_y, radius, metadata.min, metadata.max);
+  bool res =
+    cylinder_and_box_overlap_exists(center_x, center_y, radius, metadata.min, metadata.max);
   return res;
 }

--- a/map/map_loader/src/pointcloud_map_loader/utils.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/utils.cpp
@@ -93,7 +93,7 @@ bool cylinder_and_box_overlap_exists(
   const double dy1 = center_y - box_max_point.y;
 
   return std::hypot(dx0, dy0) <= radius || std::hypot(dx1, dy0) <= radius ||
-    std::hypot(dx0, dy1) <= radius || std::hypot(dx1, dy1) <= radius;
+         std::hypot(dx0, dy1) <= radius || std::hypot(dx1, dy1) <= radius;
 }
 
 bool is_grid_within_queried_area(

--- a/map/map_loader/src/pointcloud_map_loader/utils.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/utils.hpp
@@ -37,15 +37,15 @@ struct PCDFileMetadata
   }
 };
 
-std::map<std::string, PCDFileMetadata> loadPCDMetadata(const std::string & pcd_metadata_path);
-std::map<std::string, PCDFileMetadata> replaceWithAbsolutePath(
+std::map<std::string, PCDFileMetadata> load_pcd_metadata(const std::string & pcd_metadata_path);
+std::map<std::string, PCDFileMetadata> replace_with_absolute_path(
   const std::map<std::string, PCDFileMetadata> & pcd_metadata_path,
   const std::vector<std::string> & pcd_paths, std::set<std::string> & missing_pcd_names);
 
-bool cylinderAndBoxOverlapExists(
+bool cylinder_and_box_overlap_exists(
   const double center_x, const double center_y, const double radius,
-  const pcl::PointXYZ position_min, const pcl::PointXYZ position_max);
-bool isGridWithinQueriedArea(
+  const pcl::PointXYZ box_min_point, const pcl::PointXYZ box_max_point);
+bool is_grid_within_queried_area(
   const autoware_map_msgs::msg::AreaInfo area, const PCDFileMetadata metadata);
 
 #endif  // POINTCLOUD_MAP_LOADER__UTILS_HPP_

--- a/map/map_loader/test/test_cylinder_box_overlap.cpp
+++ b/map/map_loader/test/test_cylinder_box_overlap.cpp
@@ -35,7 +35,7 @@ TEST(CylinderAndBoxOverlapExists, NoOverlap)
   p_max.y = 1.0;
   p_max.z = 1.0;
 
-  bool result = cylinderAndBoxOverlapExists(center_x, center_y, radius, p_min, p_max);
+  bool result = cylinder_and_box_overlap_exists(center_x, center_y, radius, p_min, p_max);
   EXPECT_FALSE(result);
 }
 
@@ -57,7 +57,7 @@ TEST(CylinderAndBoxOverlapExists, Overlap1)
   p_max.y = 1.0;
   p_max.z = 1.0;
 
-  bool result = cylinderAndBoxOverlapExists(center_x, center_y, radius, p_min, p_max);
+  bool result = cylinder_and_box_overlap_exists(center_x, center_y, radius, p_min, p_max);
   EXPECT_TRUE(result);
 }
 
@@ -79,6 +79,6 @@ TEST(CylinderAndBoxOverlapExists, Overlap2)
   p_max.y = 1.0;
   p_max.z = -99.0;
 
-  bool result = cylinderAndBoxOverlapExists(center_x, center_y, radius, p_min, p_max);
+  bool result = cylinder_and_box_overlap_exists(center_x, center_y, radius, p_min, p_max);
   EXPECT_TRUE(result);
 }

--- a/map/map_loader/test/test_load_pcd_metadata.cpp
+++ b/map/map_loader/test/test_load_pcd_metadata.cpp
@@ -21,7 +21,7 @@
 
 using ::testing::ContainerEq;
 
-std::string createYAMLFile()
+std::string create_yaml_file()
 {
   std::filesystem::path tmp_path = std::filesystem::temp_directory_path() / "temp_metadata.yaml";
 
@@ -37,14 +37,14 @@ std::string createYAMLFile()
 
 TEST(LoadPCDMetadataTest, BasicFunctionality)
 {
-  std::string yaml_file_path = createYAMLFile();
+  std::string yaml_file_path = create_yaml_file();
 
   std::map<std::string, PCDFileMetadata> expected = {
     {"file1.pcd", {{1, 2, 0}, {6, 8, 0}}},
     {"file2.pcd", {{3, 4, 0}, {8, 10, 0}}},
   };
 
-  auto result = loadPCDMetadata(yaml_file_path);
+  auto result = load_pcd_metadata(yaml_file_path);
   ASSERT_THAT(result, ContainerEq(expected));
 }
 

--- a/map/map_loader/test/test_pointcloud_map_loader_module.cpp
+++ b/map/map_loader/test/test_pointcloud_map_loader_module.cpp
@@ -26,8 +26,6 @@
 #include <chrono>
 #include <memory>
 
-using std::chrono_literals::operator""ms;
-
 class TestPointcloudMapLoaderModule : public ::testing::Test
 {
 protected:
@@ -61,6 +59,8 @@ protected:
 
 TEST_F(TestPointcloudMapLoaderModule, LoadPCDFilesNoDownsampleTest)
 {
+  using namespace std::literals::chrono_literals;
+
   // Prepare PCD paths
   std::vector<std::string> pcd_paths = {temp_pcd_path};
 

--- a/map/map_loader/test/test_replace_with_absolute_path.cpp
+++ b/map/map_loader/test/test_replace_with_absolute_path.cpp
@@ -37,7 +37,7 @@ TEST(ReplaceWithAbsolutePathTest, BasicFunctionality)
   };
 
   std::set<std::string> missing_pcd_names;
-  auto result = replaceWithAbsolutePath(pcd_metadata_path, pcd_paths, missing_pcd_names);
+  auto result = replace_with_absolute_path(pcd_metadata_path, pcd_paths, missing_pcd_names);
   ASSERT_THAT(result, ContainerEq(expected));
 }
 
@@ -56,7 +56,7 @@ TEST(ReplaceWithAbsolutePathTest, NoMatchingFiles)
   std::map<std::string, PCDFileMetadata> expected = {};
   std::set<std::string> missing_pcd_names;
 
-  auto result = replaceWithAbsolutePath(pcd_metadata_path, pcd_paths, missing_pcd_names);
+  auto result = replace_with_absolute_path(pcd_metadata_path, pcd_paths, missing_pcd_names);
   ASSERT_THAT(result, ContainerEq(expected));
 }
 


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `map/map_loader`.
Checked with clang-tidy and cppcheck.

Fixed:
- use explicit cast
- change variable names
  - camelCase to snake_case for variable
  - align variable name in header's definition and the implementation
- remove unused
- change function/method
  - camelCase to snake_case
  - add keyword from function/method which linter suggested


not Fixed:
- safe access to members of unions by `boost::variant`
  - speed concern

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1)

If you are using the same kind of script which I used in the past PRs, you need to be careful to set the package name.

You need to change the `${TARGET_DIR}` to `/${TARGET_DIR}/`, otherwise it will check other `..._map_loader_...` packages
<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path /${TARGET_DIR}/ | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path /${TARGET_DIR}/ | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh map_loader
...
19842 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/lanelet2_map_loader/lanelet2_local_projector.hpp:33:3: warning: function 'reverse' should be marked [[nodiscard]] [modernize-use-nodiscard]
  GPSPoint reverse(const BasicPoint3d & point) const override
  ^
  [[nodiscard]] 
Suppressed 19865 warnings (19841 in non-user code, 24 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
30421 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:16: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:40: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:55: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:64: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:79: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:16: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:40: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:55: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:64: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:79: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:40:40: warning: invalid case style for function 'loadPCDMetadata' [readability-identifier-naming]
std::map<std::string, PCDFileMetadata> loadPCDMetadata(const std::string & pcd_metadata_path);
                                       ^~~~~~~~~~~~~~~
                                       load_pcd_metadata
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:41:40: warning: invalid case style for function 'replaceWithAbsolutePath' [readability-identifier-naming]
std::map<std::string, PCDFileMetadata> replaceWithAbsolutePath(
                                       ^~~~~~~~~~~~~~~~~~~~~~~
                                       replace_with_absolute_path
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:45:6: warning: invalid case style for function 'cylinderAndBoxOverlapExists' [readability-identifier-naming]
bool cylinderAndBoxOverlapExists(
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
     cylinder_and_box_overlap_exists
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:48:6: warning: invalid case style for function 'isGridWithinQueriedArea' [readability-identifier-naming]
bool isGridWithinQueriedArea(
     ^~~~~~~~~~~~~~~~~~~~~~~
     is_grid_within_queried_area
Suppressed 30407 warnings (30405 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
31058 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:36:5: warning: use auto when initializing with a template cast to avoid duplicating the type name [modernize-use-auto]
    std::string key = node.first.as<std::string>();
    ^~~~~~~~~~~
    auto
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:37:5: warning: use auto when initializing with a template cast to avoid duplicating the type name [modernize-use-auto]
    std::vector<int> values = node.second.as<std::vector<int>>();
    ^~~~~~~~~~~~~~~~
    auto
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:39:21: warning: invalid case style for variable 'fileMetadata' [readability-identifier-naming]
    PCDFileMetadata fileMetadata;
                    ^~~~~~~~~~~~
                    file_metadata
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:40:22: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    fileMetadata.min.x = values[0];
                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:40:26: warning: narrowing conversion from '__gnu_cxx::__alloc_traits<std::allocator<int>, int>::value_type' (aka 'int') to 'float' [cppcoreguidelines-narrowing-conversions]
    fileMetadata.min.x = values[0];
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:41:22: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    fileMetadata.min.y = values[1];
                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:41:26: warning: narrowing conversion from '__gnu_cxx::__alloc_traits<std::allocator<int>, int>::value_type' (aka 'int') to 'float' [cppcoreguidelines-narrowing-conversions]
    fileMetadata.min.y = values[1];
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:42:22: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    fileMetadata.max.x = values[0] + config["x_resolution"].as<float>();
                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:42:26: warning: narrowing conversion from '__gnu_cxx::__alloc_traits<std::allocator<int>, int>::value_type' (aka 'int') to 'float' [cppcoreguidelines-narrowing-conversions]
    fileMetadata.max.x = values[0] + config["x_resolution"].as<float>();
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:43:22: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    fileMetadata.max.y = values[1] + config["y_resolution"].as<float>();
                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:43:26: warning: narrowing conversion from '__gnu_cxx::__alloc_traits<std::allocator<int>, int>::value_type' (aka 'int') to 'float' [cppcoreguidelines-narrowing-conversions]
    fileMetadata.max.y = values[1] + config["y_resolution"].as<float>();
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:84:19: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.x - radius <= center_x && center_x <= box_max_point.x + radius &&
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:84:71: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.x - radius <= center_x && center_x <= box_max_point.x + radius &&
                                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:85:19: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.y - radius <= center_y && center_y <= box_max_point.y + radius) {
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:85:71: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.y - radius <= center_y && center_y <= box_max_point.y + radius) {
                                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:90:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dx0 = center_x - box_min_point.x;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:91:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dx1 = center_x - box_max_point.x;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:92:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dy0 = center_y - box_min_point.y;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:93:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dy1 = center_y - box_max_point.y;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:98:12: warning: redundant boolean literal in conditional return statement [readability-simplify-boolean-expr]
    return true;
~~~~~~~~~~~^~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:45:6: warning: function 'cylinderAndBoxOverlapExists' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]
bool cylinderAndBoxOverlapExists(
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:78:6: note: the definition seen here
bool cylinderAndBoxOverlapExists(
     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:45:6: note: differing parameters are named here: ('position_min', 'position_max'), in definition: ('box_min_point', 'box_max_point')
bool cylinderAndBoxOverlapExists(
     ^
Suppressed 31039 warnings (31037 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
33094 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:29:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.x = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:30:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.y = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:31:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.z = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:34:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.x = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:35:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.y = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:36:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.z = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:51:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.x = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:52:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.y = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:53:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.z = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:56:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.x = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:57:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.y = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:58:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.z = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:73:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.x = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:74:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.y = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:75:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.z = -100.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:78:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.x = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:79:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.y = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:80:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.z = -99.0;
        ^
... (omitted)
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
(in map/map_loader)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/lanelet2_map_loader/lanelet2_map_loader_node.cpp ...
1/14 files checked 10% done
Checking src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp ...
src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp:106:59: style: Variable 'tl_reg_elems' is assigned a value that is never used. [unreadVariable]
  std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems =
                                                          ^
2/14 files checked 33% done
Checking src/pointcloud_map_loader/differential_map_loader_module.cpp ...
src/pointcloud_map_loader/differential_map_loader_module.hpp:49:8: style: inconclusive: Technically the member function 'DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map' can be const. [functionConst]
  bool on_service_get_differential_point_cloud_map(
       ^
src/pointcloud_map_loader/differential_map_loader_module.cpp:68:35: note: Technically the member function 'DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map' can be const.
bool DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map(
                                  ^
src/pointcloud_map_loader/differential_map_loader_module.hpp:49:8: note: Technically the member function 'DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map' can be const.
  bool on_service_get_differential_point_cloud_map(
       ^
src/pointcloud_map_loader/differential_map_loader_module.cpp:31:44: style: inconclusive: Function 'differential_area_load' argument 1 names different: declaration 'area_info' definition 'area'. [funcArgNamesDifferent]
  const autoware_map_msgs::msg::AreaInfo & area, const std::vector<std::string> & cached_ids,
                                           ^
src/pointcloud_map_loader/differential_map_loader_module.hpp:53:46: note: Function 'differential_area_load' argument 1 names different: declaration 'area_info' definition 'area'.
    const autoware_map_msgs::msg::AreaInfo & area_info, const std::vector<std::string> & cached_ids,
                                             ^
src/pointcloud_map_loader/differential_map_loader_module.cpp:31:44: note: Function 'differential_area_load' argument 1 names different: declaration 'area_info' definition 'area'.
  const autoware_map_msgs::msg::AreaInfo & area, const std::vector<std::string> & cached_ids,
                                           ^
src/pointcloud_map_loader/differential_map_loader_module.cpp:32:55: style: Parameter 'response' can be declared as reference to const [constParameterReference]
  GetDifferentialPointCloudMap::Response::SharedPtr & response) const
                                                      ^
3/14 files checked 39% done
Checking src/pointcloud_map_loader/partial_map_loader_module.cpp ...
src/pointcloud_map_loader/partial_map_loader_module.hpp:49:8: style: inconclusive: Technically the member function 'PartialMapLoaderModule::on_service_get_partial_point_cloud_map' can be const. [functionConst]
  bool on_service_get_partial_point_cloud_map(
       ^
src/pointcloud_map_loader/partial_map_loader_module.cpp:55:30: note: Technically the member function 'PartialMapLoaderModule::on_service_get_partial_point_cloud_map' can be const.
bool PartialMapLoaderModule::on_service_get_partial_point_cloud_map(
                             ^
src/pointcloud_map_loader/partial_map_loader_module.hpp:49:8: note: Technically the member function 'PartialMapLoaderModule::on_service_get_partial_point_cloud_map' can be const.
  bool on_service_get_partial_point_cloud_map(
       ^
src/pointcloud_map_loader/partial_map_loader_module.cpp:31:50: style: Parameter 'response' can be declared as reference to const [constParameterReference]
  GetPartialPointCloudMap::Response::SharedPtr & response) const
                                                 ^
4/14 files checked 44% done
Checking src/pointcloud_map_loader/pointcloud_map_loader_module.cpp ...
5/14 files checked 50% done
Checking src/pointcloud_map_loader/pointcloud_map_loader_node.cpp ...
src/pointcloud_map_loader/pointcloud_map_loader_node.cpp:95:19: style: Variable 'fname' can be declared as reference to const [constVariableReference]
      for (auto & fname : missing_pcd_names) {
                  ^
6/14 files checked 58% done
Checking src/pointcloud_map_loader/selected_map_loader_module.cpp ...
src/pointcloud_map_loader/selected_map_loader_module.cpp:28:17: style: Variable 'path' is assigned a value that is never used. [unreadVariable]
    std::string path = ele.first;
                ^
7/14 files checked 66% done
Checking src/pointcloud_map_loader/utils.cpp ...
8/14 files checked 72% done
Checking test/test_cylinder_box_overlap.cpp ...
9/14 files checked 75% done
Checking test/test_differential_map_loader_module.cpp ...
10/14 files checked 81% done
Checking test/test_load_pcd_metadata.cpp ...
11/14 files checked 84% done
Checking test/test_partial_map_loader_module.cpp ...
12/14 files checked 89% done
Checking test/test_pointcloud_map_loader_module.cpp ...
13/14 files checked 96% done
Checking test/test_replace_with_absolute_path.cpp ...
14/14 files checked 100% done
src/lanelet2_map_loader/lanelet2_local_projector.hpp:28:0: style: The function 'forward' is never used. [unusedFunction]
  BasicPoint3d forward(const GPSPoint & gps) const override  // NOLINT
^
src/lanelet2_map_loader/lanelet2_local_projector.hpp:33:0: style: The function 'reverse' is never used. [unusedFunction]
  [[nodiscard]] GPSPoint reverse(const BasicPoint3d & point) const override
^
test/test_differential_map_loader_module.cpp:31:0: style: The function 'SetUp' is never used. [unusedFunction]
  void SetUp() override
^
test/test_differential_map_loader_module.cpp:62:0: style: The function 'TearDown' is never used. [unusedFunction]
  void TearDown() override { rclcpp::shutdown(); }
```
</details>

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh map_loader
...
19841 warnings generated.
Suppressed 19865 warnings (19841 in non-user code, 24 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
30417 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:16: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:40: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:55: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:64: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:35:79: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
                                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:16: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:31: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:40: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:55: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:64: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                                               ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.hpp:36:79: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
                                                                              ^
Suppressed 30407 warnings (30405 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
31045 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:40:23: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    file_metadata.min.x = static_cast<float>(values[0]);
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:41:23: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    file_metadata.min.y = static_cast<float>(values[1]);
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:42:23: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    file_metadata.max.x = static_cast<float>(values[0]) + config["x_resolution"].as<float>();
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:43:23: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    file_metadata.max.y = static_cast<float>(values[1]) + config["y_resolution"].as<float>();
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:84:19: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.x - radius <= center_x && center_x <= box_max_point.x + radius &&
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:84:71: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.x - radius <= center_x && center_x <= box_max_point.x + radius &&
                                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:85:19: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.y - radius <= center_y && center_y <= box_max_point.y + radius) {
                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:85:71: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    box_min_point.y - radius <= center_y && center_y <= box_max_point.y + radius) {
                                                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:90:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dx0 = center_x - box_min_point.x;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:91:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dx1 = center_x - box_max_point.x;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:92:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dy0 = center_y - box_min_point.y;
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/utils.cpp:93:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  const double dy1 = center_y - box_max_point.y;
                                              ^
Suppressed 31035 warnings (31033 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
33090 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:29:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.x = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:30:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.y = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:31:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.z = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:34:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.x = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:35:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.y = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:36:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.z = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:51:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.x = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:52:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.y = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:53:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.z = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:56:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.x = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:57:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.y = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:58:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.z = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:73:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.x = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:74:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.y = -1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:75:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_min.z = -100.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:78:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.x = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:79:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.y = 1.0;
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/test/test_cylinder_box_overlap.cpp:80:9: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
  p_max.z = -99.0;
        ^
Suppressed 33103 warnings (33072 in non-user code, 31 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
33729 warnings generated.
Suppressed 33761 warnings (33729 in non-user code, 32 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
13484 warnings generated.
Suppressed 13495 warnings (13484 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
28136 warnings generated.
Suppressed 28170 warnings (28136 in non-user code, 34 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
33179 warnings generated.
Suppressed 33211 warnings (33179 in non-user code, 32 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43252 warnings generated.
Suppressed 43265 warnings (43252 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
45700 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp:53:65: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
                                                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp:54:65: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
                                                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp:55:65: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
                                                                ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp:56:65: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pointcloud_map_cell_with_id.metadata.max_y = metadata.max.y;
                                                                ^
Suppressed 45709 warnings (45696 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
46310 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:35:57: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    cell_metadata_with_id.metadata.min_x = metadata.min.x;
                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:36:57: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    cell_metadata_with_id.metadata.min_y = metadata.min.y;
                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:37:57: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    cell_metadata_with_id.metadata.max_x = metadata.max.x;
                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:38:57: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    cell_metadata_with_id.metadata.max_y = metadata.max.y;
                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:85:63: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:86:63: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:87:63: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
                                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp:88:63: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    pointcloud_map_cell_with_id.metadata.max_y = metadata.max.y;
                                                              ^
... (omitted)
```
</details>

<details open>
<summary>Check with cppcheck </summary>

```
(in map/map_loader)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive . -I ../../common/geography_utils/*

Checking src/lanelet2_map_loader/lanelet2_map_loader_node.cpp ...
1/22 files checked 7% done
Checking src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp ...
2/22 files checked 25% done
Checking src/pointcloud_map_loader/differential_map_loader_module.cpp ...
3/22 files checked 30% done
Checking src/pointcloud_map_loader/partial_map_loader_module.cpp ...
4/22 files checked 33% done
Checking src/pointcloud_map_loader/pointcloud_map_loader_module.cpp ...
5/22 files checked 38% done
Checking src/pointcloud_map_loader/pointcloud_map_loader_node.cpp ...
6/22 files checked 44% done
Checking src/pointcloud_map_loader/selected_map_loader_module.cpp ...
7/22 files checked 50% done
Checking src/pointcloud_map_loader/utils.cpp ...
8/22 files checked 55% done
Checking test/test_cylinder_box_overlap.cpp ...
9/22 files checked 57% done
Checking test/test_differential_map_loader_module.cpp ...
10/22 files checked 62% done
Checking test/test_load_pcd_metadata.cpp ...
11/22 files checked 64% done
Checking test/test_partial_map_loader_module.cpp ...
12/22 files checked 68% done
Checking test/test_pointcloud_map_loader_module.cpp ...
13/22 files checked 73% done
Checking test/test_replace_with_absolute_path.cpp ...
14/22 files checked 76% done
...(omitted: not related with map_loader)
22/22 files checked 100% done
test/test_differential_map_loader_module.cpp:31:0: style: The function 'SetUp' is never used. [unusedFunction]
  void SetUp() override
^
test/test_differential_map_loader_module.cpp:62:0: style: The function 'TearDown' is never used. [unusedFunction]
  void TearDown() override { rclcpp::shutdown(); }
```
</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
