### PR TITLE
fix(autoware_behavior_path_planner_common): fix constParameterReference

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/parking_departure/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/parking_departure/utils.hpp
@@ -54,7 +54,7 @@ void modifyVelocityByDirection(
   const double acceleration);
 
 void updatePathProperty(
-  std::shared_ptr<EgoPredictedPathParams> & ego_predicted_path_params,
+  const std::shared_ptr<EgoPredictedPathParams> & ego_predicted_path_params,
   const std::pair<double, double> & pairs_terminal_velocity_and_accel);
 
 void initializeCollisionCheckDebugMap(CollisionCheckDebugMap & collision_check_debug_map);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
@@ -86,7 +86,7 @@ void modifyVelocityByDirection(
 }
 
 void updatePathProperty(
-  std::shared_ptr<EgoPredictedPathParams> & ego_predicted_path_params,
+  const std::shared_ptr<EgoPredictedPathParams> & ego_predicted_path_params,
   const std::pair<double, double> & pairs_terminal_velocity_and_accel)
 {
   // If acceleration is close to 0, the ego predicted path will be too short, so a minimum value is

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
@@ -501,7 +501,7 @@ void PathShifter::removeBehindShiftLineAndSetBaseOffset(const size_t nearest_idx
   if (!removed_shift_lines.empty()) {
     const auto last_removed_sl = std::max_element(
       removed_shift_lines.begin(), removed_shift_lines.end(),
-      [](auto & a, auto & b) { return a.end_idx > b.end_idx; });
+      [](const auto & a, const auto & b) { return a.end_idx > b.end_idx; });
     new_base_offset = last_removed_sl->end_shift_length;
   }
 
@@ -630,7 +630,7 @@ double PathShifter::getLastShiftLength() const
 
   const auto furthest = std::max_element(
     shift_lines_.begin(), shift_lines_.end(),
-    [](auto & a, auto & b) { return a.end_idx < b.end_idx; });
+    [](const auto & a, const auto & b) { return a.end_idx < b.end_idx; });
 
   return furthest->end_shift_length;
 }
@@ -643,7 +643,7 @@ std::optional<ShiftLine> PathShifter::getLastShiftLine() const
 
   const auto furthest = std::max_element(
     shift_lines_.begin(), shift_lines_.end(),
-    [](auto & a, auto & b) { return a.end_idx > b.end_idx; });
+    [](const auto & a, const auto & b) { return a.end_idx > b.end_idx; });
 
   return *furthest;
 }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp:89:45: style: Parameter 'ego_predicted_path_params' can be declared as reference to const [constParameterReference]
  std::shared_ptr<EgoPredictedPathParams> & ego_predicted_path_params,
                                            ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp:504:17: style: Parameter 'a' can be declared as reference to const [constParameterReference]
      [](auto & a, auto & b) { return a.end_idx > b.end_idx; });
                ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp:504:27: style: Parameter 'b' can be declared as reference to const [constParameterReference]
      [](auto & a, auto & b) { return a.end_idx > b.end_idx; });
                          ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp:633:15: style: Parameter 'a' can be declared as reference to const [constParameterReference]
    [](auto & a, auto & b) { return a.end_idx < b.end_idx; });
              ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp:633:25: style: Parameter 'b' can be declared as reference to const [constParameterReference]
    [](auto & a, auto & b) { return a.end_idx < b.end_idx; });
                        ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp:646:15: style: Parameter 'a' can be declared as reference to const [constParameterReference]
    [](auto & a, auto & b) { return a.end_idx > b.end_idx; });
              ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp:646:25: style: Parameter 'b' can be declared as reference to const [constParameterReference]
    [](auto & a, auto & b) { return a.end_idx > b.end_idx; });
                        ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
