### PR TITLE
fix(controller): revival of dry steering

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -271,7 +271,7 @@ private:
    */
   std::pair<bool, VectorXd> executeOptimization(
     const MPCMatrix & mpc_matrix, const VectorXd & x0, const double prediction_dt,
-    const MPCTrajectory & trajectory);
+    const MPCTrajectory & trajectory, const double current_velocity);
 
   /**
    * @brief Resample the trajectory with the MPC resampling time.
@@ -386,7 +386,8 @@ private:
    * @param reference_trajectory The reference trajectory.
    * @param current_velocity current velocity of ego.
    */
-  VectorXd calcSteerRateLimitOnTrajectory(const MPCTrajectory & trajectory) const;
+  VectorXd calcSteerRateLimitOnTrajectory(
+    const MPCTrajectory & trajectory, const double current_velocity) const;
 
   //!< @brief logging with warn and return false
   template <typename... Args>

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -766,7 +766,7 @@ VectorXd MPC::calcSteerRateLimitOnTrajectory(
   };
 
   // when the vehicle is stopped, no steering rate limit.
-  constexpr double steer_rate_lim = 5.0;
+  constexpr double steer_rate_lim = 100.0;
   const bool is_vehicle_stopped = std::fabs(current_velocity) < 0.01;
   if (is_vehicle_stopped) {
     return steer_rate_lim * VectorXd::Ones(m_param.prediction_horizon);

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -76,8 +76,9 @@ bool MPC::calculateMPC(
   const auto mpc_matrix = generateMPCMatrix(mpc_resampled_ref_trajectory, prediction_dt);
 
   // solve Optimization problem
-  const auto [success_opt, Uex] =
-    executeOptimization(mpc_matrix, x0_delayed, prediction_dt, mpc_resampled_ref_trajectory);
+  const auto [success_opt, Uex] = executeOptimization(
+    mpc_matrix, x0_delayed, prediction_dt, mpc_resampled_ref_trajectory,
+    current_kinematics.twist.twist.linear.x);
   if (!success_opt) {
     return fail_warn_throttle("optimization failed. Stop MPC.");
   }
@@ -543,7 +544,8 @@ MPCMatrix MPC::generateMPCMatrix(
  * [    -au_lim * dt    ] < [uN-uN-1] < [     au_lim * dt    ] (*N... DIM_U)
  */
 std::pair<bool, VectorXd> MPC::executeOptimization(
-  const MPCMatrix & m, const VectorXd & x0, const double prediction_dt, const MPCTrajectory & traj)
+  const MPCMatrix & m, const VectorXd & x0, const double prediction_dt, const MPCTrajectory & traj,
+  const double current_velocity)
 {
   VectorXd Uex;
 
@@ -576,7 +578,7 @@ std::pair<bool, VectorXd> MPC::executeOptimization(
   VectorXd ub = VectorXd::Constant(DIM_U_N, m_steer_lim);   // max steering angle
 
   // steering angle rate limit
-  VectorXd steer_rate_limits = calcSteerRateLimitOnTrajectory(traj);
+  VectorXd steer_rate_limits = calcSteerRateLimitOnTrajectory(traj, current_velocity);
   VectorXd ubA = steer_rate_limits * prediction_dt;
   VectorXd lbA = -steer_rate_limits * prediction_dt;
   ubA(0) = m_raw_steer_cmd_prev + steer_rate_limits(0) * m_ctrl_period;
@@ -728,7 +730,8 @@ double MPC::calcDesiredSteeringRate(
   return steer_rate;
 }
 
-VectorXd MPC::calcSteerRateLimitOnTrajectory(const MPCTrajectory & trajectory) const
+VectorXd MPC::calcSteerRateLimitOnTrajectory(
+  const MPCTrajectory & trajectory, const double current_velocity) const
 {
   const auto interp = [&](const auto & steer_rate_limit_map, const auto & current) {
     std::vector<double> reference, limits;
@@ -761,6 +764,13 @@ VectorXd MPC::calcSteerRateLimitOnTrajectory(const MPCTrajectory & trajectory) c
               << std::endl;
     return reference.back();
   };
+
+  // when the vehicle is stopped, no steering rate limit.
+  constexpr double steer_rate_lim = 5.0;
+  const bool is_vehicle_stopped = std::fabs(current_velocity) < 0.01;
+  if (is_vehicle_stopped) {
+    return steer_rate_lim * VectorXd::Ones(m_param.prediction_horizon);
+  }
 
   // calculate steering rate limit
   VectorXd steer_rate_limits = VectorXd::Zero(m_param.prediction_horizon);

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -765,7 +765,7 @@ VectorXd MPC::calcSteerRateLimitOnTrajectory(
     return reference.back();
   };
 
-  // when the vehicle is stopped, no steering rate limit.
+  // When the vehicle is stopped, a large steer rate limit is used for the dry steering.
   constexpr double steer_rate_lim = 100.0;
   const bool is_vehicle_stopped = std::fabs(current_velocity) < 0.01;
   if (is_vehicle_stopped) {

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -234,6 +234,8 @@ private:
   // debug values
   DebugValues m_debug_values;
 
+  std::optional<bool> m_prev_keep_stopped_condition{std::nullopt};
+
   std::shared_ptr<rclcpp::Time> m_last_running_time{std::make_shared<rclcpp::Time>(clock_->now())};
 
   // Diagnostic

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -718,9 +718,8 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
     if (departure_condition_from_stopped) {
       // Let vehicle start after the steering is converged for dry steering
-      const bool current_keep_stopped_condition = std::fabs(current_vel) < vel_epsilon &&
-                                                  m_enable_keep_stopped_until_steer_convergence &&
-                                                  !lateral_sync_data_.is_steer_converged;
+      const bool current_keep_stopped_condition =
+        std::fabs(current_vel) < vel_epsilon && !lateral_sync_data_.is_steer_converged;
       // NOTE: Dry steering is considered unnecessary when the steering is converged twice in a
       //       row. This is because lateral_sync_data_.is_steer_converged is not the current but
       //       the previous value due to the order controllers' run and sync functions.
@@ -728,7 +727,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         !m_prev_keep_stopped_condition ||
         (current_keep_stopped_condition || *m_prev_keep_stopped_condition);
       m_prev_keep_stopped_condition = current_keep_stopped_condition;
-      if (keep_stopped_condition) {
+      if (m_enable_keep_stopped_until_steer_convergence && keep_stopped_condition) {
         // debug print
         if (has_nonzero_target_vel) {
           debug_msg_once("target speed > 0, but keep stop condition is met. Keep STOPPED.");

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -721,6 +721,9 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
       const bool current_keep_stopped_condition = std::fabs(current_vel) < vel_epsilon &&
                                                   m_enable_keep_stopped_until_steer_convergence &&
                                                   !lateral_sync_data_.is_steer_converged;
+      // NOTE: Dry steering is considered unnecessary when the steering is converged twice in a
+      //       row. This is because lateral_sync_data_.is_steer_converged is not the current but
+      //       the previous value due to the order controllers' run and sync functions.
       const bool keep_stopped_condition =
         !m_prev_keep_stopped_condition ||
         (current_keep_stopped_condition || *m_prev_keep_stopped_condition);

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -599,21 +599,6 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
   // NOTE: the same velocity threshold as autoware::motion_utils::searchZeroVelocity
   static constexpr double vel_epsilon = 1e-3;
 
-  // Let vehicle start after the steering is converged for control accuracy
-  const bool keep_stopped_condition = std::fabs(current_vel) < vel_epsilon &&
-                                      m_enable_keep_stopped_until_steer_convergence &&
-                                      !lateral_sync_data_.is_steer_converged;
-  if (keep_stopped_condition) {
-    auto marker = createDefaultMarker(
-      "map", clock_->now(), "stop_reason", 0, Marker::TEXT_VIEW_FACING,
-      createMarkerScale(0.0, 0.0, 1.0), createMarkerColor(1.0, 1.0, 1.0, 0.999));
-    marker.pose = autoware::universe_utils::calcOffsetPose(
-      m_current_kinematic_state.pose.pose, m_wheel_base + m_front_overhang,
-      m_vehicle_width / 2 + 2.0, 1.5);
-    marker.text = "steering not\nconverged";
-    m_pub_stop_reason_marker->publish(marker);
-  }
-
   const bool stopping_condition = stop_dist < p.stopping_state_stop_dist;
 
   const bool is_stopped = std::abs(current_vel) < p.stopped_state_entry_vel &&
@@ -672,15 +657,18 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     m_under_control_starting_time =
       is_under_control ? std::make_shared<rclcpp::Time>(clock_->now()) : nullptr;
   }
+
+  if (m_control_state != ControlState::STOPPED) {
+    m_prev_keep_stopped_condition = std::nullopt;
+  }
+
   // transit state
   // in DRIVE state
   if (m_control_state == ControlState::DRIVE) {
     if (emergency_condition) {
       return changeState(ControlState::EMERGENCY);
     }
-    if (!is_under_control && stopped_condition && keep_stopped_condition) {
-      // NOTE: When the ego is stopped on manual driving, since the driving state may transit to
-      //       autonomous, keep_stopped_condition should be checked.
+    if (!is_under_control && stopped_condition) {
       return changeState(ControlState::STOPPED);
     }
 
@@ -723,19 +711,40 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
   // in STOPPED state
   if (m_control_state == ControlState::STOPPED) {
-    // -- debug print --
+    // debug print
     if (has_nonzero_target_vel && !departure_condition_from_stopped) {
       debug_msg_once("target speed > 0, but departure condition is not met. Keep STOPPED.");
     }
-    if (has_nonzero_target_vel && keep_stopped_condition) {
-      debug_msg_once("target speed > 0, but keep stop condition is met. Keep STOPPED.");
-    }
-    // ---------------
 
-    if (keep_stopped_condition) {
-      return changeState(ControlState::STOPPED);
-    }
     if (departure_condition_from_stopped) {
+      // Let vehicle start after the steering is converged for dry steering
+      const bool current_keep_stopped_condition = std::fabs(current_vel) < vel_epsilon &&
+                                                  m_enable_keep_stopped_until_steer_convergence &&
+                                                  !lateral_sync_data_.is_steer_converged;
+      const bool keep_stopped_condition =
+        !m_prev_keep_stopped_condition ||
+        (current_keep_stopped_condition || *m_prev_keep_stopped_condition);
+      m_prev_keep_stopped_condition = current_keep_stopped_condition;
+      if (keep_stopped_condition) {
+        // debug print
+        if (has_nonzero_target_vel) {
+          debug_msg_once("target speed > 0, but keep stop condition is met. Keep STOPPED.");
+        }
+
+        // publish debug marker
+        auto marker = createDefaultMarker(
+          "map", clock_->now(), "stop_reason", 0, Marker::TEXT_VIEW_FACING,
+          createMarkerScale(0.0, 0.0, 1.0), createMarkerColor(1.0, 1.0, 1.0, 0.999));
+        marker.pose = autoware::universe_utils::calcOffsetPose(
+          m_current_kinematic_state.pose.pose, m_wheel_base + m_front_overhang,
+          m_vehicle_width / 2 + 2.0, 1.5);
+        marker.text = "steering not\nconverged";
+        m_pub_stop_reason_marker->publish(marker);
+
+        // keep STOPPED
+        return;
+      }
+
       m_pid_vel.reset();
       m_lpf_vel_error->reset(0.0);
       // prevent the car from taking a long time to start to move


### PR DESCRIPTION
## Description

Once the dry steering (steering while the ego stops) was supported in the controller for the geometric path by the start/goal planner.
However, this dry steering feature does not work well currently due to the recent change.

This PR revived the the dry steering feature.

**Without this PR**
case1 (geometric path planning)
https://github.com/autowarefoundation/autoware.universe/assets/20228327/07fc0dcb-21ba-45d5-9f8e-a4a10519488a



**With this PR**
case1 (geometric path planning)
https://github.com/autowarefoundation/autoware.universe/assets/20228327/5220ed78-d093-4c24-aae8-0ef3c9bbc9e3

case2 (freespace path planning)
https://github.com/autowarefoundation/autoware.universe/assets/20228327/23891825-e5d4-46ca-bf6b-b50f6f37b58c




## Related links


- [CompanyName internal link](https://tier4.atlassian.net/browse/RT1-6805)

## How was this PR tested?
https://evaluation.tier4.jp/evaluation/reports/9cbcc1d0-bd17-5a1a-b383-c306c8e901cb?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
