### PR TITLE
fix(ekf_localizer): add imu option for roll pitch and height estimation

### DIFF
--- a/localization/ekf_localizer/config/ekf_localizer.param.yaml
+++ b/localization/ekf_localizer/config/ekf_localizer.param.yaml
@@ -49,3 +49,4 @@
       # for velocity measurement limitation (Set 0.0 if you want to ignore)
       threshold_observable_velocity_mps: 0.0 # [m/s]
       pose_frame_id: "map"
+      use_imu: false

--- a/localization/ekf_localizer/include/ekf_localizer/hyper_parameters.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/hyper_parameters.hpp
@@ -65,7 +65,8 @@ public:
     warn_ellipse_size_lateral_direction(
       node->declare_parameter<double>("diagnostics.warn_ellipse_size_lateral_direction")),
     threshold_observable_velocity_mps(
-      node->declare_parameter<double>("misc.threshold_observable_velocity_mps"))
+      node->declare_parameter<double>("misc.threshold_observable_velocity_mps")),
+    use_imu(node->declare_parameter<bool>("misc.use_imu"))
   {
   }
 
@@ -100,6 +101,7 @@ public:
   double warn_ellipse_size_lateral_direction;
 
   const double threshold_observable_velocity_mps;
+  const bool use_imu;
 };
 
 #endif  // EKF_LOCALIZER__HYPER_PARAMETERS_HPP_

--- a/localization/ekf_localizer/schema/sub/misc.sub_schema.json
+++ b/localization/ekf_localizer/schema/sub/misc.sub_schema.json
@@ -14,9 +14,14 @@
           "type": "string",
           "description": "Parent frame_id of EKF output pose",
           "default": "map"
+        },
+        "use_imu": {
+          "type": "boolean",
+          "description": "Use IMU data instead of 1D Filter for roll,pitch, position Z estimation",
+          "default": false
         }
       },
-      "required": ["threshold_observable_velocity_mps", "pose_frame_id"],
+      "required": ["threshold_observable_velocity_mps", "pose_frame_id", "use_imu"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Description
We can see that there is a wobbling of ego vehicle points as the vehicle drives through speed bumps.I repeated the tests in the simulation environment and obtained similar results. When I tried to optimize parameters in its current  EKF , I saw that I could not achieve good results in its current packet. You can find the tests I have previously done to solve this problem in the [issue](https://github.com/autowarefoundation/autoware.universe/issues/6993) comments.
Currently, 1D Filter is used for roll, pitch and position z(height) estimation in the ekf_localizer package. The angular velocity data that comes with the twist message and the orientation data in the imu data are not used in the calculations. It is calculated only by reference to the NDT poses that come as input.
However, IMU provides us with orientation information at a very high frequency. By using this data , we can localize roll, pitch and position z more accurately.
This PR suggests adding an option for those who want to use imu data instead of 1D Filters
## Related links

Related Issue: https://github.com/autowarefoundation/autoware.universe/issues/6993
- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
1. Simulation Test:
 In the tests carried out in the simulation environment, you can see below that using imu directly solves the roll, pitch, and position z in EKF instead of calculating them with the 1D Filter:
![sim-COMPARISON-Page-2 drawio](https://github.com/autowarefoundation/autoware.universe/assets/41450930/c983f8aa-251c-4c2f-910a-051515e002da)
Buna ek olarak aşağıdaki videoları inceleyebilirsiniz:
Default Autoware test video is [here](https://www.youtube.com/watch?v=U3ByvJ8QQXE)
EKF with IMU Integration test video is [here](https://www.youtube.com/watch?v=bMwIv_a8RM8)
2. Real World Test:
Although the same level of performance cannot be achieved in real-world tests due to different factors, there is an improvement. It also seems that the results are further improved by using the [3D Distortion Corrector](https://github.com/autowarefoundation/autoware.universe/pull/7137), which has been newly merged into Autoware.You can find the results below:
![COMPARISON_w-ndt_only drawio](https://github.com/autowarefoundation/autoware.universe/assets/41450930/1428fc72-d4a4-4281-b6e7-366583368612)
Real World Test Video is [here](https://www.youtube.com/watch?v=VXDYWmPCpic&t=16s)
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
