### PR TITLE
fix(autoware_surround_obstacle_checker): fix funcArgNamesDifferent

### DIFF
--- a/planning/autoware_surround_obstacle_checker/src/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.hpp
@@ -103,7 +103,7 @@ private:
     const std::string & source, const std::string & target, const rclcpp::Time & stamp,
     double duration_sec) const;
 
-  bool isStopRequired(const bool is_obstacle_found, const bool is_stopped);
+  bool isStopRequired(const bool is_obstacle_found, const bool is_vehicle_stopped);
 
   // ros
   mutable tf2_ros::Buffer tf_buffer_{get_clock()};


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings
```
planning/autoware_surround_obstacle_checker/src/node.cpp:517:44: style: inconclusive: Function 'isStopRequired' argument 2 names different: declaration 'is_stopped' definition 'is_vehicle_stopped'. [funcArgNamesDifferent]
  const bool is_obstacle_found, const bool is_vehicle_stopped)
                                           ^

```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
