### PR TITLE
fix(multi_object_tracker): fix shadowVariable

### DIFF
--- a/perception/multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -350,10 +350,10 @@ void MultiObjectTracker::publish(const rclcpp::Time & time) const
   debugger_->endPublishTime(this->now(), time);
 
   if (debugger_->shouldPublishTentativeObjects()) {
-    TrackedObjects tentative_objects_msg;
-    tentative_objects_msg.header.frame_id = world_frame_id_;
-    processor_->getTentativeObjects(time, tentative_objects_msg);
-    debugger_->publishTentativeObjects(tentative_objects_msg);
+    TrackedObjects tentative_output_msg;
+    tentative_output_msg.header.frame_id = world_frame_id_;
+    processor_->getTentativeObjects(time, tentative_output_msg);
+    debugger_->publishTentativeObjects(tentative_output_msg);
   }
   debugger_->publishObjectsMarkers();
 }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
perception/multi_object_tracker/src/multi_object_tracker_core.cpp:353:20: style: Local variable 'tentative_objects_msg' shadows outer variable [shadowVariable]
    TrackedObjects tentative_objects_msg;
                   ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
