### PR TITLE
fix(autoware_stop_filter): fix funcArgNamesDifferent

### DIFF
--- a/localization/autoware_stop_filter/src/stop_filter.hpp
+++ b/localization/autoware_stop_filter/src/stop_filter.hpp
@@ -39,7 +39,7 @@ namespace autoware::stop_filter
 class StopFilter : public rclcpp::Node
 {
 public:
-  explicit StopFilter(const rclcpp::NodeOptions & options);
+  explicit StopFilter(const rclcpp::NodeOptions & node_options);
 
 private:
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;  //!< @brief odom publisher


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
localization/autoware_stop_filter/src/stop_filter.cpp:29:52: style: inconclusive: Function 'StopFilter' argument 1 names different: declaration 'options' definition 'node_options'. [funcArgNamesDifferent]
StopFilter::StopFilter(const rclcpp::NodeOptions & node_options)
                                                   ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
