### PR TITLE
fix(autoware_external_cmd_converter): fix check_topic_state

### DIFF
--- a/vehicle/autoware_external_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_external_cmd_converter/src/node.cpp
@@ -198,7 +198,11 @@ void ExternalCmdConverterNode::check_topic_status(
 
 bool ExternalCmdConverterNode::check_emergency_stop_topic_timeout()
 {
-  if (current_gate_mode_ && current_gate_mode_->data == tier4_control_msgs::msg::GateMode::AUTO) {
+  if (!current_gate_mode_) {
+    return true;
+  }  
+
+  if (current_gate_mode_->data == tier4_control_msgs::msg::GateMode::AUTO) {
     latest_emergency_stop_heartbeat_received_time_ = nullptr;
   }
 

--- a/vehicle/autoware_external_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_external_cmd_converter/src/node.cpp
@@ -179,7 +179,7 @@ void ExternalCmdConverterNode::check_topic_status(
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
   DiagnosticStatus status;
-  
+
   current_gate_mode_ = gate_mode_sub_.takeData();
 
   if (!check_emergency_stop_topic_timeout()) {

--- a/vehicle/autoware_external_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_external_cmd_converter/src/node.cpp
@@ -179,6 +179,9 @@ void ExternalCmdConverterNode::check_topic_status(
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
   DiagnosticStatus status;
+  
+  current_gate_mode_ = gate_mode_sub_.takeData();
+
   if (!check_emergency_stop_topic_timeout()) {
     status.level = DiagnosticStatus::ERROR;
     status.message = "emergency stop topic is timeout";
@@ -195,6 +198,10 @@ void ExternalCmdConverterNode::check_topic_status(
 
 bool ExternalCmdConverterNode::check_emergency_stop_topic_timeout()
 {
+  if (current_gate_mode_ && current_gate_mode_->data == tier4_control_msgs::msg::GateMode::AUTO) {
+    latest_emergency_stop_heartbeat_received_time_ = nullptr;
+  }
+
   if (!latest_emergency_stop_heartbeat_received_time_) {
     return wait_for_first_topic_;
   }
@@ -205,8 +212,6 @@ bool ExternalCmdConverterNode::check_emergency_stop_topic_timeout()
 
 bool ExternalCmdConverterNode::check_remote_topic_rate()
 {
-  current_gate_mode_ = gate_mode_sub_.takeData();
-
   if (!current_gate_mode_) {
     return true;
   }

--- a/vehicle/autoware_external_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_external_cmd_converter/src/node.cpp
@@ -200,7 +200,7 @@ bool ExternalCmdConverterNode::check_emergency_stop_topic_timeout()
 {
   if (!current_gate_mode_) {
     return true;
-  }  
+  }
 
   if (current_gate_mode_->data == tier4_control_msgs::msg::GateMode::AUTO) {
     latest_emergency_stop_heartbeat_received_time_ = nullptr;


### PR DESCRIPTION
## Description
This pull request addresses an issue where the availability of local/remote mode becomes false after the first activation. This is achieved by making necessary adjustments to fix the check_topic_state function.

Subscribed topics in autoware_external_converter are used only when GateMode is set to EXTERNAL. Therefore, I propose that check_topic_state should return true when GateMode is set to AUTO. This change will prevent the availability of local/remote mode from becoming false due to a mischeck.

## Related links


## Tests performed

[Screencast from 2024年07月08日 17時38分38秒.webm](https://github.com/tier4/autoware.universe/assets/165623782/449de164-82e0-4ab3-8ca8-dc33342909ba)


## Notes for reviewers


## Interface changes


### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
