### PR TITLE
fix(autoware_object_velocity_splitter): fix funcArgNamesDifferent

### DIFF
--- a/perception/autoware_object_velocity_splitter/src/object_velocity_splitter_node.cpp
+++ b/perception/autoware_object_velocity_splitter/src/object_velocity_splitter_node.cpp
@@ -65,14 +65,14 @@ ObjectVelocitySplitterNode::ObjectVelocitySplitterNode(const rclcpp::NodeOptions
   pub_low_speed_objects_ = create_publisher<DetectedObjects>("~/output/low_speed_objects", 1);
 }
 
-void ObjectVelocitySplitterNode::onObjects(const DetectedObjects::ConstSharedPtr objects_data_)
+void ObjectVelocitySplitterNode::onObjects(const DetectedObjects::ConstSharedPtr msg)
 {
   DetectedObjects high_speed_objects;
   DetectedObjects low_speed_objects;
-  high_speed_objects.header = objects_data_->header;
-  low_speed_objects.header = objects_data_->header;
+  high_speed_objects.header = msg->header;
+  low_speed_objects.header = msg->header;
 
-  for (const auto & object : objects_data_->objects) {
+  for (const auto & object : msg->objects) {
     if (
       std::abs(autoware::universe_utils::calcNorm(
         object.kinematics.twist_with_covariance.twist.linear)) < node_param_.velocity_threshold) {

--- a/perception/autoware_object_velocity_splitter/src/object_velocity_splitter_node.hpp
+++ b/perception/autoware_object_velocity_splitter/src/object_velocity_splitter_node.hpp
@@ -44,10 +44,7 @@ private:
   rclcpp::Subscription<DetectedObjects>::SharedPtr sub_objects_{};
 
   // Callback
-  void onObjects(const DetectedObjects::ConstSharedPtr objects_data_);
-
-  // Data Buffer
-  DetectedObjects::ConstSharedPtr objects_data_{};
+  void onObjects(const DetectedObjects::ConstSharedPtr msg);
 
   // Publisher
   rclcpp::Publisher<DetectedObjects>::SharedPtr pub_high_speed_objects_{};

--- a/perception/autoware_object_velocity_splitter/src/object_velocity_splitter_node.hpp
+++ b/perception/autoware_object_velocity_splitter/src/object_velocity_splitter_node.hpp
@@ -44,7 +44,7 @@ private:
   rclcpp::Subscription<DetectedObjects>::SharedPtr sub_objects_{};
 
   // Callback
-  void onObjects(const DetectedObjects::ConstSharedPtr msg);
+  void onObjects(const DetectedObjects::ConstSharedPtr objects_data_);
 
   // Data Buffer
   DetectedObjects::ConstSharedPtr objects_data_{};


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
perception/object_velocity_splitter/src/object_velocity_splitter_node.cpp:68:82: style: inconclusive: Function 'onObjects' argument 1 names different: declaration 'msg' definition 'objects_data_'. [funcArgNamesDifferent]
void ObjectVelocitySplitterNode::onObjects(const DetectedObjects::ConstSharedPtr objects_data_)
                                                                                 ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
