### PR TITLE
fix(mrm_handler): add check for autonomous mode and do some refactoring

### DIFF
--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -95,10 +95,12 @@ void MrmHandler::onOperationModeAvailability(
     return;
   }
 
+  // If no time stamp is available, create one.
   stamp_autonomous_become_unavailable_ = (!stamp_autonomous_become_unavailable_.has_value())
                                            ? this->now()
                                            : stamp_autonomous_become_unavailable_;
 
+  // Check if autonomous mode unavailable time is larger than timeout threshold.
   const auto emergency_duration =
     (this->now() - stamp_autonomous_become_unavailable_.value()).seconds();
   is_emergency_holding_ = (emergency_duration > param_.timeout_emergency_recovery);

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -95,7 +95,8 @@ void MrmHandler::onOperationModeAvailability(
     return;
   }
 
-  // If no time stamp is available, create one.
+  // If no timestamp is available, the ego autonomous mode just became unavailable and the current
+  // time is recorded.
   stamp_autonomous_become_unavailable_ = (!stamp_autonomous_become_unavailable_.has_value())
                                            ? this->now()
                                            : stamp_autonomous_become_unavailable_;

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -82,28 +82,26 @@ void MrmHandler::onOperationModeAvailability(
   const tier4_system_msgs::msg::OperationModeAvailability::ConstSharedPtr msg)
 {
   stamp_operation_mode_availability_ = this->now();
+  operation_mode_availability_ = msg;
+  const bool skip_emergency_holding_check =
+    !param_.use_emergency_holding || is_emergency_holding_ || !isOperationModeAutonomous();
 
-  if (!param_.use_emergency_holding) {
-    operation_mode_availability_ = msg;
+  if (skip_emergency_holding_check) {
     return;
   }
 
-  if (!is_emergency_holding_) {
-    if (msg->autonomous) {
-      stamp_autonomous_become_unavailable_.reset();
-    } else {
-      if (!stamp_autonomous_become_unavailable_.has_value()) {
-        stamp_autonomous_become_unavailable_.emplace(this->now());
-      } else {
-        const auto emergency_duration =
-          (this->now() - stamp_autonomous_become_unavailable_.value()).seconds();
-        if (emergency_duration > param_.timeout_emergency_recovery) {
-          is_emergency_holding_ = true;
-        }
-      }
-    }
+  if (msg->autonomous) {
+    stamp_autonomous_become_unavailable_.reset();
+    return;
   }
-  operation_mode_availability_ = msg;
+
+  stamp_autonomous_become_unavailable_ = (!stamp_autonomous_become_unavailable_.has_value())
+                                           ? this->now()
+                                           : stamp_autonomous_become_unavailable_;
+
+  const auto emergency_duration =
+    (this->now() - stamp_autonomous_become_unavailable_.value()).seconds();
+  is_emergency_holding_ = (emergency_duration > param_.timeout_emergency_recovery);
 }
 
 void MrmHandler::publishHazardCmd()


### PR DESCRIPTION
## Description
Currently, if use_emergency_holding is set to true, the ego will enter emergency mode if it is not changed to autonomous mode within "timeout_emergency_recovery" seconds, which is not the expected behavior. 

This PR adds a check for Autonomous mode before increasing the timer, which solves the issue. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim


https://github.com/user-attachments/assets/f5441097-dd87-41ba-81b6-93d6faa81668


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
