### PR TITLE
fix(probabilistic_occupancy_grid_map): fix constVariableReference

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -160,7 +160,7 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
 
   // First step: Initialize cells to the final point with freespace
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
-    auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
+    const auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
 
     BinInfo end_distance;
     if (raw_pointcloud_angle_bin.empty()) {
@@ -175,8 +175,8 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
 
   // Second step: Add unknown cell
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
-    auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
-    auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
+    const auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
+    const auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
     auto raw_distance_iter = raw_pointcloud_angle_bin.begin();
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       // Calculate next raw point from obstacle point
@@ -232,7 +232,7 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
   }
 
   // Third step: Overwrite occupied cell
-  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
+  for (const auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       const auto & obstacle_point = obstacle_pointcloud_angle_bin.at(dist_index);
       setCellValue(obstacle_point.wx, obstacle_point.wy, cost_value::LETHAL_OBSTACLE);

--- a/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
@@ -285,7 +285,7 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
   if (pub_debug_grid_) converter.addLayerFromCostmap2D(*this, "added_unknown", debug_grid_);
 
   // Third step: Overwrite occupied cell
-  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
+  for (const auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       const auto & obstacle_point = obstacle_pointcloud_angle_bin.at(dist_index);
       setCellValue(obstacle_point.wx, obstacle_point.wy, cost_value::LETHAL_OBSTACLE);

--- a/perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp
+++ b/perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp
@@ -36,7 +36,7 @@ double convertCharToProbability(const unsigned char & occupancy)
 std::vector<unsigned char> convertProbabilityToChar(const std::vector<double> & probabilities)
 {
   std::vector<unsigned char> occupancies;
-  for (auto & probability : probabilities) {
+  for (const auto & probability : probabilities) {
     occupancies.push_back(convertProbabilityToChar(probability));
   }
   return occupancies;
@@ -45,7 +45,7 @@ std::vector<unsigned char> convertProbabilityToChar(const std::vector<double> & 
 std::vector<double> convertCharToProbability(const std::vector<unsigned char> & occupancies)
 {
   std::vector<double> probabilities;
-  for (auto & occupancy : occupancies) {
+  for (const auto & occupancy : occupancies) {
     probabilities.push_back(convertCharToProbability(occupancy));
   }
   return probabilities;
@@ -88,7 +88,7 @@ unsigned char overwriteFusion(const std::vector<unsigned char> & occupancies)
 
   auto fusion_occupancy = 128;  // unknown
   auto fusion_state = getApproximateState(fusion_occupancy);
-  for (auto & cell : occupancies) {
+  for (const auto & cell : occupancies) {
     auto state = getApproximateState(cell);
     if (state > fusion_state) {
       fusion_state = state;
@@ -115,7 +115,7 @@ namespace log_odds_fusion
 double logOddsFusion(const std::vector<double> & probabilities)
 {
   double log_odds = 0.0;
-  for (auto & probability : probabilities) {
+  for (const auto & probability : probabilities) {
     const double p = std::max(EPSILON_PROB, std::min(1.0 - EPSILON_PROB, probability));
     log_odds += std::log(p / (1.0 - p));
   }
@@ -252,7 +252,7 @@ struct dempsterShaferOccupancy
 double dempsterShaferFusion(const std::vector<double> & probability)
 {
   dempsterShaferOccupancy result;  // init with unknown
-  for (auto & p : probability) {
+  for (const auto & p : probability) {
     result = result + dempsterShaferOccupancy(p);
   }
   return result.getPignisticProbability();


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariableReference warnings

```
perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:163:12: style: Variable 'raw_pointcloud_angle_bin' can be declared as reference to const [constVariableReference]
    auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
           ^

perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:178:12: style: Variable 'obstacle_pointcloud_angle_bin' can be declared as reference to const [constVariableReference]
    auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
           ^

perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:179:12: style: Variable 'raw_pointcloud_angle_bin' can be declared as reference to const [constVariableReference]
    auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
           ^

perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:235:15: style: Variable 'obstacle_pointcloud_angle_bin' can be declared as reference to const [constVariableReference]
  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
              ^

perception/probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp:288:15: style: Variable 'obstacle_pointcloud_angle_bin' can be declared as reference to const [constVariableReference]
  for (auto & obstacle_pointcloud_angle_bin : obstacle_pointcloud_angle_bins) {
              ^

perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:39:15: style: Variable 'probability' can be declared as reference to const [constVariableReference]
  for (auto & probability : probabilities) {
              ^

perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:48:15: style: Variable 'occupancy' can be declared as reference to const [constVariableReference]
  for (auto & occupancy : occupancies) {
              ^

perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:91:15: style: Variable 'cell' can be declared as reference to const [constVariableReference]
  for (auto & cell : occupancies) {
              ^

perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:118:15: style: Variable 'probability' can be declared as reference to const [constVariableReference]
  for (auto & probability : probabilities) {
              ^

perception/probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:255:15: style: Variable 'p' can be declared as reference to const [constVariableReference]
  for (auto & p : probability) {
              ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
