### PR TITLE
fix(tensorrt_yolox): fix shadowVariable

### DIFF
--- a/perception/tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -130,12 +130,12 @@ std::vector<tensorrt_yolox::Colormap> get_seg_colormap(const std::string & filen
       cmap.name = name;
       colormapString.erase(0, npos + 1);
       while (!colormapString.empty()) {
-        size_t npos = colormapString.find_first_of(',');
-        if (npos != std::string::npos) {
-          substr = colormapString.substr(0, npos);
+        size_t inner_npos = colormapString.find_first_of(',');
+        if (inner_npos != std::string::npos) {
+          substr = colormapString.substr(0, inner_npos);
           unsigned char c = (unsigned char)std::stoi(trim(substr));
           cmap.color.push_back(c);
-          colormapString.erase(0, npos + 1);
+          colormapString.erase(0, inner_npos + 1);
         } else {
           unsigned char c = (unsigned char)std::stoi(trim(colormapString));
           cmap.color.push_back(c);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
perception/tensorrt_yolox/src/tensorrt_yolox.cpp:133:16: style: Local variable 'npos' shadows outer variable [shadowVariable]
        size_t npos = colormapString.find_first_of(',');
               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
