### PR TITLE
refactor(image_diagnostics): fix namespace and directory structure

### DIFF
--- a/sensing/image_diagnostics/CMakeLists.txt
+++ b/sensing/image_diagnostics/CMakeLists.txt
@@ -28,14 +28,14 @@ include_directories(
 )
 
 
-ament_auto_add_library(image_diagnostics SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/image_diagnostics_node.cpp
 )
-target_link_libraries(image_diagnostics
+target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )
-rclcpp_components_register_node(image_diagnostics
-  PLUGIN "image_diagnostics::ImageDiagNode"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::image_diagnostics::ImageDiagNode"
   EXECUTABLE image_diagnostics_node
 )
 

--- a/sensing/image_diagnostics/src/image_diagnostics_node.cpp
+++ b/sensing/image_diagnostics/src/image_diagnostics_node.cpp
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "image_diagnostics/image_diagnostics_node.hpp"
+#include "image_diagnostics_node.hpp"
 
 #include <std_msgs/msg/header.hpp>
 
-namespace image_diagnostics
+#include <vector>
+
+namespace autoware::image_diagnostics
 {
 using image_diagnostics::Image_State;
 ImageDiagNode::ImageDiagNode(const rclcpp::NodeOptions & node_options)
@@ -271,7 +273,7 @@ void ImageDiagNode::shiftImage(cv::Mat & img)
   tmp.copyTo(left_bottom);
 }
 
-}  // namespace image_diagnostics
+}  // namespace autoware::image_diagnostics
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(image_diagnostics::ImageDiagNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::image_diagnostics::ImageDiagNode)

--- a/sensing/image_diagnostics/src/image_diagnostics_node.hpp
+++ b/sensing/image_diagnostics/src/image_diagnostics_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IMAGE_DIAGNOSTICS__IMAGE_DIAGNOSTICS_NODE_HPP_
-#define IMAGE_DIAGNOSTICS__IMAGE_DIAGNOSTICS_NODE_HPP_
+#ifndef IMAGE_DIAGNOSTICS_NODE_HPP_
+#define IMAGE_DIAGNOSTICS_NODE_HPP_
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <image_transport/image_transport.hpp>
@@ -34,7 +34,8 @@
 
 #include <string>
 #include <unordered_map>
-namespace image_diagnostics
+
+namespace autoware::image_diagnostics
 {
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
@@ -98,6 +99,6 @@ protected:
   rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr image_state_pub_;
 };
 
-}  // namespace image_diagnostics
+}  // namespace autoware::image_diagnostics
 
-#endif  // IMAGE_DIAGNOSTICS__IMAGE_DIAGNOSTICS_NODE_HPP_
+#endif  // IMAGE_DIAGNOSTICS_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment.
```
# terminal 1
ros2 launch image_transport_decompressor image_transport_decompressor.launch.xml \
input_topic_name:=/sensing/camera/camera0/image_rect_color/compressed \
output_topic_name:=/sensing/camera/camera0/image_rect_color

# terminal 2
ros2 launch image_diagnostics image_diagnostics_node.launch.xml input_topic_name:=/sensing/camera/camera0/image_rect_color

# terminal 3: 
# play a bagfile contains '/sensing/camera/camera0/image_rect_color/compressed'
```

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
