### PR TITLE
fix(probabilistic_occupancy_grid_map): fix shadowVariable

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -204,8 +204,8 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
     auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
-      const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
-      setCellValue(source.wx, source.wy, cost_value::LETHAL_OBSTACLE);
+      const auto & outer_source = obstacle_pointcloud_angle_bin.at(dist_index);
+      setCellValue(outer_source.wx, outer_source.wy, cost_value::LETHAL_OBSTACLE);
 
       if (dist_index + 1 == obstacle_pointcloud_angle_bin.size()) {
         continue;

--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -203,8 +203,8 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
   // Third step: Overwrite occupied cell
   for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
-      const auto & outer_source = obstacle_pointcloud_angle_bin.at(dist_index);
-      setCellValue(outer_source.wx, outer_source.wy, cost_value::LETHAL_OBSTACLE);
+      const auto & obstacle_point = obstacle_pointcloud_angle_bin.at(dist_index);
+      setCellValue(obstacle_point.wx, obstacle_point.wy, cost_value::LETHAL_OBSTACLE);
 
       if (dist_index + 1 == obstacle_pointcloud_angle_bin.size()) {
         continue;

--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -201,8 +201,7 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
   }
 
   // Third step: Overwrite occupied cell
-  for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
-    auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
+  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       const auto & outer_source = obstacle_pointcloud_angle_bin.at(dist_index);
       setCellValue(outer_source.wx, outer_source.wy, cost_value::LETHAL_OBSTACLE);

--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
@@ -261,8 +261,7 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
   if (pub_debug_grid_) converter.addLayerFromCostmap2D(*this, "added_unknown", debug_grid_);
 
   // Third step: Overwrite occupied cell
-  for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
-    auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
+  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       const auto & outer_source = obstacle_pointcloud_angle_bin.at(dist_index);
       setCellValue(outer_source.wx, outer_source.wy, cost_value::LETHAL_OBSTACLE);

--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
@@ -264,8 +264,8 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
     auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
-      const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
-      setCellValue(source.wx, source.wy, cost_value::LETHAL_OBSTACLE);
+      const auto & outer_source = obstacle_pointcloud_angle_bin.at(dist_index);
+      setCellValue(outer_source.wx, outer_source.wy, cost_value::LETHAL_OBSTACLE);
 
       if (dist_index + 1 == obstacle_pointcloud_angle_bin.size()) {
         continue;

--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
@@ -263,8 +263,8 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
   // Third step: Overwrite occupied cell
   for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
-      const auto & outer_source = obstacle_pointcloud_angle_bin.at(dist_index);
-      setCellValue(outer_source.wx, outer_source.wy, cost_value::LETHAL_OBSTACLE);
+      const auto & obstacle_point = obstacle_pointcloud_angle_bin.at(dist_index);
+      setCellValue(obstacle_point.wx, obstacle_point.wy, cost_value::LETHAL_OBSTACLE);
 
       if (dist_index + 1 == obstacle_pointcloud_angle_bin.size()) {
         continue;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:218:22: style: Local variable 'source' shadows outer variable [shadowVariable]
        const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
                     ^

probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp:278:22: style: Local variable 'source' shadows outer variable [shadowVariable]
        const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
                     ^
```
Using range-based for loop.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
