### PR TITLE
fix(static_obstacle_avoidance): stop position is unstable

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -113,10 +113,8 @@ void AvoidanceByLaneChange::updateSpecialData()
                    : Direction::RIGHT;
   }
 
-  utils::static_obstacle_avoidance::updateRegisteredObject(
-    registered_objects_, avoidance_data_.target_objects, p);
-  utils::static_obstacle_avoidance::compensateDetectionLost(
-    registered_objects_, avoidance_data_.target_objects, avoidance_data_.other_objects);
+  utils::static_obstacle_avoidance::compensateLostTargetObjects(
+    registered_objects_, avoidance_data_, clock_.now(), planner_data_, p);
 
   std::sort(
     avoidance_data_.target_objects.begin(), avoidance_data_.target_objects.end(),

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/debug.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/debug.hpp
@@ -47,6 +47,8 @@ MarkerArray createTargetObjectsMarkerArray(const ObjectDataArray & objects, cons
 MarkerArray createOtherObjectsMarkerArray(
   const ObjectDataArray & objects, const ObjectInfo & info, const bool verbose);
 
+MarkerArray createStopTargetObjectMarkerArray(const AvoidancePlanningData & data);
+
 MarkerArray createDebugMarkerArray(
   const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug,
   const std::shared_ptr<AvoidanceParameters> & parameters);

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -267,6 +267,12 @@ private:
   void fillAvoidanceTargetObjects(AvoidancePlanningData & data, DebugData & debug) const;
 
   /**
+   * @brief fill additional data which are necessary to plan avoidance path/velocity.
+   * @param avoidance target objects.
+   */
+  void fillAvoidanceTargetData(ObjectDataArray & objects) const;
+
+  /**
    * @brief fill candidate shift lines.
    * @param avoidance data.
    * @param debug data.

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp
@@ -118,15 +118,12 @@ void fillObjectStoppableJudge(
   ObjectData & object_data, const ObjectDataArray & registered_objects,
   const double feasible_stop_distance, const std::shared_ptr<AvoidanceParameters> & parameters);
 
-void updateRegisteredObject(
-  ObjectDataArray & registered_objects, const ObjectDataArray & now_objects,
-  const std::shared_ptr<AvoidanceParameters> & parameters);
-
 void updateClipObject(ObjectDataArray & clip_objects, AvoidancePlanningData & data);
 
-void compensateDetectionLost(
-  const ObjectDataArray & registered_objects, ObjectDataArray & now_objects,
-  ObjectDataArray & other_objects);
+void compensateLostTargetObjects(
+  ObjectDataArray & stored_objects, AvoidancePlanningData & data, const rclcpp::Time & now,
+  const std::shared_ptr<const PlannerData> & planner_data,
+  const std::shared_ptr<AvoidanceParameters> & parameters);
 
 void filterTargetObjects(
   ObjectDataArray & objects, AvoidancePlanningData & data, const double forward_detection_range,

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
@@ -466,6 +466,23 @@ MarkerArray createOtherObjectsMarkerArray(
   return msg;
 }
 
+MarkerArray createStopTargetObjectMarkerArray(const AvoidancePlanningData & data)
+{
+  MarkerArray msg;
+
+  if (!data.stop_target_object.has_value()) {
+    return msg;
+  }
+
+  appendMarkerArray(
+    createObjectsCubeMarkerArray(
+      {data.stop_target_object.value()}, "stop_target", createMarkerScale(3.4, 1.9, 1.9),
+      createMarkerColor(1.0, 0.0, 0.42, 0.5)),
+    &msg);
+
+  return msg;
+}
+
 MarkerArray createDrivableBounds(
   const AvoidancePlanningData & data, std::string && ns, const float & r, const float & g,
   const float & b)


### PR DESCRIPTION
## Description

This module compensates object even after the system lost them until the time has passed more than threshold.

However, since the longitudinal distance of compensated object was not updated, the avoidance stop point was not calculated expectedly. 0:30~ in following movie, the stop point moved forward even though the target object kept stopping.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/141bd0e8-4d25-4b9a-8497-982e0c1148bf

In this PR, I fixed to update longitudinal for compensated objects in following function.

```c++
void compensateLostTargetObjects(
  ObjectDataArray & stored_objects, AvoidancePlanningData & data, const rclcpp::Time & now,
  const std::shared_ptr<const PlannerData> & planner_data,
  const std::shared_ptr<AvoidanceParameters> & parameters)
{
  const auto include = [](const auto & objects, const auto & search_id) {
    return std::all_of(objects.begin(), objects.end(), [&search_id](const auto & o) {
      return o.object.object_id != search_id;
    });
  };

  // STEP.1 UPDATE STORED OBJECTS.
  const auto match = [&data](auto & object) {
    const auto & search_id = object.object.object_id;
    const auto same_id_object = std::find_if(
      data.target_objects.begin(), data.target_objects.end(),
      [&search_id](const auto & o) { return o.object.object_id == search_id; });

    // same id object is detected. update registered.
    if (same_id_object != data.target_objects.end()) {
      object = *same_id_object;
      return true;
    }

    const auto similar_pos_obj = std::find_if(
      data.target_objects.begin(), data.target_objects.end(), [&object](const auto & o) {
        constexpr auto POS_THR = 1.5;
        return calcDistance2d(object.getPose(), o.getPose()) < POS_THR;
      });

    // same id object is not detected, but object is found around registered. update registered.
    if (similar_pos_obj != data.target_objects.end()) {
      object = *similar_pos_obj;
      return true;
    }

    // Same ID nor similar position object does not found.
    return false;
  };

  // STEP1-1: REMOVE EXPIRED OBJECTS.
  const auto itr = std::remove_if(
    stored_objects.begin(), stored_objects.end(), [&now, &match, &parameters](auto & o) {
      if (!match(o)) {
        o.lost_time = (now - o.last_seen).seconds();
      } else {
        o.last_seen = now;
        o.lost_time = 0.0;
      }

      return o.lost_time > parameters->object_last_seen_threshold;
    });

  stored_objects.erase(itr, stored_objects.end());

  // STEP1-2: UPDATE STORED OBJECTS IF THERE ARE NEW OBJECTS.
  for (const auto & current_object : data.target_objects) {
    if (!include(stored_objects, current_object.object.object_id)) {
      stored_objects.push_back(current_object);
    }
  }

  // STEP2: COMPENSATE CURRENT TARGET OBJECTS
  const auto is_detected = [&](const auto & object_id) {
    return std::any_of(
      data.target_objects.begin(), data.target_objects.end(),
      [&object_id](const auto & o) { return o.object.object_id == object_id; });
  };

  const auto is_ignored = [&](const auto & object_id) {
    return std::any_of(
      data.other_objects.begin(), data.other_objects.end(),
      [&object_id](const auto & o) { return o.object.object_id == object_id; });
  };

  for (auto & stored_object : stored_objects) {
    if (is_detected(stored_object.object.object_id)) {
      continue;
    }
    if (is_ignored(stored_object.object.object_id)) {
      continue;
    }

    const auto & ego_pos = planner_data->self_odometry->pose.pose.position;
    fillLongitudinalAndLengthByClosestEnvelopeFootprint(
      data.reference_path_rough, ego_pos, stored_object);

    data.target_objects.push_back(stored_object);
  }
}

```

## Related links

**Parent Issue:**

- 

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] Psim + reproducer

https://github.com/autowarefoundation/autoware.universe/assets/44889564/e004d53c-769b-476e-9027-b8d494fa2abf

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/d3979b5a-6564-51ce-b57f-0edbff7ab261?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
