### PR TITLE
fix(lidar_apollo_instance_segmentation): fix shadowVariable

### DIFF
--- a/perception/lidar_apollo_instance_segmentation/src/debugger.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/debugger.cpp
@@ -34,12 +34,12 @@ void Debugger::publishColoredPointCloud(
 {
   using autoware_perception_msgs::msg::ObjectClassification;
   pcl::PointCloud<pcl::PointXYZRGB> colored_pointcloud;
-  for (size_t i = 0; i < input.feature_objects.size(); i++) {
+  for (const auto & feature_object : input.feature_objects) {
     pcl::PointCloud<pcl::PointXYZI> object_pointcloud;
-    pcl::fromROSMsg(input.feature_objects.at(i).feature.cluster, object_pointcloud);
+    pcl::fromROSMsg(feature_object.feature.cluster, object_pointcloud);
 
     int red = 0, green = 0, blue = 0;
-    switch (input.feature_objects.at(i).object.classification.front().label) {
+    switch (feature_object.object.classification.front().label) {
       case ObjectClassification::CAR: {
         red = 255;
         green = 0;
@@ -84,11 +84,11 @@ void Debugger::publishColoredPointCloud(
       }
     }
 
-    for (size_t i = 0; i < object_pointcloud.size(); i++) {
+    for (const auto & point : object_pointcloud) {
       pcl::PointXYZRGB colored_point;
-      colored_point.x = object_pointcloud[i].x;
-      colored_point.y = object_pointcloud[i].y;
-      colored_point.z = object_pointcloud[i].z;
+      colored_point.x = point.x;
+      colored_point.y = point.y;
+      colored_point.z = point.z;
       colored_point.r = red;
       colored_point.g = green;
       colored_point.b = blue;

--- a/perception/lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/detector.cpp
@@ -181,10 +181,10 @@ bool LidarApolloInstanceSegmentation::detectDynamicObjects(
     score_threshold_, height_thresh, min_pts_num, output, transformed_cloud.header);
 
   // move down pointcloud z_offset in z axis
-  for (std::size_t i = 0; i < output.feature_objects.size(); i++) {
+  for (auto & feature_object : output.feature_objects) {
     sensor_msgs::msg::PointCloud2 updated_cloud;
-    transformCloud(output.feature_objects.at(i).feature.cluster, updated_cloud, -z_offset_);
-    output.feature_objects.at(i).feature.cluster = updated_cloud;
+    transformCloud(feature_object.feature.cluster, updated_cloud, -z_offset_);
+    feature_object.feature.cluster = updated_cloud;
   }
 
   output.header = transformed_cloud.header;

--- a/perception/lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/detector.cpp
@@ -182,9 +182,9 @@ bool LidarApolloInstanceSegmentation::detectDynamicObjects(
 
   // move down pointcloud z_offset in z axis
   for (std::size_t i = 0; i < output.feature_objects.size(); i++) {
-    sensor_msgs::msg::PointCloud2 transformed_cloud;
-    transformCloud(output.feature_objects.at(i).feature.cluster, transformed_cloud, -z_offset_);
-    output.feature_objects.at(i).feature.cluster = transformed_cloud;
+    sensor_msgs::msg::PointCloud2 updated_cloud;
+    transformCloud(output.feature_objects.at(i).feature.cluster, updated_cloud, -z_offset_);
+    output.feature_objects.at(i).feature.cluster = updated_cloud;
   }
 
   output.header = transformed_cloud.header;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
perception/lidar_apollo_instance_segmentation/src/debugger.cpp:87:17: style: Local variable 'i' shadows outer variable [shadowVariable]
    for (size_t i = 0; i < object_pointcloud.size(); i++) {
                ^
```
Using range-based for loop.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
