### PR TITLE
refactor(traffic_light_fine_detector): fix namespace and directory structure

### DIFF
--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
@@ -137,7 +137,7 @@ def launch_setup(context, *args, **kwargs):
         composable_node_descriptions=[
             ComposableNode(
                 package="traffic_light_fine_detector",
-                plugin="autoware::traffic_light::TrafficLightFineDetectorNodelet",
+                plugin="autoware::traffic_light::TrafficLightFineDetectorNode",
                 name="traffic_light_fine_detector",
                 namespace="detection",
                 parameters=[fine_detector_model_param],

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
@@ -137,7 +137,7 @@ def launch_setup(context, *args, **kwargs):
         composable_node_descriptions=[
             ComposableNode(
                 package="traffic_light_fine_detector",
-                plugin="traffic_light::TrafficLightFineDetectorNodelet",
+                plugin="autoware::traffic_light::TrafficLightFineDetectorNodelet",
                 name="traffic_light_fine_detector",
                 namespace="detection",
                 parameters=[fine_detector_model_param],

--- a/perception/traffic_light_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_fine_detector/CMakeLists.txt
@@ -75,15 +75,15 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${CUDA_INCLUDE_DIRS}
   )
 
-  ament_auto_add_library(traffic_light_fine_detector_nodelet SHARED
-    src/nodelet.cpp
+  ament_auto_add_library(${PROJECT_NAME} SHARED
+    src/traffic_light_fine_detector_node.cpp
   )
 
-  target_include_directories(traffic_light_fine_detector_nodelet PUBLIC
+  target_include_directories(${PROJECT_NAME} PUBLIC
     lib/include
   )
 
-  target_link_libraries(traffic_light_fine_detector_nodelet
+  target_link_libraries(${PROJECT_NAME}
     ${NVINFER}
     ${NVONNXPARSER}
     ${NVINFER_PLUGIN}
@@ -94,8 +94,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     stdc++fs
   )
 
-  rclcpp_components_register_node(traffic_light_fine_detector_nodelet
-    PLUGIN "traffic_light::TrafficLightFineDetectorNodelet"
+  rclcpp_components_register_node(${PROJECT_NAME}
+    PLUGIN "autoware::traffic_light::TrafficLightFineDetectorNodelet"
     EXECUTABLE traffic_light_fine_detector_node
   )
 

--- a/perception/traffic_light_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_fine_detector/CMakeLists.txt
@@ -95,7 +95,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   )
 
   rclcpp_components_register_node(${PROJECT_NAME}
-    PLUGIN "autoware::traffic_light::TrafficLightFineDetectorNodelet"
+    PLUGIN "autoware::traffic_light::TrafficLightFineDetectorNode"
     EXECUTABLE traffic_light_fine_detector_node
   )
 

--- a/perception/traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
+++ b/perception/traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "traffic_light_fine_detector/nodelet.hpp"
+#include "traffic_light_fine_detector_node.hpp"
 
 #if (defined(_MSC_VER) or (defined(__GNUC__) and (7 <= __GNUC_MAJOR__)))
 #include <filesystem>
@@ -22,6 +22,7 @@ namespace fs = ::std::filesystem;
 namespace fs = ::std::experimental::filesystem;
 #endif
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -46,7 +47,7 @@ float calWeightedIou(
 
 }  // namespace
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 inline std::vector<float> toFloatVector(const std::vector<double> double_vector)
 {
@@ -354,7 +355,7 @@ bool TrafficLightFineDetectorNodelet::readLabelFile(
   return tlr_label_id_.size() != 0;
 }
 
-}  // namespace traffic_light
+}  // namespace autoware::traffic_light
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(traffic_light::TrafficLightFineDetectorNodelet)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::TrafficLightFineDetectorNodelet)

--- a/perception/traffic_light_fine_detector/src/traffic_light_fine_detector_node.hpp
+++ b/perception/traffic_light_fine_detector/src/traffic_light_fine_detector_node.hpp
@@ -52,13 +52,13 @@ typedef struct Detection
 
 namespace autoware::traffic_light
 {
-class TrafficLightFineDetectorNodelet : public rclcpp::Node
+class TrafficLightFineDetectorNode : public rclcpp::Node
 {
   using TrafficLightRoi = tier4_perception_msgs::msg::TrafficLightRoi;
   using TrafficLightRoiArray = tier4_perception_msgs::msg::TrafficLightRoiArray;
 
 public:
-  explicit TrafficLightFineDetectorNodelet(const rclcpp::NodeOptions & options);
+  explicit TrafficLightFineDetectorNode(const rclcpp::NodeOptions & options);
   void connectCb();
   /**
    * @brief main process function.
@@ -168,7 +168,7 @@ private:
 
   int batch_size_;
   std::unique_ptr<tensorrt_yolox::TrtYoloX> trt_yolox_;
-};  // TrafficLightFineDetectorNodelet
+};  // TrafficLightFineDetectorNode
 
 }  // namespace autoware::traffic_light
 

--- a/perception/traffic_light_fine_detector/src/traffic_light_fine_detector_node.hpp
+++ b/perception/traffic_light_fine_detector/src/traffic_light_fine_detector_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TRAFFIC_LIGHT_FINE_DETECTOR__NODELET_HPP_
-#define TRAFFIC_LIGHT_FINE_DETECTOR__NODELET_HPP_
+#ifndef TRAFFIC_LIGHT_FINE_DETECTOR_NODE_HPP_
+#define TRAFFIC_LIGHT_FINE_DETECTOR_NODE_HPP_
 
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
@@ -50,7 +50,7 @@ typedef struct Detection
   float x, y, w, h, prob;
 } Detection;
 
-namespace traffic_light
+namespace autoware::traffic_light
 {
 class TrafficLightFineDetectorNodelet : public rclcpp::Node
 {
@@ -170,6 +170,6 @@ private:
   std::unique_ptr<tensorrt_yolox::TrtYoloX> trt_yolox_;
 };  // TrafficLightFineDetectorNodelet
 
-}  // namespace traffic_light
+}  // namespace autoware::traffic_light
 
-#endif  // TRAFFIC_LIGHT_FINE_DETECTOR__NODELET_HPP_
+#endif  // TRAFFIC_LIGHT_FINE_DETECTOR_NODE_HPP_


### PR DESCRIPTION
## Description
This PR puts headers in the `autoware` namespace.

Additional works
1. Align directory structure to follow [the coding guidelines.](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#exporting-a-composable-node-component-executables)


## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
