### PR TITLE
feat(obstacle_cruise_planner): improve stop and cruise behavior for cut-in & out

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -80,6 +80,7 @@
       pointcloud_min_cluster_size: 1
       pointcloud_max_cluster_size: 100000
 
+      max_lateral_time_margin: 3.0 # maximum time margin to filtering obstacles for collision checking
       decimate_trajectory_step_length : 2.0 # longitudinal step length to calculate trajectory polygon for collision checking
 
       prediction_resampling_time_interval: 0.1

--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -110,6 +110,7 @@
       stop:
         max_lat_margin: 0.3 # lateral margin between the obstacles except for unknown and ego's footprint
         max_lat_margin_against_unknown: 0.3 # lateral margin between the unknown obstacles and ego's footprint
+        min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         outside_obstacle:
           max_lateral_time_margin: 4.0 # time threshold of lateral margin between the obstacles and ego's footprint [s]
           num_of_predicted_paths: 3 # number of the highest confidence predicted path to check collision between obstacle and ego

--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -114,6 +114,8 @@
         outside_obstacle:
           max_lateral_time_margin: 4.0 # time threshold of lateral margin between the obstacles and ego's footprint [s]
           num_of_predicted_paths: 3 # number of the highest confidence predicted path to check collision between obstacle and ego
+          pedestrian_deceleration_rate: 0.5 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
+          bicycle_deceleration_rate: 0.5 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
         crossing_obstacle:
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 

--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -29,15 +29,26 @@
       suppress_sudden_obstacle_stop: false
 
       stop_obstacle_type:
-        unknown: true
-        car: true
-        truck: true
-        bus: true
-        trailer: true
-        motorcycle: true
-        bicycle: true
-        pedestrian: true
         pointcloud: false
+        inside:
+          unknown: true
+          car: true
+          truck: true
+          bus: true
+          trailer: true
+          motorcycle: true
+          bicycle: true
+          pedestrian: true
+
+        outside:
+          unknown: false
+          car: true
+          truck: true
+          bus: true
+          trailer: true
+          motorcycle: true
+          bicycle: true
+          pedestrian: true
 
       cruise_obstacle_type:
         inside:
@@ -80,7 +91,6 @@
       pointcloud_min_cluster_size: 1
       pointcloud_max_cluster_size: 100000
 
-      max_lateral_time_margin: 3.0 # maximum time margin to filtering obstacles for collision checking
       decimate_trajectory_step_length : 2.0 # longitudinal step length to calculate trajectory polygon for collision checking
 
       prediction_resampling_time_interval: 0.1
@@ -100,6 +110,9 @@
       stop:
         max_lat_margin: 0.3 # lateral margin between the obstacles except for unknown and ego's footprint
         max_lat_margin_against_unknown: 0.3 # lateral margin between the unknown obstacles and ego's footprint
+        outside_obstacle:
+          max_lateral_time_margin: 4.0 # time threshold of lateral margin between the obstacles and ego's footprint [s]
+          num_of_predicted_paths: 3 # number of the highest confidence predicted path to check collision between obstacle and ego
         crossing_obstacle:
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
@@ -109,6 +122,8 @@
           obstacle_velocity_threshold : 3.5 # minimum velocity threshold of obstacles outside the trajectory to cruise or stop [m/s]
           ego_obstacle_overlap_time_threshold : 2.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
+          max_lateral_time_margin: 5.0 # time threshold of lateral margin between obstacle and trajectory band with ego's width [s]
+          num_of_predicted_paths: 3 # number of the highest confidence predicted path to check collision between obstacle and ego
         yield:
           enable_yield: true
           lat_distance_threshold: 5.0 # lateral margin between obstacle in neighbor lanes and trajectory band with ego's width for yielding

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
@@ -58,10 +58,13 @@ struct Obstacle
   Obstacle(
     const rclcpp::Time & arg_stamp, const PredictedObject & object,
     const geometry_msgs::msg::Pose & arg_pose, const double ego_to_obstacle_distance,
-    const double lat_dist_from_obstacle_to_traj)
+    const double lat_dist_from_obstacle_to_traj, const double tangent_velocity,
+    const double normal_velocity)
   : stamp(arg_stamp),
     ego_to_obstacle_distance(ego_to_obstacle_distance),
     lat_dist_from_obstacle_to_traj(lat_dist_from_obstacle_to_traj),
+    tangent_velocity(tangent_velocity),
+    normal_velocity(normal_velocity),
     pose(arg_pose),
     orientation_reliable(true),
     twist(object.kinematics.initial_twist_with_covariance.twist),
@@ -94,6 +97,8 @@ struct Obstacle
   rclcpp::Time stamp;  // This is not the current stamp, but when the object was observed.
   double ego_to_obstacle_distance;
   double lat_dist_from_obstacle_to_traj;
+  double tangent_velocity;
+  double normal_velocity;
 
   // for PredictedObject
   geometry_msgs::msg::Pose pose;  // interpolated with the current stamp

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
@@ -58,13 +58,13 @@ struct Obstacle
   Obstacle(
     const rclcpp::Time & arg_stamp, const PredictedObject & object,
     const geometry_msgs::msg::Pose & arg_pose, const double ego_to_obstacle_distance,
-    const double lat_dist_from_obstacle_to_traj, const double tangent_velocity,
-    const double normal_velocity)
+    const double lat_dist_from_obstacle_to_traj, const double longitudinal_velocity,
+    const double approach_velocity)
   : stamp(arg_stamp),
     ego_to_obstacle_distance(ego_to_obstacle_distance),
     lat_dist_from_obstacle_to_traj(lat_dist_from_obstacle_to_traj),
-    tangent_velocity(tangent_velocity),
-    normal_velocity(normal_velocity),
+    longitudinal_velocity(longitudinal_velocity),
+    approach_velocity(approach_velocity),
     pose(arg_pose),
     orientation_reliable(true),
     twist(object.kinematics.initial_twist_with_covariance.twist),
@@ -97,8 +97,8 @@ struct Obstacle
   rclcpp::Time stamp;  // This is not the current stamp, but when the object was observed.
   double ego_to_obstacle_distance;
   double lat_dist_from_obstacle_to_traj;
-  double tangent_velocity;
-  double normal_velocity;
+  double longitudinal_velocity;
+  double approach_velocity;
 
   // for PredictedObject
   geometry_msgs::msg::Pose pose;  // interpolated with the current stamp

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -239,6 +239,8 @@ private:
     int num_of_predicted_paths_for_outside_stop_obstacle;
     // obstacle hold
     double stop_obstacle_hold_time_threshold;
+    // reach collision point
+    double min_velocity_to_reach_collision_point;
     // prediction resampling
     double prediction_resampling_time_interval;
     double prediction_resampling_time_horizon;

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -79,6 +79,11 @@ private:
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<Polygon2d> & traj_polys, const Obstacle & obstacle,
     const double precise_lateral_dist) const;
+  std::optional<std::pair<geometry_msgs::msg::Point, double>>
+  createCollisionPointForOutsideStopObstacle(
+    const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<Polygon2d> & traj_polys, const Obstacle & obstacle,
+    const PredictedPath & resampled_predicted_path, double max_lat_margin_for_stop) const;
   std::optional<StopObstacle> createStopObstacleForPointCloud(
     const std::vector<TrajectoryPoint> & traj_points, const Obstacle & obstacle,
     const double precise_lateral_dist) const;
@@ -87,9 +92,6 @@ private:
   bool isOutsideCruiseObstacle(const uint8_t label) const;
   bool isCruiseObstacle(const uint8_t label) const;
   bool isSlowDownObstacle(const uint8_t label) const;
-  std::optional<geometry_msgs::msg::Point> createCollisionPointForStopObstacle(
-    const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
-    const Obstacle & obstacle) const;
   std::optional<CruiseObstacle> createYieldCruiseObstacle(
     const Obstacle & obstacle, const std::vector<TrajectoryPoint> & traj_points);
   std::optional<std::vector<CruiseObstacle>> findYieldCruiseObstacles(
@@ -129,7 +131,9 @@ private:
   bool isFrontCollideObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const Obstacle & obstacle,
     const size_t first_collision_idx) const;
-
+  double calcTimeToReachCollisionPoint(
+    const Odometry & odometry, const geometry_msgs::msg::Point & collision_point,
+    const std::vector<TrajectoryPoint> & traj_points, const double abs_ego_offset) const;
   bool enable_debug_info_;
   bool enable_calculation_time_info_;
   bool use_pointcloud_for_stop_;

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -226,6 +226,7 @@ private:
     double ego_obstacle_overlap_time_threshold;
     double max_prediction_time_for_collision_check;
     double crossing_obstacle_traj_angle_threshold;
+    double max_lateral_time_margin;
     // obstacle hold
     double stop_obstacle_hold_time_threshold;
     // prediction resampling

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -88,6 +88,8 @@ private:
   std::optional<StopObstacle> createStopObstacleForPointCloud(
     const std::vector<TrajectoryPoint> & traj_points, const Obstacle & obstacle,
     const double precise_lateral_dist) const;
+  bool isInsideStopObstacle(const uint8_t label) const;
+  bool isOutsideStopObstacle(const uint8_t label) const;
   bool isStopObstacle(const uint8_t label) const;
   bool isInsideCruiseObstacle(const uint8_t label) const;
   bool isOutsideCruiseObstacle(const uint8_t label) const;
@@ -98,8 +100,9 @@ private:
   std::optional<std::vector<CruiseObstacle>> findYieldCruiseObstacles(
     const std::vector<Obstacle> & obstacles, const std::vector<TrajectoryPoint> & traj_points);
   std::optional<CruiseObstacle> createCruiseObstacle(
-    const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
-    const Obstacle & obstacle, const double precise_lat_dist);
+    const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<Polygon2d> & traj_polys, const Obstacle & obstacle,
+    const double precise_lat_dist);
   std::optional<std::vector<PointWithStamp>> createCollisionPointsForInsideCruiseObstacle(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polys,
     const Obstacle & obstacle) const;
@@ -145,7 +148,8 @@ private:
   double min_safe_distance_margin_on_curve_;
   bool suppress_sudden_obstacle_stop_;
 
-  std::vector<int> stop_obstacle_types_;
+  std::vector<int> inside_stop_obstacle_types_;
+  std::vector<int> outside_stop_obstacle_types_;
   std::vector<int> inside_cruise_obstacle_types_;
   std::vector<int> outside_cruise_obstacle_types_;
   std::vector<int> slow_down_obstacle_types_;
@@ -231,12 +235,16 @@ private:
     double ego_obstacle_overlap_time_threshold;
     double max_prediction_time_for_collision_check;
     double crossing_obstacle_traj_angle_threshold;
-    double max_lateral_time_margin;
+    int num_of_predicted_paths_for_outside_cruise_obstacle;
+    int num_of_predicted_paths_for_outside_stop_obstacle;
     // obstacle hold
     double stop_obstacle_hold_time_threshold;
     // prediction resampling
     double prediction_resampling_time_interval;
     double prediction_resampling_time_horizon;
+    // max lateral time margin
+    double max_lat_time_margin_for_stop;
+    double max_lat_time_margin_for_cruise;
     // max lateral margin
     double max_lat_margin_for_stop;
     double max_lat_margin_for_stop_against_unknown;

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::motion_planning

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -237,6 +237,8 @@ private:
     double crossing_obstacle_traj_angle_threshold;
     int num_of_predicted_paths_for_outside_cruise_obstacle;
     int num_of_predicted_paths_for_outside_stop_obstacle;
+    double pedestrian_deceleration_rate;
+    double bicycle_deceleration_rate;
     // obstacle hold
     double stop_obstacle_hold_time_threshold;
     // reach collision point

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/polygon_utils.hpp
@@ -43,6 +43,11 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
   const Obstacle & obstacle, const bool is_driving_forward,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
 
+std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
+  const std::vector<TrajectoryPoint> & traj_points, const size_t collision_idx,
+  const std::vector<PointWithStamp> & collision_points, const bool is_driving_forward,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+
 std::vector<PointWithStamp> getCollisionPoints(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,

--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -1876,9 +1876,6 @@ double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
   const Odometry & odometry, const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & traj_points, const bool is_driving_forward) const
 {
-  const auto & ego_pose = odometry.pose.pose;
-  const double ego_vel = odometry.twist.twist.linear.x;
-
   const double abs_ego_offset = is_driving_forward
                                   ? std::abs(vehicle_info_.max_longitudinal_offset_m)
                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);

--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -1518,7 +1518,7 @@ ObstacleCruisePlannerNode::createCollisionPointForOutsideStopObstacle(
   if (collision_points.empty()) {
     RCLCPP_INFO_EXPRESSION(
       get_logger(), enable_debug_info_,
-      "[Stop] Ignore inside obstacle (%s) since there is no collision point between the "
+      "[Stop] Ignore outside obstacle (%s) since there is no collision point between the "
       "predicted path "
       "and the ego.",
       object_id.c_str());
@@ -1531,7 +1531,7 @@ ObstacleCruisePlannerNode::createCollisionPointForOutsideStopObstacle(
   if (p.collision_time_margin < collision_time_margin) {
     RCLCPP_INFO_EXPRESSION(
       get_logger(), enable_debug_info_,
-      "[Stop] Ignore inside obstacle (%s) since it will not collide with the ego.",
+      "[Stop] Ignore outside obstacle (%s) since it will not collide with the ego.",
       object_id.c_str());
     debug_data_ptr_->intentionally_ignored_obstacles.push_back(obstacle);
     return std::nullopt;

--- a/planning/autoware_obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/polygon_utils.cpp
@@ -125,6 +125,37 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
       *max_collision_length);
 }
 
+std::optional<std::pair<geometry_msgs::msg::Point, double>> getCollisionPoint(
+  const std::vector<TrajectoryPoint> & traj_points, const size_t collision_idx,
+  const std::vector<PointWithStamp> & collision_points, const bool is_driving_forward,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+{
+  std::pair<size_t, std::vector<PointWithStamp>> collision_info;
+  collision_info.first = collision_idx;
+  collision_info.second = collision_points;
+
+  const double x_diff_to_bumper = is_driving_forward ? vehicle_info.max_longitudinal_offset_m
+                                                     : vehicle_info.min_longitudinal_offset_m;
+  const auto bumper_pose = autoware::universe_utils::calcOffsetPose(
+    traj_points.at(collision_info.first).pose, x_diff_to_bumper, 0.0, 0.0);
+
+  std::optional<double> max_collision_length = std::nullopt;
+  std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;
+  for (const auto & poly_vertex : collision_info.second) {
+    const double dist_from_bumper =
+      std::abs(autoware::universe_utils::inverseTransformPoint(poly_vertex.point, bumper_pose).x);
+
+    if (!max_collision_length.has_value() || dist_from_bumper > *max_collision_length) {
+      max_collision_length = dist_from_bumper;
+      max_collision_point = poly_vertex.point;
+    }
+  }
+  return std::make_pair(
+    *max_collision_point,
+    autoware::motion_utils::calcSignedArcLength(traj_points, 0, collision_info.first) -
+      *max_collision_length);
+}
+
 // NOTE: max_lat_dist is used for efficient calculation to suppress boost::geometry's polygon
 // calculation.
 std::vector<PointWithStamp> getCollisionPoints(


### PR DESCRIPTION
## Description

- To increase the response capacity of the `obstacle_cruise_planner` within the scope of Dense-Urban ODD, we want it to be sensitive to dynamic objects approaching from outside Ego's path and stop if there is a collision risk, as mentioned in the issue.

- Avoiding unnecessary stopping of Ego in the presence of transient objects that do not pose a risk of collision. To solve these problems and provide a more human-like autonomous driving experience, we needed to improve the stop behavior of the `obstacle_cruise_planner`.

- We want to improve the cruising behavior for the outside obstacle. If another vehicle in the side lanes is approaching Ego's trajectory, cruise planning starts too late. 

**Improvement on filtering:**

In `obstacle_cruise_planner`, all the `PredictedObjects` were filtered if their lateral distance exceeded some small distance limitations. To achieve a behavior determination for PredictedObjects who are away from trajectory but approaching with some velocity, I needed to change the filtering algorithm. 

With the current implementation, if the predicted object is far away but its perpendicular velocity to the trajectory is high and if it is inside the trajectory within the time parameter `max_lateral_time_margin`, it will be considered as a target obstacle and we can use it for the behavior determination. 

![road_with_predicted_objects drawio](https://github.com/user-attachments/assets/4735295d-87fe-482f-bd6e-74cd3caa4429)

**Improvement on stop behavior:**

To handle both transient objects and objects that come to the trajectory that may cause a collision, I divided the stop behavior into two: inside and outside.

For the objects that are inside the trajectory (precise_lat_dist > max_lat_margin_for_stop), we are checking the collision point. If there is a collision point, we are looking object's position when the Ego reaches the collision point. If there is no intersection with the future position, we don't set stop, otherwise set stop.

**Improvement on cruising:**

![road_with_predicted_objects drawio](https://github.com/user-attachments/assets/9e0c5193-4136-4db9-b1f1-b8f46b28e3b6)

To be able to select the vehicles in side lanes who intend to drive through our trajectory, we added a time margin that calculates the time to reach the trajectory.  By using this, we can select the vehicles earlier as cruise obstacle.


## Related links

**Parent Issue:**
- https://github.com/autowarefoundation/autoware.universe/issues/7864

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PR tested by using PSim, however, I am currently working to create some scenarios for a detailed test of this feature. I will upload them into AWF Project asap.

**Transient Obstacle Tests:**

https://github.com/user-attachments/assets/d90577f9-0fab-4d38-954f-1416114dbd3c

**Possible Collision Obstacles:**

https://github.com/user-attachments/assets/b36ca8b0-e039-4113-830f-678e3318c711

**Cruising for Vehicles come from side lane:**

https://github.com/user-attachments/assets/a4cdab86-587f-4d28-81b0-9c44b1fdcf00


## Notes for reviewers
Please test this PR with the parameters below:
- https://github.com/autowarefoundation/autoware_launch/pull/1142
## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name                                      | Type   | Default Value | Description                                                                      |
|:--------------|:----------------------------------------------------|:-------|:--------------|:---------------------------------------------------------------------------------|
| Modified      | common.min_behavior_stop_margin                     | double | 6.0           | Updated minimum stop margin for behavior-based stopping.                         |
| Modified      | behavior_determination.obstacle_velocity_threshold_from_cruise_to_stop | double | 1.0   | Updated velocity threshold for switching from cruise to stop.                    |
| Modified      | behavior_determination.obstacle_velocity_threshold_from_stop_to_cruise | double | 1.5   | Updated velocity threshold for switching from stop to cruise.                    |
| Modified      | behavior_determination.crossing_obstacle.obstacle_velocity_threshold | double | 1.0   | Updated velocity threshold for determining crossing obstacles for cruise or stop.|
| Modified      | behavior_determination.crossing_obstacle.obstacle_traj_angle_threshold | double | 0.523599 | Updated yaw angle threshold for crossing obstacles.                              |
| Added         | behavior_determination.stop.outside_obstacle.max_lateral_time_margin | double | 4.0   | Maximum time margin for lateral collision checking between obstacles and ego.    |
| Added         | behavior_determination.stop.outside_obstacle.num_of_predicted_paths | int    | 3     | Number of highest confidence predicted paths to check collision between obstacle and ego. |
| Modified      | behavior_determination.stop.crossing_obstacle.collision_time_margin | double | 2.0   | Updated time threshold for collision between obstacle and ego.                   |
| Added         | behavior_determination.cruise.outside_obstacle.max_lateral_time_margin | double | 5.0   | Maximum time margin for lateral collision checking between obstacles and trajectory band with ego's width. |
| Added         | behavior_determination.cruise.outside_obstacle.num_of_predicted_paths | int    | 3     | Number of highest confidence predicted paths to check collision between obstacle and ego. |
| Modified      | behavior_determination.cruise.outside_obstacle.obstacle_velocity_threshold | double | 1.5   | Updated velocity threshold for obstacles outside the trajectory to cruise or stop.|
| Modified      | behavior_determination.cruise.outside_obstacle.ego_obstacle_overlap_time_threshold | double | 0.2 | Updated time threshold to decide cut-in obstacle for cruise or stop.             |
| Modified      | behavior_determination.cruise.outside_obstacle.max_prediction_time_for_collision_check | double | 10.0 | Updated prediction time for checking collision between obstacle and ego.         |
| Added      | behavior_determination.stop.min_velocity_to_reach_collision_point | double | 2.0 |  minimum velocity margin to calculate time to reach collision        |
## Effects on system behavior

None.
