### PR TITLE
chore(cppcheck): delete cstyleCast from .cppcheck_suppressions

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -4,7 +4,6 @@ checkersReport
 constParameterReference
 constVariableReference
 // cspell: ignore cstyle
-cstyleCast
 funcArgNamesDifferent
 functionConst
 functionStatic

--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -3,7 +3,6 @@
 checkersReport
 constParameterReference
 constVariableReference
-// cspell: ignore cstyle
 funcArgNamesDifferent
 functionConst
 functionStatic


### PR DESCRIPTION
## Description
Remove cstyleCast
## Related links

**Parent Issue:**
See cppcheck-daily
- https://github.com/autowarefoundation/autoware.universe/actions/runs/9802237058

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
