### PR TITLE
fix(autoware_velocity_smoother): fix constVariableReference

### DIFF
--- a/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
@@ -229,7 +229,7 @@ void setZeroVelocity(TrajectoryPoints & trajectory)
 double getMaxVelocity(const TrajectoryPoints & trajectory)
 {
   double max_vel = 0.0;
-  for (auto & tp : trajectory) {
+  for (const auto & tp : trajectory) {
     if (tp.longitudinal_velocity_mps > max_vel) {
       max_vel = tp.longitudinal_velocity_mps;
     }
@@ -240,7 +240,7 @@ double getMaxVelocity(const TrajectoryPoints & trajectory)
 double getMaxAbsVelocity(const TrajectoryPoints & trajectory)
 {
   double max_vel = 0.0;
-  for (auto & tp : trajectory) {
+  for (const auto & tp : trajectory) {
     double abs_vel = std::fabs(tp.longitudinal_velocity_mps);
     if (abs_vel > max_vel) {
       max_vel = abs_vel;
@@ -434,7 +434,7 @@ std::optional<TrajectoryPoints> applyDecelFilterWithJerkConstraint(
   const std::map<double, double> & jerk_profile)
 {
   double t_total{0.0};
-  for (auto & it : jerk_profile) {
+  for (const auto & it : jerk_profile) {
     t_total += it.second;
   }
 
@@ -544,7 +544,7 @@ std::optional<std::tuple<double, double, double, double>> updateStateWithJerkCon
   double x{0.0};
   double t_sum{0.0};
 
-  for (auto & it : jerk_profile) {
+  for (const auto & it : jerk_profile) {
     j = it.first;
     t_sum += it.second;
     if (t > t_sum) {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariableReference warnings

```
planning/autoware_velocity_smoother/src/trajectory_utils.cpp:232:15: style: Variable 'tp' can be declared as reference to const [constVariableReference]
  for (auto & tp : trajectory) {
              ^

planning/autoware_velocity_smoother/src/trajectory_utils.cpp:243:15: style: Variable 'tp' can be declared as reference to const [constVariableReference]
  for (auto & tp : trajectory) {
              ^

planning/autoware_velocity_smoother/src/trajectory_utils.cpp:437:15: style: Variable 'it' can be declared as reference to const [constVariableReference]
  for (auto & it : jerk_profile) {
              ^

planning/autoware_velocity_smoother/src/trajectory_utils.cpp:547:15: style: Variable 'it' can be declared as reference to const [constVariableReference]
  for (auto & it : jerk_profile) {
              ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
