### PR TITLE
fix(autoware_behavior_velocity_run_out_module): fix constParameterReference

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp
@@ -166,7 +166,7 @@ void insertPathVelocityFromIndex(
   }
 }
 
-std::optional<size_t> findFirstStopPointIdx(PathPointsWithLaneId & path_points)
+std::optional<size_t> findFirstStopPointIdx(const PathPointsWithLaneId & path_points)
 {
   for (size_t i = 0; i < path_points.size(); i++) {
     const auto vel = path_points.at(i).point.longitudinal_velocity_mps;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.hpp
@@ -235,7 +235,7 @@ void insertPathVelocityFromIndexLimited(
 void insertPathVelocityFromIndex(
   const size_t & start_idx, const float velocity_mps, PathPointsWithLaneId & path_points);
 
-std::optional<size_t> findFirstStopPointIdx(PathPointsWithLaneId & path_points);
+std::optional<size_t> findFirstStopPointIdx(const PathPointsWithLaneId & path_points);
 
 LineString2d createLineString2d(const lanelet::BasicPolygon2d & poly);
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp:169:68: style: Parameter 'path_points' can be declared as reference to const [constParameterReference]
std::optional<size_t> findFirstStopPointIdx(PathPointsWithLaneId & path_points)
                                                                   ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
