### PR TITLE
refactor(localization_util): move diagnostics_module

### DIFF
--- a/localization/localization_util/CMakeLists.txt
+++ b/localization/localization_util/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(localization_util SHARED
   src/util_func.cpp
+  src/diagnostics_module.cpp
   src/smart_pose_buffer.cpp
   src/tree_structured_parzen_estimator.cpp
   src/covariance_ellipse.cpp

--- a/localization/localization_util/include/localization_util/diagnostics_module.hpp
+++ b/localization/localization_util/include/localization_util/diagnostics_module.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NDT_SCAN_MATCHER__DIAGNOSTICS_MODULE_HPP_
-#define NDT_SCAN_MATCHER__DIAGNOSTICS_MODULE_HPP_
+#ifndef LOCALIZATION_UTIL__DIAGNOSTICS_MODULE_HPP_
+#define LOCALIZATION_UTIL__DIAGNOSTICS_MODULE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -57,4 +57,4 @@ void DiagnosticsModule::add_key_value(const std::string & key, const std::string
 template <>
 void DiagnosticsModule::add_key_value(const std::string & key, const bool & value);
 
-#endif  // NDT_SCAN_MATCHER__DIAGNOSTICS_MODULE_HPP_
+#endif  // LOCALIZATION_UTIL__DIAGNOSTICS_MODULE_HPP_

--- a/localization/localization_util/src/diagnostics_module.cpp
+++ b/localization/localization_util/src/diagnostics_module.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ndt_scan_matcher/diagnostics_module.hpp"
+#include "localization_util/diagnostics_module.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -26,7 +26,6 @@ find_package(PCL REQUIRED COMPONENTS common io registration)
 include_directories(${PCL_INCLUDE_DIRS})
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/diagnostics_module.cpp
   src/map_update_module.cpp
   src/ndt_scan_matcher_core.cpp
   src/particle.cpp

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
@@ -15,8 +15,8 @@
 #ifndef NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_HPP_
 #define NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_HPP_
 
+#include "localization_util/diagnostics_module.hpp"
 #include "localization_util/util_func.hpp"
-#include "ndt_scan_matcher/diagnostics_module.hpp"
 #include "ndt_scan_matcher/hyper_parameters.hpp"
 #include "ndt_scan_matcher/particle.hpp"
 

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -17,8 +17,8 @@
 
 #define FMT_HEADER_ONLY
 
+#include "localization_util/diagnostics_module.hpp"
 #include "localization_util/smart_pose_buffer.hpp"
-#include "ndt_scan_matcher/diagnostics_module.hpp"
 #include "ndt_scan_matcher/hyper_parameters.hpp"
 #include "ndt_scan_matcher/map_update_module.hpp"
 


### PR DESCRIPTION
## Description
Moved diagnostics_module from ndt_scan_matcher to localization_util.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- Check that localization works correctly in logging_simulator.
- Check that the diagnostics topic in ndt_scan_matcher is published.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
