### PR TITLE
fix(motion_planning): fix processing time debug type and topic name

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -83,6 +83,8 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
   velocity_factor_publisher_ =
     this->create_publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>(
       "~/output/velocity_factors", 1);
+  processing_diag_publisher_ = autoware::universe_utils::ProcessingTimePublisher(
+    this, "~/debug/total_time/processing_time_ms_diag");
   processing_time_publisher_ = this->create_publisher<tier4_debug_msgs::msg::Float64Stamped>(
     "~/debug/total_time/processing_time_ms", 1);
 


### PR DESCRIPTION
## Description

Fix the debug time type and topic name of the diagnostic processing time broadcasting.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PSim.

## Notes for reviewers

None.

## Interface changes


### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Publication | `~/motion_velocity_planner/debug/processing_time_ms` | `diagnostic_msgs/DiagnosticStatus` | Topic description |
| New   | Publication | `~/motion_velocity_planner/debug/total_time/processing_time_ms_diag` | `diagnostic_msgs/DiagnosticStatus` | Topic description |

As in other planning nodes, `processing_time_ms` should be `tier4_debug_msgs/floatXXStamped`, while `processing_time_diag` should be `diagnostic_msgs/DiagnosticStatus`. This PR fixes the incoherence in the original code.


## Effects on system behavior

None.
