### PR TITLE
fix(detected_object_validation): fix constParameterReference

### DIFF
--- a/perception/detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -38,7 +38,7 @@ namespace bg = boost::geometry;
 using Shape = autoware_perception_msgs::msg::Shape;
 using Polygon2d = autoware::universe_utils::Polygon2d;
 
-Validator::Validator(PointsNumThresholdParam & points_num_threshold_param)
+Validator::Validator(const PointsNumThresholdParam & points_num_threshold_param)
 {
   points_num_threshold_param_.min_points_num = points_num_threshold_param.min_points_num;
   points_num_threshold_param_.max_points_num = points_num_threshold_param.max_points_num;

--- a/perception/detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
@@ -64,7 +64,7 @@ protected:
   pcl::PointCloud<pcl::PointXYZ>::Ptr cropped_pointcloud_;
 
 public:
-  explicit Validator(PointsNumThresholdParam & points_num_threshold_param);
+  explicit Validator(const PointsNumThresholdParam & points_num_threshold_param);
   inline pcl::PointCloud<pcl::PointXYZ>::Ptr getDebugPointCloudWithinObject()
   {
     return cropped_pointcloud_;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
perception/detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp:41:48: style: Parameter 'points_num_threshold_param' can be declared as reference to const [constParameterReference]
Validator::Validator(PointsNumThresholdParam & points_num_threshold_param)
                                               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
