### PR TITLE
refactor(euclidean_cluster)!: fix namespace and directory structure

### DIFF
--- a/perception/detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/detection_by_tracker/src/debugger/debugger.hpp
@@ -17,9 +17,6 @@
 
 #include "autoware/universe_utils/ros/debug_publisher.hpp"
 #include "autoware/universe_utils/system/stop_watch.hpp"
-#include "euclidean_cluster/euclidean_cluster.hpp"
-#include "euclidean_cluster/utils.hpp"
-#include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/perception/detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -115,7 +115,7 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
   setMaxSearchRange();
 
   shape_estimator_ = std::make_shared<autoware::shape_estimation::ShapeEstimator>(true, true);
-  cluster_ = std::make_shared<euclidean_cluster::VoxelGridBasedEuclideanCluster>(
+  cluster_ = std::make_shared<autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster>(
     false, 10, 10000, 0.7, 0.3, 0);
   debugger_ = std::make_shared<Debugger>(this);
   published_time_publisher_ =
@@ -277,7 +277,7 @@ float DetectionByTracker::optimizeUnderSegmentedObject(
   const auto & label = target_object.classification.front().label;
 
   // initialize clustering parameters
-  euclidean_cluster::VoxelGridBasedEuclideanCluster cluster(
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster cluster(
     false, 4, 10000, initial_cluster_range, initial_voxel_size, 0);
 
   // convert to pcl

--- a/perception/detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -18,9 +18,9 @@
 #include "autoware/shape_estimation/shape_estimator.hpp"
 #include "autoware/universe_utils/ros/published_time_publisher.hpp"
 #include "debugger/debugger.hpp"
-#include "euclidean_cluster/euclidean_cluster.hpp"
-#include "euclidean_cluster/utils.hpp"
-#include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 #include "tracker/tracker_handler.hpp"
 #include "utils/utils.hpp"
 
@@ -69,7 +69,7 @@ private:
 
   TrackerHandler tracker_handler_;
   std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
-  std::shared_ptr<euclidean_cluster::EuclideanClusterInterface> cluster_;
+  std::shared_ptr<autoware::euclidean_cluster::EuclideanClusterInterface> cluster_;
   std::shared_ptr<Debugger> debugger_;
   std::map<uint8_t, int> max_search_distance_for_merger_;
   std::map<uint8_t, int> max_search_distance_for_divider_;

--- a/perception/detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -15,12 +15,12 @@
 #ifndef DETECTION_BY_TRACKER_NODE_HPP_
 #define DETECTION_BY_TRACKER_NODE_HPP_
 
-#include "autoware/shape_estimation/shape_estimator.hpp"
-#include "autoware/universe_utils/ros/published_time_publisher.hpp"
-#include "debugger/debugger.hpp"
 #include "autoware/euclidean_cluster/euclidean_cluster.hpp"
 #include "autoware/euclidean_cluster/utils.hpp"
 #include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "autoware/shape_estimation/shape_estimator.hpp"
+#include "autoware/universe_utils/ros/published_time_publisher.hpp"
+#include "debugger/debugger.hpp"
 #include "tracker/tracker_handler.hpp"
 #include "utils/utils.hpp"
 

--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -13,45 +13,45 @@ include_directories(
   ${PCL_INCLUDE_DIRS}
 )
 
-ament_auto_add_library(cluster_lib SHARED
-  lib/utils.cpp
+ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   lib/euclidean_cluster.cpp
   lib/voxel_grid_based_euclidean_cluster.cpp
+  lib/utils.cpp
 )
 
-target_link_libraries(cluster_lib
+target_link_libraries(${PROJECT_NAME}_lib
   ${PCL_LIBRARIES}
 )
 
-target_include_directories(cluster_lib
+target_include_directories(${PROJECT_NAME}_lib
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-ament_auto_add_library(euclidean_cluster_node_core SHARED
+ament_auto_add_library(${PROJECT_NAME}_node_core SHARED
   src/euclidean_cluster_node.cpp
 )
-target_link_libraries(euclidean_cluster_node_core
+target_link_libraries(${PROJECT_NAME}_node_core
   ${PCL_LIBRARIES}
-  cluster_lib
+  ${PROJECT_NAME}_lib
 )
 
-rclcpp_components_register_node(euclidean_cluster_node_core
-  PLUGIN "euclidean_cluster::EuclideanClusterNode"
+rclcpp_components_register_node(${PROJECT_NAME}_node_core
+  PLUGIN "autoware::euclidean_cluster::EuclideanClusterNode"
   EXECUTABLE euclidean_cluster_node
 )
 
-ament_auto_add_library(voxel_grid_based_euclidean_cluster_node_core SHARED
+ament_auto_add_library(${PROJECT_NAME}_voxel_grid_node_core SHARED
   src/voxel_grid_based_euclidean_cluster_node.cpp
 )
-target_link_libraries(voxel_grid_based_euclidean_cluster_node_core
+target_link_libraries(${PROJECT_NAME}_voxel_grid_node_core
   ${PCL_LIBRARIES}
-  cluster_lib
+  ${PROJECT_NAME}_lib
 )
 
-rclcpp_components_register_node(voxel_grid_based_euclidean_cluster_node_core
-  PLUGIN "euclidean_cluster::VoxelGridBasedEuclideanClusterNode"
+rclcpp_components_register_node(${PROJECT_NAME}_voxel_grid_node_core
+  PLUGIN "autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterNode"
   EXECUTABLE voxel_grid_based_euclidean_cluster_node
 )
 

--- a/perception/euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include "euclidean_cluster/euclidean_cluster_interface.hpp"
-#include "euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
 
 #include <pcl/point_types.h>
 
 #include <vector>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 class EuclideanCluster : public EuclideanClusterInterface
 {
@@ -42,4 +42,4 @@ private:
   float tolerance_;
 };
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 class EuclideanClusterInterface
 {
@@ -54,4 +54,4 @@ protected:
   int max_cluster_size_;
 };
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/include/autoware/euclidean_cluster/utils.hpp
+++ b/perception/euclidean_cluster/include/autoware/euclidean_cluster/utils.hpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 geometry_msgs::msg::Point getCentroid(const sensor_msgs::msg::PointCloud2 & pointcloud);
 void convertPointCloudClusters2Msg(
@@ -37,4 +37,4 @@ void convertPointCloudClusters2Msg(
 void convertObjectMsg2SensorMsg(
   const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input,
   sensor_msgs::msg::PointCloud2 & output);
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -14,15 +14,15 @@
 
 #pragma once
 
-#include "euclidean_cluster/euclidean_cluster_interface.hpp"
-#include "euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
 
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/point_types.h>
 
 #include <vector>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 class VoxelGridBasedEuclideanCluster : public EuclideanClusterInterface
 {
@@ -52,4 +52,4 @@ private:
   int min_points_number_per_voxel_;
 };
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/launch/euclidean_cluster.launch.py
+++ b/perception/euclidean_cluster/launch/euclidean_cluster.launch.py
@@ -49,7 +49,7 @@ def launch_setup(context, *args, **kwargs):
 
     use_low_height_euclidean_component = ComposableNode(
         package=pkg,
-        plugin="euclidean_cluster::EuclideanClusterNode",
+        plugin="autoware::euclidean_cluster::EuclideanClusterNode",
         name=AnonName("euclidean_cluster"),
         remappings=[
             ("input", "low_height/pointcloud"),
@@ -60,7 +60,7 @@ def launch_setup(context, *args, **kwargs):
 
     disuse_low_height_euclidean_component = ComposableNode(
         package=pkg,
-        plugin="euclidean_cluster::EuclideanClusterNode",
+        plugin="autoware::euclidean_cluster::EuclideanClusterNode",
         name=AnonName("euclidean_cluster"),
         remappings=[
             ("input", LaunchConfiguration("input_pointcloud")),

--- a/perception/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.py
+++ b/perception/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.py
@@ -49,7 +49,7 @@ def launch_setup(context, *args, **kwargs):
     use_low_height_euclidean_component = ComposableNode(
         package=pkg,
         namespace=ns,
-        plugin="euclidean_cluster::VoxelGridBasedEuclideanClusterNode",
+        plugin="autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterNode",
         name="euclidean_cluster",
         remappings=[
             ("input", "low_height/pointcloud"),
@@ -61,7 +61,7 @@ def launch_setup(context, *args, **kwargs):
     disuse_low_height_euclidean_component = ComposableNode(
         package=pkg,
         namespace=ns,
-        plugin="euclidean_cluster::VoxelGridBasedEuclideanClusterNode",
+        plugin="autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterNode",
         name="euclidean_cluster",
         remappings=[
             ("input", LaunchConfiguration("input_pointcloud")),

--- a/perception/euclidean_cluster/lib/euclidean_cluster.cpp
+++ b/perception/euclidean_cluster/lib/euclidean_cluster.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "euclidean_cluster/euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/euclidean_cluster.hpp"
 
 #include <pcl/kdtree/kdtree.h>
 #include <pcl/segmentation/extract_clusters.h>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 EuclideanCluster::EuclideanCluster()
 {
@@ -93,4 +93,4 @@ bool EuclideanCluster::cluster(
   return true;
 }
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/lib/utils.cpp
+++ b/perception/euclidean_cluster/lib/utils.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
@@ -19,7 +19,7 @@
 #include <tier4_perception_msgs/msg/detected_object_with_feature.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 geometry_msgs::msg::Point getCentroid(const sensor_msgs::msg::PointCloud2 & pointcloud)
 {
@@ -128,4 +128,4 @@ void convertObjectMsg2SensorMsg(
   output.height = 1;
   output.is_dense = false;
 }
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
 #include <pcl/kdtree/kdtree.h>
 #include <pcl/segmentation/extract_clusters.h>
 
 #include <unordered_map>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 VoxelGridBasedEuclideanCluster::VoxelGridBasedEuclideanCluster()
 {
@@ -166,4 +166,4 @@ bool VoxelGridBasedEuclideanCluster::cluster(
   return true;
 }
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
@@ -14,11 +14,11 @@
 
 #include "euclidean_cluster_node.hpp"
 
-#include "euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
 
 #include <vector>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 EuclideanClusterNode::EuclideanClusterNode(const rclcpp::NodeOptions & options)
 : Node("euclidean_cluster_node", options)
@@ -86,8 +86,8 @@ void EuclideanClusterNode::onPointCloud(
   }
 }
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster
 
 #include <rclcpp_components/register_node_macro.hpp>
 
-RCLCPP_COMPONENTS_REGISTER_NODE(euclidean_cluster::EuclideanClusterNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::euclidean_cluster::EuclideanClusterNode)

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.hpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "euclidean_cluster/euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/euclidean_cluster.hpp"
 
 #include <autoware/universe_utils/ros/debug_publisher.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
@@ -26,7 +26,8 @@
 
 #include <chrono>
 #include <memory>
-namespace euclidean_cluster
+
+namespace autoware::euclidean_cluster
 {
 class EuclideanClusterNode : public rclcpp::Node
 {
@@ -45,4 +46,4 @@ private:
   std::unique_ptr<autoware::universe_utils::DebugPublisher> debug_publisher_;
 };
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
@@ -14,11 +14,11 @@
 
 #include "voxel_grid_based_euclidean_cluster_node.hpp"
 
-#include "euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
 
 #include <vector>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 VoxelGridBasedEuclideanClusterNode::VoxelGridBasedEuclideanClusterNode(
   const rclcpp::NodeOptions & options)
@@ -89,8 +89,8 @@ void VoxelGridBasedEuclideanClusterNode::onPointCloud(
   }
 }
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster
 
 #include <rclcpp_components/register_node_macro.hpp>
 
-RCLCPP_COMPONENTS_REGISTER_NODE(euclidean_cluster::VoxelGridBasedEuclideanClusterNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterNode)

--- a/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.hpp
+++ b/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
 #include <autoware/universe_utils/ros/debug_publisher.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
@@ -26,7 +26,7 @@
 
 #include <memory>
 
-namespace euclidean_cluster
+namespace autoware::euclidean_cluster
 {
 class VoxelGridBasedEuclideanClusterNode : public rclcpp::Node
 {
@@ -45,4 +45,4 @@ private:
   std::unique_ptr<autoware::universe_utils::DebugPublisher> debug_publisher_;
 };
 
-}  // namespace euclidean_cluster
+}  // namespace autoware::euclidean_cluster

--- a/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -25,7 +25,7 @@
 #include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 #endif
 
-#include "euclidean_cluster/utils.hpp"
+#include "autoware/euclidean_cluster/utils.hpp"
 
 namespace image_projection_based_fusion
 {
@@ -68,7 +68,7 @@ void RoiPointCloudFusionNode::postprocess(
   // publish debug cluster
   if (cluster_debug_pub_->get_subscription_count() > 0) {
     sensor_msgs::msg::PointCloud2 debug_cluster_msg;
-    euclidean_cluster::convertObjectMsg2SensorMsg(output_msg, debug_cluster_msg);
+    autoware::euclidean_cluster::convertObjectMsg2SensorMsg(output_msg, debug_cluster_msg);
     cluster_debug_pub_->publish(debug_cluster_msg);
   }
 }


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the [TIER IV Cloud](https://evaluation.tier4.jp/evaluation/reports/955a612c-f809-5855-95c7-6ce0843e2ce1?project_id=prd_jt) environment.


## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
