### PR TITLE
feat(autoware_behavior_path_planner): prevent infinite loop in approving scene module process

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -1,6 +1,5 @@
 /**:
   ros__parameters:
-    max_iteration_num: 100
     traffic_light_signal_timeout: 1.0
     planning_hz: 10.0
     backward_path_length: 5.0

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -96,7 +96,7 @@ struct SceneModuleStatus
 class PlannerManager
 {
 public:
-  PlannerManager(rclcpp::Node & node, const size_t max_iteration_num);
+  explicit PlannerManager(rclcpp::Node & node);
 
   /**
    * @brief run all candidate and approved modules.

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -396,11 +396,13 @@ private:
    * @brief run all modules in approved_module_ptrs_ and get a planning result as
    * approved_modules_output.
    * @param planner data.
+   * @param deleted modules.
    * @return valid planning result.
    * @details in this function, expired modules (ModuleStatus::FAILURE or ModuleStatus::SUCCESS) are
-   * removed from approved_module_ptrs_.
+   * removed from approved_module_ptrs_ and added to deleted_modules.
    */
-  BehaviorModuleOutput runApprovedModules(const std::shared_ptr<PlannerData> & data);
+  BehaviorModuleOutput runApprovedModules(
+    const std::shared_ptr<PlannerData> & data, std::vector<SceneModulePtr> & deleted_modules);
 
   /**
    * @brief select a module that should be execute at first.
@@ -420,10 +422,12 @@ private:
   /**
    * @brief get all modules that make execution request.
    * @param decided (=approved) path.
+   * @param deleted modules.
    * @return request modules.
    */
   std::vector<SceneModulePtr> getRequestModules(
-    const BehaviorModuleOutput & previous_module_output) const;
+    const BehaviorModuleOutput & previous_module_output,
+    const std::vector<SceneModulePtr> & deleted_modules) const;
 
   /**
    * @brief checks whether a path of trajectory has forward driving direction

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -112,6 +112,13 @@ public:
   void launchScenePlugin(rclcpp::Node & node, const std::string & name);
 
   /**
+   * @brief set max iteration numbers
+   * @param number of scene module
+   *
+   */
+  void calculateMaxIterationNum(const size_t scene_module_num);
+
+  /**
    * @brief unregister managers.
    * @param node.
    * @param plugin name.

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -112,7 +112,7 @@ public:
   void launchScenePlugin(rclcpp::Node & node, const std::string & name);
 
   /**
-   * @brief set max iteration numbers
+   * @brief calculate max iteration numbers
    * @param number of scene module
    *
    */

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -112,7 +112,11 @@ public:
   void launchScenePlugin(rclcpp::Node & node, const std::string & name);
 
   /**
-   * @brief calculate max iteration numbers
+   * @brief calculate max iteration numbers.
+   * Let N be the number of scene modules. The maximum number of iterations executed in a loop is N,
+   * but after that, if there are any modules that have succeeded or failed, the approve_modules of
+   * all modules are cleared, and the loop is executed for N-1 modules. As this process repeats, it
+   * becomes N + (N-1) + (N-2) + … + 1, therefore the maximum number of iterations is N(N+1)/2.
    * @param number of scene module
    *
    */

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -70,8 +70,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
     const std::lock_guard<std::mutex> lock(mutex_manager_);  // for planner_manager_
 
-    const auto & p = planner_data_->parameters;
-    planner_manager_ = std::make_shared<PlannerManager>(*this, p.max_iteration_num);
+    planner_manager_ = std::make_shared<PlannerManager>(*this);
 
     size_t scene_module_num = 0;
     for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
@@ -150,7 +149,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
 {
   BehaviorPathPlannerParameters p{};
 
-  p.max_iteration_num = declare_parameter<int>("max_iteration_num");
   p.traffic_light_signal_timeout = declare_parameter<double>("traffic_light_signal_timeout");
 
   // vehicle info

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -73,13 +73,16 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     const auto & p = planner_data_->parameters;
     planner_manager_ = std::make_shared<PlannerManager>(*this, p.max_iteration_num);
 
+    size_t scene_module_num = 0;
     for (const auto & name : declare_parameter<std::vector<std::string>>("launch_modules")) {
       // workaround: Since ROS 2 can't get empty list, launcher set [''] on the parameter.
       if (name == "") {
         break;
       }
       planner_manager_->launchScenePlugin(*this, name);
+      scene_module_num++;
     }
+    planner_manager_->calculateMaxIterationNum(scene_module_num);
 
     for (const auto & manager : planner_manager_->getSceneModuleManagers()) {
       path_candidate_publishers_.emplace(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -66,6 +66,12 @@ void PlannerManager::launchScenePlugin(rclcpp::Node & node, const std::string & 
   }
 }
 
+void PlannerManager::calculateMaxIterationNum(const size_t scene_module_num)
+{
+  max_iteration_num_ = scene_module_num * (scene_module_num + 1) / 2;
+
+}
+
 void PlannerManager::removeScenePlugin(rclcpp::Node & node, const std::string & name)
 {
   auto it = std::remove_if(manager_ptrs_.begin(), manager_ptrs_.end(), [&](const auto plugin) {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -30,13 +30,12 @@
 
 namespace autoware::behavior_path_planner
 {
-PlannerManager::PlannerManager(rclcpp::Node & node, const size_t max_iteration_num)
+PlannerManager::PlannerManager(rclcpp::Node & node)
 : plugin_loader_(
     "autoware_behavior_path_planner",
     "autoware::behavior_path_planner::SceneModuleManagerInterface"),
   logger_(node.get_logger().get_child("planner_manager")),
-  clock_(*node.get_clock()),
-  max_iteration_num_{max_iteration_num}
+  clock_(*node.get_clock())
 {
   processing_time_.emplace("total_time", 0.0);
   debug_publisher_ptr_ = std::make_unique<DebugPublisher>(&node, "~/debug");

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -69,7 +69,6 @@ void PlannerManager::launchScenePlugin(rclcpp::Node & node, const std::string & 
 void PlannerManager::calculateMaxIterationNum(const size_t scene_module_num)
 {
   max_iteration_num_ = scene_module_num * (scene_module_num + 1) / 2;
-
 }
 
 void PlannerManager::removeScenePlugin(rclcpp::Node & node, const std::string & name)


### PR DESCRIPTION
## Description

This [PR](https://github.com/autowarefoundation/autoware_launch/pull/1064) should be merged first.

### Current potential issue:
When scene modules A > B > C are in the approved state and A fails, all modules (A, B, C) are removed from `approved_modules`. Additionally, `candidate_modules` becomes empty, causing all modules A-Z to be re-evaluated through `getRequestModules` -> `runRequestModules`. This leads to A > B > C being approved again, and if A fails once more, an infinite loop may occur.

### Proposed solution:
Prevent modules that have been removed from `approved_modules` due to success or failure from being added again by `getRequestModules`.

1. In `runApprovedModules`, add modules that have transitioned to success or failure state to `deleted_modules`.
2. In `getRequestModules`, skip the execution request judgment for modules that have been added to `deleted_modules`.

### Additional change:
By implementing a process to delete modules that have either succeeded or failed in the loop, the maximum number of loops can now be theoretically determined based on the number of scene modules. As a result, I've changed the method to calculate the theoretical maximum instead of using a parameter definition.

## How was this PR tested?

- [x] run psim
- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/d8ae06cc-a08f-5ec6-adb0-85e11d79bd5e?project_id=prd_jt)
- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/cd6fc206-db8f-5e75-8270-0d1ae8ff8571?project_id=prd_jt) with removing `max_iteration_num` parameter

## Notes for reviewers

None.

## Effects on system behavior

None.
