### PR TITLE
fix(autoware_behavior_path_goal_planner_module): fix shadowVariable

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp
@@ -122,8 +122,8 @@ std::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
     partial_paths, pairs_terminal_velocity_and_accel, velocity_, 0);
 
   // Check if driving forward for each path, return empty if not
-  for (auto & path : partial_paths) {
-    if (!autoware::motion_utils::isDrivingForward(path.points)) {
+  for (auto & partial_path : partial_paths) {
+    if (!autoware::motion_utils::isDrivingForward(partial_path.points)) {
       return {};
     }
   }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp:125:15: style: Local variable 'path' shadows outer variable [shadowVariable]
  for (auto & path : partial_paths) {
              ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
