### PR TITLE
fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix shadowVariable

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
@@ -71,10 +71,10 @@ void calculateSteeringAngles(TrajectoryPoints & trajectory, const double wheel_b
   auto prev_point = trajectory.front();
   auto prev_heading = tf2::getYaw(prev_point.pose.orientation);
   for (auto i = 1ul; i < trajectory.size(); ++i) {
-    const auto & current_prev_point = trajectory[i - 1];
+    prev_point = trajectory[i - 1];
     auto & point = trajectory[i];
-    const auto dt = autoware::universe_utils::calcDistance2d(current_prev_point, point) /
-                    current_prev_point.longitudinal_velocity_mps;
+    const auto dt = autoware::universe_utils::calcDistance2d(prev_point, point) /
+                    prev_point.longitudinal_velocity_mps;
     const auto heading = tf2::getYaw(point.pose.orientation);
     const auto d_heading = heading - prev_heading;
     prev_heading = heading;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
@@ -71,10 +71,10 @@ void calculateSteeringAngles(TrajectoryPoints & trajectory, const double wheel_b
   auto prev_point = trajectory.front();
   auto prev_heading = tf2::getYaw(prev_point.pose.orientation);
   for (auto i = 1ul; i < trajectory.size(); ++i) {
-    const auto & prev_point = trajectory[i - 1];
+    const auto & current_prev_point = trajectory[i - 1];
     auto & point = trajectory[i];
-    const auto dt = autoware::universe_utils::calcDistance2d(prev_point, point) /
-                    prev_point.longitudinal_velocity_mps;
+    const auto dt = autoware::universe_utils::calcDistance2d(current_prev_point, point) /
+                    current_prev_point.longitudinal_velocity_mps;
     const auto heading = tf2::getYaw(point.pose.orientation);
     const auto d_heading = heading - prev_heading;
     prev_heading = heading;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp:74:18: style: Local variable 'prev_point' shadows outer variable [shadowVariable]
    const auto & prev_point = trajectory[i - 1];
                 ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
