### PR TITLE
fix(control_launch): fix control launch control_evaluator plugin name

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -216,7 +216,7 @@
 
     <!-- control evaluator -->
     <load_composable_node target="/control/control_container">
-      <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::controlEvaluatorNode" name="control_evaluator">
+      <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::ControlEvaluatorNode" name="control_evaluator">
         <remap from="~/input/diagnostics" to="/diagnostics"/>
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
         <remap from="~/input/acceleration" to="/localization/acceleration"/>


### PR DESCRIPTION
## Description
The name is not correct which does not let Autoware launch the control evaluator
## Related links

**Parent Issue:**

- [Link](https://github.com/autowarefoundation/autoware.universe/pull/7682)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim +  ros2 topic echo /diagnostic/control_evaluator/metrics

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
