### PR TITLE
fix(predicted_path_checker): fix constParameterReference 

### DIFF
--- a/control/predicted_path_checker/include/predicted_path_checker/utils.hpp
+++ b/control/predicted_path_checker/include/predicted_path_checker/utils.hpp
@@ -65,7 +65,7 @@ TrajectoryPoint calcInterpolatedPoint(
 
 std::pair<size_t, TrajectoryPoint> findStopPoint(
   TrajectoryPoints & predicted_trajectory_array, const size_t collision_idx,
-  const double stop_margin, autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+  const double stop_margin, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
 
 bool isInBrakeDistance(
   const TrajectoryPoints & trajectory, const size_t stop_idx, const double relative_velocity,

--- a/control/predicted_path_checker/src/predicted_path_checker_node/utils.cpp
+++ b/control/predicted_path_checker/src/predicted_path_checker_node/utils.cpp
@@ -148,7 +148,7 @@ TrajectoryPoint calcInterpolatedPoint(
 
 std::pair<size_t, TrajectoryPoint> findStopPoint(
   TrajectoryPoints & trajectory_array, const size_t collision_idx, const double stop_margin,
-  autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
   // It returns the stop point and segment of the point on trajectory.
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
control/predicted_path_checker/src/predicted_path_checker_node/utils.cpp:151:47: style: Parameter 'vehicle_info' can be declared as reference to const [constParameterReference]
  autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
                                              ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
