### PR TITLE
fix(autoware_behavior_velocity_crosswalk_module): fix shadowVariable

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -382,7 +382,7 @@ std::optional<StopFactor> CrosswalkModule::checkStopForCrosswalkUsers(
   // Check if ego moves forward enough to ignore yield.
   const auto & p = planner_param_;
   if (!path_intersects.empty()) {
-    const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
+    const double inner_base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
     const double dist_ego2crosswalk =
       calcSignedArcLength(ego_path.points, ego_pos, path_intersects.front());
     const auto braking_distance_opt =
@@ -391,7 +391,7 @@ std::optional<StopFactor> CrosswalkModule::checkStopForCrosswalkUsers(
         p.min_jerk_for_no_stop_decision);
     const double braking_distance = braking_distance_opt ? *braking_distance_opt : 0.0;
     if (
-      dist_ego2crosswalk - base_link2front - braking_distance <
+      dist_ego2crosswalk - inner_base_link2front - braking_distance <
       p.max_offset_to_crosswalk_for_yield) {
       return {};
     }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp:385:18: style: Local variable 'base_link2front' shadows outer variable [shadowVariable]
    const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
                 ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
