### PR TITLE
fix(tensorrt_common): fix constParameterReference

### DIFF
--- a/common/tensorrt_common/include/tensorrt_common/simple_profiler.hpp
+++ b/common/tensorrt_common/include/tensorrt_common/simple_profiler.hpp
@@ -58,7 +58,7 @@ public:
 
   void setProfDict(nvinfer1::ILayer * layer) noexcept;
 
-  friend std::ostream & operator<<(std::ostream & out, SimpleProfiler & value);
+  friend std::ostream & operator<<(std::ostream & out, const SimpleProfiler & value);
 
 private:
   std::string m_name;

--- a/common/tensorrt_common/src/simple_profiler.cpp
+++ b/common/tensorrt_common/src/simple_profiler.cpp
@@ -78,7 +78,7 @@ void SimpleProfiler::setProfDict(nvinfer1::ILayer * layer) noexcept
   }
 }
 
-std::ostream & operator<<(std::ostream & out, SimpleProfiler & value)
+std::ostream & operator<<(std::ostream & out, const SimpleProfiler & value)
 {
   out << "========== " << value.m_name << " profile ==========" << std::endl;
   float totalTime = 0;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
common/tensorrt_common/src/simple_profiler.cpp:81:64: style: Parameter 'value' can be declared as reference to const [constParameterReference]
std::ostream & operator<<(std::ostream & out, SimpleProfiler & value)
                                                               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
