### PR TITLE
fix(autoware_obstacle_stop_planner): fix funcArgNamesDifferent

### DIFF
--- a/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
@@ -53,7 +53,7 @@ public:
     const TrajectoryPoints & trajectory, const int nearest_collision_point_idx,
     const geometry_msgs::msg::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
     const rclcpp::Time nearest_collision_point_time,
-    const nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr, bool * need_to_stop,
+    const nav_msgs::msg::Odometry::ConstSharedPtr current_odometry_ptr, bool * need_to_stop,
     TrajectoryPoints * output_trajectory, const std_msgs::msg::Header trajectory_header,
     const PredictedObject & target_object);
 

--- a/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
@@ -46,7 +46,7 @@ public:
     const geometry_msgs::msg::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
     const rclcpp::Time nearest_collision_point_time,
     const autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr object_ptr,
-    const nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr, bool * need_to_stop,
+    const nav_msgs::msg::Odometry::ConstSharedPtr current_odometry_ptr, bool * need_to_stop,
     TrajectoryPoints * output_trajectory, const std_msgs::msg::Header trajectory_header);
 
   void insertAdaptiveCruiseVelocity(


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp:203:49: style: inconclusive: Function 'insertAdaptiveCruiseVelocity' argument 7 names different: declaration 'current_velocity_ptr' definition 'current_odometry_ptr'. [funcArgNamesDifferent]
  const nav_msgs::msg::Odometry::ConstSharedPtr current_odometry_ptr, bool * need_to_stop,
                                                ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
