### PR TITLE
fix(yabloc_image_processing): fix shadowFunction

### DIFF
--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -53,14 +53,12 @@ public:
       qos = rclcpp::QoS(10).durability_volatile().best_effort();
     }
 
-    auto on_image = std::bind(&UndistortNode::on_image, this, _1);
-    auto on_compressed_image = std::bind(&UndistortNode::on_compressed_image, this, _1);
-    auto on_info = std::bind(&UndistortNode::on_info, this, _1);
-    sub_image_ = create_subscription<Image>("~/input/image_raw", qos, std::move(on_image));
+    sub_image_ = create_subscription<Image>(
+      "~/input/image_raw", qos, std::bind(&UndistortNode::on_image, this, _1));
     sub_compressed_image_ = create_subscription<CompressedImage>(
-      "~/input/image_raw/compressed", qos, std::move(on_compressed_image));
-
-    sub_info_ = create_subscription<CameraInfo>("~/input/camera_info", qos, std::move(on_info));
+      "~/input/image_raw/compressed", qos, std::move(std::bind(&UndistortNode::on_compressed_image, this, _1)));
+    sub_info_ = create_subscription<CameraInfo>(
+      "~/input/camera_info", qos, std::bind(&UndistortNode::on_info, this, _1));
 
     pub_info_ = create_publisher<CameraInfo>("~/output/resized_info", 10);
     pub_image_ = create_publisher<Image>("~/output/resized_image", 10);

--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -56,7 +56,8 @@ public:
     sub_image_ = create_subscription<Image>(
       "~/input/image_raw", qos, std::bind(&UndistortNode::on_image, this, _1));
     sub_compressed_image_ = create_subscription<CompressedImage>(
-      "~/input/image_raw/compressed", qos, std::bind(&UndistortNode::on_compressed_image, this, _1));
+      "~/input/image_raw/compressed", qos,
+      std::bind(&UndistortNode::on_compressed_image, this, _1));
     sub_info_ = create_subscription<CameraInfo>(
       "~/input/camera_info", qos, std::bind(&UndistortNode::on_info, this, _1));
 

--- a/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
+++ b/localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp
@@ -56,7 +56,7 @@ public:
     sub_image_ = create_subscription<Image>(
       "~/input/image_raw", qos, std::bind(&UndistortNode::on_image, this, _1));
     sub_compressed_image_ = create_subscription<CompressedImage>(
-      "~/input/image_raw/compressed", qos, std::move(std::bind(&UndistortNode::on_compressed_image, this, _1)));
+      "~/input/image_raw/compressed", qos, std::bind(&UndistortNode::on_compressed_image, this, _1));
     sub_info_ = create_subscription<CameraInfo>(
       "~/input/camera_info", qos, std::bind(&UndistortNode::on_info, this, _1));
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `shadowFunction` warnings

```
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:56:10: style: Local variable 'on_image' shadows outer function [shadowFunction]
    auto on_image = std::bind(&UndistortNode::on_image, this, _1);
         ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:140:8: note: Shadowed declaration
  void on_image(const Image & msg)
       ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:56:10: note: Shadow variable
    auto on_image = std::bind(&UndistortNode::on_image, this, _1);
         ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:57:10: style: Local variable 'on_compressed_image' shadows outer function [shadowFunction]
    auto on_compressed_image = std::bind(&UndistortNode::on_compressed_image, this, _1);
         ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:159:8: note: Shadowed declaration
  void on_compressed_image(const CompressedImage & msg)
       ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:57:10: note: Shadow variable
    auto on_compressed_image = std::bind(&UndistortNode::on_compressed_image, this, _1);
         ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:58:10: style: Local variable 'on_info' shadows outer function [shadowFunction]
    auto on_info = std::bind(&UndistortNode::on_info, this, _1);
         ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:173:8: note: Shadowed declaration
  void on_info(const CameraInfo & msg) { info_ = msg; }
       ^
localization/yabloc/yabloc_image_processing/src/undistort/undistort_node.cpp:58:10: note: Shadow variable
    auto on_info = std::bind(&UndistortNode::on_info, this, _1);
         ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
