### PR TITLE
fix(radar_tracks_msgs_converter): fix constVariableReference

### DIFF
--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
@@ -175,7 +175,7 @@ DetectedObjects RadarTracksMsgsConverterNode::convertTrackedObjectsToDetectedObj
   DetectedObjects detected_objects;
   detected_objects.header = objects.header;
 
-  for (auto & object : objects.objects) {
+  for (const auto & object : objects.objects) {
     DetectedObject detected_object;
     detected_object.existence_probability = 1.0;
     detected_object.shape = object.shape;
@@ -224,7 +224,7 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
   tracked_objects.header = radar_data_->header;
   tracked_objects.header.frame_id = node_param_.new_frame_id;
 
-  for (auto & radar_track : radar_data_->tracks) {
+  for (const auto & radar_track : radar_data_->tracks) {
     TrackedObject tracked_object;
 
     tracked_object.object_id = radar_track.uuid;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariableReference warnings


```
## Related linksperception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp:178:15: style: Variable 'object' can be declared as reference to const [constVariableReference]
  for (auto & object : objects.objects) {
              ^

perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp:227:15: style: Variable 'radar_track' can be declared as reference to const [constVariableReference]
  for (auto & radar_track : radar_data_->tracks) {
              ^
```

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
