### PR TITLE
feat(planning_evaluator,control_evaluator, evaluator utils): add diagnostics subscriber to planning eval

### DIFF
--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -52,13 +52,6 @@ class ControlEvaluatorNode : public rclcpp::Node
 {
 public:
   explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
-  void removeOldDiagnostics(const rclcpp::Time & stamp);
-  void removeDiagnosticsByName(const std::string & name);
-  void addDiagnostic(const DiagnosticStatus & diag, const rclcpp::Time & stamp);
-  void updateDiagnosticQueue(
-    const DiagnosticArray & input_diagnostics, const std::string & function,
-    const rclcpp::Time & stamp);
-
   DiagnosticStatus generateLateralDeviationDiagnosticStatus(
     const Trajectory & traj, const Point & ego_point);
   DiagnosticStatus generateYawDeviationDiagnosticStatus(

--- a/evaluator/autoware_evaluator_utils/CMakeLists.txt
+++ b/evaluator/autoware_evaluator_utils/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_evaluator_utils)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(evaluator_utils SHARED
+  src/evaluator_utils.cpp
+)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+)

--- a/evaluator/autoware_evaluator_utils/README.md
+++ b/evaluator/autoware_evaluator_utils/README.md
@@ -1,0 +1,5 @@
+# Evaluator Utils
+
+## Purpose
+
+This package provides utils functions for other evaluator packages

--- a/evaluator/autoware_evaluator_utils/include/autoware/evaluator_utils/evaluator_utils.hpp
+++ b/evaluator/autoware_evaluator_utils/include/autoware/evaluator_utils/evaluator_utils.hpp
@@ -1,0 +1,45 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__EVALUATOR_UTILS__EVALUATOR_UTILS_HPP_
+#define AUTOWARE__EVALUATOR_UTILS__EVALUATOR_UTILS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::evaluator_utils
+{
+
+using diagnostic_msgs::msg::DiagnosticArray;
+using diagnostic_msgs::msg::DiagnosticStatus;
+using DiagnosticQueue = std::deque<std::pair<DiagnosticStatus, rclcpp::Time>>;
+
+void removeOldDiagnostics(const rclcpp::Time & stamp, DiagnosticQueue & diag_queue);
+void removeDiagnosticsByName(const std::string & name, DiagnosticQueue & diag_queue);
+void addDiagnostic(
+  const DiagnosticStatus & diag, const rclcpp::Time & stamp, DiagnosticQueue & diag_queue);
+void updateDiagnosticQueue(
+  const DiagnosticArray & input_diagnostics, const std::string & function,
+  const rclcpp::Time & stamp, DiagnosticQueue & diag_queue);
+
+}  // namespace autoware::evaluator_utils
+
+#endif  // AUTOWARE__EVALUATOR_UTILS__EVALUATOR_UTILS_HPP_

--- a/evaluator/autoware_evaluator_utils/package.xml
+++ b/evaluator/autoware_evaluator_utils/package.xml
@@ -1,33 +1,22 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>autoware_control_evaluator</name>
+  <name>autoware_evaluator_utils</name>
   <version>0.1.0</version>
   <description>ROS 2 node for evaluating control</description>
   <maintainer email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</maintainer>
-  <maintainer email="takayuki.murooka@tier4.jp">takayuki MUROOKA</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki MUROOKA</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</author>
-  <author email="takayuki.murooka@tier4.jp">takayuki MUROOKA</author>
+  <author email="takayuki.murooka@tier4.jp">Takayuki MUROOKA</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_evaluator_utils</depend>
-  <depend>autoware_motion_utils</depend>
-  <depend>autoware_planning_msgs</depend>
-  <depend>autoware_route_handler</depend>
-  <depend>autoware_universe_utils</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <!-- <depend>nav_msgs</depend> -->
-
-  <test_depend>ament_cmake_ros</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>autoware_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/evaluator/autoware_evaluator_utils/src/evaluator_utils.cpp
+++ b/evaluator/autoware_evaluator_utils/src/evaluator_utils.cpp
@@ -1,0 +1,66 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/evaluator_utils/evaluator_utils.hpp"
+
+#include <algorithm>
+
+namespace autoware::evaluator_utils
+{
+void removeOldDiagnostics(const rclcpp::Time & stamp, DiagnosticQueue & diag_queue)
+{
+  constexpr double KEEP_TIME = 1.0;
+  diag_queue.erase(
+    std::remove_if(
+      diag_queue.begin(), diag_queue.end(),
+      [stamp](const std::pair<DiagnosticStatus, rclcpp::Time> & p) {
+        return (stamp - p.second).seconds() > KEEP_TIME;
+      }),
+    diag_queue.end());
+}
+
+void removeDiagnosticsByName(const std::string & name, DiagnosticQueue & diag_queue)
+{
+  diag_queue.erase(
+    std::remove_if(
+      diag_queue.begin(), diag_queue.end(),
+      [&name](const std::pair<DiagnosticStatus, rclcpp::Time> & p) {
+        return p.first.name.find(name) != std::string::npos;
+      }),
+    diag_queue.end());
+}
+
+void addDiagnostic(
+  const DiagnosticStatus & diag, const rclcpp::Time & stamp, DiagnosticQueue & diag_queue)
+{
+  diag_queue.push_back(std::make_pair(diag, stamp));
+}
+
+void updateDiagnosticQueue(
+  const DiagnosticArray & input_diagnostics, const std::string & function,
+  const rclcpp::Time & stamp, DiagnosticQueue & diag_queue)
+{
+  const auto it = std::find_if(
+    input_diagnostics.status.begin(), input_diagnostics.status.end(),
+    [&function](const DiagnosticStatus & diag) {
+      return diag.name.find(function) != std::string::npos;
+    });
+  if (it != input_diagnostics.status.end()) {
+    removeDiagnosticsByName(it->name, diag_queue);
+    addDiagnostic(*it, input_diagnostics.header.stamp, diag_queue);
+  }
+
+  removeOldDiagnostics(stamp, diag_queue);
+}
+}  // namespace autoware::evaluator_utils

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -32,6 +32,7 @@
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <diagnostic_msgs/msg/detail/diagnostic_status__struct.hpp>
 
 #include <array>
 #include <deque>
@@ -103,6 +104,11 @@ public:
    */
   DiagnosticStatus generateDiagnosticStatus(
     const Metric & metric, const Stat<double> & metric_stat) const;
+
+  /**
+   * @brief publish current ego lane info
+   */
+  DiagnosticStatus generateDiagnosticEvaluationStatus(const DiagnosticStatus & diag);
 
   /**
    * @brief publish current ego lane info

--- a/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
@@ -7,6 +7,7 @@
   <arg name="input/modified_goal" default="/planning/scenario_planning/modified_goal"/>
   <arg name="input/map_topic" default="/map/vector_map"/>
   <arg name="input/route_topic" default="/planning/mission_planning/route"/>
+  <arg name="input/diagnostics" default="/diagnostics"/>
 
   <!-- planning evaluator -->
   <group>
@@ -15,6 +16,7 @@
       <remap from="~/input/odometry" to="$(var input/odometry)"/>
       <remap from="~/input/acceleration" to="$(var input/acceleration)"/>
       <remap from="~/input/trajectory" to="$(var input/trajectory)"/>
+      <remap from="~/input/diagnostics" to="$(var input/diagnostics)"/>
       <remap from="~/input/reference_trajectory" to="$(var input/reference_trajectory)"/>
       <remap from="~/input/objects" to="$(var input/objects)"/>
       <remap from="~/input/modified_goal" to="$(var input/modified_goal)"/>

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_evaluator_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>


### PR DESCRIPTION
## Description
This PR adds subscription from the planning evaluator side to the /diagnostics topic to monitor the obstacle_cruise outputs. It also adds a common evaluator utils library to reduce code repetition.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?


psim
https://evaluation.ci.tier4.jp/evaluation/reports/6d538dbe-2fd0-5fb4-82c7-8fa02b16e5e0?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
