### PR TITLE
fix(diagnostic_graph_aggregator): fix constParameterReference

### DIFF
--- a/system/diagnostic_graph_aggregator/src/common/graph/config.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.cpp
@@ -253,7 +253,7 @@ void apply_edits(FileConfig & config)
   config.links = std::move(filtered_links);
 }
 
-void topological_sort(FileConfig & config)
+void topological_sort(const FileConfig & config)
 {
   std::unordered_map<UnitConfig *, int> degrees;
   std::deque<UnitConfig *> units;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings
```
system/diagnostic_graph_aggregator/src/common/graph/config.cpp:256:36: style: Parameter 'config' can be declared as reference to const [constParameterReference]
void topological_sort(FileConfig & config)
                                   ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
