### PR TITLE
fix(multi_object_tracker): fix shadowVariable

### DIFF
--- a/perception/multi_object_tracker/lib/association/successive_shortest_path/ssp.cpp
+++ b/perception/multi_object_tracker/lib/association/successive_shortest_path/ssp.cpp
@@ -330,12 +330,12 @@ void SSP::maximizeLinearAssignment(
 
 #ifndef NDEBUG
     // Check if the potentials are feasible potentials
-    for (int v = 0; v < n_nodes; ++v) {
-      for (auto it_incident_edge = adjacency_list.at(v).cbegin();
-           it_incident_edge != adjacency_list.at(v).cend(); ++it_incident_edge) {
+    for (int j = 0; j < n_nodes; ++j) {
+      for (auto it_incident_edge = adjacency_list.at(j).cbegin();
+           it_incident_edge != adjacency_list.at(j).cend(); ++it_incident_edge) {
         if (it_incident_edge->capacity > 0) {
           double reduced_cost =
-            it_incident_edge->cost + potentials.at(v) - potentials.at(it_incident_edge->dst);
+            it_incident_edge->cost + potentials.at(j) - potentials.at(it_incident_edge->dst);
           assert(reduced_cost >= 0);
         }
       }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings

```
perception/multi_object_tracker/lib/association/successive_shortest_path/ssp.cpp:333:14: style: Local variable 'v' shadows outer variable [shadowVariable]
    for (int v = 0; v < n_nodes; ++v) {
             ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
