### PR TITLE
feat(universe_utils): add GJK implementation for 2D convex polygon collision check

### DIFF
--- a/common/autoware_universe_utils/CMakeLists.txt
+++ b/common/autoware_universe_utils/CMakeLists.txt
@@ -14,6 +14,8 @@ ament_auto_add_library(autoware_universe_utils SHARED
   src/geometry/geometry.cpp
   src/geometry/pose_deviation.cpp
   src/geometry/boost_polygon_utils.cpp
+  src/geometry/random_convex_polygon.cpp
+  src/geometry/gjk_2d.cpp
   src/math/sin_table.cpp
   src/math/trigonometry.cpp
   src/ros/msg_operation.cpp

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020-2024 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -18,8 +18,11 @@
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 #include "autoware/universe_utils/math/constants.hpp"
 #include "autoware/universe_utils/math/normalization.hpp"
+#include "autoware/universe_utils/ros/msg_covariance.hpp"
 
+#include <exception>
 #include <string>
+#include <vector>
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -18,14 +18,8 @@
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 #include "autoware/universe_utils/math/constants.hpp"
 #include "autoware/universe_utils/math/normalization.hpp"
-#include "autoware/universe_utils/ros/msg_covariance.hpp"
 
-#include <boost/geometry/arithmetic/dot_product.hpp>
-
-#include <exception>
-#include <limits>
 #include <string>
-#include <vector>
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -584,7 +584,7 @@ std::optional<geometry_msgs::msg::Point> intersect(
  * @brief Check if 2 convex polygons intersect using the GJK algorithm
  * @details much faster than boost::geometry::intersects()
  */
-bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
+bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
 
 }  // namespace autoware::universe_utils
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -20,7 +20,10 @@
 #include "autoware/universe_utils/math/normalization.hpp"
 #include "autoware/universe_utils/ros/msg_covariance.hpp"
 
+#include <boost/geometry/arithmetic/dot_product.hpp>
+
 #include <exception>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -576,6 +579,12 @@ bool isTwistCovarianceValid(const geometry_msgs::msg::TwistWithCovariance & twis
 std::optional<geometry_msgs::msg::Point> intersect(
   const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2,
   const geometry_msgs::msg::Point & p3, const geometry_msgs::msg::Point & p4);
+
+/**
+ * @brief Check if 2 convex polygons intersect using the GJK algorithm
+ * @details much faster than boost::geometry::intersects()
+ */
+bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
 
 }  // namespace autoware::universe_utils
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -581,7 +581,7 @@ std::optional<geometry_msgs::msg::Point> intersect(
  * @brief Check if 2 convex polygons intersect using the GJK algorithm
  * @details much faster than boost::geometry::intersects()
  */
-bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
+bool intersects_convex(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
 
 }  // namespace autoware::universe_utils
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
@@ -19,16 +19,6 @@
 
 namespace autoware::universe_utils::gjk
 {
-
-namespace
-{
-/// @brief get the polygon vertex that is the furthest away from a direction vector
-size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction);
-Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const Point2d & direction);
-bool same_direction(const Point2d & p1, const Point2d & p2);
-double dot_product(const Point2d & p1, const Point2d & p2);
-Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3);
-}  // namespace
 /**
  * @brief Check if 2 convex polygons intersect using the GJK algorithm
  * @details much faster than boost::geometry::overlaps() but limited to convex polygons

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
@@ -1,0 +1,138 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__UNIVERSE_UTILS__GEOMETRY__GJK_2D_HPP_
+#define AUTOWARE__UNIVERSE_UTILS__GEOMETRY__GJK_2D_HPP_
+
+#include "autoware/universe_utils/geometry/boost_geometry.hpp"
+
+#include <boost/geometry.hpp>
+
+#include <limits>
+
+namespace autoware::universe_utils::gjk
+{
+
+namespace
+{
+
+double dot_product(const Point2d & p1, const Point2d & p2)
+{
+  return p1.x() * p2.x() + p1.y() * p2.y();
+}
+
+/// @brief return the polygon polygon that is the furthest away from a direction vector
+size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
+{
+  auto furthest_distance = std::numeric_limits<double>::lowest();
+  size_t furthest_idx;
+  for (auto i = 0UL; i < poly.outer().size(); ++i) {
+    const auto distance = dot_product(poly.outer()[i], direction);
+    if (distance > furthest_distance) {
+      furthest_distance = distance;
+      furthest_idx = i;
+    }
+  }
+  return furthest_idx;
+}
+
+Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const Point2d & direction)
+{
+  const auto opposite_direction = Point2d(-direction.x(), -direction.y());
+  const auto idx1 = furthest_vertex_idx(poly1, direction);
+  const auto idx2 = furthest_vertex_idx(poly2, opposite_direction);
+  return Point2d(
+    poly1.outer()[idx1].x() - poly2.outer()[idx2].x(),
+    poly1.outer()[idx1].y() - poly2.outer()[idx2].y());
+}
+
+bool same_direction(const Point2d & p1, const Point2d & p2)
+{
+  return dot_product(p1, p2) > 0.0;
+}
+
+Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3)
+{
+  const auto tmp = p1.x() * p2.y() - p1.y() * p2.x();
+  return Point2d(-p3.y() * tmp, p3.x() * tmp);
+}
+}  // namespace
+/**
+ * @brief Check if 2 convex polygons intersect using the GJK algorithm
+ * @details much faster than boost::geometry::intersects()
+ */
+inline bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
+{
+  if (convex_polygon1.outer().empty() || convex_polygon2.outer().empty()) {
+    return false;
+  }
+  if (boost::geometry::equals(convex_polygon1, convex_polygon2)) {
+    return true;
+  }
+
+  Point2d direction = {1.0, 0.0};
+  Point2d a = support_vertex(convex_polygon1, convex_polygon2, direction);
+  direction = {-a.x(), -a.y()};
+  Point2d b = support_vertex(convex_polygon1, convex_polygon2, direction);
+  if (dot_product(b, direction) <= 0.0) {
+    return false;
+  }
+  if (a.isZero() || b.isZero()) {  // the 2 polygons intersect at a vertex
+    return true;
+  }
+  Point2d ab = {b.x() - a.x(), b.y() - a.y()};
+  Point2d ao = {-a.x(), -a.y()};
+  // Prepare loop variables to not recreate them at each iteration
+  Point2d c;
+  Point2d co;
+  Point2d ca;
+  Point2d cb;
+  Point2d ca_perpendicular;
+  Point2d cb_perpendicular;
+  direction = cross_product(ab, ao, ab);
+  while (true) {
+    c = support_vertex(convex_polygon1, convex_polygon2, direction);
+    if (c.isZero()) {  // the 2 polygons intersect at a vertex
+      return true;
+    }
+    if (!same_direction(c, direction)) {
+      return false;
+    }
+    co.x() = -c.x();
+    co.y() = -c.y();
+    ca.x() = a.x() - c.x();
+    ca.y() = a.y() - c.y();
+    cb.x() = b.x() - c.x();
+    cb.y() = b.y() - c.y();
+    ca_perpendicular = cross_product(cb, ca, ca);
+    cb_perpendicular = cross_product(ca, cb, cb);
+    if (same_direction(ca_perpendicular, co)) {
+      b.x() = c.x();
+      b.y() = c.y();
+      direction.x() = ca_perpendicular.x();
+      direction.y() = ca_perpendicular.y();
+    } else if (same_direction(cb_perpendicular, co)) {
+      a.x() = c.x();
+      a.y() = c.y();
+      direction.x() = cb_perpendicular.x();
+      direction.y() = cb_perpendicular.y();
+    } else {
+      return true;
+    }
+  }
+  return true;
+}
+}  // namespace autoware::universe_utils::gjk
+
+#endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__GJK_2D_HPP_

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
@@ -31,9 +31,9 @@ Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3
 }  // namespace
 /**
  * @brief Check if 2 convex polygons intersect using the GJK algorithm
- * @details much faster than boost::geometry::intersects()
+ * @details much faster than boost::geometry::overlaps() but limited to convex polygons
  */
-bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
+bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
 }  // namespace autoware::universe_utils::gjk
 
 #endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__GJK_2D_HPP_

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/gjk_2d.hpp
@@ -17,122 +17,23 @@
 
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 
-#include <boost/geometry.hpp>
-
-#include <limits>
-
 namespace autoware::universe_utils::gjk
 {
 
 namespace
 {
-
-double dot_product(const Point2d & p1, const Point2d & p2)
-{
-  return p1.x() * p2.x() + p1.y() * p2.y();
-}
-
-/// @brief return the polygon polygon that is the furthest away from a direction vector
-size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
-{
-  auto furthest_distance = std::numeric_limits<double>::lowest();
-  size_t furthest_idx;
-  for (auto i = 0UL; i < poly.outer().size(); ++i) {
-    const auto distance = dot_product(poly.outer()[i], direction);
-    if (distance > furthest_distance) {
-      furthest_distance = distance;
-      furthest_idx = i;
-    }
-  }
-  return furthest_idx;
-}
-
-Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const Point2d & direction)
-{
-  const auto opposite_direction = Point2d(-direction.x(), -direction.y());
-  const auto idx1 = furthest_vertex_idx(poly1, direction);
-  const auto idx2 = furthest_vertex_idx(poly2, opposite_direction);
-  return Point2d(
-    poly1.outer()[idx1].x() - poly2.outer()[idx2].x(),
-    poly1.outer()[idx1].y() - poly2.outer()[idx2].y());
-}
-
-bool same_direction(const Point2d & p1, const Point2d & p2)
-{
-  return dot_product(p1, p2) > 0.0;
-}
-
-Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3)
-{
-  const auto tmp = p1.x() * p2.y() - p1.y() * p2.x();
-  return Point2d(-p3.y() * tmp, p3.x() * tmp);
-}
+/// @brief get the polygon vertex that is the furthest away from a direction vector
+size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction);
+Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const Point2d & direction);
+bool same_direction(const Point2d & p1, const Point2d & p2);
+double dot_product(const Point2d & p1, const Point2d & p2);
+Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3);
 }  // namespace
 /**
  * @brief Check if 2 convex polygons intersect using the GJK algorithm
  * @details much faster than boost::geometry::intersects()
  */
-inline bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
-{
-  if (convex_polygon1.outer().empty() || convex_polygon2.outer().empty()) {
-    return false;
-  }
-  if (boost::geometry::equals(convex_polygon1, convex_polygon2)) {
-    return true;
-  }
-
-  Point2d direction = {1.0, 0.0};
-  Point2d a = support_vertex(convex_polygon1, convex_polygon2, direction);
-  direction = {-a.x(), -a.y()};
-  Point2d b = support_vertex(convex_polygon1, convex_polygon2, direction);
-  if (dot_product(b, direction) <= 0.0) {
-    return false;
-  }
-  if (a.isZero() || b.isZero()) {  // the 2 polygons intersect at a vertex
-    return true;
-  }
-  Point2d ab = {b.x() - a.x(), b.y() - a.y()};
-  Point2d ao = {-a.x(), -a.y()};
-  // Prepare loop variables to not recreate them at each iteration
-  Point2d c;
-  Point2d co;
-  Point2d ca;
-  Point2d cb;
-  Point2d ca_perpendicular;
-  Point2d cb_perpendicular;
-  direction = cross_product(ab, ao, ab);
-  while (true) {
-    c = support_vertex(convex_polygon1, convex_polygon2, direction);
-    if (c.isZero()) {  // the 2 polygons intersect at a vertex
-      return true;
-    }
-    if (!same_direction(c, direction)) {
-      return false;
-    }
-    co.x() = -c.x();
-    co.y() = -c.y();
-    ca.x() = a.x() - c.x();
-    ca.y() = a.y() - c.y();
-    cb.x() = b.x() - c.x();
-    cb.y() = b.y() - c.y();
-    ca_perpendicular = cross_product(cb, ca, ca);
-    cb_perpendicular = cross_product(ca, cb, cb);
-    if (same_direction(ca_perpendicular, co)) {
-      b.x() = c.x();
-      b.y() = c.y();
-      direction.x() = ca_perpendicular.x();
-      direction.y() = ca_perpendicular.y();
-    } else if (same_direction(cb_perpendicular, co)) {
-      a.x() = c.x();
-      a.y() = c.y();
-      direction.x() = cb_perpendicular.x();
-      direction.y() = cb_perpendicular.y();
-    } else {
-      return true;
-    }
-  }
-  return true;
-}
+bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2);
 }  // namespace autoware::universe_utils::gjk
 
 #endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__GJK_2D_HPP_

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/random_convex_polygon.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/random_convex_polygon.hpp
@@ -1,0 +1,29 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__UNIVERSE_UTILS__GEOMETRY__RANDOM_CONVEX_POLYGON_HPP_
+#define AUTOWARE__UNIVERSE_UTILS__GEOMETRY__RANDOM_CONVEX_POLYGON_HPP_
+
+#include <autoware/universe_utils/geometry/geometry.hpp>
+
+namespace autoware::universe_utils
+{
+/// @brief generate a random convex polygon
+/// @param vertices number of vertices for the desired polygon
+/// @param max points will be generated in the range [-max,max]
+/// @details algorithm from https://cglab.ca/~sander/misc/ConvexGeneration/convex.html
+Polygon2d random_convex_polygon(const size_t vertices, const double max);
+}  // namespace autoware::universe_utils
+
+#endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__RANDOM_CONVEX_POLYGON_HPP_

--- a/common/autoware_universe_utils/src/geometry/geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/geometry.cpp
@@ -385,7 +385,7 @@ std::optional<geometry_msgs::msg::Point> intersect(
   return intersect_point;
 }
 
-bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
+bool intersects_convex(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
 {
   return gjk::intersects(convex_polygon1, convex_polygon2);
 }

--- a/common/autoware_universe_utils/src/geometry/geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/geometry.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/autoware_universe_utils/src/geometry/geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/geometry.cpp
@@ -385,9 +385,9 @@ std::optional<geometry_msgs::msg::Point> intersect(
   return intersect_point;
 }
 
-bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
+bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
 {
-  return gjk::intersect(convex_polygon1, convex_polygon2);
+  return gjk::intersects(convex_polygon1, convex_polygon2);
 }
 
 }  // namespace autoware::universe_utils

--- a/common/autoware_universe_utils/src/geometry/geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/geometry.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
 
+#include "autoware/universe_utils/geometry/gjk_2d.hpp"
+
 #include <Eigen/Geometry>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -381,6 +383,11 @@ std::optional<geometry_msgs::msg::Point> intersect(
   intersect_point.y = t * p1.y + (1.0 - t) * p2.y;
   intersect_point.z = t * p1.z + (1.0 - t) * p2.z;
   return intersect_point;
+}
+
+bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
+{
+  return gjk::intersect(convex_polygon1, convex_polygon2);
 }
 
 }  // namespace autoware::universe_utils

--- a/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
+++ b/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
@@ -31,7 +31,6 @@ double dot_product(const Point2d & p1, const Point2d & p2)
   return p1.x() * p2.x() + p1.y() * p2.y();
 }
 
-/// @brief return the polygon polygon that is the furthest away from a direction vector
 size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
 {
   auto furthest_distance = std::numeric_limits<double>::lowest();
@@ -67,11 +66,8 @@ Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3
   return Point2d(-p3.y() * tmp, p3.x() * tmp);
 }
 }  // namespace
-/**
- * @brief Check if 2 convex polygons intersect using the GJK algorithm
- * @details much faster than boost::geometry::intersects()
- */
-bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
+
+bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
 {
   if (convex_polygon1.outer().empty() || convex_polygon2.outer().empty()) {
     return false;

--- a/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
+++ b/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
@@ -24,11 +24,13 @@ namespace autoware::universe_utils::gjk
 namespace
 {
 
+/// @brief calculate the dot product between 2 points
 double dot_product(const Point2d & p1, const Point2d & p2)
 {
   return p1.x() * p2.x() + p1.y() * p2.y();
 }
 
+/// @brief calculate the index of the furthest polygon vertex in the given direction
 size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
 {
   auto furthest_distance = dot_product(poly.outer()[0], direction);
@@ -43,6 +45,7 @@ size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
   return furthest_idx;
 }
 
+/// @brief calculate the next Minkowski difference vertex in the given direction
 Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const Point2d & direction)
 {
   const auto opposite_direction = Point2d(-direction.x(), -direction.y());
@@ -53,11 +56,13 @@ Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const P
     poly1.outer()[idx1].y() - poly2.outer()[idx2].y());
 }
 
+/// @brief return true if both points are in the same direction
 bool same_direction(const Point2d & p1, const Point2d & p2)
 {
   return dot_product(p1, p2) > 0.0;
 }
 
+/// @brief return the triple cross product of the given points
 Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3)
 {
   const auto tmp = p1.x() * p2.y() - p1.y() * p2.x();
@@ -65,6 +70,9 @@ Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3
 }
 }  // namespace
 
+/// @brief return true if the two given polygons intersect
+/// @details if the intersection area is 0 (e.g., only one point or one edge intersect), the return
+/// value is false
 bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
 {
   if (convex_polygon1.outer().empty() || convex_polygon2.outer().empty()) {
@@ -81,9 +89,6 @@ bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_poly
   if (dot_product(b, direction) <= 0.0) {
     return false;
   }
-  if (a.isZero() || b.isZero()) {  // the 2 polygons intersect at a vertex
-    return true;
-  }
   Point2d ab = {b.x() - a.x(), b.y() - a.y()};
   Point2d ao = {-a.x(), -a.y()};
   // Prepare loop variables to not recreate them at each iteration
@@ -96,9 +101,6 @@ bool intersects(const Polygon2d & convex_polygon1, const Polygon2d & convex_poly
   direction = cross_product(ab, ao, ab);
   while (true) {
     c = support_vertex(convex_polygon1, convex_polygon2, direction);
-    if (c.isZero()) {  // the 2 polygons intersect at a vertex
-      return true;
-    }
     if (!same_direction(c, direction)) {
       return false;
     }

--- a/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
+++ b/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
@@ -18,8 +18,6 @@
 
 #include <boost/geometry/algorithms/equals.hpp>
 
-#include <limits>
-
 namespace autoware::universe_utils::gjk
 {
 
@@ -33,9 +31,9 @@ double dot_product(const Point2d & p1, const Point2d & p2)
 
 size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
 {
-  auto furthest_distance = std::numeric_limits<double>::lowest();
-  size_t furthest_idx;
-  for (auto i = 0UL; i < poly.outer().size(); ++i) {
+  auto furthest_distance = dot_product(poly.outer()[0], direction);
+  size_t furthest_idx = 0UL;
+  for (auto i = 1UL; i < poly.outer().size(); ++i) {
     const auto distance = dot_product(poly.outer()[i], direction);
     if (distance > furthest_distance) {
       furthest_distance = distance;

--- a/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
+++ b/common/autoware_universe_utils/src/geometry/gjk_2d.cpp
@@ -1,0 +1,135 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/universe_utils/geometry/gjk_2d.hpp"
+
+#include "autoware/universe_utils/geometry/boost_geometry.hpp"
+
+#include <boost/geometry/algorithms/equals.hpp>
+
+#include <limits>
+
+namespace autoware::universe_utils::gjk
+{
+
+namespace
+{
+
+double dot_product(const Point2d & p1, const Point2d & p2)
+{
+  return p1.x() * p2.x() + p1.y() * p2.y();
+}
+
+/// @brief return the polygon polygon that is the furthest away from a direction vector
+size_t furthest_vertex_idx(const Polygon2d & poly, const Point2d & direction)
+{
+  auto furthest_distance = std::numeric_limits<double>::lowest();
+  size_t furthest_idx;
+  for (auto i = 0UL; i < poly.outer().size(); ++i) {
+    const auto distance = dot_product(poly.outer()[i], direction);
+    if (distance > furthest_distance) {
+      furthest_distance = distance;
+      furthest_idx = i;
+    }
+  }
+  return furthest_idx;
+}
+
+Point2d support_vertex(const Polygon2d & poly1, const Polygon2d & poly2, const Point2d & direction)
+{
+  const auto opposite_direction = Point2d(-direction.x(), -direction.y());
+  const auto idx1 = furthest_vertex_idx(poly1, direction);
+  const auto idx2 = furthest_vertex_idx(poly2, opposite_direction);
+  return Point2d(
+    poly1.outer()[idx1].x() - poly2.outer()[idx2].x(),
+    poly1.outer()[idx1].y() - poly2.outer()[idx2].y());
+}
+
+bool same_direction(const Point2d & p1, const Point2d & p2)
+{
+  return dot_product(p1, p2) > 0.0;
+}
+
+Point2d cross_product(const Point2d & p1, const Point2d & p2, const Point2d & p3)
+{
+  const auto tmp = p1.x() * p2.y() - p1.y() * p2.x();
+  return Point2d(-p3.y() * tmp, p3.x() * tmp);
+}
+}  // namespace
+/**
+ * @brief Check if 2 convex polygons intersect using the GJK algorithm
+ * @details much faster than boost::geometry::intersects()
+ */
+bool intersect(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
+{
+  if (convex_polygon1.outer().empty() || convex_polygon2.outer().empty()) {
+    return false;
+  }
+  if (boost::geometry::equals(convex_polygon1, convex_polygon2)) {
+    return true;
+  }
+
+  Point2d direction = {1.0, 0.0};
+  Point2d a = support_vertex(convex_polygon1, convex_polygon2, direction);
+  direction = {-a.x(), -a.y()};
+  Point2d b = support_vertex(convex_polygon1, convex_polygon2, direction);
+  if (dot_product(b, direction) <= 0.0) {
+    return false;
+  }
+  if (a.isZero() || b.isZero()) {  // the 2 polygons intersect at a vertex
+    return true;
+  }
+  Point2d ab = {b.x() - a.x(), b.y() - a.y()};
+  Point2d ao = {-a.x(), -a.y()};
+  // Prepare loop variables to not recreate them at each iteration
+  Point2d c;
+  Point2d co;
+  Point2d ca;
+  Point2d cb;
+  Point2d ca_perpendicular;
+  Point2d cb_perpendicular;
+  direction = cross_product(ab, ao, ab);
+  while (true) {
+    c = support_vertex(convex_polygon1, convex_polygon2, direction);
+    if (c.isZero()) {  // the 2 polygons intersect at a vertex
+      return true;
+    }
+    if (!same_direction(c, direction)) {
+      return false;
+    }
+    co.x() = -c.x();
+    co.y() = -c.y();
+    ca.x() = a.x() - c.x();
+    ca.y() = a.y() - c.y();
+    cb.x() = b.x() - c.x();
+    cb.y() = b.y() - c.y();
+    ca_perpendicular = cross_product(cb, ca, ca);
+    cb_perpendicular = cross_product(ca, cb, cb);
+    if (same_direction(ca_perpendicular, co)) {
+      b.x() = c.x();
+      b.y() = c.y();
+      direction.x() = ca_perpendicular.x();
+      direction.y() = ca_perpendicular.y();
+    } else if (same_direction(cb_perpendicular, co)) {
+      a.x() = c.x();
+      a.y() = c.y();
+      direction.x() = cb_perpendicular.x();
+      direction.y() = cb_perpendicular.y();
+    } else {
+      return true;
+    }
+  }
+  return true;
+}
+}  // namespace autoware::universe_utils::gjk

--- a/common/autoware_universe_utils/src/geometry/random_convex_polygon.cpp
+++ b/common/autoware_universe_utils/src/geometry/random_convex_polygon.cpp
@@ -1,0 +1,103 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/universe_utils/geometry/random_convex_polygon.hpp"
+
+#include <boost/geometry/algorithms/correct.hpp>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+namespace autoware::universe_utils
+{
+Polygon2d random_convex_polygon(const size_t vertices, const double max)
+{
+  struct VectorsWithMin
+  {
+    std::vector<double> vectors;
+    double min;
+  };
+
+  std::random_device r;
+  std::default_random_engine e1(r());
+  std::uniform_real_distribution<double> uniform_dist(-max, max);
+  std::uniform_int_distribution random_bool(0, 1);
+  const auto prepare_coordinate_vectors = [&]() {
+    std::vector<double> v;
+    for (auto i = 0UL; i < vertices; ++i) {
+      v.push_back(uniform_dist(e1));
+    }
+    std::sort(v.begin(), v.end());
+    const auto min_v = v.front();
+    const auto max_v = v.back();
+    std::vector<double> v1;
+    v1.push_back(min_v);
+    std::vector<double> v2;
+    v2.push_back(min_v);
+    for (auto i = 1UL; i + 1 < v.size(); ++i) {
+      if (random_bool(e1) == 0) {
+        v1.push_back((v[i]));
+      } else {
+        v2.push_back((v[i]));
+      }
+    }
+    v1.push_back(max_v);
+    v2.push_back(max_v);
+    std::vector<double> diffs;
+    for (auto i = 0UL; i + 1 < v1.size(); ++i) {
+      diffs.push_back(v1[i + 1] - v1[i]);
+    }
+    for (auto i = 0UL; i + 1 < v2.size(); ++i) {
+      diffs.push_back(v2[i] - v2[i + 1]);
+    }
+    VectorsWithMin vectors;
+    vectors.vectors = diffs;
+    vectors.min = min_v;
+    return vectors;
+  };
+  auto xs = prepare_coordinate_vectors();
+  auto ys = prepare_coordinate_vectors();
+  std::shuffle(ys.vectors.begin(), ys.vectors.end(), e1);
+  LinearRing2d vectors;
+  for (auto i = 0UL; i < xs.vectors.size(); ++i) {
+    vectors.emplace_back(xs.vectors[i], ys.vectors[i]);
+  }
+  std::sort(vectors.begin(), vectors.end(), [](const Point2d & p1, const Point2d & p2) {
+    return std::atan2(p1.y(), p1.x()) < std::atan2(p2.y(), p2.x());
+  });
+  auto min_x = max;
+  auto min_y = max;
+  auto x = 0.0;
+  auto y = 0.0;
+  LinearRing2d points;
+  for (const auto & p : vectors) {
+    points.emplace_back(x, y);
+    x += p.x();
+    y += p.y();
+    min_x = std::min(p.x(), min_x);
+    min_y = std::min(p.y(), min_y);
+  }
+  const auto shift_x = min_x - xs.min;
+  const auto shift_y = min_y - ys.min;
+  for (auto & p : points) {
+    p.x() += shift_x;
+    p.y() += shift_y;
+  }
+  Polygon2d poly;
+  poly.outer() = points;
+  boost::geometry::correct(poly);
+  return poly;
+}
+}  // namespace autoware::universe_utils

--- a/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 #include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/geometry/gjk_2d.hpp"
 #include "autoware/universe_utils/geometry/random_convex_polygon.hpp"
 #include "autoware/universe_utils/math/unit_conversion.hpp"
 #include "autoware/universe_utils/system/stop_watch.hpp"
@@ -1850,7 +1849,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(0, 1);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_TRUE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_TRUE(autoware::universe_utils::intersects(poly1, poly2));
   }
   {  // 2 triangles with no intersection (but they share an edge)
     autoware::universe_utils::Polygon2d poly1, poly2;
@@ -1862,7 +1861,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(2, 2);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
   }
   {  // 2 triangles with no intersection (but they share a point)
     autoware::universe_utils::Polygon2d poly1, poly2;
@@ -1874,7 +1873,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(2, 2);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
   }
   {  // 2 triangles with no intersection and no touching
     autoware::universe_utils::Polygon2d poly1, poly2;
@@ -1886,7 +1885,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(3, 5);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
   }
   {  // triangle and quadrilateral with intersection
     autoware::universe_utils::Polygon2d poly1, poly2;
@@ -1899,7 +1898,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(12, 7);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_TRUE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_TRUE(autoware::universe_utils::intersects(poly1, poly2));
   }
 }
 
@@ -1922,7 +1921,7 @@ TEST(geometry, intersectPolygonRand)
       const auto ground_truth = boost::geometry::intersects(polygons[i], polygons[j]);
       ground_truth_ns += sw.toc();
       sw.tic();
-      const auto gjk = autoware::universe_utils::gjk::intersect(polygons[i], polygons[j]);
+      const auto gjk = autoware::universe_utils::intersects(polygons[i], polygons[j]);
       gjk_ns += sw.toc();
       if (ground_truth != gjk) {
         std::cout << "Failed for the 2 polygons: ";

--- a/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
@@ -1946,7 +1946,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(2, 2);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_TRUE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersect(poly1, poly2));
   }
   {  // 2 triangles with no intersection (but they share a point)
     autoware::universe_utils::Polygon2d poly1, poly2;
@@ -1958,7 +1958,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(2, 2);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_TRUE(autoware::universe_utils::intersect(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersect(poly1, poly2));
   }
   {  // 2 triangles with no intersection and no touching
     autoware::universe_utils::Polygon2d poly1, poly2;

--- a/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
@@ -1875,6 +1875,20 @@ TEST(geometry, intersectPolygon)
     boost::geometry::correct(poly2);
     EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
   }
+  {  // 2 triangles sharing a point and then with very small intersection
+    autoware::universe_utils::Polygon2d poly1, poly2;
+    poly1.outer().emplace_back(0, 0);
+    poly1.outer().emplace_back(2, 2);
+    poly1.outer().emplace_back(4, 0);
+    poly2.outer().emplace_back(0, 4);
+    poly2.outer().emplace_back(2, 2);
+    poly2.outer().emplace_back(4, 4);
+    boost::geometry::correct(poly1);
+    boost::geometry::correct(poly2);
+    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
+    poly1.outer()[1].y() += 1e-12;
+    EXPECT_TRUE(autoware::universe_utils::intersects(poly1, poly2));
+  }
   {  // 2 triangles with no intersection and no touching
     autoware::universe_utils::Polygon2d poly1, poly2;
     poly1.outer().emplace_back(0, 2);

--- a/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
@@ -1840,7 +1840,8 @@ TEST(geometry, intersect)
 TEST(geometry, intersectPolygon)
 {
   {  // 2 triangles with intersection
-    autoware::universe_utils::Polygon2d poly1, poly2;
+    autoware::universe_utils::Polygon2d poly1;
+    autoware::universe_utils::Polygon2d poly2;
     poly1.outer().emplace_back(0, 2);
     poly1.outer().emplace_back(2, 2);
     poly1.outer().emplace_back(2, 0);
@@ -1849,10 +1850,11 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(0, 1);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_TRUE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_TRUE(autoware::universe_utils::intersects_convex(poly1, poly2));
   }
   {  // 2 triangles with no intersection (but they share an edge)
-    autoware::universe_utils::Polygon2d poly1, poly2;
+    autoware::universe_utils::Polygon2d poly1;
+    autoware::universe_utils::Polygon2d poly2;
     poly1.outer().emplace_back(0, 2);
     poly1.outer().emplace_back(2, 2);
     poly1.outer().emplace_back(0, 0);
@@ -1861,10 +1863,11 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(2, 2);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects_convex(poly1, poly2));
   }
   {  // 2 triangles with no intersection (but they share a point)
-    autoware::universe_utils::Polygon2d poly1, poly2;
+    autoware::universe_utils::Polygon2d poly1;
+    autoware::universe_utils::Polygon2d poly2;
     poly1.outer().emplace_back(0, 2);
     poly1.outer().emplace_back(2, 2);
     poly1.outer().emplace_back(0, 0);
@@ -1873,10 +1876,11 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(2, 2);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects_convex(poly1, poly2));
   }
   {  // 2 triangles sharing a point and then with very small intersection
-    autoware::universe_utils::Polygon2d poly1, poly2;
+    autoware::universe_utils::Polygon2d poly1;
+    autoware::universe_utils::Polygon2d poly2;
     poly1.outer().emplace_back(0, 0);
     poly1.outer().emplace_back(2, 2);
     poly1.outer().emplace_back(4, 0);
@@ -1885,12 +1889,13 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(4, 4);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects_convex(poly1, poly2));
     poly1.outer()[1].y() += 1e-12;
-    EXPECT_TRUE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_TRUE(autoware::universe_utils::intersects_convex(poly1, poly2));
   }
   {  // 2 triangles with no intersection and no touching
-    autoware::universe_utils::Polygon2d poly1, poly2;
+    autoware::universe_utils::Polygon2d poly1;
+    autoware::universe_utils::Polygon2d poly2;
     poly1.outer().emplace_back(0, 2);
     poly1.outer().emplace_back(2, 2);
     poly1.outer().emplace_back(0, 0);
@@ -1899,10 +1904,11 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(3, 5);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_FALSE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_FALSE(autoware::universe_utils::intersects_convex(poly1, poly2));
   }
   {  // triangle and quadrilateral with intersection
-    autoware::universe_utils::Polygon2d poly1, poly2;
+    autoware::universe_utils::Polygon2d poly1;
+    autoware::universe_utils::Polygon2d poly2;
     poly1.outer().emplace_back(4, 11);
     poly1.outer().emplace_back(4, 5);
     poly1.outer().emplace_back(9, 9);
@@ -1912,7 +1918,7 @@ TEST(geometry, intersectPolygon)
     poly2.outer().emplace_back(12, 7);
     boost::geometry::correct(poly1);
     boost::geometry::correct(poly2);
-    EXPECT_TRUE(autoware::universe_utils::intersects(poly1, poly2));
+    EXPECT_TRUE(autoware::universe_utils::intersects_convex(poly1, poly2));
   }
 }
 
@@ -1945,7 +1951,7 @@ TEST(geometry, intersectPolygonRand)
           ground_truth_no_intersect_ns += sw.toc();
         }
         sw.tic();
-        const auto gjk = autoware::universe_utils::intersects(polygons[i], polygons[j]);
+        const auto gjk = autoware::universe_utils::intersects_convex(polygons[i], polygons[j]);
         if (gjk) {
           gjk_intersect_ns += sw.toc();
         } else {


### PR DESCRIPTION
## Description
Implement the GJK algorithm allowing ~4x speed compared to `boost::geometry::intersects` to determine if 2 polygons intersects.
:warning: the polygons must be convex.

## Related links

## How was this PR tested?

Unit tests.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
