### PR TITLE
feat(cruise_planner,planning_evaluator): add cruise and slow down diags

### DIFF
--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -181,7 +181,9 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   // queue for diagnostics and time stamp
   std::deque<std::pair<DiagnosticStatus, rclcpp::Time>> diag_queue_;
-  const std::vector<std::string> target_functions_ = {"obstacle_cruise_planner"};
+  const std::vector<std::string> target_functions_ = {
+    "obstacle_cruise_planner_stop", "obstacle_cruise_planner_slow_down",
+    "obstacle_cruise_planner_cruise"};
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
 };
 }  // namespace planning_diagnostics

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -122,7 +122,21 @@ DiagnosticStatus PlanningEvaluatorNode::generateDiagnosticEvaluationStatus(
   });
   const bool found = it != diag.values.end();
   status.level = (found) ? status.OK : status.ERROR;
-  status.values.push_back((found) ? *it : diagnostic_msgs::msg::KeyValue{});
+
+  auto get_key_value = [&]() {
+    if (!found) {
+      return diagnostic_msgs::msg::KeyValue{};
+    }
+    if (it->value.find("none") != std::string::npos) {
+      return *it;
+    }
+    diagnostic_msgs::msg::KeyValue key_value;
+    key_value.key = "decision";
+    key_value.value = "deceleration";
+    return key_value;
+  };
+
+  status.values.push_back(get_key_value());
   return status;
 }
 

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
@@ -25,6 +25,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -286,6 +288,9 @@ struct DebugData
   MarkerArray cruise_wall_marker;
   MarkerArray slow_down_wall_marker;
   std::vector<autoware::universe_utils::Polygon2d> detection_polygons;
+  std::optional<diagnostic_msgs::msg::DiagnosticStatus> stop_reason_diag{std::nullopt};
+  std::optional<diagnostic_msgs::msg::DiagnosticStatus> slow_down_reason_diag{std::nullopt};
+  std::optional<diagnostic_msgs::msg::DiagnosticStatus> cruise_reason_diag{std::nullopt};
 };
 
 struct EgoNearestParam

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/planner_interface.hpp
@@ -95,6 +95,14 @@ public:
     const std::vector<SlowDownObstacle> & slow_down_obstacles,
     std::optional<VelocityLimit> & vel_limit);
 
+  DiagnosticStatus makeEmptyDiagnostic(const std::string & reason);
+  DiagnosticStatus makeDiagnostic(
+    const std::string & reason, const std::optional<PlannerData> & planner_data = std::nullopt,
+    const std::optional<geometry_msgs::msg::Pose> & stop_pose = std::nullopt,
+    const std::optional<StopObstacle> & stop_obstacle = std::nullopt);
+  void publishDiagnostics(const rclcpp::Time & current_time);
+  void clearDiagnostics();
+
   void onParam(const std::vector<rclcpp::Parameter> & parameters)
   {
     updateCommonParam(parameters);

--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -636,6 +636,7 @@ void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr ms
 
   // 8. Publish debug data
   published_time_publisher_->publish_if_subscribed(trajectory_pub_, output_traj.header.stamp);
+  planner_ptr_->publishDiagnostics(now());
   publishDebugMarker();
   publishDebugInfo();
 

--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -199,6 +199,7 @@ std::vector<TrajectoryPoint> OptimizationBasedPlanner::generateCruiseTrajectory(
       output.at(i).longitudinal_velocity_mps = 0.0;
     }
     prev_output_ = output;
+    debug_data_ptr_->cruise_reason_diag = makeDiagnostic("cruise", planner_data);
     return output;
   } else if (opt_position.size() == 1) {
     RCLCPP_DEBUG(
@@ -255,6 +256,7 @@ std::vector<TrajectoryPoint> OptimizationBasedPlanner::generateCruiseTrajectory(
   // Insert Closest Stop Point
   autoware::motion_utils::insertStopPoint(0, closest_stop_dist, output);
 
+  debug_data_ptr_->cruise_reason_diag = makeDiagnostic("cruise", planner_data);
   prev_output_ = output;
   return output;
 }

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -323,6 +323,7 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::planCruise(
 
       // cruise obstacle
       debug_data_ptr_->obstacles_to_cruise.push_back(cruise_obstacle_info->obstacle);
+      debug_data_ptr_->cruise_reason_diag = makeDiagnostic("cruise", planner_data);
     }
 
     // do cruise planning


### PR DESCRIPTION
## Description
This PR adds cruise and slow down diag info to the cruise planner. The planning_evaluator interprets all 3 messages and outputs the corresponding result. 


https://github.com/autowarefoundation/autoware.universe/assets/25967964/de651924-3237-48ec-a1c3-92ae90620725


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
