### PR TITLE
refactor(radar_scan_to_pointcloud2): fix namespace and directory structure

### DIFF
--- a/sensing/radar_scan_to_pointcloud2/CMakeLists.txt
+++ b/sensing/radar_scan_to_pointcloud2/CMakeLists.txt
@@ -5,9 +5,18 @@ project(radar_scan_to_pointcloud2)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(PCL REQUIRED COMPONENTS common)
+
 # Targets
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/radar_scan_to_pointcloud2_node.cpp
+)
+
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC ${PCL_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME}
+  ${PCL_LIBRARIES}
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/sensing/radar_scan_to_pointcloud2/CMakeLists.txt
+++ b/sensing/radar_scan_to_pointcloud2/CMakeLists.txt
@@ -6,12 +6,12 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 # Targets
-ament_auto_add_library(radar_scan_to_pointcloud2_node_component SHARED
-  src/radar_scan_to_pointcloud2_node/radar_scan_to_pointcloud2_node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/radar_scan_to_pointcloud2_node.cpp
 )
 
-rclcpp_components_register_node(radar_scan_to_pointcloud2_node_component
-  PLUGIN "radar_scan_to_pointcloud2::RadarScanToPointcloud2Node"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::radar_scan_to_pointcloud2::RadarScanToPointcloud2Node"
   EXECUTABLE radar_scan_to_pointcloud2_node
 )
 

--- a/sensing/radar_scan_to_pointcloud2/package.xml
+++ b/sensing/radar_scan_to_pointcloud2/package.xml
@@ -14,8 +14,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>libpcl-common</depend>
   <depend>pcl_conversions</depend>
-  <depend>pcl_ros</depend>
   <depend>radar_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/sensing/radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.cpp
+++ b/sensing/radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "radar_scan_to_pointcloud2/radar_scan_to_pointcloud2_node.hpp"
+#include "radar_scan_to_pointcloud2_node.hpp"
 
 #include <pcl/pcl_base.h>
 #include <pcl/point_cloud.h>
@@ -87,7 +87,7 @@ sensor_msgs::msg::PointCloud2 toDopplerPointcloud2(const radar_msgs::msg::RadarS
 }
 }  // namespace
 
-namespace radar_scan_to_pointcloud2
+namespace autoware::radar_scan_to_pointcloud2
 {
 using radar_msgs::msg::RadarReturn;
 using radar_msgs::msg::RadarScan;
@@ -153,7 +153,7 @@ void RadarScanToPointcloud2Node::onData(const RadarScan::ConstSharedPtr radar_ms
   }
 }
 
-}  // namespace radar_scan_to_pointcloud2
+}  // namespace autoware::radar_scan_to_pointcloud2
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(radar_scan_to_pointcloud2::RadarScanToPointcloud2Node)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::radar_scan_to_pointcloud2::RadarScanToPointcloud2Node)

--- a/sensing/radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.hpp
+++ b/sensing/radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RADAR_SCAN_TO_POINTCLOUD2__RADAR_SCAN_TO_POINTCLOUD2_NODE_HPP_
-#define RADAR_SCAN_TO_POINTCLOUD2__RADAR_SCAN_TO_POINTCLOUD2_NODE_HPP_
+#ifndef RADAR_SCAN_TO_POINTCLOUD2_NODE_HPP_
+#define RADAR_SCAN_TO_POINTCLOUD2_NODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-namespace radar_scan_to_pointcloud2
+namespace autoware::radar_scan_to_pointcloud2
 {
 using radar_msgs::msg::RadarReturn;
 using radar_msgs::msg::RadarScan;
@@ -65,6 +65,6 @@ private:
   NodeParam node_param_{};
 };
 
-}  // namespace radar_scan_to_pointcloud2
+}  // namespace autoware::radar_scan_to_pointcloud2
 
-#endif  // RADAR_SCAN_TO_POINTCLOUD2__RADAR_SCAN_TO_POINTCLOUD2_NODE_HPP_
+#endif  // RADAR_SCAN_TO_POINTCLOUD2_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)
2. [Clean unused dependencies](https://github.com/autowarefoundation/autoware/issues/3468)   [LIST](https://github.com/autowarefoundation/autoware.universe/pull/3606)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the [TIER IV Cloud ](https://evaluation.tier4.jp/evaluation/reports/4c0e46a3-ab5b-5d2d-b35b-d16ca7fd4f38?project_id=prd_jt)environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
