### PR TITLE
refactor(lanelet2_map_preprocessor): apply static analysis

### DIFF
--- a/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
@@ -49,10 +49,8 @@ lanelet::Lanelets convert_to_vector(const lanelet::LaneletMapPtr & lanelet_map_p
 {
   lanelet::Lanelets lanelets;
   std::copy(
-    lanelet_map_ptr->laneletLayer.begin(),
-    lanelet_map_ptr->laneletLayer.end(),
-    std::back_inserter(lanelets)
-  );
+    lanelet_map_ptr->laneletLayer.begin(), lanelet_map_ptr->laneletLayer.end(),
+    std::back_inserter(lanelets));
   return lanelets;
 }
 void fix_tags(lanelet::LaneletMapPtr & lanelet_map_ptr)

--- a/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
@@ -27,10 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
-using lanelet::utils::getId;
-using lanelet::utils::to2D;
-
-bool loadLaneletMap(
+bool load_lanelet_map(
   const std::string & llt_map_path, lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::Projector & projector)
 {
@@ -48,32 +45,34 @@ bool loadLaneletMap(
   return true;
 }
 
-lanelet::Lanelets convertToVector(lanelet::LaneletMapPtr & lanelet_map_ptr)
+lanelet::Lanelets convert_to_vector(const lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::Lanelets lanelets;
-  for (lanelet::Lanelet lanelet : lanelet_map_ptr->laneletLayer) {
-    lanelets.push_back(lanelet);
-  }
+  std::copy(
+    lanelet_map_ptr->laneletLayer.begin(),
+    lanelet_map_ptr->laneletLayer.end(),
+    std::back_inserter(lanelets)
+  );
   return lanelets;
 }
-void fixTags(lanelet::LaneletMapPtr & lanelet_map_ptr)
+void fix_tags(lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
-  auto lanelets = convertToVector(lanelet_map_ptr);
-  lanelet::traffic_rules::TrafficRulesPtr trafficRules =
+  auto lanelets = convert_to_vector(lanelet_map_ptr);
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules =
     lanelet::traffic_rules::TrafficRulesFactory::create(
       lanelet::Locations::Germany, lanelet::Participants::Vehicle);
-  lanelet::routing::RoutingGraphUPtr routingGraph =
-    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr, *trafficRules);
+  lanelet::routing::RoutingGraphUPtr routing_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr, *traffic_rules);
 
   for (auto & llt : lanelets) {
-    if (!routingGraph->conflicting(llt).empty()) {
+    if (!routing_graph->conflicting(llt).empty()) {
       continue;
     }
     llt.attributes().erase("turn_direction");
-    if (!!routingGraph->adjacentRight(llt)) {
+    if (!!routing_graph->adjacentRight(llt)) {
       llt.rightBound().attributes()["lane_change"] = "yes";
     }
-    if (!!routingGraph->adjacentLeft(llt)) {
+    if (!!routing_graph->adjacentLeft(llt)) {
       llt.leftBound().attributes()["lane_change"] = "yes";
     }
   }
@@ -91,11 +90,11 @@ int main(int argc, char * argv[])
   lanelet::LaneletMapPtr llt_map_ptr(new lanelet::LaneletMap);
   lanelet::projection::MGRSProjector projector;
 
-  if (!loadLaneletMap(llt_map_path, llt_map_ptr, projector)) {
+  if (!load_lanelet_map(llt_map_path, llt_map_ptr, projector)) {
     return EXIT_FAILURE;
   }
 
-  fixTags(llt_map_ptr);
+  fix_tags(llt_map_ptr);
   lanelet::write(output_path, *llt_map_ptr, projector);
 
   rclcpp::shutdown();

--- a/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp
@@ -46,8 +46,8 @@ bool load_lanelet_map(
 }
 
 bool load_pcd_map(
-  const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr
-) {
+  const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr)
+{
   if (pcl::io::loadPCDFile<pcl::PointXYZ>(pcd_map_path, *pcd_map_ptr) == -1) {  //* load the file
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("loadPCDMap"), "Couldn't read file: " << pcd_map_path);
     return false;
@@ -93,8 +93,8 @@ double get_min_height_around_point(
 
 void adjust_height(
   const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr,
-  const lanelet::LaneletMapPtr & lanelet_map_ptr
-) {
+  const lanelet::LaneletMapPtr & lanelet_map_ptr)
+{
   std::unordered_set<lanelet::Id> done;
   double search_radius2d = 0.5;
   double search_radius3d = 10;

--- a/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp
@@ -27,7 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
-bool loadLaneletMap(
+bool load_lanelet_map(
   const std::string & llt_map_path, lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::Projector & projector)
 {
@@ -45,8 +45,9 @@ bool loadLaneletMap(
   return true;
 }
 
-bool loadPCDMap(const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr)
-{
+bool load_pcd_map(
+  const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr
+) {
   if (pcl::io::loadPCDFile<pcl::PointXYZ>(pcd_map_path, *pcd_map_ptr) == -1) {  //* load the file
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("loadPCDMap"), "Couldn't read file: " << pcd_map_path);
     return false;
@@ -56,16 +57,16 @@ bool loadPCDMap(const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>
   return true;
 }
 
-double getMinHeightAroundPoint(
+double get_min_height_around_point(
   const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr,
   const pcl::KdTreeFLANN<pcl::PointXYZ> & kdtree, const pcl::PointXYZ & search_pt,
   const double search_radius3d, const double search_radius2d)
 {
-  std::vector<int> pointIdxRadiusSearch;
-  std::vector<float> pointRadiusSquaredDistance;
+  std::vector<int> point_idx_radius_search;
+  std::vector<float> point_radius_squared_distance;
   if (
     kdtree.radiusSearch(
-      search_pt, search_radius3d, pointIdxRadiusSearch, pointRadiusSquaredDistance) <= 0) {
+      search_pt, search_radius3d, point_idx_radius_search, point_radius_squared_distance) <= 0) {
     std::cout << "no points found within 3d radius " << search_radius3d << std::endl;
     return search_pt.z;
   }
@@ -73,8 +74,7 @@ double getMinHeightAroundPoint(
   double min_height = std::numeric_limits<double>::max();
   bool found = false;
 
-  for (std::size_t i = 0; i < pointIdxRadiusSearch.size(); i++) {
-    std::size_t pt_idx = pointIdxRadiusSearch.at(i);
+  for (auto pt_idx : point_idx_radius_search) {
     const auto pt = pcd_map_ptr->points.at(pt_idx);
     if (pt.z > min_height) {
       continue;
@@ -91,9 +91,10 @@ double getMinHeightAroundPoint(
   return min_height;
 }
 
-void adjustHeight(
-  const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr, lanelet::LaneletMapPtr & lanelet_map_ptr)
-{
+void adjust_height(
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr,
+  const lanelet::LaneletMapPtr & lanelet_map_ptr
+) {
   std::unordered_set<lanelet::Id> done;
   double search_radius2d = 0.5;
   double search_radius3d = 10;
@@ -107,11 +108,11 @@ void adjustHeight(
         continue;
       }
       pcl::PointXYZ pcl_pt;
-      pcl_pt.x = pt.x();
-      pcl_pt.y = pt.y();
-      pcl_pt.z = pt.z();
+      pcl_pt.x = static_cast<float>(pt.x());
+      pcl_pt.y = static_cast<float>(pt.y());
+      pcl_pt.z = static_cast<float>(pt.z());
       double min_height =
-        getMinHeightAroundPoint(pcd_map_ptr, kdtree, pcl_pt, search_radius3d, search_radius2d);
+        get_min_height_around_point(pcd_map_ptr, kdtree, pcl_pt, search_radius3d, search_radius2d);
       std::cout << "moving from " << pt.z() << " to " << min_height << std::endl;
       pt.z() = min_height;
       done.insert(pt.id());
@@ -121,11 +122,11 @@ void adjustHeight(
         continue;
       }
       pcl::PointXYZ pcl_pt;
-      pcl_pt.x = pt.x();
-      pcl_pt.y = pt.y();
-      pcl_pt.z = pt.z();
+      pcl_pt.x = static_cast<float>(pt.x());
+      pcl_pt.y = static_cast<float>(pt.y());
+      pcl_pt.z = static_cast<float>(pt.z());
       double min_height =
-        getMinHeightAroundPoint(pcd_map_ptr, kdtree, pcl_pt, search_radius3d, search_radius2d);
+        get_min_height_around_point(pcd_map_ptr, kdtree, pcl_pt, search_radius3d, search_radius2d);
       std::cout << "moving from " << pt.z() << " to " << min_height << std::endl;
       pt.z() = min_height;
       done.insert(pt.id());
@@ -148,14 +149,14 @@ int main(int argc, char * argv[])
 
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcd_map_ptr(new pcl::PointCloud<pcl::PointXYZ>);
 
-  if (!loadLaneletMap(llt_map_path, llt_map_ptr, projector)) {
+  if (!load_lanelet_map(llt_map_path, llt_map_ptr, projector)) {
     return EXIT_FAILURE;
   }
-  if (!loadPCDMap(pcd_map_path, pcd_map_ptr)) {
+  if (!load_pcd_map(pcd_map_path, pcd_map_ptr)) {
     return EXIT_FAILURE;
   }
 
-  adjustHeight(pcd_map_ptr, llt_map_ptr);
+  adjust_height(pcd_map_ptr, llt_map_ptr);
   lanelet::write(llt_output_path, *llt_map_ptr, projector);
 
   rclcpp::shutdown();

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
@@ -45,14 +45,12 @@ bool load_lanelet_map(
 }
 
 lanelet::LineStrings3d convert_line_layer_to_line_strings(
-  const lanelet::LaneletMapPtr & lanelet_map_ptr
-) {
+  const lanelet::LaneletMapPtr & lanelet_map_ptr)
+{
   lanelet::LineStrings3d lines;
   std::copy(
-    lanelet_map_ptr->lineStringLayer.begin(),
-    lanelet_map_ptr->lineStringLayer.end(),
-    std::back_inserter(lines)
-  );
+    lanelet_map_ptr->lineStringLayer.begin(), lanelet_map_ptr->lineStringLayer.end(),
+    std::back_inserter(lines));
   return lines;
 }
 
@@ -66,16 +64,14 @@ lanelet::ConstPoint3d get3_d_point_from2_d_arc_length(
   auto prev_pt = line.front();
   for (size_t i = 1; i < line.size(); i++) {
     const auto & pt = line[i];
-    double distance2d = lanelet::geometry::distance2d(
-      lanelet::utils::to2D(prev_pt), lanelet::utils::to2D(pt)
-    );
+    double distance2d =
+      lanelet::geometry::distance2d(lanelet::utils::to2D(prev_pt), lanelet::utils::to2D(pt));
     if (accumulated_distance2d + distance2d >= s) {
       double ratio = (s - accumulated_distance2d) / distance2d;
       auto interpolated_pt = prev_pt.basicPoint() * (1 - ratio) + pt.basicPoint() * ratio;
       std::cout << interpolated_pt << std::endl;
       return lanelet::ConstPoint3d{
-        lanelet::utils::getId(), interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z()
-      };
+        lanelet::utils::getId(), interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z()};
     }
     accumulated_distance2d += distance2d;
     prev_pt = pt;
@@ -98,16 +94,14 @@ bool are_lines_same(
     return false;
   }
 
-  double sum_distance = std::accumulate(line1.begin(), line1.end(), 0.0,
-    [&line2](double sum, const auto& pt) {
+  double sum_distance =
+    std::accumulate(line1.begin(), line1.end(), 0.0, [&line2](double sum, const auto & pt) {
       return sum + boost::geometry::distance(pt.basicPoint(), line2);
-    }
-  );
-  sum_distance += std::accumulate(line2.begin(), line2.end(), 0.0,
-    [&line1](double sum, const auto& pt) {
+    });
+  sum_distance +=
+    std::accumulate(line2.begin(), line2.end(), 0.0, [&line1](double sum, const auto & pt) {
       return sum + boost::geometry::distance(pt.basicPoint(), line1);
-    }
-  );
+    });
 
   double avg_distance = sum_distance / static_cast<double>(line1.size() + line2.size());
   std::cout << line1 << " " << line2 << " " << avg_distance << std::endl;
@@ -118,8 +112,7 @@ lanelet::BasicPoint3d get_closest_point_on_line(
   const lanelet::BasicPoint3d & search_point, const lanelet::ConstLineString3d & line)
 {
   auto arc_coordinate = lanelet::geometry::toArcCoordinates(
-    lanelet::utils::to2D(line), lanelet::utils::to2D(search_point)
-  );
+    lanelet::utils::to2D(line), lanelet::utils::to2D(search_point));
   std::cout << arc_coordinate.length << " " << arc_coordinate.distance << std::endl;
   return get3_d_point_from2_d_arc_length(line, arc_coordinate.length).basicPoint();
 }
@@ -129,7 +122,7 @@ lanelet::LineString3d merge_two_lines(
 {
   lanelet::Points3d new_points;
   for (const auto & p1 : line1) {
-    const lanelet::BasicPoint3d& p1_basic_point = p1.basicPoint();
+    const lanelet::BasicPoint3d & p1_basic_point = p1.basicPoint();
     lanelet::BasicPoint3d p2_basic_point = get_closest_point_on_line(p1, line2);
     lanelet::BasicPoint3d new_basic_point = (p1_basic_point + p2_basic_point) / 2;
     lanelet::Point3d new_point(lanelet::utils::getId(), new_basic_point);

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
@@ -54,7 +54,7 @@ lanelet::LineStrings3d convert_line_layer_to_line_strings(
   return lines;
 }
 
-lanelet::ConstPoint3d get3_d_point_from2_d_arc_length(
+lanelet::ConstPoint3d get3d_point_from2d_arc_length(
   const lanelet::ConstLineString3d & line, const double s)
 {
   double accumulated_distance2d = 0;
@@ -114,7 +114,7 @@ lanelet::BasicPoint3d get_closest_point_on_line(
   auto arc_coordinate = lanelet::geometry::toArcCoordinates(
     lanelet::utils::to2D(line), lanelet::utils::to2D(search_point));
   std::cout << arc_coordinate.length << " " << arc_coordinate.distance << std::endl;
-  return get3_d_point_from2_d_arc_length(line, arc_coordinate.length).basicPoint();
+  return get3d_point_from2d_arc_length(line, arc_coordinate.length).basicPoint();
 }
 
 lanelet::LineString3d merge_two_lines(
@@ -135,9 +135,7 @@ void copy_data(lanelet::LineString3d & dst, const lanelet::LineString3d & src)
 {
   dst.clear();
   for (const lanelet::ConstPoint3d & pt : src) {
-    lanelet::Point3d pt_casted;
-    pt_casted = static_cast<lanelet::Point3d>(pt);
-    dst.push_back(pt_casted);
+    dst.push_back(static_cast<lanelet::Point3d>(pt));
   }
 }
 

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp
@@ -26,10 +26,7 @@
 #include <unordered_set>
 #include <vector>
 
-using lanelet::utils::getId;
-using lanelet::utils::to2D;
-
-bool loadLaneletMap(
+bool load_lanelet_map(
   const std::string & llt_map_path, lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::Projector & projector)
 {
@@ -47,21 +44,19 @@ bool loadLaneletMap(
   return true;
 }
 
-bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
-{
-  return set.find(element) != set.end();
-}
-
-lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)
-{
+lanelet::LineStrings3d convert_line_layer_to_line_strings(
+  const lanelet::LaneletMapPtr & lanelet_map_ptr
+) {
   lanelet::LineStrings3d lines;
-  for (const lanelet::LineString3d & line : lanelet_map_ptr->lineStringLayer) {
-    lines.push_back(line);
-  }
+  std::copy(
+    lanelet_map_ptr->lineStringLayer.begin(),
+    lanelet_map_ptr->lineStringLayer.end(),
+    std::back_inserter(lines)
+  );
   return lines;
 }
 
-lanelet::ConstPoint3d get3DPointFrom2DArcLength(
+lanelet::ConstPoint3d get3_d_point_from2_d_arc_length(
   const lanelet::ConstLineString3d & line, const double s)
 {
   double accumulated_distance2d = 0;
@@ -71,27 +66,25 @@ lanelet::ConstPoint3d get3DPointFrom2DArcLength(
   auto prev_pt = line.front();
   for (size_t i = 1; i < line.size(); i++) {
     const auto & pt = line[i];
-    double distance2d = lanelet::geometry::distance2d(to2D(prev_pt), to2D(pt));
+    double distance2d = lanelet::geometry::distance2d(
+      lanelet::utils::to2D(prev_pt), lanelet::utils::to2D(pt)
+    );
     if (accumulated_distance2d + distance2d >= s) {
       double ratio = (s - accumulated_distance2d) / distance2d;
       auto interpolated_pt = prev_pt.basicPoint() * (1 - ratio) + pt.basicPoint() * ratio;
       std::cout << interpolated_pt << std::endl;
-      return lanelet::ConstPoint3d(
-        lanelet::utils::getId(), interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z());
+      return lanelet::ConstPoint3d{
+        lanelet::utils::getId(), interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z()
+      };
     }
     accumulated_distance2d += distance2d;
     prev_pt = pt;
   }
   RCLCPP_ERROR(rclcpp::get_logger("merge_close_lines"), "interpolation failed");
-  return lanelet::ConstPoint3d();
+  return {};
 }
 
-double getLineLength(const lanelet::ConstLineString3d & line)
-{
-  return boost::geometry::length(line.basicLineString());
-}
-
-bool areLinesSame(
+bool are_lines_same(
   const lanelet::ConstLineString3d & line1, const lanelet::ConstLineString3d & line2)
 {
   bool same_ends = false;
@@ -105,66 +98,68 @@ bool areLinesSame(
     return false;
   }
 
-  double sum_distance = 0;
-  for (const auto & pt : line1) {
-    sum_distance += boost::geometry::distance(pt.basicPoint(), line2);
-  }
-  for (const auto & pt : line2) {
-    sum_distance += boost::geometry::distance(pt.basicPoint(), line1);
-  }
+  double sum_distance = std::accumulate(line1.begin(), line1.end(), 0.0,
+    [&line2](double sum, const auto& pt) {
+      return sum + boost::geometry::distance(pt.basicPoint(), line2);
+    }
+  );
+  sum_distance += std::accumulate(line2.begin(), line2.end(), 0.0,
+    [&line1](double sum, const auto& pt) {
+      return sum + boost::geometry::distance(pt.basicPoint(), line1);
+    }
+  );
 
-  double avg_distance = sum_distance / (line1.size() + line2.size());
+  double avg_distance = sum_distance / static_cast<double>(line1.size() + line2.size());
   std::cout << line1 << " " << line2 << " " << avg_distance << std::endl;
-  if (avg_distance < 1.0) {
-    return true;
-  } else {
-    return false;
-  }
+  return avg_distance < 1.0;
 }
 
-lanelet::BasicPoint3d getClosestPointOnLine(
+lanelet::BasicPoint3d get_closest_point_on_line(
   const lanelet::BasicPoint3d & search_point, const lanelet::ConstLineString3d & line)
 {
-  auto arc_coordinate = lanelet::geometry::toArcCoordinates(to2D(line), to2D(search_point));
+  auto arc_coordinate = lanelet::geometry::toArcCoordinates(
+    lanelet::utils::to2D(line), lanelet::utils::to2D(search_point)
+  );
   std::cout << arc_coordinate.length << " " << arc_coordinate.distance << std::endl;
-  return get3DPointFrom2DArcLength(line, arc_coordinate.length).basicPoint();
+  return get3_d_point_from2_d_arc_length(line, arc_coordinate.length).basicPoint();
 }
 
-lanelet::LineString3d mergeTwoLines(
+lanelet::LineString3d merge_two_lines(
   const lanelet::LineString3d & line1, const lanelet::ConstLineString3d & line2)
 {
   lanelet::Points3d new_points;
   for (const auto & p1 : line1) {
-    lanelet::BasicPoint3d p1_basic_point = p1.basicPoint();
-    lanelet::BasicPoint3d p2_basic_point = getClosestPointOnLine(p1, line2);
+    const lanelet::BasicPoint3d& p1_basic_point = p1.basicPoint();
+    lanelet::BasicPoint3d p2_basic_point = get_closest_point_on_line(p1, line2);
     lanelet::BasicPoint3d new_basic_point = (p1_basic_point + p2_basic_point) / 2;
     lanelet::Point3d new_point(lanelet::utils::getId(), new_basic_point);
     new_points.push_back(new_point);
   }
-  return lanelet::LineString3d(lanelet::utils::getId(), new_points);
+  return lanelet::LineString3d{lanelet::utils::getId(), new_points};
 }
 
-void copyData(lanelet::LineString3d & dst, lanelet::LineString3d & src)
+void copy_data(lanelet::LineString3d & dst, const lanelet::LineString3d & src)
 {
-  lanelet::Points3d points;
   dst.clear();
-  for (lanelet::Point3d & pt : src) {
-    dst.push_back(pt);
+  for (const lanelet::ConstPoint3d & pt : src) {
+    lanelet::Point3d pt_casted;
+    pt_casted = static_cast<lanelet::Point3d>(pt);
+    dst.push_back(pt_casted);
   }
 }
 
-void mergeLines(lanelet::LaneletMapPtr & lanelet_map_ptr)
+void merge_lines(lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
-  auto lines = convertLineLayerToLineStrings(lanelet_map_ptr);
+  auto lines = convert_line_layer_to_line_strings(lanelet_map_ptr);
 
   for (size_t i = 0; i < lines.size(); i++) {
     auto line_i = lines.at(i);
     for (size_t j = 0; j < i; j++) {
       auto line_j = lines.at(j);
-      if (areLinesSame(line_i, line_j)) {
-        auto merged_line = mergeTwoLines(line_i, line_j);
-        copyData(line_i, merged_line);
-        copyData(line_j, merged_line);
+      if (are_lines_same(line_i, line_j)) {
+        auto merged_line = merge_two_lines(line_i, line_j);
+        copy_data(line_i, merged_line);
+        copy_data(line_j, merged_line);
         line_i.setId(line_j.id());
         std::cout << line_j << " " << line_i << std::endl;
         // lanelet_map_ptr->add(merged_line);
@@ -189,11 +184,11 @@ int main(int argc, char * argv[])
   lanelet::LaneletMapPtr llt_map_ptr(new lanelet::LaneletMap);
   lanelet::projection::MGRSProjector projector;
 
-  if (!loadLaneletMap(llt_map_path, llt_map_ptr, projector)) {
+  if (!load_lanelet_map(llt_map_path, llt_map_ptr, projector)) {
     return EXIT_FAILURE;
   }
 
-  mergeLines(llt_map_ptr);
+  merge_lines(llt_map_ptr);
   lanelet::write(output_path, *llt_map_ptr, projector);
 
   rclcpp::shutdown();

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp
@@ -47,10 +47,8 @@ lanelet::Points3d convert_points_layer_to_points(const lanelet::LaneletMapPtr & 
 {
   lanelet::Points3d points;
   std::copy(
-    lanelet_map_ptr->pointLayer.begin(),
-    lanelet_map_ptr->pointLayer.end(),
-    std::back_inserter(points)
-  );
+    lanelet_map_ptr->pointLayer.begin(), lanelet_map_ptr->pointLayer.end(),
+    std::back_inserter(points));
   return points;
 }
 

--- a/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp
@@ -25,7 +25,7 @@
 #include <unordered_set>
 #include <vector>
 
-bool loadLaneletMap(
+bool load_lanelet_map(
   const std::string & llt_map_path, lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::Projector & projector)
 {
@@ -43,17 +43,14 @@ bool loadLaneletMap(
   return true;
 }
 
-bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
-{
-  return set.find(element) != set.end();
-}
-
-lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
+lanelet::Points3d convert_points_layer_to_points(const lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::Points3d points;
-  for (const lanelet::Point3d & pt : lanelet_map_ptr->pointLayer) {
-    points.push_back(pt);
-  }
+  std::copy(
+    lanelet_map_ptr->pointLayer.begin(),
+    lanelet_map_ptr->pointLayer.end(),
+    std::back_inserter(points)
+  );
   return points;
 }
 
@@ -72,9 +69,9 @@ lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_ma
 //   return lanelet::LineString3d(lanelet::utils::getId(), new_points);
 // }
 
-void mergePoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
+void merge_points(const lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
-  const auto & points = convertPointsLayerToPoints(lanelet_map_ptr);
+  const auto & points = convert_points_layer_to_points(lanelet_map_ptr);
 
   for (size_t i = 0; i < points.size(); i++) {
     auto point_i = points.at(i);
@@ -109,11 +106,11 @@ int main(int argc, char * argv[])
   lanelet::LaneletMapPtr llt_map_ptr(new lanelet::LaneletMap);
   lanelet::projection::MGRSProjector projector;
 
-  if (!loadLaneletMap(llt_map_path, llt_map_ptr, projector)) {
+  if (!load_lanelet_map(llt_map_path, llt_map_ptr, projector)) {
     return EXIT_FAILURE;
   }
 
-  mergePoints(llt_map_ptr);
+  merge_points(llt_map_ptr);
   lanelet::write(output_path, *llt_map_ptr, projector);
 
   rclcpp::shutdown();

--- a/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp
@@ -47,29 +47,25 @@ lanelet::Points3d convert_points_layer_to_points(const lanelet::LaneletMapPtr & 
 {
   lanelet::Points3d points;
   std::copy(
-    lanelet_map_ptr->pointLayer.begin(),
-    lanelet_map_ptr->pointLayer.end(),
-    std::back_inserter(points)
-  );
+    lanelet_map_ptr->pointLayer.begin(), lanelet_map_ptr->pointLayer.end(),
+    std::back_inserter(points));
   return points;
 }
 
 lanelet::LineStrings3d convert_line_layer_to_line_strings(
-  const lanelet::LaneletMapPtr & lanelet_map_ptr
-) {
+  const lanelet::LaneletMapPtr & lanelet_map_ptr)
+{
   lanelet::LineStrings3d lines;
   std::copy(
-    lanelet_map_ptr->lineStringLayer.begin(),
-    lanelet_map_ptr->lineStringLayer.end(),
-    std::back_inserter(lines)
-  );
+    lanelet_map_ptr->lineStringLayer.begin(), lanelet_map_ptr->lineStringLayer.end(),
+    std::back_inserter(lines));
   return lines;
 }
 
 void remove_unreferenced_geometry(lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::LaneletMapPtr new_map(new lanelet::LaneletMap);
-  for (const auto& llt : lanelet_map_ptr->laneletLayer) {
+  for (const auto & llt : lanelet_map_ptr->laneletLayer) {
     new_map->add(llt);
   }
   lanelet_map_ptr = new_map;

--- a/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp
@@ -25,7 +25,7 @@
 #include <unordered_set>
 #include <vector>
 
-bool loadLaneletMap(
+bool load_lanelet_map(
   const std::string & llt_map_path, lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::Projector & projector)
 {
@@ -43,28 +43,33 @@ bool loadLaneletMap(
   return true;
 }
 
-lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
+lanelet::Points3d convert_points_layer_to_points(const lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::Points3d points;
-  for (const lanelet::Point3d & pt : lanelet_map_ptr->pointLayer) {
-    points.push_back(pt);
-  }
+  std::copy(
+    lanelet_map_ptr->pointLayer.begin(),
+    lanelet_map_ptr->pointLayer.end(),
+    std::back_inserter(points)
+  );
   return points;
 }
 
-lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)
-{
+lanelet::LineStrings3d convert_line_layer_to_line_strings(
+  const lanelet::LaneletMapPtr & lanelet_map_ptr
+) {
   lanelet::LineStrings3d lines;
-  for (const lanelet::LineString3d & line : lanelet_map_ptr->lineStringLayer) {
-    lines.push_back(line);
-  }
+  std::copy(
+    lanelet_map_ptr->lineStringLayer.begin(),
+    lanelet_map_ptr->lineStringLayer.end(),
+    std::back_inserter(lines)
+  );
   return lines;
 }
 
-void removeUnreferencedGeometry(lanelet::LaneletMapPtr & lanelet_map_ptr)
+void remove_unreferenced_geometry(lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   lanelet::LaneletMapPtr new_map(new lanelet::LaneletMap);
-  for (auto llt : lanelet_map_ptr->laneletLayer) {
+  for (const auto& llt : lanelet_map_ptr->laneletLayer) {
     new_map->add(llt);
   }
   lanelet_map_ptr = new_map;
@@ -82,10 +87,10 @@ int main(int argc, char * argv[])
   lanelet::LaneletMapPtr llt_map_ptr(new lanelet::LaneletMap);
   lanelet::projection::MGRSProjector projector;
 
-  if (!loadLaneletMap(llt_map_path, llt_map_ptr, projector)) {
+  if (!load_lanelet_map(llt_map_path, llt_map_ptr, projector)) {
     return EXIT_FAILURE;
   }
-  removeUnreferencedGeometry(llt_map_ptr);
+  remove_unreferenced_geometry(llt_map_ptr);
   lanelet::write(output_path, *llt_map_ptr, projector);
 
   rclcpp::shutdown();

--- a/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp
@@ -46,8 +46,8 @@ bool load_lanelet_map(
 }
 
 bool load_pcd_map(
-  const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr
-) {
+  const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr)
+{
   if (pcl::io::loadPCDFile<pcl::PointXYZ>(pcd_map_path, *pcd_map_ptr) == -1) {  //* load the file
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("loadPCDMap"), "Couldn't read file: " << pcd_map_path);
     return false;
@@ -59,8 +59,7 @@ bool load_pcd_map(
 
 void transform_maps(
   const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr,
-  const lanelet::LaneletMapPtr & lanelet_map_ptr,
-  const Eigen::Affine3d& affine)
+  const lanelet::LaneletMapPtr & lanelet_map_ptr, const Eigen::Affine3d & affine)
 {
   {
     for (lanelet::Point3d & pt : lanelet_map_ptr->pointLayer) {

--- a/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp
@@ -27,7 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
-bool loadLaneletMap(
+bool load_lanelet_map(
   const std::string & llt_map_path, lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::Projector & projector)
 {
@@ -45,8 +45,9 @@ bool loadLaneletMap(
   return true;
 }
 
-bool loadPCDMap(const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr)
-{
+bool load_pcd_map(
+  const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr
+) {
   if (pcl::io::loadPCDFile<pcl::PointXYZ>(pcd_map_path, *pcd_map_ptr) == -1) {  //* load the file
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("loadPCDMap"), "Couldn't read file: " << pcd_map_path);
     return false;
@@ -56,9 +57,10 @@ bool loadPCDMap(const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>
   return true;
 }
 
-void transformMaps(
-  pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr, lanelet::LaneletMapPtr & lanelet_map_ptr,
-  const Eigen::Affine3d affine)
+void transform_maps(
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr,
+  const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const Eigen::Affine3d& affine)
 {
   {
     for (lanelet::Point3d & pt : lanelet_map_ptr->pointLayer) {
@@ -74,14 +76,14 @@ void transformMaps(
     for (auto & pt : pcd_map_ptr->points) {
       Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
       auto transformed_pt = affine * eigen_pt;
-      pt.x = transformed_pt.x();
-      pt.y = transformed_pt.y();
-      pt.z = transformed_pt.z();
+      pt.x = static_cast<float>(transformed_pt.x());
+      pt.y = static_cast<float>(transformed_pt.y());
+      pt.z = static_cast<float>(transformed_pt.z());
     }
   }
 }
 
-Eigen::Affine3d createAffineMatrixFromXYZRPY(
+Eigen::Affine3d create_affine_matrix_from_xyzrpy(
   const double x, const double y, const double z, const double roll, const double pitch,
   const double yaw)
 {
@@ -127,19 +129,19 @@ int main(int argc, char * argv[])
 
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcd_map_ptr(new pcl::PointCloud<pcl::PointXYZ>);
 
-  if (!loadLaneletMap(llt_map_path, llt_map_ptr, projector)) {
+  if (!load_lanelet_map(llt_map_path, llt_map_ptr, projector)) {
     return EXIT_FAILURE;
   }
-  if (!loadPCDMap(pcd_map_path, pcd_map_ptr)) {
+  if (!load_pcd_map(pcd_map_path, pcd_map_ptr)) {
     return EXIT_FAILURE;
   }
-  Eigen::Affine3d affine = createAffineMatrixFromXYZRPY(x, y, z, roll, pitch, yaw);
+  Eigen::Affine3d affine = create_affine_matrix_from_xyzrpy(x, y, z, roll, pitch, yaw);
 
   const auto mgrs_grid =
     node->declare_parameter<std::string>("mgrs_grid", projector.getProjectedMGRSGrid());
   std::cout << "using mgrs grid: " << mgrs_grid << std::endl;
 
-  transformMaps(pcd_map_ptr, llt_map_ptr, affine);
+  transform_maps(pcd_map_ptr, llt_map_ptr, affine);
   lanelet::write(llt_output_path, *llt_map_ptr, projector);
   pcl::io::savePCDFileBinary(pcd_output_path, *pcd_map_ptr);
 


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `map/util/lanelet2_map_preprocessor`.
Checked with clang-tidy and cppcheck.

Fixed:
- use explicit cast
- change variable names
    - camelCase to snake_case
- change function/method
    - camelCase to snake_case
    - add or removed keyword from function/method which linter suggested
- removed unused function/method
- avoid using raw loop

not Fixed:
- safe access to members of unions by `boost::variant`
  - speed concern
- possibly throwing an exception in main warning [bugprone-exception-escape](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/exception-escape.html)
 
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1)

Use `.cppcheck_suppressions` for suppressing some notation from cppcheck.

<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh lanelet2_map_preprocessor
...
47990 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:30:6: warning: invalid case style for function 'loadLaneletMap' [readability-identifier-naming]
bool loadLaneletMap(
     ^~~~~~~~~~~~~~
     load_lanelet_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:48:6: warning: invalid case style for function 'loadPCDMap' [readability-identifier-naming]
bool loadPCDMap(const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr)
     ^~~~~~~~~~
     load_pcd_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:59:8: warning: invalid case style for function 'getMinHeightAroundPoint' [readability-identifier-naming]
double getMinHeightAroundPoint(
       ^~~~~~~~~~~~~~~~~~~~~~~
       get_min_height_around_point
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:64:20: warning: invalid case style for variable 'pointIdxRadiusSearch' [readability-identifier-naming]
  std::vector<int> pointIdxRadiusSearch;
                   ^
note: this fix will not be applied because it overlaps with another fix
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:65:22: warning: invalid case style for variable 'pointRadiusSquaredDistance' [readability-identifier-naming]
  std::vector<float> pointRadiusSquaredDistance;
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
                     point_radius_squared_distance
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:70:22: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return search_pt.z;
                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:76:3: warning: use range-based for loop instead [modernize-loop-convert]
  for (std::size_t i = 0; i < pointIdxRadiusSearch.size(); i++) {
  ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      (unsigned long pt_idx : pointIdxRadiusSearch)
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:79:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    if (pt.z > min_height) {
           ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:39: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:53: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:59: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                                          ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:73: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:85:23: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      min_height = pt.z;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:89:28: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    min_height = search_pt.z;
                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:94:6: warning: invalid case style for function 'adjustHeight' [readability-identifier-naming]
void adjustHeight(
     ^~~~~~~~~~~~
     adjust_height
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:110:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.x = pt.x();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:110:18: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      pcl_pt.x = pt.x();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:111:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.y = pt.y();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:111:18: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      pcl_pt.y = pt.y();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:112:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.z = pt.z();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:112:18: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      pcl_pt.z = pt.z();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:124:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.x = pt.x();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:124:18: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      pcl_pt.x = pt.x();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:125:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.y = pt.y();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:125:18: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      pcl_pt.y = pt.y();
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:126:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.z = pt.z();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:126:18: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
      pcl_pt.z = pt.z();
                 ^
Suppressed 48045 warnings (47963 in non-user code, 82 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
50930 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:30:6: warning: invalid case style for function 'loadLaneletMap' [readability-identifier-naming]
bool loadLaneletMap(
     ^~~~~~~~~~~~~~
     load_lanelet_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:48:6: warning: invalid case style for function 'loadPCDMap' [readability-identifier-naming]
bool loadPCDMap(const std::string & pcd_map_path, pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr)
     ^~~~~~~~~~
     load_pcd_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:59:6: warning: invalid case style for function 'transformMaps' [readability-identifier-naming]
void transformMaps(
     ^~~~~~~~~~~~~
     transform_maps
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:61:25: warning: the const qualified parameter 'affine' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  const Eigen::Affine3d affine)
                        ^
                       &
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:75:35: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:75:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:75:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:77:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pt.x = transformed_pt.x();
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:77:14: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0>, 1>::Scalar' (aka 'double') to 'float' [cppcoreguidelines-narrowing-conversions]
      pt.x = transformed_pt.x();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:78:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pt.y = transformed_pt.y();
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:78:14: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0>, 1>::Scalar' (aka 'double') to 'float' [cppcoreguidelines-narrowing-conversions]
      pt.y = transformed_pt.y();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:79:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pt.z = transformed_pt.z();
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:79:14: warning: narrowing conversion from 'Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0>, 1>::Scalar' (aka 'double') to 'float' [cppcoreguidelines-narrowing-conversions]
      pt.z = transformed_pt.z();
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:84:17: warning: invalid case style for function 'createAffineMatrixFromXYZRPY' [readability-identifier-naming]
Eigen::Affine3d createAffineMatrixFromXYZRPY(
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                create_affine_matrix_from_xyzrpy
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:100:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
int main(int argc, char * argv[])
    ^
Suppressed 50997 warnings (50915 in non-user code, 82 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
55196 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp:28:6: warning: invalid case style for function 'loadLaneletMap' [readability-identifier-naming]
bool loadLaneletMap(
     ^~~~~~~~~~~~~~
     load_lanelet_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp:46:19: warning: invalid case style for function 'convertPointsLayerToPoints' [readability-identifier-naming]
lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
                  convert_points_layer_to_points
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp:55:24: warning: invalid case style for function 'convertLineLayerToLineStrings' [readability-identifier-naming]
lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       convert_line_layer_to_line_strings
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp:64:6: warning: invalid case style for function 'removeUnreferencedGeometry' [readability-identifier-naming]
void removeUnreferencedGeometry(lanelet::LaneletMapPtr & lanelet_map_ptr)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
     remove_unreferenced_geometry
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/remove_unreferenced_geometry.cpp:67:13: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
  for (auto llt : lanelet_map_ptr->laneletLayer) {
            ^
       const  &
Suppressed 55274 warnings (55191 in non-user code, 83 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
56586 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:29:23: error: using decl 'getId' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::utils::getId;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:29:23: note: remove the using
using lanelet::utils::getId;
~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:32:6: warning: invalid case style for function 'loadLaneletMap' [readability-identifier-naming]
bool loadLaneletMap(
     ^~~~~~~~~~~~~~
     load_lanelet_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:55:24: warning: invalid case style for function 'convertLineLayerToLineStrings' [readability-identifier-naming]
lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       convert_line_layer_to_line_strings
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:64:23: warning: invalid case style for function 'get3DPointFrom2DArcLength' [readability-identifier-naming]
lanelet::ConstPoint3d get3DPointFrom2DArcLength(
                      ^~~~~~~~~~~~~~~~~~~~~~~~~
                      get3_d_point_from2_d_arc_length
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:79:14: warning: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list]
      return lanelet::ConstPoint3d(
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:86:10: warning: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list]
  return lanelet::ConstPoint3d();
         ^~~~~~~~~~~~~~~~~~~~~~~
         {}
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:89:8: warning: invalid case style for function 'getLineLength' [readability-identifier-naming]
double getLineLength(const lanelet::ConstLineString3d & line)
       ^~~~~~~~~~~~~
       get_line_length
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:91:10: warning: narrowing conversion from 'typename default_length_result<vector<Matrix<double, 3, 1, 0>>>::type' (aka 'long double') to 'double' [cppcoreguidelines-narrowing-conversions]
  return boost::geometry::length(line.basicLineString());
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:94:6: warning: invalid case style for function 'areLinesSame' [readability-identifier-naming]
bool areLinesSame(
     ^~~~~~~~~~~~
     are_lines_same
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:116:40: warning: narrowing conversion from 'unsigned long' to 'double' [cppcoreguidelines-narrowing-conversions]
  double avg_distance = sum_distance / (line1.size() + line2.size());
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:119:12: warning: redundant boolean literal in conditional return statement [readability-simplify-boolean-expr]
    return true;
~~~~~~~~~~~^~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:120:5: warning: do not use 'else' after 'return' [readability-else-after-return]
  } else {
    ^~~~
note: this fix will not be applied because it overlaps with another fix
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:125:23: warning: invalid case style for function 'getClosestPointOnLine' [readability-identifier-naming]
lanelet::BasicPoint3d getClosestPointOnLine(
                      ^~~~~~~~~~~~~~~~~~~~~
                      get_closest_point_on_line
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:133:23: warning: invalid case style for function 'mergeTwoLines' [readability-identifier-naming]
lanelet::LineString3d mergeTwoLines(
                      ^~~~~~~~~~~~~
                      merge_two_lines
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:138:27: warning: the variable 'p1_basic_point' is copy-constructed from a const reference but is only used as const reference; consider making it a const reference [performance-unnecessary-copy-initialization]
    lanelet::BasicPoint3d p1_basic_point = p1.basicPoint();
                          ^
    const                &
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:144:10: warning: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list]
  return lanelet::LineString3d(lanelet::utils::getId(), new_points);
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:147:6: warning: invalid case style for function 'copyData' [readability-identifier-naming]
void copyData(lanelet::LineString3d & dst, lanelet::LineString3d & src)
     ^~~~~~~~
     copy_data
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:156:6: warning: invalid case style for function 'mergeLines' [readability-identifier-naming]
void mergeLines(lanelet::LaneletMapPtr & lanelet_map_ptr)
     ^~~~~~~~~~
     merge_lines
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:180:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
int main(int argc, char * argv[])
    ^
Suppressed 56651 warnings (56567 in non-user code, 84 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
55668 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp:28:6: warning: invalid case style for function 'loadLaneletMap' [readability-identifier-naming]
bool loadLaneletMap(
     ^~~~~~~~~~~~~~
     load_lanelet_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp:51:19: warning: invalid case style for function 'convertPointsLayerToPoints' [readability-identifier-naming]
lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
                  convert_points_layer_to_points
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp:75:6: warning: invalid case style for function 'mergePoints' [readability-identifier-naming]
void mergePoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
     ^~~~~~~~~~~
     merge_points
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp:100:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
int main(int argc, char * argv[])
    ^
Suppressed 55747 warnings (55664 in non-user code, 83 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
55804 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:30:23: error: using decl 'getId' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::utils::getId;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:30:23: note: remove the using
using lanelet::utils::getId;
~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:31:23: error: using decl 'to2D' is unused [misc-unused-using-decls,-warnings-as-errors]
using lanelet::utils::to2D;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:31:23: note: remove the using
using lanelet::utils::to2D;
~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:33:6: warning: invalid case style for function 'loadLaneletMap' [readability-identifier-naming]
bool loadLaneletMap(
     ^~~~~~~~~~~~~~
     load_lanelet_map
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:51:19: warning: invalid case style for function 'convertToVector' [readability-identifier-naming]
lanelet::Lanelets convertToVector(lanelet::LaneletMapPtr & lanelet_map_ptr)
                  ^~~~~~~~~~~~~~~
                  convert_to_vector
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:54:25: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
  for (lanelet::Lanelet lanelet : lanelet_map_ptr->laneletLayer) {
                        ^
       const           &
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:59:6: warning: invalid case style for function 'fixTags' [readability-identifier-naming]
void fixTags(lanelet::LaneletMapPtr & lanelet_map_ptr)
     ^~~~~~~
     fix_tags
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:62:43: warning: invalid case style for variable 'trafficRules' [readability-identifier-naming]
  lanelet::traffic_rules::TrafficRulesPtr trafficRules =
                                          ^~~~~~~~~~~~
                                          traffic_rules
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp:65:38: warning: invalid case style for variable 'routingGraph' [readability-identifier-naming]
  lanelet::routing::RoutingGraphUPtr routingGraph =
                                     ^~~~~~~~~~~~
                                     routing_graph
Suppressed 55883 warnings (55796 in non-user code, 87 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
2 warnings treated as errors
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
(in map/util/lanelet2_map_preprocessor)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/fix_lane_change_tags.cpp ...
src/fix_lane_change_tags.cpp:51:60: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
lanelet::Lanelets convertToVector(lanelet::LaneletMapPtr & lanelet_map_ptr)
                                                           ^
src/fix_lane_change_tags.cpp:55:14: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
    lanelets.push_back(lanelet);
             ^
1/6 files checked 12% done
Checking src/fix_z_value_by_pcd.cpp ...
src/fix_z_value_by_pcd.cpp:95:85: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
  const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr, lanelet::LaneletMapPtr & lanelet_map_ptr)
                                                                                    ^
2/6 files checked 32% done
Checking src/merge_close_lines.cpp ...
src/merge_close_lines.cpp:55:79: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)
                                                                              ^
src/merge_close_lines.cpp:59:11: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
    lines.push_back(line);
          ^
src/merge_close_lines.cpp:110:18: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
    sum_distance += boost::geometry::distance(pt.basicPoint(), line2);
                 ^
src/merge_close_lines.cpp:113:18: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
    sum_distance += boost::geometry::distance(pt.basicPoint(), line1);
                 ^
src/merge_close_lines.cpp:152:9: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
    dst.push_back(pt);
        ^
3/6 files checked 55% done
Checking src/merge_close_points.cpp ...
src/merge_close_points.cpp:51:71: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
                                                                      ^
src/merge_close_points.cpp:55:12: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
    points.push_back(pt);
           ^
4/6 files checked 70% done
Checking src/remove_unreferenced_geometry.cpp ...
src/remove_unreferenced_geometry.cpp:46:71: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
lanelet::Points3d convertPointsLayerToPoints(lanelet::LaneletMapPtr & lanelet_map_ptr)
                                                                      ^
src/remove_unreferenced_geometry.cpp:55:79: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
lanelet::LineStrings3d convertLineLayerToLineStrings(lanelet::LaneletMapPtr & lanelet_map_ptr)
                                                                              ^
src/remove_unreferenced_geometry.cpp:50:12: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
    points.push_back(pt);
           ^
src/remove_unreferenced_geometry.cpp:59:11: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
    lines.push_back(line);
          ^
5/6 files checked 80% done
Checking src/transform_maps.cpp ...
src/transform_maps.cpp:60:41: style: Parameter 'pcd_map_ptr' can be declared as reference to const [constParameterReference]
  pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr, lanelet::LaneletMapPtr & lanelet_map_ptr,
                                        ^
src/transform_maps.cpp:60:79: style: Parameter 'lanelet_map_ptr' can be declared as reference to const [constParameterReference]
  pcl::PointCloud<pcl::PointXYZ>::Ptr & pcd_map_ptr, lanelet::LaneletMapPtr & lanelet_map_ptr,
                                                                              ^
6/6 files checked 100% done
src/merge_close_lines.cpp:50:0: style: The function 'exists' is never used. [unusedFunction]
bool exists(std::unordered_set<lanelet::Id> & set, lanelet::Id element)
^
src/merge_close_lines.cpp:89:0: style: The function 'getLineLength' is never used. [unusedFunction]
double getLineLength(const lanelet::ConstLineString3d & line)
```
</details>

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh lanelet2_map_preprocessor
...
47977 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:71:22: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    return search_pt.z;
                     ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:79:12: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    if (pt.z > min_height) {
           ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:39: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:53: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:59: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                                          ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:82:73: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    double distance2d = std::hypot(pt.x - search_pt.x, pt.y - search_pt.y);
                                                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:85:23: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      min_height = pt.z;
                      ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:89:28: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
    min_height = search_pt.z;
                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:111:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.x = static_cast<float>(pt.x());
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:112:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.y = static_cast<float>(pt.y());
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:113:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.z = static_cast<float>(pt.z());
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:125:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.x = static_cast<float>(pt.x());
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:126:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.y = static_cast<float>(pt.y());
             ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/fix_z_value_by_pcd.cpp:127:14: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pcl_pt.z = static_cast<float>(pt.z());
             ^
Suppressed 48045 warnings (47963 in non-user code, 82 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
50922 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:77:35: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:77:41: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:77:47: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      Eigen::Vector3d eigen_pt(pt.x, pt.y, pt.z);
                                              ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:79:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pt.x = static_cast<float>(transformed_pt.x());
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:80:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pt.y = static_cast<float>(transformed_pt.y());
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:81:10: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      pt.z = static_cast<float>(transformed_pt.z());
         ^
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/transform_maps.cpp:102:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
int main(int argc, char * argv[])
    ^
Suppressed 50997 warnings (50915 in non-user code, 82 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
55191 warnings generated.
Suppressed 55274 warnings (55191 in non-user code, 83 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
55640 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_points.cpp:97:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
int main(int argc, char * argv[])
    ^
Suppressed 55722 warnings (55639 in non-user code, 83 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
56491 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/map/util/lanelet2_map_preprocessor/src/merge_close_lines.cpp:174:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
int main(int argc, char * argv[])
    ^
Suppressed 56574 warnings (56490 in non-user code, 84 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
55796 warnings generated.
Suppressed 55883 warnings (55796 in non-user code, 87 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

<details open>
<summary>Check with cppcheck </summary>

```
(in map/util/lanelet2_map_preprocessor)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive .

Checking src/fix_lane_change_tags.cpp ...
1/6 files checked 12% done
Checking src/fix_z_value_by_pcd.cpp ...
2/6 files checked 32% done
Checking src/merge_close_lines.cpp ...
3/6 files checked 55% done
Checking src/merge_close_points.cpp ...
4/6 files checked 69% done
Checking src/remove_unreferenced_geometry.cpp ...
5/6 files checked 80% done
Checking src/transform_maps.cpp ...

```
</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
