### PR TITLE
fix(autoware_radar_object_clustering): fix funcArgNamesDifferent

### DIFF
--- a/perception/autoware_radar_object_clustering/src/radar_object_clustering_node.cpp
+++ b/perception/autoware_radar_object_clustering/src/radar_object_clustering_node.cpp
@@ -91,11 +91,11 @@ RadarObjectClusteringNode::RadarObjectClusteringNode(const rclcpp::NodeOptions &
   pub_objects_ = create_publisher<DetectedObjects>("~/output/objects", 1);
 }
 
-void RadarObjectClusteringNode::onObjects(const DetectedObjects::ConstSharedPtr objects_data_)
+void RadarObjectClusteringNode::onObjects(const DetectedObjects::ConstSharedPtr msg)
 {
   DetectedObjects output_objects;
-  output_objects.header = objects_data_->header;
-  std::vector<DetectedObject> objects = objects_data_->objects;
+  output_objects.header = msg->header;
+  std::vector<DetectedObject> objects = msg->objects;
 
   std::vector<bool> used_flags(objects.size(), false);
 

--- a/perception/autoware_radar_object_clustering/src/radar_object_clustering_node.hpp
+++ b/perception/autoware_radar_object_clustering/src/radar_object_clustering_node.hpp
@@ -52,10 +52,7 @@ private:
   rclcpp::Subscription<DetectedObjects>::SharedPtr sub_objects_{};
 
   // Callback
-  void onObjects(const DetectedObjects::ConstSharedPtr objects_data_);
-
-  // Data Buffer
-  DetectedObjects::ConstSharedPtr objects_data_{};
+  void onObjects(const DetectedObjects::ConstSharedPtr msg);
 
   // Publisher
   rclcpp::Publisher<DetectedObjects>::SharedPtr pub_objects_{};

--- a/perception/autoware_radar_object_clustering/src/radar_object_clustering_node.hpp
+++ b/perception/autoware_radar_object_clustering/src/radar_object_clustering_node.hpp
@@ -52,7 +52,7 @@ private:
   rclcpp::Subscription<DetectedObjects>::SharedPtr sub_objects_{};
 
   // Callback
-  void onObjects(const DetectedObjects::ConstSharedPtr msg);
+  void onObjects(const DetectedObjects::ConstSharedPtr objects_data_);
 
   // Data Buffer
   DetectedObjects::ConstSharedPtr objects_data_{};


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
perception/radar_object_clustering/src/radar_object_clustering_node.cpp:94:81: style: inconclusive: Function 'onObjects' argument 1 names different: declaration 'msg' definition 'objects_data_'. [funcArgNamesDifferent]
void RadarObjectClusteringNode::onObjects(const DetectedObjects::ConstSharedPtr objects_data_)
                                                                                ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
