### PR TITLE
fix(system_monitor): fix shadowVariable

### DIFF
--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -684,8 +684,8 @@ void HddMonitor::updateHddInfoList()
   // Restore HDD information list
   try {
     std::istringstream iss(buf);
-    boost::archive::text_iarchive oa(iss);
-    oa >> hdd_info_list_;
+    boost::archive::text_iarchive ia(iss);
+    ia >> hdd_info_list_;
   } catch (const std::exception & e) {
     connect_diag_.summary(DiagStatus::ERROR, "recv error");
     connect_diag_.add("recv", e.what());


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
system/system_monitor/src/hdd_monitor/hdd_monitor.cpp:687:35: style: Local variable 'oa' shadows outer variable [shadowVariable]
    boost::archive::text_iarchive oa(iss);
                                  ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
