### PR TITLE
refactor(radar_static_pointcloud_filter): fix namespace and directory structure

### DIFF
--- a/sensing/radar_static_pointcloud_filter/CMakeLists.txt
+++ b/sensing/radar_static_pointcloud_filter/CMakeLists.txt
@@ -6,12 +6,12 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 # Targets
-ament_auto_add_library(radar_static_pointcloud_filter_node_component SHARED
-  src/radar_static_pointcloud_filter_node/radar_static_pointcloud_filter_node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/radar_static_pointcloud_filter_node.cpp
 )
 
-rclcpp_components_register_node(radar_static_pointcloud_filter_node_component
-  PLUGIN "radar_static_pointcloud_filter::RadarStaticPointcloudFilterNode"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::radar_static_pointcloud_filter::RadarStaticPointcloudFilterNode"
   EXECUTABLE radar_static_pointcloud_filter_node
 )
 

--- a/sensing/radar_static_pointcloud_filter/package.xml
+++ b/sensing/radar_static_pointcloud_filter/package.xml
@@ -20,9 +20,6 @@
   <depend>radar_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>tf2_ros</depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/sensing/radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
+++ b/sensing/radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "radar_static_pointcloud_filter/radar_static_pointcloud_filter_node.hpp"
+#include "radar_static_pointcloud_filter_node.hpp"
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance.hpp>
@@ -75,7 +75,7 @@ geometry_msgs::msg::Vector3 compensateEgoVehicleTwist(
 }
 }  // namespace
 
-namespace radar_static_pointcloud_filter
+namespace autoware::radar_static_pointcloud_filter
 {
 using nav_msgs::msg::Odometry;
 using radar_msgs::msg::RadarReturn;
@@ -167,7 +167,8 @@ bool RadarStaticPointcloudFilterNode::isStaticPointcloud(
          (compensated_velocity.x < node_param_.doppler_velocity_sd);
 }
 
-}  // namespace radar_static_pointcloud_filter
+}  // namespace autoware::radar_static_pointcloud_filter
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(radar_static_pointcloud_filter::RadarStaticPointcloudFilterNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::radar_static_pointcloud_filter::RadarStaticPointcloudFilterNode)

--- a/sensing/radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.hpp
+++ b/sensing/radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RADAR_STATIC_POINTCLOUD_FILTER__RADAR_STATIC_POINTCLOUD_FILTER_NODE_HPP_
-#define RADAR_STATIC_POINTCLOUD_FILTER__RADAR_STATIC_POINTCLOUD_FILTER_NODE_HPP_
+#ifndef RADAR_STATIC_POINTCLOUD_FILTER_NODE_HPP_
+#define RADAR_STATIC_POINTCLOUD_FILTER_NODE_HPP_
 
 #include "autoware/universe_utils/ros/transform_listener.hpp"
 
@@ -31,7 +31,7 @@
 #include <string>
 #include <vector>
 
-namespace radar_static_pointcloud_filter
+namespace autoware::radar_static_pointcloud_filter
 {
 using nav_msgs::msg::Odometry;
 using radar_msgs::msg::RadarReturn;
@@ -77,6 +77,6 @@ private:
     const RadarReturn & radar_return, const Odometry::ConstSharedPtr & odom_msg,
     geometry_msgs::msg::TransformStamped::ConstSharedPtr transform);
 };
-}  // namespace radar_static_pointcloud_filter
+}  // namespace autoware::radar_static_pointcloud_filter
 
-#endif  // RADAR_STATIC_POINTCLOUD_FILTER__RADAR_STATIC_POINTCLOUD_FILTER_NODE_HPP_
+#endif  // RADAR_STATIC_POINTCLOUD_FILTER_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)
2. [Clean unused dependencies](https://github.com/autowarefoundation/autoware/issues/3468)   [LIST](https://github.com/autowarefoundation/autoware.universe/pull/3606)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the [TIER IV Cloud ](https://evaluation.tier4.jp/evaluation/reports/4c0e46a3-ab5b-5d2d-b35b-d16ca7fd4f38?project_id=prd_jt)environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
