### PR TITLE
fix(traffic_light_map_based_detector): fix constVariableReference

### DIFF
--- a/perception/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_map_based_detector/src/node.cpp
@@ -187,7 +187,7 @@ bool MapBasedDetector::getTransform(
     geometry_msgs::msg::TransformStamped transform =
       tf_buffer_.lookupTransform("map", frame_id, t, rclcpp::Duration::from_seconds(0.2));
     tf2::fromMsg(transform.transform, tf);
-  } catch (tf2::TransformException & ex) {
+  } catch (const tf2::TransformException & ex) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariableReference warnings

```
perception/traffic_light_map_based_detector/src/node.cpp:190:38: style: Variable 'ex' can be declared as reference to const [constVariableReference]
  } catch (tf2::TransformException & ex) {
                                     ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
