### PR TITLE
fix(perception_online_evaluator): fix shadowVariable

### DIFF
--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -247,55 +247,54 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
   updateParam<double>(parameters, "objects_count_window_seconds", p->objects_count_window_seconds);
 
   // update parameters for each object class
-  const auto update_object_param = [&p, &parameters](
-                                     const auto & semantic, const std::string & ns) {
-    auto & config = p->object_parameters.at(semantic);
-    updateParam<bool>(parameters, ns + "check_lateral_deviation", config.check_lateral_deviation);
-    updateParam<bool>(parameters, ns + "check_yaw_deviation", config.check_yaw_deviation);
-    updateParam<bool>(
-      parameters, ns + "check_predicted_path_deviation", config.check_predicted_path_deviation);
-    updateParam<bool>(parameters, ns + "check_yaw_rate", config.check_yaw_rate);
-    updateParam<bool>(
-      parameters, ns + "check_total_objects_count", config.check_total_objects_count);
-    updateParam<bool>(
-      parameters, ns + "check_average_objects_count", config.check_average_objects_count);
-    updateParam<bool>(
-      parameters, ns + "check_interval_average_objects_count",
-      config.check_interval_average_objects_count);
-  };
-  const std::string ns = "target_object.";
-  update_object_param(ObjectClassification::MOTORCYCLE, ns + "motorcycle.");
-  update_object_param(ObjectClassification::CAR, ns + "car.");
-  update_object_param(ObjectClassification::TRUCK, ns + "truck.");
-  update_object_param(ObjectClassification::TRAILER, ns + "trailer.");
-  update_object_param(ObjectClassification::BUS, ns + "bus.");
-  update_object_param(ObjectClassification::PEDESTRIAN, ns + "pedestrian.");
-  update_object_param(ObjectClassification::BICYCLE, ns + "bicycle.");
-  update_object_param(ObjectClassification::UNKNOWN, ns + "unknown.");
-
+  {
+    const auto update_object_param = [&p, &parameters](
+                                       const auto & semantic, const std::string & ns) {
+      auto & config = p->object_parameters.at(semantic);
+      updateParam<bool>(parameters, ns + "check_lateral_deviation", config.check_lateral_deviation);
+      updateParam<bool>(parameters, ns + "check_yaw_deviation", config.check_yaw_deviation);
+      updateParam<bool>(
+        parameters, ns + "check_predicted_path_deviation", config.check_predicted_path_deviation);
+      updateParam<bool>(parameters, ns + "check_yaw_rate", config.check_yaw_rate);
+      updateParam<bool>(
+        parameters, ns + "check_total_objects_count", config.check_total_objects_count);
+      updateParam<bool>(
+        parameters, ns + "check_average_objects_count", config.check_average_objects_count);
+      updateParam<bool>(
+        parameters, ns + "check_interval_average_objects_count",
+        config.check_interval_average_objects_count);
+    };
+    const std::string ns = "target_object.";
+    update_object_param(ObjectClassification::MOTORCYCLE, ns + "motorcycle.");
+    update_object_param(ObjectClassification::CAR, ns + "car.");
+    update_object_param(ObjectClassification::TRUCK, ns + "truck.");
+    update_object_param(ObjectClassification::TRAILER, ns + "trailer.");
+    update_object_param(ObjectClassification::BUS, ns + "bus.");
+    update_object_param(ObjectClassification::PEDESTRIAN, ns + "pedestrian.");
+    update_object_param(ObjectClassification::BICYCLE, ns + "bicycle.");
+    update_object_param(ObjectClassification::UNKNOWN, ns + "unknown.");
+  }
   // update debug marker parameters
   {
-    const std::string name_space = "debug_marker.";
+    const std::string ns = "debug_marker.";
     updateParam<bool>(
-      parameters, name_space + "history_path", p->debug_marker_parameters.show_history_path);
+      parameters, ns + "history_path", p->debug_marker_parameters.show_history_path);
     updateParam<bool>(
-      parameters, name_space + "history_path_arrows",
-      p->debug_marker_parameters.show_history_path_arrows);
+      parameters, ns + "history_path_arrows", p->debug_marker_parameters.show_history_path_arrows);
     updateParam<bool>(
-      parameters, name_space + "smoothed_history_path",
+      parameters, ns + "smoothed_history_path",
       p->debug_marker_parameters.show_smoothed_history_path);
     updateParam<bool>(
-      parameters, name_space + "smoothed_history_path_arrows",
+      parameters, ns + "smoothed_history_path_arrows",
       p->debug_marker_parameters.show_smoothed_history_path_arrows);
     updateParam<bool>(
-      parameters, name_space + "predicted_path", p->debug_marker_parameters.show_predicted_path);
+      parameters, ns + "predicted_path", p->debug_marker_parameters.show_predicted_path);
     updateParam<bool>(
-      parameters, name_space + "predicted_path_gt",
-      p->debug_marker_parameters.show_predicted_path_gt);
+      parameters, ns + "predicted_path_gt", p->debug_marker_parameters.show_predicted_path_gt);
     updateParam<bool>(
-      parameters, name_space + "deviation_lines", p->debug_marker_parameters.show_deviation_lines);
+      parameters, ns + "deviation_lines", p->debug_marker_parameters.show_deviation_lines);
     updateParam<bool>(
-      parameters, name_space + "object_polygon", p->debug_marker_parameters.show_object_polygon);
+      parameters, ns + "object_polygon", p->debug_marker_parameters.show_object_polygon);
   }
 
   rcl_interfaces::msg::SetParametersResult result;

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -279,7 +279,8 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
     updateParam<bool>(
       parameters, name_space + "history_path", p->debug_marker_parameters.show_history_path);
     updateParam<bool>(
-      parameters, name_space + "history_path_arrows", p->debug_marker_parameters.show_history_path_arrows);
+      parameters, name_space + "history_path_arrows",
+      p->debug_marker_parameters.show_history_path_arrows);
     updateParam<bool>(
       parameters, name_space + "smoothed_history_path",
       p->debug_marker_parameters.show_smoothed_history_path);
@@ -289,7 +290,8 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
     updateParam<bool>(
       parameters, name_space + "predicted_path", p->debug_marker_parameters.show_predicted_path);
     updateParam<bool>(
-      parameters, name_space + "predicted_path_gt", p->debug_marker_parameters.show_predicted_path_gt);
+      parameters, name_space + "predicted_path_gt",
+      p->debug_marker_parameters.show_predicted_path_gt);
     updateParam<bool>(
       parameters, name_space + "deviation_lines", p->debug_marker_parameters.show_deviation_lines);
     updateParam<bool>(

--- a/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
+++ b/evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp
@@ -275,25 +275,25 @@ rcl_interfaces::msg::SetParametersResult PerceptionOnlineEvaluatorNode::onParame
 
   // update debug marker parameters
   {
-    const std::string ns = "debug_marker.";
+    const std::string name_space = "debug_marker.";
     updateParam<bool>(
-      parameters, ns + "history_path", p->debug_marker_parameters.show_history_path);
+      parameters, name_space + "history_path", p->debug_marker_parameters.show_history_path);
     updateParam<bool>(
-      parameters, ns + "history_path_arrows", p->debug_marker_parameters.show_history_path_arrows);
+      parameters, name_space + "history_path_arrows", p->debug_marker_parameters.show_history_path_arrows);
     updateParam<bool>(
-      parameters, ns + "smoothed_history_path",
+      parameters, name_space + "smoothed_history_path",
       p->debug_marker_parameters.show_smoothed_history_path);
     updateParam<bool>(
-      parameters, ns + "smoothed_history_path_arrows",
+      parameters, name_space + "smoothed_history_path_arrows",
       p->debug_marker_parameters.show_smoothed_history_path_arrows);
     updateParam<bool>(
-      parameters, ns + "predicted_path", p->debug_marker_parameters.show_predicted_path);
+      parameters, name_space + "predicted_path", p->debug_marker_parameters.show_predicted_path);
     updateParam<bool>(
-      parameters, ns + "predicted_path_gt", p->debug_marker_parameters.show_predicted_path_gt);
+      parameters, name_space + "predicted_path_gt", p->debug_marker_parameters.show_predicted_path_gt);
     updateParam<bool>(
-      parameters, ns + "deviation_lines", p->debug_marker_parameters.show_deviation_lines);
+      parameters, name_space + "deviation_lines", p->debug_marker_parameters.show_deviation_lines);
     updateParam<bool>(
-      parameters, ns + "object_polygon", p->debug_marker_parameters.show_object_polygon);
+      parameters, name_space + "object_polygon", p->debug_marker_parameters.show_object_polygon);
   }
 
   rcl_interfaces::msg::SetParametersResult result;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
evaluator/perception_online_evaluator/src/perception_online_evaluator_node.cpp:278:23: style: Local variable 'ns' shadows outer variable [shadowVariable]
    const std::string ns = "debug_marker.";
                      ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
