### PR TITLE
fix(autoware_behavior_velocity_intersection_module): fix funcArgNamesDifferent

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
@@ -127,8 +127,8 @@ public:
    */
   void initialize(
     const autoware_perception_msgs::msg::PredictedObject & object,
-    std::optional<lanelet::ConstLanelet> attention_lanelet_opt_,
-    std::optional<lanelet::ConstLineString3d> stopline_opt_);
+    std::optional<lanelet::ConstLanelet> attention_lanelet_opt,
+    std::optional<lanelet::ConstLineString3d> stopline_opt);
 
   /**
    * @brief update unsafe_knowledge
@@ -195,13 +195,13 @@ private:
   autoware_perception_msgs::msg::PredictedObject predicted_object_;
 
   //! null if the object in intersection_area but not in attention_area
-  std::optional<lanelet::ConstLanelet> attention_lanelet_opt{std::nullopt};
+  std::optional<lanelet::ConstLanelet> attention_lanelet_opt_{std::nullopt};
 
   //! null if the object in intersection_area but not in attention_area
-  std::optional<lanelet::ConstLineString3d> stopline_opt{std::nullopt};
+  std::optional<lanelet::ConstLineString3d> stopline_opt_{std::nullopt};
 
   //! null if the object in intersection_area but not in attention_area
-  std::optional<double> dist_to_stopline_opt{std::nullopt};
+  std::optional<double> dist_to_stopline_opt_{std::nullopt};
 
   //! store the information if judged as UNSAFE
   std::optional<CollisionInterval> unsafe_interval_{std::nullopt};

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
@@ -126,16 +126,16 @@ public:
    * @brief update predicted_object_, attention_lanelet, stopline, dist_to_stopline
    */
   void initialize(
-    const autoware_perception_msgs::msg::PredictedObject & predicted_object,
-    std::optional<lanelet::ConstLanelet> attention_lanelet_opt,
-    std::optional<lanelet::ConstLineString3d> stopline_opt);
+    const autoware_perception_msgs::msg::PredictedObject & object,
+    std::optional<lanelet::ConstLanelet> attention_lanelet_opt_,
+    std::optional<lanelet::ConstLineString3d> stopline_opt_);
 
   /**
    * @brief update unsafe_knowledge
    */
   void update_safety(
-    const std::optional<CollisionInterval> & unsafe_interval_opt,
-    const std::optional<CollisionInterval> & safe_interval_opt,
+    const std::optional<CollisionInterval> & unsafe_interval,
+    const std::optional<CollisionInterval> & safe_interval,
     const bool safe_under_traffic_control);
 
   /**
@@ -230,11 +230,11 @@ class ObjectInfoManager
 public:
   std::shared_ptr<ObjectInfo> registerObject(
     const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-    const bool belong_intersection_area, const bool is_parked);
+    const bool belong_intersection_area, const bool is_parked_vehicle);
 
   void registerExistingObject(
     const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-    const bool belong_intersection_area, const bool is_parked, std::shared_ptr<ObjectInfo> object);
+    const bool belong_intersection_area, const bool is_parked_vehicle, std::shared_ptr<ObjectInfo> object);
 
   void clearObjects();
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
@@ -135,8 +135,7 @@ public:
    */
   void update_safety(
     const std::optional<CollisionInterval> & unsafe_interval,
-    const std::optional<CollisionInterval> & safe_interval,
-    const bool safe_under_traffic_control);
+    const std::optional<CollisionInterval> & safe_interval, const bool safe_under_traffic_control);
 
   /**
    * @brief find the estimated position of the object in the past
@@ -234,7 +233,8 @@ public:
 
   void registerExistingObject(
     const unique_identifier_msgs::msg::UUID & uuid, const bool belong_attention_area,
-    const bool belong_intersection_area, const bool is_parked_vehicle, std::shared_ptr<ObjectInfo> object);
+    const bool belong_intersection_area, const bool is_parked_vehicle,
+    std::shared_ptr<ObjectInfo> object);
 
   void clearObjects();
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -590,7 +590,7 @@ private:
    * @brief generate discretized detection lane linestring.
    */
   std::vector<lanelet::ConstLineString3d> generateDetectionLaneDivisions(
-    lanelet::ConstLanelets detection_lanelets,
+    lanelet::ConstLanelets detection_lanelets_all,
     const lanelet::routing::RoutingGraphPtr routing_graph_ptr, const double resolution) const;
   /** @} */
 
@@ -752,7 +752,7 @@ private:
 
   void cutPredictPathWithinDuration(
     const builtin_interfaces::msg::Time & object_stamp, const double time_thr,
-    autoware_perception_msgs::msg::PredictedPath * predicted_path) const;
+    autoware_perception_msgs::msg::PredictedPath * path) const;
 
   /**
    * @brief check if there are any objects around the stoplines on the attention areas when ego
@@ -809,7 +809,7 @@ private:
   TimeDistanceArray calcIntersectionPassingTime(
     const tier4_planning_msgs::msg::PathWithLaneId & path, const bool is_prioritized,
     const IntersectionStopLines & intersection_stoplines,
-    tier4_debug_msgs::msg::Float64MultiArrayStamped * debug_ttc_array) const;
+    tier4_debug_msgs::msg::Float64MultiArrayStamped * ego_ttc_array) const;
   /** @} */
 
   mutable DebugData debug_data_;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:76:58: style: inconclusive: Function 'initialize' argument 1 names different: declaration 'predicted_object' definition 'object'. [funcArgNamesDifferent]
  const autoware_perception_msgs::msg::PredictedObject & object,
                                                         ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:77:40: style: inconclusive: Function 'initialize' argument 2 names different: declaration 'attention_lanelet_opt' definition 'attention_lanelet_opt_'. [funcArgNamesDifferent]
  std::optional<lanelet::ConstLanelet> attention_lanelet_opt_,
                                       ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:78:45: style: inconclusive: Function 'initialize' argument 3 names different: declaration 'stopline_opt' definition 'stopline_opt_'. [funcArgNamesDifferent]
  std::optional<lanelet::ConstLineString3d> stopline_opt_)
                                            ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:88:44: style: inconclusive: Function 'update_safety' argument 1 names different: declaration 'unsafe_interval_opt' definition 'unsafe_interval'. [funcArgNamesDifferent]
  const std::optional<CollisionInterval> & unsafe_interval,
                                           ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:89:44: style: inconclusive: Function 'update_safety' argument 2 names different: declaration 'safe_interval_opt' definition 'safe_interval'. [funcArgNamesDifferent]
  const std::optional<CollisionInterval> & safe_interval, const bool safe_under_traffic_control)
                                           ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:197:51: style: inconclusive: Function 'registerObject' argument 4 names different: declaration 'is_parked' definition 'is_parked_vehicle'. [funcArgNamesDifferent]
  const bool belong_intersection_area, const bool is_parked_vehicle)
                                                  ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp:217:51: style: inconclusive: Function 'registerExistingObject' argument 4 names different: declaration 'is_parked' definition 'is_parked_vehicle'. [funcArgNamesDifferent]
  const bool belong_intersection_area, const bool is_parked_vehicle,
                                                  ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp:402:50: style: inconclusive: Function 'cutPredictPathWithinDuration' argument 3 names different: declaration 'predicted_path' definition 'path'. [funcArgNamesDifferent]
  autoware_perception_msgs::msg::PredictedPath * path) const
                                                 ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp:809:53: style: inconclusive: Function 'calcIntersectionPassingTime' argument 4 names different: declaration 'debug_ttc_array' definition 'ego_ttc_array'. [funcArgNamesDifferent]
  tier4_debug_msgs::msg::Float64MultiArrayStamped * ego_ttc_array) const
                                                    ^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp:854:26: style: inconclusive: Function 'generateDetectionLaneDivisions' argument 1 names different: declaration 'detection_lanelets' definition 'detection_lanelets_all'. [funcArgNamesDifferent]
  lanelet::ConstLanelets detection_lanelets_all,
                         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
