### PR TITLE
fix: added temporary retrocompatibility to old perception data

### DIFF
--- a/sensing/pointcloud_preprocessor/src/filter.cpp
+++ b/sensing/pointcloud_preprocessor/src/filter.cpp
@@ -413,12 +413,19 @@ bool pointcloud_preprocessor::Filter::convert_output_costly(std::unique_ptr<Poin
 void pointcloud_preprocessor::Filter::faster_input_indices_callback(
   const PointCloud2ConstPtr cloud, const PointIndicesConstPtr indices)
 {
-  if (
+  // TODO(knzo25): This first branch is to give temporary compatibility with old perception data.
+  // Should be deleted soon
+  if (utils::is_data_layout_compatible_with_point_xyzi(*cloud)) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 10000,
+      "The pointcloud layout is compatible with PointXYZI. You may be using legacy "
+      "code/data. Continue at your own risk");
+  } else if (
     !utils::is_data_layout_compatible_with_point_xyzircaedt(*cloud) &&
     !utils::is_data_layout_compatible_with_point_xyzirc(*cloud)) {
     RCLCPP_ERROR(
       get_logger(),
-      "The pointcloud layout is not compatible with PointXYZIRCAEDT not PointXYZIRC. Aborting");
+      "The pointcloud layout is not compatible with PointXYZIRCAEDT/PointXYZIRC. Aborting");
 
     if (utils::is_data_layout_compatible_with_point_xyziradrt(*cloud)) {
       RCLCPP_ERROR(


### PR DESCRIPTION
## Description
Some of our code is still using data with the old pointcloud type. In this PR I add temporary retro-compatibility by disabling the related memory checks

## Related links


- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03S84LDJGG/p1720571462988769)

<!-- ⬇️🟢
**Private Links:**


⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
