### PR TITLE
refactor(traffic_light_map_based_detector): fix namespace and directory structure

### DIFF
--- a/perception/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_map_based_detector/CMakeLists.txt
@@ -11,12 +11,12 @@ include_directories(
     ${EIGEN3_INCLUDE_DIR}
 )
 
-ament_auto_add_library(traffic_light_map_based_detector SHARED
-  src/node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light_map_based_detector_node.cpp
 )
 
-rclcpp_components_register_node(traffic_light_map_based_detector
-  PLUGIN "traffic_light::MapBasedDetector"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::traffic_light::MapBasedDetector"
   EXECUTABLE traffic_light_map_based_detector_node
 )
 

--- a/perception/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_map_based_detector/package.xml
@@ -15,7 +15,6 @@
 
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>image_geometry</depend>

--- a/perception/traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.cpp
+++ b/perception/traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.cpp
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "traffic_light_map_based_detector/node.hpp"
+#define EIGEN_MPL2_ONLY
 
+#include "traffic_light_map_based_detector_node.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <autoware/universe_utils/math/normalization.hpp>
 #include <autoware/universe_utils/math/unit_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
@@ -26,10 +30,6 @@
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Transform.h>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -118,7 +118,7 @@ tf2::Vector3 getTrafficLightCenter(const lanelet::ConstLineString3d & traffic_li
 
 }  // namespace
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 MapBasedDetector::MapBasedDetector(const rclcpp::NodeOptions & node_options)
 : Node("traffic_light_map_based_detector", node_options),
@@ -605,7 +605,7 @@ void MapBasedDetector::publishVisibleTrafficLights(
   }
   pub->publish(output_msg);
 }
-}  // namespace traffic_light
+}  // namespace autoware::traffic_light
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(traffic_light::MapBasedDetector)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MapBasedDetector)

--- a/perception/traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.hpp
+++ b/perception/traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TRAFFIC_LIGHT_MAP_BASED_DETECTOR__NODE_HPP_
-#define TRAFFIC_LIGHT_MAP_BASED_DETECTOR__NODE_HPP_
+#ifndef TRAFFIC_LIGHT_MAP_BASED_DETECTOR_NODE_HPP_
+#define TRAFFIC_LIGHT_MAP_BASED_DETECTOR_NODE_HPP_
 
 #include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -44,7 +44,7 @@
 #include <string>
 #include <vector>
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 class MapBasedDetector : public rclcpp::Node
 {
@@ -196,5 +196,5 @@ private:
     const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
     const rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub);
 };
-}  // namespace traffic_light
-#endif  // TRAFFIC_LIGHT_MAP_BASED_DETECTOR__NODE_HPP_
+}  // namespace autoware::traffic_light
+#endif  // TRAFFIC_LIGHT_MAP_BASED_DETECTOR_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)
2. [Clean unused dependencies](https://github.com/autowarefoundation/autoware/issues/3468)   [LIST](https://github.com/autowarefoundation/autoware.universe/pull/3606)


## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
