### PR TITLE
fix(autoware_mission_planner): fix funcArgNamesDifferent

### DIFF
--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -52,7 +52,7 @@ public:
   void clearRoute() override;
   MarkerArray visualize(const LaneletRoute & route) const override;
   MarkerArray visualize_debug_footprint(
-    autoware::universe_utils::LinearRing2d goal_footprint_) const;
+    autoware::universe_utils::LinearRing2d goal_footprint) const;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
 private:


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:219:42: style: inconclusive: Function 'visualize_debug_footprint' argument 1 names different: declaration 'goal_footprint_' definition 'goal_footprint'. [funcArgNamesDifferent]
  autoware::universe_utils::LinearRing2d goal_footprint) const
                                         ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
