### PR TITLE
fix(system_error_monitor): fix shadowVariable

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -288,10 +288,10 @@ void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
     //                     or required_modules.key.module.parameter
     const auto split_names = split(param_name, '.');
     const auto & param_required_modules = split_names.at(0);
-    const auto & param_key = split_names.at(1);
+    const auto & split_param_key = split_names.at(1);
     const auto & param_module = split_names.at(2);
     const auto module_name_with_prefix =
-      fmt::format("{0}.{1}.{2}", param_required_modules, param_key, param_module);
+      fmt::format("{0}.{1}.{2}", param_required_modules, split_param_key, param_module);
 
     // Skip duplicate parameter
     if (module_names.count(module_name_with_prefix) != 0) {

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -271,7 +271,8 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
 void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
 {
   const uint64_t depth = 3;
-  const auto param_names = this->list_parameters({std::string("required_modules.") + key}, depth).names;
+  const auto param_names =
+    this->list_parameters({std::string("required_modules.") + key}, depth).names;
 
   if (param_names.empty()) {
     throw std::runtime_error(fmt::format("no parameter found: required_modules.{}", key));

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -270,13 +270,11 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
 
 void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
 {
-  const auto param_key = std::string("required_modules.") + key;
-
   const uint64_t depth = 3;
-  const auto param_names = this->list_parameters({param_key}, depth).names;
+  const auto param_names = this->list_parameters({std::string(required_modules.) + "key"}, depth).names;
 
   if (param_names.empty()) {
-    throw std::runtime_error(fmt::format("no parameter found: {}", param_key));
+    throw std::runtime_error(fmt::format("no parameter found: required_modules.{}", key));
   }
 
   // Load module names from parameter key
@@ -288,10 +286,10 @@ void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
     //                     or required_modules.key.module.parameter
     const auto split_names = split(param_name, '.');
     const auto & param_required_modules = split_names.at(0);
-    const auto & split_param_key = split_names.at(1);
+    const auto & param_key = split_names.at(1);
     const auto & param_module = split_names.at(2);
     const auto module_name_with_prefix =
-      fmt::format("{0}.{1}.{2}", param_required_modules, split_param_key, param_module);
+      fmt::format("{0}.{1}.{2}", param_required_modules, param_key, param_module);
 
     // Skip duplicate parameter
     if (module_names.count(module_name_with_prefix) != 0) {

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -271,7 +271,7 @@ AutowareErrorMonitor::AutowareErrorMonitor(const rclcpp::NodeOptions & options)
 void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
 {
   const uint64_t depth = 3;
-  const auto param_names = this->list_parameters({std::string(required_modules.) + "key"}, depth).names;
+  const auto param_names = this->list_parameters({std::string("required_modules.") + key}, depth).names;
 
   if (param_names.empty()) {
     throw std::runtime_error(fmt::format("no parameter found: required_modules.{}", key));


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings
```
system/system_error_monitor/src/system_error_monitor_core.cpp:291:18: style: Local variable 'param_key' shadows outer variable [shadowVariable]
    const auto & param_key = split_names.at(1);
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
