### PR TITLE
fix(autoware_operation_mode_transition_manager): fix funcArgNamesDifferent

### DIFF
--- a/control/autoware_operation_mode_transition_manager/src/node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.hpp
@@ -59,7 +59,7 @@ private:
   void onTimer();
   void publishData();
   void changeControlMode(ControlModeCommandType mode);
-  void changeOperationMode(std::optional<OperationMode> mode);
+  void changeOperationMode(std::optional<OperationMode> request_mode);
   void cancelTransition();
   void processTransition();
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
control/autoware_operation_mode_transition_manager/src/node.cpp:116:87: style: inconclusive: Function 'changeOperationMode' argument 1 names different: declaration 'mode' definition 'request_mode'. [funcArgNamesDifferent]
void OperationModeTransitionManager::changeOperationMode(std::optional<OperationMode> request_mode)
                                                                                      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
