### PR TITLE
fix(autoware_behavior_path_planner_common): fix shadowVariable

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -1268,8 +1268,8 @@ lanelet::ConstLanelets getCurrentLanesFromPath(
   const auto & p = planner_data->parameters;
 
   std::set<lanelet::Id> lane_ids;
-  for (const auto & p : path.points) {
-    for (const auto & id : p.lane_ids) {
+  for (const auto & point : path.points) {
+    for (const auto & id : point.lane_ids) {
       lane_ids.insert(id);
     }
   }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:1271:21: style: Local variable 'p' shadows outer variable [shadowVariable]
  for (const auto & p : path.points) {
                    ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
