### PR TITLE
fix: make sure ament_package() is called when CUDA is not found

### DIFF
--- a/common/tensorrt_common/CMakeLists.txt
+++ b/common/tensorrt_common/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(TENSORRT)
 
 if(NOT (CUDAToolkit_FOUND AND CUDNN_FOUND AND TENSORRT_FOUND))
   message(WARNING "cuda, cudnn, tensorrt libraries are not found")
+  ament_package()
   return()
 endif()
 

--- a/perception/tensorrt_classifier/CMakeLists.txt
+++ b/perception/tensorrt_classifier/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(OpenCV REQUIRED)
 
 if(NOT (${CUDA_FOUND} AND ${CUDNN_FOUND} AND ${TENSORRT_FOUND}))
   message(WARNING "cuda, cudnn, tensorrt libraries are not found")
+  ament_auto_package()
   return()
 endif()
 


### PR DESCRIPTION
## Description

Resolves https://github.com/autowarefoundation/autoware.universe/issues/7916

## Related links
- https://github.com/autowarefoundation/autoware.universe/issues/7916

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Install Autoware on machines without CUDA installed and run `source install/setup.bash`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
