### PR TITLE
fix(learning_based_vehicle_model): fix constVariableReference

### DIFF
--- a/simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp
+++ b/simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp
@@ -32,7 +32,7 @@ std::vector<int> createConnectionsMap(
   std::vector<int> connection_map;
   // index in "connection_map" is index in "connection_names_2" and value in "connection_map" is
   // index in "connection_names_1"
-  for (const auto & name_2 : connection_names_2) {
+  for (const auto * const name_2 : connection_names_2) {
     int mapped_idx = -1;  // -1 means that we cannot create a connection between some signals
     for (std::size_t NAME_1_IDX = 0; NAME_1_IDX < connection_names_1.size(); NAME_1_IDX++) {
       if (strcmp(name_2, connection_names_1[NAME_1_IDX]) == 0) {  // 0 means strings are the same


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariableReference warnings

```
simulator/learning_based_vehicle_model/src/model_connections_helpers.cpp:35:21: style: Variable 'name_2' can be declared as pointer to const [constVariableReference]
  for (const auto & name_2 : connection_names_2) {
                    ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
