### PR TITLE
fix(lidar_apollo_segmentation_tvm): fix shadowVariable

### DIFF
--- a/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
@@ -202,10 +202,10 @@ std::shared_ptr<const DetectedObjectsWithFeature> ApolloLidarSegmentation::detec
   output->header = input.header;
 
   // move down pointcloud z_offset in z axis
-  for (std::size_t i = 0; i < output->feature_objects.size(); i++) {
-    sensor_msgs::msg::PointCloud2 transformed_cloud;
-    transformCloud(output->feature_objects.at(i).feature.cluster, transformed_cloud, -z_offset_);
-    output->feature_objects.at(i).feature.cluster = transformed_cloud;
+  for (auto & feature_object : output->feature_objects) {
+    sensor_msgs::msg::PointCloud2 updated_cloud;
+    transformCloud(feature_object.feature.cluster, updated_cloud, -z_offset_);
+    feature_object.feature.cluster = updated_cloud;
   }
 
   return output;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp:170:33: style: Local variable 'transformed_cloud' shadows outer variable [shadowVariable]
    sensor_msgs::msg::PointCloud2 transformed_cloud;
                                  ^
```
Using range-based for loop.
                                  
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
