### PR TITLE
fix(pointcloud_preprocessor): fix constParameterReference

### DIFF
--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -504,17 +504,17 @@ void PointCloudConcatenateDataSynchronizerComponent::convertToXYZIRCCloud(
   output_modifier.reserve(input_ptr->width);
 
   bool has_valid_intensity =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "intensity" && field.datatype == sensor_msgs::msg::PointField::UINT8;
     });
 
   bool has_valid_return_type =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "return_type" && field.datatype == sensor_msgs::msg::PointField::UINT8;
     });
 
   bool has_valid_channel =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "channel" && field.datatype == sensor_msgs::msg::PointField::UINT16;
     });
 

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
@@ -338,17 +338,17 @@ void PointCloudConcatenationComponent::convertToXYZIRCCloud(
   output_modifier.reserve(input_ptr->width);
 
   bool has_valid_intensity =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "intensity" && field.datatype == sensor_msgs::msg::PointField::UINT8;
     });
 
   bool has_valid_return_type =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "return_type" && field.datatype == sensor_msgs::msg::PointField::UINT8;
     });
 
   bool has_valid_channel =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "channel" && field.datatype == sensor_msgs::msg::PointField::UINT16;
     });
 

--- a/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp
@@ -441,17 +441,17 @@ void PointCloudDataSynchronizerComponent::convertToXYZIRCCloud(
   output_modifier.reserve(input_ptr->width);
 
   bool has_valid_intensity =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "intensity" && field.datatype == sensor_msgs::msg::PointField::UINT8;
     });
 
   bool has_valid_return_type =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "return_type" && field.datatype == sensor_msgs::msg::PointField::UINT8;
     });
 
   bool has_valid_channel =
-    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
+    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](const auto & field) {
       return field.name == "channel" && field.datatype == sensor_msgs::msg::PointField::UINT16;
     });
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp:507:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                              ^
sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp:512:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                              ^
sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp:517:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {

sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp:507:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                              ^
sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp:512:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                              ^
sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp:517:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {

sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp:444:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                              ^
sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp:449:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                              ^
sensing/pointcloud_preprocessor/src/time_synchronizer/time_synchronizer_nodelet.cpp:454:79: style: Parameter 'field' can be declared as reference to const [constParameterReference]
    std::any_of(input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) {
                                                                             ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
