### PR TITLE
fix(autoware_static_centerline_generator): fix funcArgNamesDifferent

### DIFF
--- a/planning/autoware_static_centerline_generator/src/utils.hpp
+++ b/planning/autoware_static_centerline_generator/src/utils.hpp
@@ -39,8 +39,8 @@ geometry_msgs::msg::Pose get_center_pose(
 
 PathWithLaneId get_path_with_lane_id(
   const RouteHandler & route_handler, const lanelet::ConstLanelets lanelets,
-  const geometry_msgs::msg::Pose & start_pose, const double nearest_ego_dist_threshold,
-  const double nearest_ego_yaw_threshold);
+  const geometry_msgs::msg::Pose & start_pose, const double ego_nearest_dist_threshold,
+  const double ego_nearest_yaw_threshold);
 
 void update_centerline(
   lanelet::LaneletMapPtr lanelet_map_ptr, const lanelet::ConstLanelets & lanelets,


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings
```
planning/autoware_static_centerline_generator/src/utils.cpp:106:61: style: inconclusive: Function 'get_path_with_lane_id' argument 4 names different: declaration 'nearest_ego_dist_threshold' definition 'ego_nearest_dist_threshold'. [funcArgNamesDifferent]
  const geometry_msgs::msg::Pose & start_pose, const double ego_nearest_dist_threshold,
                                                            ^

planning/autoware_static_centerline_generator/src/utils.cpp:107:16: style: inconclusive: Function 'get_path_with_lane_id' argument 5 names different: declaration 'nearest_ego_yaw_threshold' definition 'ego_nearest_yaw_threshold'. [funcArgNamesDifferent]
  const double ego_nearest_yaw_threshold)
               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
