### PR TITLE
feat(static_obstacle_avoidance): enable force execution under unsafe conditions

### DIFF
--- a/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
+++ b/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
@@ -60,7 +60,6 @@ public:
   void clearCooperateStatus();
   bool isActivated(const UUID & uuid) const;
   bool isForceActivated(const UUID & uuid) const;
-  bool isForceDeactivated(const UUID & uuid) const;
   bool isRegistered(const UUID & uuid) const;
   bool isRTCEnabled(const UUID & uuid) const;
   void lockCommandUpdate();

--- a/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
+++ b/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
@@ -59,6 +59,8 @@ public:
   void removeExpiredCooperateStatus();
   void clearCooperateStatus();
   bool isActivated(const UUID & uuid) const;
+  bool isForceActivated(const UUID & uuid) const;
+  bool isForceDeactivated(const UUID & uuid) const;
   bool isRegistered(const UUID & uuid) const;
   bool isRTCEnabled(const UUID & uuid) const;
   void lockCommandUpdate();

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -340,29 +340,6 @@ bool RTCInterface::isForceActivated(const UUID & uuid) const
   return false;
 }
 
-bool RTCInterface::isForceDeactivated(const UUID & uuid) const
-{
-  std::lock_guard<std::mutex> lock(mutex_);
-  const auto itr = std::find_if(
-    registered_status_.statuses.begin(), registered_status_.statuses.end(),
-    [uuid](auto & s) { return s.uuid == uuid; });
-
-  if (itr != registered_status_.statuses.end()) {
-    if (itr->state.type != State::RUNNING) {
-      return false;
-    }
-    if (itr->safe) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  RCLCPP_WARN_STREAM(
-    getLogger(), "[isForceDeactivated] uuid" << to_string(uuid) << " is not found" << std::endl);
-  return false;
-}
-
 bool RTCInterface::isRegistered(const UUID & uuid) const
 {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -317,6 +317,52 @@ bool RTCInterface::isActivated(const UUID & uuid) const
   return false;
 }
 
+bool RTCInterface::isForceActivated(const UUID & uuid) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto itr = std::find_if(
+    registered_status_.statuses.begin(), registered_status_.statuses.end(),
+    [uuid](auto & s) { return s.uuid == uuid; });
+
+  if (itr != registered_status_.statuses.end()) {
+    if (itr->state.type > State::RUNNING) {
+      return false;
+    }
+    if (itr->command_status.type == Command::ACTIVATE && !itr->safe) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  RCLCPP_WARN_STREAM(
+    getLogger(), "[isForceActivated] uuid : " << to_string(uuid) << " is not found" << std::endl);
+  return false;
+}
+
+bool RTCInterface::isForceDeactivated(const UUID & uuid) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto itr = std::find_if(
+    registered_status_.statuses.begin(), registered_status_.statuses.end(),
+    [uuid](auto & s) { return s.uuid == uuid; });
+
+  if (itr != registered_status_.statuses.end()) {
+    if (itr->state.type != State::RUNNING) {
+      return false;
+    }
+    if (itr->safe) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  RCLCPP_WARN_STREAM(
+    getLogger(), "[isForceDeactivated] uuid" << to_string(uuid) << " is not found" << std::endl);
+  return false;
+}
+
 bool RTCInterface::isRegistered(const UUID & uuid) const
 {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -322,10 +322,10 @@ bool RTCInterface::isForceActivated(const UUID & uuid) const
   std::lock_guard<std::mutex> lock(mutex_);
   const auto itr = std::find_if(
     registered_status_.statuses.begin(), registered_status_.statuses.end(),
-    [uuid](auto & s) { return s.uuid == uuid; });
+    [uuid](const auto & s) { return s.uuid == uuid; });
 
   if (itr != registered_status_.statuses.end()) {
-    if (itr->state.type > State::RUNNING) {
+    if (itr->state.type != State::WAITING_FOR_EXECUTION && itr->state.type != State::RUNNING) {
       return false;
     }
     if (itr->command_status.type == Command::ACTIVATE && !itr->safe) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -118,8 +118,15 @@ private:
       const double start_distance = autoware::motion_utils::calcSignedArcLength(
         path.points, ego_idx, left_shift.start_pose.position);
       const double finish_distance = start_distance + left_shift.relative_longitudinal;
-      rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
-        left_shift.uuid, true, State::RUNNING, start_distance, finish_distance, clock_->now());
+
+      if (rtc_interface_ptr_map_.at("left")->isForceActivated(left_shift.uuid)) {
+        rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
+          left_shift.uuid, false, State::RUNNING, start_distance, finish_distance, clock_->now());
+      } else {
+        rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
+          left_shift.uuid, true, State::RUNNING, start_distance, finish_distance, clock_->now());
+      }
+
       if (finish_distance > -1.0e-03) {
         steering_factor_interface_ptr_->updateSteeringFactor(
           {left_shift.start_pose, left_shift.finish_pose}, {start_distance, finish_distance},
@@ -131,8 +138,15 @@ private:
       const double start_distance = autoware::motion_utils::calcSignedArcLength(
         path.points, ego_idx, right_shift.start_pose.position);
       const double finish_distance = start_distance + right_shift.relative_longitudinal;
-      rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
-        right_shift.uuid, true, State::RUNNING, start_distance, finish_distance, clock_->now());
+
+      if (rtc_interface_ptr_map_.at("right")->isForceActivated(right_shift.uuid)) {
+        rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
+          right_shift.uuid, false, State::RUNNING, start_distance, finish_distance, clock_->now());
+      } else {
+        rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
+          right_shift.uuid, true, State::RUNNING, start_distance, finish_distance, clock_->now());
+      }
+
       if (finish_distance > -1.0e-03) {
         steering_factor_interface_ptr_->updateSteeringFactor(
           {right_shift.start_pose, right_shift.finish_pose}, {start_distance, finish_distance},

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -119,6 +119,7 @@ private:
         path.points, ego_idx, left_shift.start_pose.position);
       const double finish_distance = start_distance + left_shift.relative_longitudinal;
 
+      // If force activated keep safety to false
       if (rtc_interface_ptr_map_.at("left")->isForceActivated(left_shift.uuid)) {
         rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
           left_shift.uuid, false, State::RUNNING, start_distance, finish_distance, clock_->now());

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -606,7 +606,6 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
-
   /**
    * Check if any registered shift line is force activated
    */

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -602,40 +602,44 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
-  if (left_shift_array_.empty()) {
-    if (isActivated() && candidate_uuid_ == uuid_map_.at("left")) {
-      if (rtc_interface_ptr_map_.at("left")->isForceActivated(candidate_uuid_)) {
-        data.yield_required = false;
-        data.safe_shift_line = data.new_shift_line;
-        return;
+  auto candidate_sl_force_activated = [&](const std::string & direction) {
+    // If statement to avoid unnecessary warning occurring from isForceActivated function
+    if (candidate_uuid_ == uuid_map_.at(direction)) {
+      if (rtc_interface_ptr_map_.at(direction)->isForceActivated(candidate_uuid_)) {
+        return true;
       }
     }
-  } else {
-    for (const auto & left_shift : left_shift_array_) {
-      if (rtc_interface_ptr_map_.at("left")->isForceActivated(left_shift.uuid)) {
-        data.yield_required = false;
-        data.safe_shift_line = data.new_shift_line;
-        return;
-      }
+    return false;
+  };
+
+  auto registered_sl_force_activated =
+    [&](const std::string & direction, const RegisteredShiftLineArray shift_line_array) {
+      return std::any_of(
+        shift_line_array.begin(), shift_line_array.end(), [&](const auto & shift_line) {
+          return rtc_interface_ptr_map_.at(direction)->isForceActivated(shift_line.uuid);
+        });
+    };
+
+  /**
+   * Check if the candidate avoidance path is force activated
+   */
+  if (isActivated()) {
+    if (candidate_sl_force_activated("left") || candidate_sl_force_activated("right")) {
+      data.yield_required = false;
+      data.safe_shift_line = data.new_shift_line;
+      return;
     }
   }
 
-  if (right_shift_array_.empty()) {
-    if (isActivated() && candidate_uuid_ == uuid_map_.at("right")) {
-      if (rtc_interface_ptr_map_.at("right")->isForceActivated(candidate_uuid_)) {
-        data.yield_required = false;
-        data.safe_shift_line = data.new_shift_line;
-        return;
-      }
-    }
-  } else {
-    for (const auto & right_shift : right_shift_array_) {
-      if (rtc_interface_ptr_map_.at("right")->isForceActivated(right_shift.uuid)) {
-        data.yield_required = false;
-        data.safe_shift_line = data.new_shift_line;
-        return;
-      }
-    }
+  /**
+   * Check if any registered shift line is force activated
+   */
+  if (
+    registered_sl_force_activated("left", left_shift_array_) ||
+    registered_sl_force_activated("right", right_shift_array_)) {
+    data.yield_required = false;
+    data.safe_shift_line = data.new_shift_line;
+    return;
   }
 
   /**

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -602,8 +602,8 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
-  if (left_shift_array_.empty()){
-    if(isActivated() && candidate_uuid_ == uuid_map_.at("left")) {
+  if (left_shift_array_.empty()) {
+    if (isActivated() && candidate_uuid_ == uuid_map_.at("left")) {
       if (rtc_interface_ptr_map_.at("left")->isForceActivated(candidate_uuid_)) {
         data.yield_required = false;
         data.safe_shift_line = data.new_shift_line;
@@ -620,8 +620,8 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     }
   }
 
-  if (right_shift_array_.empty()){
-    if(isActivated() && candidate_uuid_ == uuid_map_.at("right")) {
+  if (right_shift_array_.empty()) {
+    if (isActivated() && candidate_uuid_ == uuid_map_.at("right")) {
       if (rtc_interface_ptr_map_.at("right")->isForceActivated(candidate_uuid_)) {
         data.yield_required = false;
         data.safe_shift_line = data.new_shift_line;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -602,6 +602,42 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
+  if (left_shift_array_.empty()){
+    if(isActivated() && candidate_uuid_ == uuid_map_.at("left")) {
+      if (rtc_interface_ptr_map_.at("left")->isForceActivated(candidate_uuid_)) {
+        data.yield_required = false;
+        data.safe_shift_line = data.new_shift_line;
+        return;
+      }
+    }
+  } else {
+    for (const auto & left_shift : left_shift_array_) {
+      if (rtc_interface_ptr_map_.at("left")->isForceActivated(left_shift.uuid)) {
+        data.yield_required = false;
+        data.safe_shift_line = data.new_shift_line;
+        return;
+      }
+    }
+  }
+
+  if (right_shift_array_.empty()){
+    if(isActivated() && candidate_uuid_ == uuid_map_.at("right")) {
+      if (rtc_interface_ptr_map_.at("right")->isForceActivated(candidate_uuid_)) {
+        data.yield_required = false;
+        data.safe_shift_line = data.new_shift_line;
+        return;
+      }
+    }
+  } else {
+    for (const auto & right_shift : right_shift_array_) {
+      if (rtc_interface_ptr_map_.at("right")->isForceActivated(right_shift.uuid)) {
+        data.yield_required = false;
+        data.safe_shift_line = data.new_shift_line;
+        return;
+      }
+    }
+  }
+
   /**
    * Transit yield maneuver. Clear shift lines and output yield path.
    */


### PR DESCRIPTION
## Description
When static obstacle avoidance was force activated by operators under unsafe condition, the yield maneuver activates and the avoidance is canceled.
Although, when force activated it should activate the avoidance maneuver (never cancel) regardless to the safe/unsafe judgement inside the module. This PR enables static obstacle avoidance once the the avoidance path is force activated via RTC.

## Related links

## How was this PR tested?
Psim
[Before](https://github.com/user-attachments/assets/0319e799-5a65-47c0-bfe3-23c104bfc20e)
[After](https://github.com/user-attachments/assets/876ac81d-5076-4d9d-b0c9-142151c840f9)

[TIER IV internal test](https://evaluation.tier4.jp/evaluation/reports/0a9c3bda-f162-5d37-b2de-e25ee177602a?project_id=prd_jt)

## Notes for reviewers
The RTC interface module is changed as well

## Interface changes
None.

## Effects on system behavior
None.
