### PR TITLE
fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix funcArgNamesDifferent

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/occupancy_grid_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/occupancy_grid_utils.hpp
@@ -28,7 +28,7 @@ namespace autoware::motion_velocity_planner::obstacle_velocity_limiter
 /// @brief mask gridmap cells that are inside the given polygons
 /// @param[in, out] grid_map the grid map to modify
 /// @param[in] polygons the polygons to mask from the grid map
-void maskPolygons(grid_map::GridMap & grid_map, const ObstacleMasks & masks);
+void maskPolygons(grid_map::GridMap & grid_map, const ObstacleMasks & obstacle_masks);
 
 /// @brief apply a threshold to the grid map
 /// @param[in, out] grid_map the grid map to modify


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings
```
planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/occupancy_grid_utils.cpp:27:71: style: inconclusive: Function 'maskPolygons' argument 2 names different: declaration 'masks' definition 'obstacle_masks'. [funcArgNamesDifferent]
void maskPolygons(grid_map::GridMap & grid_map, const ObstacleMasks & obstacle_masks)
                                                                      ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
