### PR TITLE
refactor(vehicle_velocity_converter): apply static analysis

### DIFF
--- a/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp
+++ b/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp
@@ -29,10 +29,9 @@ class VehicleVelocityConverter : public rclcpp::Node
 {
 public:
   explicit VehicleVelocityConverter(const rclcpp::NodeOptions & options);
-  ~VehicleVelocityConverter() = default;
 
 private:
-  void callbackVelocityReport(const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr msg);
+  void callback_velocity_report(const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr msg);
 
   rclcpp::Subscription<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_report_sub_;
 
@@ -43,7 +42,6 @@ private:
   double stddev_vx_;
   double stddev_wz_;
   double speed_scale_factor_;
-  std::array<double, 36> twist_covariance_;
 };
 
 #endif  // VEHICLE_VELOCITY_CONVERTER__VEHICLE_VELOCITY_CONVERTER_HPP_

--- a/sensing/vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
+++ b/sensing/vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
@@ -25,13 +25,13 @@ VehicleVelocityConverter::VehicleVelocityConverter(const rclcpp::NodeOptions & o
 
   vehicle_report_sub_ = create_subscription<autoware_vehicle_msgs::msg::VelocityReport>(
     "velocity_status", rclcpp::QoS{100},
-    std::bind(&VehicleVelocityConverter::callbackVelocityReport, this, std::placeholders::_1));
+    std::bind(&VehicleVelocityConverter::callback_velocity_report, this, std::placeholders::_1));
 
   twist_with_covariance_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
     "twist_with_covariance", rclcpp::QoS{10});
 }
 
-void VehicleVelocityConverter::callbackVelocityReport(
+void VehicleVelocityConverter::callback_velocity_report(
   const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr msg)
 {
   if (msg->header.frame_id != frame_id_) {


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to `sensing/vehicle_velocity_converter`.
Checked with clang-tidy and cppcheck.

Fixed:
- change function/method
  - camelCase to snake_case
- removed
  - unused var
  - explicit default destructor

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1).

Use `.cppcheck_suppressions` for suppressing some notation from cppcheck.

<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh vehicle_velocity_converter
...
13350 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp:28:7: warning: class 'VehicleVelocityConverter' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [cppcoreguidelines-special-member-functions]
class VehicleVelocityConverter : public rclcpp::Node
      ^
/home/masakibaba/autoware/src/universe/autoware.universe/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp:32:3: error: annotate this function with 'override' or (rarely) 'final' [modernize-use-override,-warnings-as-errors]
  ~VehicleVelocityConverter() = default;
  ^
                              override 
/home/masakibaba/autoware/src/universe/autoware.universe/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp:35:8: warning: invalid case style for function 'callbackVelocityReport' [readability-identifier-naming]
  void callbackVelocityReport(const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr msg);
       ^~~~~~~~~~~~~~~~~~~~~~
       callback_velocity_report
Suppressed 13358 warnings (13347 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
16317 warnings and 1 error generated.
Error while processing /home/masakibaba/autoware/src/universe/autoware.universe/sensing/vehicle_velocity_converter/src/vehicle_velocity_converter.cpp.
/home/masakibaba/autoware/src/universe/autoware.universe/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp:46:26: error: private field 'twist_covariance_' is not used [clang-diagnostic-unused-private-field]
  std::array<double, 36> twist_covariance_;
                         ^
/home/masakibaba/autoware/src/universe/autoware.universe/sensing/vehicle_velocity_converter/src/vehicle_velocity_converter.cpp:17:1: warning: constructor does not initialize these fields: twist_covariance_ [cppcoreguidelines-pro-type-member-init]
VehicleVelocityConverter::VehicleVelocityConverter(const rclcpp::NodeOptions & options)
^
Suppressed 16327 warnings (16316 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).

```
</details>

Check with cppcheck: (nothing to change)

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh vehicle_velocity_converter
...
13347 warnings generated.
Suppressed 13358 warnings (13347 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
16313 warnings generated.
Suppressed 16324 warnings (16313 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
