### PR TITLE
fix(autoware_behavior_velocity_no_drivable_lane_module): fix bug of uninitialization

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.cpp
@@ -149,7 +149,7 @@ void NoDrivableLaneModule::handle_approaching_state(PathWithLaneId * path, StopR
 
   const auto & op_target_point_idx =
     autoware::motion_utils::insertTargetPoint(target_segment_idx, target_point, path->points, 5e-2);
-  size_t target_point_idx;
+  size_t target_point_idx = 0;
   if (op_target_point_idx) {
     target_point_idx = op_target_point_idx.value();
   }


### PR DESCRIPTION
## Description

Fix errors found by using clang

```cpp
  // size_t target_point_idx; <= uninitilized
  size_t target_point_idx = 0;
  if (op_target_point_idx) {
    target_point_idx = op_target_point_idx.value();
  }
  geometry_msgs::msg::Point stop_point =
    autoware::universe_utils::getPoint(path->points.at(target_point_idx).point);
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
