### PR TITLE
refactor(radar_threshold_filter): fix namespace and directory structure

### DIFF
--- a/sensing/radar_threshold_filter/CMakeLists.txt
+++ b/sensing/radar_threshold_filter/CMakeLists.txt
@@ -6,12 +6,12 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ## Targets
-ament_auto_add_library(radar_threshold_filter_node_component SHARED
-  src/radar_threshold_filter_node/radar_threshold_filter_node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/radar_threshold_filter_node.cpp
 )
 
-rclcpp_components_register_node(radar_threshold_filter_node_component
-  PLUGIN "radar_threshold_filter::RadarThresholdFilterNode"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::radar_threshold_filter::RadarThresholdFilterNode"
   EXECUTABLE radar_threshold_filter_node
 )
 
@@ -24,10 +24,10 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   file(GLOB_RECURSE test_files test/**/*.cpp)
-  ament_add_ros_isolated_gtest(radar_threshold_filter ${test_files})
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test ${test_files})
 
-  target_link_libraries(radar_threshold_filter
-    radar_threshold_filter_node_component
+  target_link_libraries(${PROJECT_NAME}_test
+    ${PROJECT_NAME}
   )
 endif()
 

--- a/sensing/radar_threshold_filter/src/radar_threshold_filter_node.cpp
+++ b/sensing/radar_threshold_filter/src/radar_threshold_filter_node.cpp
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "radar_threshold_filter/radar_threshold_filter_node.hpp"
+#include "radar_threshold_filter_node.hpp"
 
 #include <radar_msgs/msg/radar_scan.hpp>
 
 #include <memory>
 #include <string>
 #include <vector>
-
-using std::placeholders::_1;
 
 namespace
 {
@@ -51,10 +49,11 @@ bool isWithin(double value, double max, double min)
 }
 }  // namespace
 
-namespace radar_threshold_filter
+namespace autoware::radar_threshold_filter
 {
 using radar_msgs::msg::RadarReturn;
 using radar_msgs::msg::RadarScan;
+using std::placeholders::_1;
 
 RadarThresholdFilterNode::RadarThresholdFilterNode(const rclcpp::NodeOptions & node_options)
 : Node("radar_threshold_filter", node_options)
@@ -156,7 +155,7 @@ bool RadarThresholdFilterNode::isWithinThreshold(const RadarReturn & radar_retur
   return true;
 }
 
-}  // namespace radar_threshold_filter
+}  // namespace autoware::radar_threshold_filter
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(radar_threshold_filter::RadarThresholdFilterNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::radar_threshold_filter::RadarThresholdFilterNode)

--- a/sensing/radar_threshold_filter/src/radar_threshold_filter_node.hpp
+++ b/sensing/radar_threshold_filter/src/radar_threshold_filter_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RADAR_THRESHOLD_FILTER__RADAR_THRESHOLD_FILTER_NODE_HPP_
-#define RADAR_THRESHOLD_FILTER__RADAR_THRESHOLD_FILTER_NODE_HPP_
+#ifndef RADAR_THRESHOLD_FILTER_NODE_HPP_
+#define RADAR_THRESHOLD_FILTER_NODE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace radar_threshold_filter
+namespace autoware::radar_threshold_filter
 {
 using radar_msgs::msg::RadarReturn;
 using radar_msgs::msg::RadarScan;
@@ -73,6 +73,6 @@ public:
   bool isWithinThreshold(const RadarReturn & radar_return);
 };
 
-}  // namespace radar_threshold_filter
+}  // namespace autoware::radar_threshold_filter
 
-#endif  // RADAR_THRESHOLD_FILTER__RADAR_THRESHOLD_FILTER_NODE_HPP_
+#endif  // RADAR_THRESHOLD_FILTER_NODE_HPP_

--- a/sensing/radar_threshold_filter/test/radar_threshold_filter/test_radar_threshold_filter.cpp
+++ b/sensing/radar_threshold_filter/test/radar_threshold_filter/test_radar_threshold_filter.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "radar_threshold_filter/radar_threshold_filter_node.hpp"
+#include "../../src/radar_threshold_filter_node.hpp"
 
 #include <radar_msgs/msg/radar_scan.hpp>
 
@@ -21,8 +21,8 @@
 TEST(RadarThresholdFilter, isWithinThreshold)
 {
   rclcpp::init(0, nullptr);
+  using autoware::radar_threshold_filter::RadarThresholdFilterNode;
   using radar_msgs::msg::RadarReturn;
-  using radar_threshold_filter::RadarThresholdFilterNode;
 
   const double amplitude_min = -10.0;
   const double amplitude_max = 100.0;


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the [TIER IV Cloud ](https://evaluation.tier4.jp/evaluation/reports/4c0e46a3-ab5b-5d2d-b35b-d16ca7fd4f38?project_id=prd_jt)environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
