### PR TITLE
refactor(traffic_light_occlusion_predictor): fix namespace and directory structure

### DIFF
--- a/perception/traffic_light_occlusion_predictor/CMakeLists.txt
+++ b/perception/traffic_light_occlusion_predictor/CMakeLists.txt
@@ -13,18 +13,18 @@ include_directories(
     ${PCL_INCLUDE_DIRS}
 )
 
-ament_auto_add_library(traffic_light_occlusion_predictor SHARED
-  src/nodelet.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/node.cpp
   src/occlusion_predictor.cpp
 )
 
-rclcpp_components_register_node(traffic_light_occlusion_predictor
-  PLUGIN "traffic_light::TrafficLightOcclusionPredictorNodelet"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::traffic_light::TrafficLightOcclusionPredictorNode"
   EXECUTABLE traffic_light_occlusion_predictor_node
 )
 
 link_directories(${PCL_LIBRARY_DIRS})
-target_link_libraries(traffic_light_occlusion_predictor ${PCL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
 
 ament_auto_package(INSTALL_TO_SHARE
   config

--- a/perception/traffic_light_occlusion_predictor/src/node.hpp
+++ b/perception/traffic_light_occlusion_predictor/src/node.hpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__NODELET_HPP_
-#define TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__NODELET_HPP_
+#ifndef NODE_HPP_
+#define NODE_HPP_
+
+#include "occlusion_predictor.hpp"
 
 #include <perception_utils/prime_synchronizer.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <traffic_light_occlusion_predictor/occlusion_predictor.hpp>
 #include <traffic_light_utils/traffic_light_utils.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -44,12 +45,12 @@
 #include <mutex>
 #include <vector>
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
-class TrafficLightOcclusionPredictorNodelet : public rclcpp::Node
+class TrafficLightOcclusionPredictorNode : public rclcpp::Node
 {
 public:
-  explicit TrafficLightOcclusionPredictorNodelet(const rclcpp::NodeOptions & node_options);
+  explicit TrafficLightOcclusionPredictorNode(const rclcpp::NodeOptions & node_options);
 
 private:
   struct Config
@@ -108,5 +109,5 @@ private:
   std::vector<int> occlusion_ratios_;
   tier4_perception_msgs::msg::TrafficLightArray out_msg_;
 };
-}  // namespace traffic_light
-#endif  // TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__NODELET_HPP_
+}  // namespace autoware::traffic_light
+#endif  // NODE_HPP_

--- a/perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp
+++ b/perception/traffic_light_occlusion_predictor/src/occlusion_predictor.cpp
@@ -13,14 +13,15 @@
 // limitations under the License.
 //
 
-#include "traffic_light_occlusion_predictor/occlusion_predictor.hpp"
+#include "occlusion_predictor.hpp"
 
+#include <algorithm>
 namespace
 {
 
-traffic_light::Ray point2ray(const pcl::PointXYZ & pt)
+autoware::traffic_light::Ray point2ray(const pcl::PointXYZ & pt)
 {
-  traffic_light::Ray ray;
+  autoware::traffic_light::Ray ray;
   ray.dist = std::sqrt(pt.x * pt.x + pt.y * pt.y + pt.z * pt.z);
   ray.elevation = RAD2DEG(std::atan2(pt.y, std::hypot(pt.x, pt.z)));
   ray.azimuth = RAD2DEG(std::atan2(pt.x, pt.z));
@@ -29,7 +30,7 @@ traffic_light::Ray point2ray(const pcl::PointXYZ & pt)
 
 }  // namespace
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 
 CloudOcclusionPredictor::CloudOcclusionPredictor(
@@ -253,4 +254,4 @@ uint32_t CloudOcclusionPredictor::predict(
   return 100 * occluded_num / tl_sample_cloud.size();
 }
 
-}  // namespace traffic_light
+}  // namespace autoware::traffic_light

--- a/perception/traffic_light_occlusion_predictor/src/occlusion_predictor.hpp
+++ b/perception/traffic_light_occlusion_predictor/src/occlusion_predictor.hpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 
-#ifndef TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__OCCLUSION_PREDICTOR_HPP_
-#define TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__OCCLUSION_PREDICTOR_HPP_
+#ifndef OCCLUSION_PREDICTOR_HPP_
+#define OCCLUSION_PREDICTOR_HPP_
 
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/pcl_conversion.hpp>
@@ -43,7 +43,7 @@
 #include <string>
 #include <vector>
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 
 struct Ray
@@ -93,6 +93,6 @@ private:
   float elevation_occlusion_resolution_deg_;
 };
 
-}  // namespace traffic_light
+}  // namespace autoware::traffic_light
 
-#endif  // TRAFFIC_LIGHT_OCCLUSION_PREDICTOR__OCCLUSION_PREDICTOR_HPP_
+#endif  // OCCLUSION_PREDICTOR_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
