### PR TITLE
refactor(traffic_light_multi_camera_fusion): fix namespace and directory structure

### DIFF
--- a/perception/traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -8,12 +8,12 @@ include_directories(
   SYSTEM
 )
 
-ament_auto_add_library(traffic_light_multi_camera_fusion SHARED
-  src/node.cpp
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light_multi_camera_fusion_node.cpp
 )
 
-rclcpp_components_register_node(traffic_light_multi_camera_fusion
-  PLUGIN "traffic_light::MultiCameraFusion"
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::traffic_light::MultiCameraFusion"
   EXECUTABLE traffic_light_multi_camera_fusion_node
 )
 

--- a/perception/traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "traffic_light_multi_camera_fusion/node.hpp"
+#include "traffic_light_multi_camera_fusion_node.hpp"
 
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace
@@ -39,7 +40,7 @@ bool isUnknown(const tier4_perception_msgs::msg::TrafficLight & signal)
  * @param record    fusion record
  * @return 0 if traffic light is truncated, otherwise 1
  */
-int calVisibleScore(const traffic_light::FusionRecord & record)
+int calVisibleScore(const autoware::traffic_light::FusionRecord & record)
 {
   const uint32_t boundary = 5;
   uint32_t x1 = record.roi.roi.x_offset;
@@ -55,7 +56,9 @@ int calVisibleScore(const traffic_light::FusionRecord & record)
   }
 }
 
-int compareRecord(const traffic_light::FusionRecord & r1, const traffic_light::FusionRecord & r2)
+int compareRecord(
+  const autoware::traffic_light::FusionRecord & r1,
+  const autoware::traffic_light::FusionRecord & r2)
 {
   /*
   if both records are from the same sensor but different stamp, trust the latest one
@@ -133,7 +136,7 @@ autoware_perception_msgs::msg::TrafficLightElement convert(
 
 }  // namespace
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 
 MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
@@ -319,7 +322,7 @@ void MultiCameraFusion::groupFusion(
   }
 }
 
-}  // namespace traffic_light
+}  // namespace autoware::traffic_light
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(traffic_light::MultiCameraFusion)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MultiCameraFusion)

--- a/perception/traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TRAFFIC_LIGHT_MULTI_CAMERA_FUSION__NODE_HPP_
-#define TRAFFIC_LIGHT_MULTI_CAMERA_FUSION__NODE_HPP_
+#ifndef TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
+#define TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 
 namespace mf = message_filters;
@@ -125,5 +125,5 @@ private:
   */
   double message_lifespan_;
 };
-}  // namespace traffic_light
-#endif  // TRAFFIC_LIGHT_MULTI_CAMERA_FUSION__NODE_HPP_
+}  // namespace autoware::traffic_light
+#endif  // TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)


## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
