### PR TITLE
fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions

### DIFF
--- a/common/fake_test_node/test/test_fake_test_node.cpp
+++ b/common/fake_test_node/test/test_fake_test_node.cpp
@@ -96,8 +96,7 @@ TEST_F(FakeNodeFixture, Test)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  FakeNodeFixtureTests, FakeNodeFixtureParametrized,
-  ::testing::Values(-5, 0, 42));
+  FakeNodeFixtureTests, FakeNodeFixtureParametrized, ::testing::Values(-5, 0, 42));
 
 /// @test Test that we can use a parametrized test.
 TEST_P(FakeNodeFixtureParametrized, Test)

--- a/common/fake_test_node/test/test_fake_test_node.cpp
+++ b/common/fake_test_node/test/test_fake_test_node.cpp
@@ -97,7 +97,6 @@ TEST_F(FakeNodeFixture, Test)
 
 INSTANTIATE_TEST_SUITE_P(
   FakeNodeFixtureTests, FakeNodeFixtureParametrized,
-  // cppcheck-suppress syntaxError  // cppcheck doesn't like the trailing comma.
   ::testing::Values(-5, 0, 42));
 
 /// @test Test that we can use a parametrized test.

--- a/common/osqp_interface/test/test_osqp_interface.cpp
+++ b/common/osqp_interface/test/test_osqp_interface.cpp
@@ -37,7 +37,6 @@ namespace
 // y = [-2.9, 0.0, 0.2, 0.0]`
 // obj = 1.88
 
-// cppcheck-suppress syntaxError
 TEST(TestOsqpInterface, BasicQp)
 {
   using autoware::common::osqp::calCSCMatrix;

--- a/common/qp_interface/test/test_osqp_interface.cpp
+++ b/common/qp_interface/test/test_osqp_interface.cpp
@@ -37,7 +37,6 @@ namespace
 // y = [-2.9, 0.0, 0.2, 0.0]`
 // obj = 1.88
 
-// cppcheck-suppress syntaxError
 TEST(TestOsqpInterface, BasicQp)
 {
   using qp::calCSCMatrix;

--- a/common/qp_interface/test/test_proxqp_interface.cpp
+++ b/common/qp_interface/test/test_proxqp_interface.cpp
@@ -38,7 +38,6 @@ namespace
 // y = [-2.9, 0.0, 0.2, 0.0]`
 // obj = 1.88
 
-// cppcheck-suppress syntaxError
 TEST(TestProxqpInterface, BasicQp)
 {
   auto check_result = [](const auto & solution) {


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warnings.

```
common/fake_test_node/test/test_fake_test_node.cpp:101:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
  ::testing::Values(-5, 0, 42));
^
common/osqp_interface/test/test_osqp_interface.cpp:41:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
TEST(TestOsqpInterface, BasicQp)
^
common/qp_interface/test/test_osqp_interface.cpp:41:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
TEST(TestOsqpInterface, BasicQp)
^
common/qp_interface/test/test_proxqp_interface.cpp:42:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
TEST(TestProxqpInterface, BasicQp)
^
```

There is no need to suppress cppcheck errors in `test` directories since they are out of scope of cppcheck CI.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
