### PR TITLE
fix(autoware_pure_pursuit): fix shadowVariable

### DIFF
--- a/control/autoware_pure_pursuit/src/autoware_pure_pursuit_core/interpolate.cpp
+++ b/control/autoware_pure_pursuit/src/autoware_pure_pursuit_core/interpolate.cpp
@@ -229,8 +229,8 @@ bool SplineInterpolate::interpolate(
   generateSpline(base_value);
 
   // interpolate by spline  with normalized index
-  for (int i = 0; i < static_cast<int>(normalized_idx.size()); ++i) {
-    return_value.push_back(getValue(normalized_idx[i]));
+  for (int j = 0; j < static_cast<int>(normalized_idx.size()); ++j) {
+    return_value.push_back(getValue(normalized_idx[j]));
   }
   return true;
 }

--- a/control/autoware_pure_pursuit/src/autoware_pure_pursuit_core/interpolate.cpp
+++ b/control/autoware_pure_pursuit/src/autoware_pure_pursuit_core/interpolate.cpp
@@ -229,8 +229,8 @@ bool SplineInterpolate::interpolate(
   generateSpline(base_value);
 
   // interpolate by spline  with normalized index
-  for (int j = 0; j < static_cast<int>(normalized_idx.size()); ++j) {
-    return_value.push_back(getValue(normalized_idx[j]));
+  for (const auto & index : normalized_idx) {
+    return_value.push_back(getValue(index));
   }
   return true;
 }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
control/autoware_pure_pursuit/src/autoware_pure_pursuit_core/interpolate.cpp:232:12: style: Local variable 'i' shadows outer variable [shadowVariable]
  for (int i = 0; i < static_cast<int>(normalized_idx.size()); ++i) {
           ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
