### PR TITLE
fix(image_projection_based_fusion): segmentation pointcloud fusion param update

### DIFF
--- a/perception/image_projection_based_fusion/config/segmentation_pointcloud_fusion.param.yaml
+++ b/perception/image_projection_based_fusion/config/segmentation_pointcloud_fusion.param.yaml
@@ -14,7 +14,7 @@
       BIKE: false
       ROAD: true
       SIDEWALK: false
-      ROADPAINT: false
+      ROAD_PAINT: false
       CURBSTONE: false
       CROSSWALK: false
       VEGETATION: true

--- a/perception/image_projection_based_fusion/config/segmentation_pointcloud_fusion.param.yaml
+++ b/perception/image_projection_based_fusion/config/segmentation_pointcloud_fusion.param.yaml
@@ -22,12 +22,3 @@
 
     # the maximum distance of pointcloud to be applied filter
     filter_distance_threshold: 60.0
-
-    # debug
-    debug_mode: false
-    filter_scope_min_x: -100.0
-    filter_scope_max_x: 100.0
-    filter_scope_min_y: -100.0
-    filter_scope_max_y: 100.0
-    filter_scope_min_z: -100.0
-    filter_scope_max_z: 100.0

--- a/perception/image_projection_based_fusion/config/segmentation_pointcloud_fusion.param.yaml
+++ b/perception/image_projection_based_fusion/config/segmentation_pointcloud_fusion.param.yaml
@@ -1,32 +1,26 @@
 /**:
   ros__parameters:
     # if the semantic label is applied for pointcloud filtering
+
     filter_semantic_label_target:
-      [
-      true, # road
-      true, # sidewalk
-      true, # building
-      true, # wall
-      true, # fence
-      true, # pole
-      true, # traffic_light
-      true, # traffic_sign
-      true, # vegetation
-      true, # terrain
-      true, # sky
-      false, # person
-      false, # ride
-      false, # car
-      false, # truck
-      false, # bus
-      false, # train
-      false, # motorcycle
-      false, # bicycle
-      false, # others
-      ]
-    # the maximum distance of pointcloud to be applied filter,
-    # this is selected based on semantic segmentation model accuracy,
-    # calibration accuracy and unknown reaction distance
+      UNKNOWN: false
+      BUILDING: true
+      WALL: true
+      OBSTACLE: false
+      TRAFFIC_LIGHT: false
+      TRAFFIC_SIGN: false
+      PERSON: false
+      VEHICLE: false
+      BIKE: false
+      ROAD: true
+      SIDEWALK: false
+      ROADPAINT: false
+      CURBSTONE: false
+      CROSSWALK: false
+      VEGETATION: true
+      SKY: false
+
+    # the maximum distance of pointcloud to be applied filter
     filter_distance_threshold: 60.0
 
     # debug

--- a/perception/image_projection_based_fusion/docs/segmentation-pointcloud-fusion.md
+++ b/perception/image_projection_based_fusion/docs/segmentation-pointcloud-fusion.md
@@ -32,9 +32,7 @@ The node `segmentation_pointcloud_fusion` is a package for filtering pointcloud 
 
 ### Core Parameters
 
-| Name          | Type | Description              |
-| ------------- | ---- | ------------------------ |
-| `rois_number` | int  | the number of input rois |
+{{ json_to_markdown("perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json") }}
 
 ## Assumptions / Known limits
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
@@ -20,6 +20,7 @@
 #include <image_projection_based_fusion/utils/utils.hpp>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
@@ -36,7 +37,13 @@ private:
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_pointcloud_ptr_;
   std::vector<bool> filter_semantic_label_target_;
   float filter_distance_threshold_;
-  /* data */
+  // declare list of semantic label target, depend on trained data of yolox segmentation model
+  std::vector<std::pair<std::string, bool>> filter_semantic_label_target_list_ = {
+    {"UNKNOWN", false},       {"BUILDING", false},     {"WALL", false},       {"OBSTACLE", false},
+    {"TRAFFIC_LIGHT", false}, {"TRAFFIC_SIGN", false}, {"PERSON", false},     {"VEHICLE", false},
+    {"BIKE", false},          {"ROAD", false},         {"SIDEWALK", false},   {"ROADPAINT", false},
+    {"CURBSTONE", false},     {"CROSSWALK", false},    {"VEGETATION", false}, {"SKY", false}};
+
 public:
   explicit SegmentPointCloudFusionNode(const rclcpp::NodeOptions & options);
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
@@ -41,7 +41,7 @@ private:
   std::vector<std::pair<std::string, bool>> filter_semantic_label_target_list_ = {
     {"UNKNOWN", false},       {"BUILDING", false},     {"WALL", false},       {"OBSTACLE", false},
     {"TRAFFIC_LIGHT", false}, {"TRAFFIC_SIGN", false}, {"PERSON", false},     {"VEHICLE", false},
-    {"BIKE", false},          {"ROAD", false},         {"SIDEWALK", false},   {"ROADPAINT", false},
+    {"BIKE", false},          {"ROAD", false},         {"SIDEWALK", false},   {"ROAD_PAINT", false},
     {"CURBSTONE", false},     {"CROSSWALK", false},    {"VEGETATION", false}, {"SKY", false}};
 
 public:

--- a/perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json
+++ b/perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Segmentation Pointcloud Fusion Node",
+  "type": "object",
+  "definitions": {
+    "segmentation_pointcloud_fusion": {
+      "type": "object",
+      "properties": {
+        "filter_semantic_label_target":{
+          "type": "object",
+          "properties": {
+              "UNKNOWN": {
+                  "type": "boolean",
+                  "description": "If true, UNKNOWN class of semantic will be filtered.",
+                  "default": false
+              },
+              "BUILDING": {
+                  "type": "boolean",
+                  "description": "If true, BUILDING class of semantic will be filtered.",
+                  "default": true
+              },
+              "WALL": {
+                  "type": "boolean",
+                  "description": "If true, WALL class of semantic will be filtered.",
+                  "default": true
+              },
+              "OBSTACLE": {
+                  "type": "boolean",
+                  "description": "If true, OBSTACLE class of semantic will be filtered.",
+                  "default": false
+              },
+              "TRAFFIC_LIGHT": {
+                  "type": "boolean",
+                  "description": "If true, TRAFFIC_LIGHT class of semantic will be filtered.",
+                  "default": false
+              },
+              "TRAFFIC_SIGN": {
+                  "type": "boolean",
+                  "description": "If true, TRAFFIC_SIGN class of semantic will be filtered.",
+                  "default": false
+              },
+              "PERSON": {
+                  "type": "boolean",
+                  "description": "If true, PERSON class of semantic will be filtered.",
+                  "default": false
+              },
+              "VEHICLE": {
+                  "type": "boolean",
+                  "description": "If true, VEHICLE class of semantic will be filtered.",
+                  "default": false
+              },
+              "BIKE": {
+                  "type": "boolean",
+                  "description": "If true, BIKE class of semantic will be filtered.",
+                  "default": false
+              },
+              "ROAD": {
+                  "type": "boolean",
+                  "description": "If true, ROAD class of semantic will be filtered.",
+                  "default": true
+              },
+              "SIDEWALK": {
+                  "type": "boolean",
+                  "description": "If true, SIDEWALK class of semantic will be filtered.",
+                  "default": false
+              },
+              "ROADPAINT": {
+                  "type": "boolean",
+                  "description": "If true, ROADPAINT class of semantic will be filtered.",
+                  "default": false
+              },
+              "CURBSTONE": {
+                  "type": "boolean",
+                  "description": "If true, CURBSTONE class of semantic will be filtered.",
+                  "default": false
+              },
+              "CROSSWALK": {
+                  "type": "boolean",
+                  "description": "If true, CROSSWALK class of semantic will be filtered.",
+                  "default": false
+              },
+              "VEGETATION": {
+                  "type": "boolean",
+                  "description": "If true, VEGETATION class of semantic will be filtered.",
+                  "default": true
+              },
+              "SKY": {
+                  "type": "boolean",
+                  "description": "If true, SKY class of semantic will be filtered.",
+                  "default": false
+              }
+          },
+          "required": [
+              "UNKNOWN", "BUILDING", "WALL", "OBSTACLE", "TRAFFIC_LIGHT", "TRAFFIC_SIGN", "PERSON", "VEHICLE", "BIKE", "ROAD", "SIDEWALK", "ROADPAINT", "CURBSTONE", "CROSSWALK", "VEGETATION", "SKY"]
+        },
+        "filter_distance_threshold":{
+          "type": "number",
+          "description": "A maximum distance of pointcloud to apply filter [m].",
+          "default": 60.0,
+          "minimum": 0.0
+        }
+      },
+      "required": ["filter_semantic_label_target","filter_distance_threshold"]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/segmentation_pointcloud_fusion"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}
+  

--- a/perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json
+++ b/perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json
@@ -6,101 +6,117 @@
     "segmentation_pointcloud_fusion": {
       "type": "object",
       "properties": {
-        "filter_semantic_label_target":{
+        "filter_semantic_label_target": {
           "type": "object",
           "properties": {
-              "UNKNOWN": {
-                  "type": "boolean",
-                  "description": "If true, UNKNOWN class of semantic will be filtered.",
-                  "default": false
-              },
-              "BUILDING": {
-                  "type": "boolean",
-                  "description": "If true, BUILDING class of semantic will be filtered.",
-                  "default": true
-              },
-              "WALL": {
-                  "type": "boolean",
-                  "description": "If true, WALL class of semantic will be filtered.",
-                  "default": true
-              },
-              "OBSTACLE": {
-                  "type": "boolean",
-                  "description": "If true, OBSTACLE class of semantic will be filtered.",
-                  "default": false
-              },
-              "TRAFFIC_LIGHT": {
-                  "type": "boolean",
-                  "description": "If true, TRAFFIC_LIGHT class of semantic will be filtered.",
-                  "default": false
-              },
-              "TRAFFIC_SIGN": {
-                  "type": "boolean",
-                  "description": "If true, TRAFFIC_SIGN class of semantic will be filtered.",
-                  "default": false
-              },
-              "PERSON": {
-                  "type": "boolean",
-                  "description": "If true, PERSON class of semantic will be filtered.",
-                  "default": false
-              },
-              "VEHICLE": {
-                  "type": "boolean",
-                  "description": "If true, VEHICLE class of semantic will be filtered.",
-                  "default": false
-              },
-              "BIKE": {
-                  "type": "boolean",
-                  "description": "If true, BIKE class of semantic will be filtered.",
-                  "default": false
-              },
-              "ROAD": {
-                  "type": "boolean",
-                  "description": "If true, ROAD class of semantic will be filtered.",
-                  "default": true
-              },
-              "SIDEWALK": {
-                  "type": "boolean",
-                  "description": "If true, SIDEWALK class of semantic will be filtered.",
-                  "default": false
-              },
-              "ROADPAINT": {
-                  "type": "boolean",
-                  "description": "If true, ROADPAINT class of semantic will be filtered.",
-                  "default": false
-              },
-              "CURBSTONE": {
-                  "type": "boolean",
-                  "description": "If true, CURBSTONE class of semantic will be filtered.",
-                  "default": false
-              },
-              "CROSSWALK": {
-                  "type": "boolean",
-                  "description": "If true, CROSSWALK class of semantic will be filtered.",
-                  "default": false
-              },
-              "VEGETATION": {
-                  "type": "boolean",
-                  "description": "If true, VEGETATION class of semantic will be filtered.",
-                  "default": true
-              },
-              "SKY": {
-                  "type": "boolean",
-                  "description": "If true, SKY class of semantic will be filtered.",
-                  "default": false
-              }
+            "UNKNOWN": {
+              "type": "boolean",
+              "description": "If true, UNKNOWN class of semantic will be filtered.",
+              "default": false
+            },
+            "BUILDING": {
+              "type": "boolean",
+              "description": "If true, BUILDING class of semantic will be filtered.",
+              "default": true
+            },
+            "WALL": {
+              "type": "boolean",
+              "description": "If true, WALL class of semantic will be filtered.",
+              "default": true
+            },
+            "OBSTACLE": {
+              "type": "boolean",
+              "description": "If true, OBSTACLE class of semantic will be filtered.",
+              "default": false
+            },
+            "TRAFFIC_LIGHT": {
+              "type": "boolean",
+              "description": "If true, TRAFFIC_LIGHT class of semantic will be filtered.",
+              "default": false
+            },
+            "TRAFFIC_SIGN": {
+              "type": "boolean",
+              "description": "If true, TRAFFIC_SIGN class of semantic will be filtered.",
+              "default": false
+            },
+            "PERSON": {
+              "type": "boolean",
+              "description": "If true, PERSON class of semantic will be filtered.",
+              "default": false
+            },
+            "VEHICLE": {
+              "type": "boolean",
+              "description": "If true, VEHICLE class of semantic will be filtered.",
+              "default": false
+            },
+            "BIKE": {
+              "type": "boolean",
+              "description": "If true, BIKE class of semantic will be filtered.",
+              "default": false
+            },
+            "ROAD": {
+              "type": "boolean",
+              "description": "If true, ROAD class of semantic will be filtered.",
+              "default": true
+            },
+            "SIDEWALK": {
+              "type": "boolean",
+              "description": "If true, SIDEWALK class of semantic will be filtered.",
+              "default": false
+            },
+            "ROADPAINT": {
+              "type": "boolean",
+              "description": "If true, ROADPAINT class of semantic will be filtered.",
+              "default": false
+            },
+            "CURBSTONE": {
+              "type": "boolean",
+              "description": "If true, CURBSTONE class of semantic will be filtered.",
+              "default": false
+            },
+            "CROSSWALK": {
+              "type": "boolean",
+              "description": "If true, CROSSWALK class of semantic will be filtered.",
+              "default": false
+            },
+            "VEGETATION": {
+              "type": "boolean",
+              "description": "If true, VEGETATION class of semantic will be filtered.",
+              "default": true
+            },
+            "SKY": {
+              "type": "boolean",
+              "description": "If true, SKY class of semantic will be filtered.",
+              "default": false
+            }
           },
           "required": [
-              "UNKNOWN", "BUILDING", "WALL", "OBSTACLE", "TRAFFIC_LIGHT", "TRAFFIC_SIGN", "PERSON", "VEHICLE", "BIKE", "ROAD", "SIDEWALK", "ROADPAINT", "CURBSTONE", "CROSSWALK", "VEGETATION", "SKY"]
+            "UNKNOWN",
+            "BUILDING",
+            "WALL",
+            "OBSTACLE",
+            "TRAFFIC_LIGHT",
+            "TRAFFIC_SIGN",
+            "PERSON",
+            "VEHICLE",
+            "BIKE",
+            "ROAD",
+            "SIDEWALK",
+            "ROADPAINT",
+            "CURBSTONE",
+            "CROSSWALK",
+            "VEGETATION",
+            "SKY"
+          ]
         },
-        "filter_distance_threshold":{
+        "filter_distance_threshold": {
           "type": "number",
           "description": "A maximum distance of pointcloud to apply filter [m].",
           "default": 60.0,
           "minimum": 0.0
         }
       },
-      "required": ["filter_semantic_label_target","filter_distance_threshold"]
+      "required": ["filter_semantic_label_target", "filter_distance_threshold"]
     }
   },
   "properties": {
@@ -116,4 +132,3 @@
   },
   "required": ["/**"]
 }
-  

--- a/perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json
+++ b/perception/image_projection_based_fusion/schema/segmentation_pointcloud_fusion.schema.json
@@ -64,9 +64,9 @@
               "description": "If true, SIDEWALK class of semantic will be filtered.",
               "default": false
             },
-            "ROADPAINT": {
+            "ROAD_PAINT": {
               "type": "boolean",
-              "description": "If true, ROADPAINT class of semantic will be filtered.",
+              "description": "If true, ROAD_PAINT class of semantic will be filtered.",
               "default": false
             },
             "CURBSTONE": {
@@ -102,7 +102,7 @@
             "BIKE",
             "ROAD",
             "SIDEWALK",
-            "ROADPAINT",
+            "ROAD_PAINT",
             "CURBSTONE",
             "CROSSWALK",
             "VEGETATION",

--- a/perception/image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
@@ -31,8 +31,13 @@ SegmentPointCloudFusionNode::SegmentPointCloudFusionNode(const rclcpp::NodeOptio
 : FusionNode<PointCloud2, PointCloud2, Image>("segmentation_pointcloud_fusion", options)
 {
   filter_distance_threshold_ = declare_parameter<float>("filter_distance_threshold");
-  filter_semantic_label_target_ =
-    declare_parameter<std::vector<bool>>("filter_semantic_label_target");
+  for (auto & item : filter_semantic_label_target_list_) {
+    item.second = declare_parameter<bool>("filter_semantic_label_target." + item.first);
+  }
+  for (const auto & item : filter_semantic_label_target_list_) {
+    RCLCPP_INFO(
+      this->get_logger(), "filter_semantic_label_target: %s %d", item.first.c_str(), item.second);
+  }
 }
 
 void SegmentPointCloudFusionNode::preprocess(__attribute__((unused)) PointCloud2 & pointcloud_msg)
@@ -129,12 +134,12 @@ void SegmentPointCloudFusionNode::fuseOnSingleImage(
     // skip filtering pointcloud where semantic id out of the defined list
     uint8_t semantic_id = mask.at<uint8_t>(
       static_cast<uint16_t>(projected_point.y()), static_cast<uint16_t>(projected_point.x()));
-    if (static_cast<size_t>(semantic_id) >= filter_semantic_label_target_.size()) {
+    if (static_cast<size_t>(semantic_id) >= filter_semantic_label_target_list_.size()) {
       copyPointCloud(
         input_pointcloud_msg, point_step, global_offset, output_cloud, output_pointcloud_size);
       continue;
     }
-    if (!filter_semantic_label_target_.at(semantic_id)) {
+    if (!filter_semantic_label_target_list_.at(semantic_id).second) {
       copyPointCloud(
         input_pointcloud_msg, point_step, global_offset, output_cloud, output_pointcloud_size);
     }


### PR DESCRIPTION
## Description

- To change the parameter declaration to avoid unintentional error.

## Related links

**Parent Issue:**


- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-3590)

<!-- ⬇️🟢
**Private Links:**

⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
