### PR TITLE
fix(autoware_lane_departure_checker): fix shadowVariable

### DIFF
--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -329,15 +329,15 @@ LaneDepartureChecker::getFusedLaneletPolygonForPath(
   const auto lanelets_distance_pair = getLaneletsFromPath(lanelet_map_ptr, path);
   auto to_polygon2d =
     [](const lanelet::BasicPolygon2d & poly) -> autoware::universe_utils::Polygon2d {
-    autoware::universe_utils::Polygon2d p;
-    auto & outer = p.outer();
+    autoware::universe_utils::Polygon2d polygon;
+    auto & outer = polygon.outer();
 
     for (const auto & p : poly) {
       autoware::universe_utils::Point2d p2d(p.x(), p.y());
       outer.push_back(p2d);
     }
-    boost::geometry::correct(p);
-    return p;
+    boost::geometry::correct(polygon);
+    return polygon;
   };
 
   // Fuse lanelets into a single BasicPolygon2d


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp:335:23: style: Local variable 'p' shadows outer variable [shadowVariable]
    for (const auto & p : poly) {
                      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
