### PR TITLE
fix(probabilistic_occupancy_grid_map): fix funcArgNamesDifferent

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/src/fusion/synchronized_grid_map_fusion_node.hpp
+++ b/perception/probabilistic_occupancy_grid_map/src/fusion/synchronized_grid_map_fusion_node.hpp
@@ -61,7 +61,7 @@ public:
 private:
   void onGridMap(
     const nav_msgs::msg::OccupancyGrid::ConstSharedPtr & occupancy_grid_msg,
-    const std::string & input_topic);
+    const std::string & topic_name);
   nav_msgs::msg::OccupancyGrid::UniquePtr OccupancyGridMapToMsgPtr(
     const std::string & frame_id, const builtin_interfaces::msg::Time & stamp,
     const float & robot_pose_z, const nav2_costmap_2d::Costmap2D & occupancy_grid_map);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck funcArgNamesDifferent warnings

```
perception/probabilistic_occupancy_grid_map/src/fusion/synchronized_grid_map_fusion_node.cpp:183:23: style: inconclusive: Function 'onGridMap' argument 2 names different: declaration 'input_topic' definition 'topic_name'. [funcArgNamesDifferent]
  const std::string & topic_name)
                      ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
