### PR TITLE
fix(autoware_map_based_prediction): adjust the predicted path of the object in bidirectional lanes

### DIFF
--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -5,6 +5,7 @@
       vehicle: 15.0 #[s]
       pedestrian: 10.0 #[s]
       unknown: 10.0 #[s]
+    check_bidirectional_lanelets: false
     lateral_control_time_horizon: 5.0 #[s]
     prediction_sampling_delta_time: 0.5 #[s]
     min_velocity_for_map_based_prediction: 1.39 #[m/s]

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -268,7 +268,7 @@ private:
     const geometry_msgs::msg::Point & point1, const geometry_msgs::msg::Point & point2,
     const lanelet::ConstPoint3d & point3, const lanelet::ConstPoint3d & point4);
 
-  bool isRelativelyLeft(const TrackedObject & object);
+  bool isLeft(const TrackedObject & object);
 
   PredictedObjectKinematics convertToPredictedKinematics(
     const TrackedObjectKinematics & tracked_object);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -280,6 +280,11 @@ private:
   void removeStaleTrafficLightInfo(const TrackedObjects::ConstSharedPtr in_objects);
 
   LaneletsData getCurrentLanelets(const TrackedObject & object);
+
+  LaneletsData getBidirectionalLanelets(
+    const std::vector<std::pair<double, lanelet::Lanelet>> & surrounding_lanelets,
+    const TrackedObject & object);
+
   bool checkCloseLaneletCondition(
     const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object);
   float calculateLocalLikelihood(

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -209,6 +209,7 @@ private:
   // Parameters
   bool enable_delay_compensation_;
   PredictionTimeHorizon prediction_time_horizon_;
+  bool check_bidirectional_lanelets_;
   double lateral_control_time_horizon_;
   double prediction_time_horizon_rate_for_validate_lane_length_;
   double prediction_sampling_time_interval_;

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -121,6 +121,7 @@ struct LaneletData
 {
   lanelet::Lanelet lanelet;
   float probability;
+  bool is_bidirectional = false;
 };
 
 struct PredictedRefPath

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -268,6 +268,8 @@ private:
     const geometry_msgs::msg::Point & point1, const geometry_msgs::msg::Point & point2,
     const lanelet::ConstPoint3d & point3, const lanelet::ConstPoint3d & point4);
 
+  bool isRelativelyLeft(const TrackedObject & object);
+
   PredictedObjectKinematics convertToPredictedKinematics(
     const TrackedObjectKinematics & tracked_object);
 

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -83,7 +83,7 @@ class PathGenerator
 public:
   PathGenerator(const double sampling_time_interval, const double min_crosswalk_user_velocity);
 
-  PredictedPath shiftPath(const PredictedPath & path, const double shift_distance);
+  PredictedPath shiftPath(const PosePath & ref_paths, const double shift_distance);
 
   void setTimeKeeper(std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr);
 
@@ -101,7 +101,7 @@ public:
     const double lateral_duration, const double speed_limit = 0.0) const;
 
   PredictedPath generateShiftedPathForOnLaneVehicle(
-    const TrackedObject & object, const PredictedPath & predicted_path, const double duration,
+    const TrackedObject & object, const PosePath & ref_paths, const double duration,
     const double lateral_duration, const double shift_length, const double speed_limit = 0.0);
 
   PredictedPath generatePathForCrosswalkUser(

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -100,6 +100,10 @@ public:
     const TrackedObject & object, const PosePath & ref_paths, const double duration,
     const double lateral_duration, const double speed_limit = 0.0) const;
 
+  PredictedPath generateShiftedPathForOnLaneVehicle(
+    const TrackedObject & object, const PredictedPath & predicted_path, const double duration,
+    const double lateral_duration, const double shift_length, const double speed_limit = 0.0);
+
   PredictedPath generatePathForCrosswalkUser(
     const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk,
     const double duration) const;

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -83,6 +83,8 @@ class PathGenerator
 public:
   PathGenerator(const double sampling_time_interval, const double min_crosswalk_user_velocity);
 
+  PredictedPath shiftPath(const PredictedPath & path, const double shift_distance);
+
   void setTimeKeeper(std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr);
 
   PredictedPath generatePathForNonVehicleObject(

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1689,18 +1689,18 @@ void MapBasedPredictionNode::removeStaleTrafficLightInfo(
 
 LaneletsData MapBasedPredictionNode::getBidirectionalLanelets(
   const std::vector<std::pair<double, lanelet::Lanelet>> & surrounding_lanelets,
-  const TrackedObject & object) {
-
+  const TrackedObject & object)
+{
   LaneletsData bidirectional_lanelets;
   constexpr double epsilon = 1e-3;
 
   for (size_t t = 0; t < surrounding_lanelets.size(); t++) {
     for (size_t j = t + 1; j < surrounding_lanelets.size(); j++) {
-      if (surrounding_lanelets[t].second.leftBound().id() ==
-            surrounding_lanelets[j].second.rightBound().id() &&
-          surrounding_lanelets[t].second.rightBound().id() ==
-            surrounding_lanelets[j].second.leftBound().id()) {
-
+      if (
+        surrounding_lanelets[t].second.leftBound().id() ==
+          surrounding_lanelets[j].second.rightBound().id() &&
+        surrounding_lanelets[t].second.rightBound().id() ==
+          surrounding_lanelets[j].second.leftBound().id()) {
         const auto prev_bidirectional_lane = LaneletData{
           surrounding_lanelets[t].second,
           calculateLocalLikelihood(surrounding_lanelets[t].second, object), true};
@@ -1712,8 +1712,7 @@ LaneletsData MapBasedPredictionNode::getBidirectionalLanelets(
         double lane_yaw = lanelet::utils::getLaneletAngle(
           surrounding_lanelets[t].second, object.kinematics.pose_with_covariance.pose.position);
         double delta_yaw = object_yaw - lane_yaw;
-        const double normalized_delta_yaw =
-          autoware::universe_utils::normalizeRadian(delta_yaw);
+        const double normalized_delta_yaw = autoware::universe_utils::normalizeRadian(delta_yaw);
         const double abs_norm_delta = std::fabs(normalized_delta_yaw);
 
         if (abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_) {
@@ -1733,7 +1732,8 @@ LaneletsData MapBasedPredictionNode::getBidirectionalLanelets(
   return bidirectional_lanelets;
 }
 
-LaneletsData MapBasedPredictionNode::getCurrentLanelets(const TrackedObject & object) {
+LaneletsData MapBasedPredictionNode::getCurrentLanelets(const TrackedObject & object)
+{
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1161,7 +1161,7 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         for (const auto & ref_path : ref_paths) {
           PredictedPath predicted_path{};
           // convert PredictedRefPath to PredictedPath
-          for (const auto &current_lanelet : current_lanelets) {
+          for (const auto & current_lanelet : current_lanelets) {
             if (current_lanelet.is_bidirectional) {
               if (isLeft(transformed_object)) {
                 predicted_path = path_generator_->generateShiftedPathForOnLaneVehicle(
@@ -1704,14 +1704,18 @@ LaneletsData MapBasedPredictionNode::getBidirectionalLanelets(
     if (right_match != right_bound_map.end() && left_match != left_bound_map.end()) {
       const auto & matching_lanelet = right_match->second;
 
-      const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-      const double lane_yaw = lanelet::utils::getLaneletAngle(lanelet, object.kinematics.pose_with_covariance.pose.position);
+      const double object_yaw =
+        tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+      const double lane_yaw = lanelet::utils::getLaneletAngle(
+        lanelet, object.kinematics.pose_with_covariance.pose.position);
       const double delta_yaw = object_yaw - lane_yaw;
       const double normalized_delta_yaw = autoware::universe_utils::normalizeRadian(delta_yaw);
       const double abs_norm_delta = std::fabs(normalized_delta_yaw);
 
-      const auto prev_bidirectional_lane = LaneletData{lanelet, calculateLocalLikelihood(lanelet, object), true};
-      const auto next_bidirectional_lane = LaneletData{matching_lanelet, calculateLocalLikelihood(matching_lanelet, object), true};
+      const auto prev_bidirectional_lane =
+        LaneletData{lanelet, calculateLocalLikelihood(lanelet, object), true};
+      const auto next_bidirectional_lane =
+        LaneletData{matching_lanelet, calculateLocalLikelihood(matching_lanelet, object), true};
 
       if (abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_) {
         bidirectional_lanelets.push_back(prev_bidirectional_lane);

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1095,16 +1095,20 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
                 const auto & obj_pos = object.kinematics.pose_with_covariance.pose.position;
                 const lanelet::BasicPoint2d obj_point(obj_pos.x, obj_pos.y);
                 prev_left_bound_dist = lanelet::geometry::distance2d(
-                  lanelet::utils::to2D(surrounding_lanelets[t].second.leftBound().basicLineString()),
+                  lanelet::utils::to2D(
+                    surrounding_lanelets[t].second.leftBound().basicLineString()),
                   obj_point);
                 prev_right_bound_dist = lanelet::geometry::distance2d(
-                  lanelet::utils::to2D(surrounding_lanelets[t].second.rightBound().basicLineString()),
+                  lanelet::utils::to2D(
+                    surrounding_lanelets[t].second.rightBound().basicLineString()),
                   obj_point);
                 next_left_bound_dist = lanelet::geometry::distance2d(
-                  lanelet::utils::to2D(surrounding_lanelets[j].second.leftBound().basicLineString()),
+                  lanelet::utils::to2D(
+                    surrounding_lanelets[j].second.leftBound().basicLineString()),
                   obj_point);
                 next_right_bound_dist = lanelet::geometry::distance2d(
-                  lanelet::utils::to2D(surrounding_lanelets[j].second.rightBound().basicLineString()),
+                  lanelet::utils::to2D(
+                    surrounding_lanelets[j].second.rightBound().basicLineString()),
                   obj_point);
                 bound_to_centerline = lanelet::geometry::distance2d(
                   lanelet::utils::to2D(current_lanelet.lanelet.leftBound().basicLineString()),
@@ -1195,8 +1199,12 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
           predicted_path.path = ref_path.path;
           predicted_path.confidence = ref_path.probability;
 
-          if (prev_left_bound_dist != 0 && prev_right_bound_dist != 0 && next_left_bound_dist != 0 && next_right_bound_dist != 0) {
-            if ((prev_right_bound_dist < prev_left_bound_dist) && (next_left_bound_dist < next_right_bound_dist)) {
+          if (
+            prev_left_bound_dist != 0 && prev_right_bound_dist != 0 && next_left_bound_dist != 0 &&
+            next_right_bound_dist != 0) {
+            if (
+              (prev_right_bound_dist < prev_left_bound_dist) &&
+              (next_left_bound_dist < next_right_bound_dist)) {
               predicted_path = path_generator_->shiftPath(predicted_path, -bound_to_centerline / 2);
               shifted_predicted_path = path_generator_->generatePathForOnLaneVehicle(
                 yaw_fixed_transformed_object, predicted_path.path, prediction_time_horizon_.vehicle,
@@ -1207,7 +1215,9 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
               predicted_object_vehicle.kinematics.predicted_paths.push_back(shifted_predicted_path);
               output.objects.push_back(predicted_object_vehicle);
 
-            } else if ((prev_right_bound_dist > prev_left_bound_dist) && (next_left_bound_dist > next_right_bound_dist)){
+            } else if (
+              (prev_right_bound_dist > prev_left_bound_dist) &&
+              (next_left_bound_dist > next_right_bound_dist)) {
               predicted_path = path_generator_->shiftPath(predicted_path, bound_to_centerline / 2);
               shifted_predicted_path = path_generator_->generatePathForOnLaneVehicle(
                 yaw_fixed_transformed_object, predicted_path.path, prediction_time_horizon_.vehicle,
@@ -1732,17 +1742,25 @@ LaneletsData MapBasedPredictionNode::getCurrentLanelets(const TrackedObject & ob
         for (size_t j = t + 1; j < surrounding_lanelets.size(); j++) {
           // Check the lanes have same left and right bounds
           if (
-            surrounding_lanelets[t].second.leftBound().id() == surrounding_lanelets[j].second.rightBound().id() &&
-            surrounding_lanelets[t].second.rightBound().id() == surrounding_lanelets[j].second.leftBound().id()) {
-            const auto prev_bidirectional_lane = LaneletData{surrounding_lanelets[t].second, calculateLocalLikelihood(surrounding_lanelets[t].second, object), true};
-            const auto next_bidirectional_lane = LaneletData{surrounding_lanelets[j].second, calculateLocalLikelihood(surrounding_lanelets[j].second, object), true};
-            const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+            surrounding_lanelets[t].second.leftBound().id() ==
+              surrounding_lanelets[j].second.rightBound().id() &&
+            surrounding_lanelets[t].second.rightBound().id() ==
+              surrounding_lanelets[j].second.leftBound().id()) {
+            const auto prev_bidirectional_lane = LaneletData{
+              surrounding_lanelets[t].second,
+              calculateLocalLikelihood(surrounding_lanelets[t].second, object), true};
+            const auto next_bidirectional_lane = LaneletData{
+              surrounding_lanelets[j].second,
+              calculateLocalLikelihood(surrounding_lanelets[j].second, object), true};
+            const double object_yaw =
+              tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
             const double lane_yaw = lanelet::utils::getLaneletAngle(
               surrounding_lanelets[t].second, object.kinematics.pose_with_covariance.pose.position);
             const double delta_yaw = object_yaw - lane_yaw;
-            const double normalized_delta_yaw = autoware::universe_utils::normalizeRadian(delta_yaw);
+            const double normalized_delta_yaw =
+              autoware::universe_utils::normalizeRadian(delta_yaw);
             const double abs_norm_delta = std::fabs(normalized_delta_yaw);
-            //check the angle difference between the object and lane
+            // check the angle difference between the object and lane
             if (abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_) {
               object_lanelets.push_back(prev_bidirectional_lane);
             } else {

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -750,6 +750,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
     google::InstallFailureSignalHandler();
   }
   enable_delay_compensation_ = declare_parameter<bool>("enable_delay_compensation");
+  check_bidirectional_lanelets_ = declare_parameter<bool>("check_bidirectional_lanelets");
   prediction_time_horizon_.vehicle = declare_parameter<double>("prediction_time_horizon.vehicle");
   prediction_time_horizon_.pedestrian =
     declare_parameter<double>("prediction_time_horizon.pedestrian");
@@ -1075,12 +1076,14 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         // Get Closest Lanelet
         const auto current_lanelets = getCurrentLanelets(transformed_object);
         double bound_to_centerline = 0.0;
-        for (const auto & current_lanelet : current_lanelets) {
-          // Check if the lanelet is bidirectional
-          if (current_lanelet.is_bidirectional) {
-            bound_to_centerline = lanelet::geometry::distance2d(
-              lanelet::utils::to2D(current_lanelet.lanelet.leftBound().basicLineString()),
-              lanelet::utils::to2D(current_lanelet.lanelet.centerline().basicLineString()));
+        if (check_bidirectional_lanelets_) {
+          for (const auto & current_lanelet : current_lanelets) {
+            // Check if the lanelet is bidirectional
+            if (current_lanelet.is_bidirectional) {
+              bound_to_centerline = lanelet::geometry::distance2d(
+                lanelet::utils::to2D(current_lanelet.lanelet.leftBound().basicLineString()),
+                lanelet::utils::to2D(current_lanelet.lanelet.centerline().basicLineString()));
+            }
           }
         }
         // Update Objects History

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1092,24 +1092,22 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
           if (current_lanelet.is_bidirectional) {
             for (size_t t = 0; t < surrounding_lanelets.size(); t++) {
               for (size_t j = t + 1; j < surrounding_lanelets.size(); j++) {
-                const auto & obj_pos = object.kinematics.pose_with_covariance.pose.position;
-                const lanelet::BasicPoint2d obj_point(obj_pos.x, obj_pos.y);
                 prev_left_bound_dist = lanelet::geometry::distance2d(
                   lanelet::utils::to2D(
                     surrounding_lanelets[t].second.leftBound().basicLineString()),
-                  obj_point);
+                  search_point);
                 prev_right_bound_dist = lanelet::geometry::distance2d(
                   lanelet::utils::to2D(
                     surrounding_lanelets[t].second.rightBound().basicLineString()),
-                  obj_point);
+                  search_point);
                 next_left_bound_dist = lanelet::geometry::distance2d(
                   lanelet::utils::to2D(
                     surrounding_lanelets[j].second.leftBound().basicLineString()),
-                  obj_point);
+                  search_point);
                 next_right_bound_dist = lanelet::geometry::distance2d(
                   lanelet::utils::to2D(
                     surrounding_lanelets[j].second.rightBound().basicLineString()),
-                  obj_point);
+                  search_point);
                 bound_to_centerline = lanelet::geometry::distance2d(
                   lanelet::utils::to2D(current_lanelet.lanelet.leftBound().basicLineString()),
                   lanelet::utils::to2D(current_lanelet.lanelet.centerline().basicLineString()));

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1078,11 +1078,12 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
         // Get Closest Lanelet
         const auto current_lanelets = getCurrentLanelets(transformed_object);
         double bound_to_centerline = 0.0;
-          for (const auto & current_lanelet : current_lanelets) {
+        for (const auto & current_lanelet : current_lanelets) {
           // Check if the lanelet is bidirectional
           if (current_lanelet.is_bidirectional) {
-            bound_to_centerline = lanelet::geometry::distance2d(lanelet::utils::to2D(current_lanelet.lanelet.leftBound().basicLineString()),
-                                                                       lanelet::utils::to2D(current_lanelet.lanelet.centerline().basicLineString()));
+            bound_to_centerline = lanelet::geometry::distance2d(
+              lanelet::utils::to2D(current_lanelet.lanelet.leftBound().basicLineString()),
+              lanelet::utils::to2D(current_lanelet.lanelet.centerline().basicLineString()));
           }
         }
         // Update Objects History
@@ -1170,12 +1171,12 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
             if (isRelativelyLeft(transformed_object)) {
               predicted_path = path_generator_->generateShiftedPathForOnLaneVehicle(
                 yaw_fixed_transformed_object, predicted_path, prediction_time_horizon_.vehicle,
-                lateral_control_time_horizon_, -bound_to_centerline/2, ref_path.speed_limit);
+                lateral_control_time_horizon_, -bound_to_centerline / 2, ref_path.speed_limit);
 
             } else if (!isRelativelyLeft(transformed_object)) {
               predicted_path = path_generator_->generateShiftedPathForOnLaneVehicle(
                 yaw_fixed_transformed_object, predicted_path, prediction_time_horizon_.vehicle,
-                lateral_control_time_horizon_, bound_to_centerline/2, ref_path.speed_limit);
+                lateral_control_time_horizon_, bound_to_centerline / 2, ref_path.speed_limit);
             }
           } else {
             predicted_path = path_generator_->generatePathForOnLaneVehicle(
@@ -1426,8 +1427,7 @@ bool MapBasedPredictionNode::isIntersecting(
   return intersection.has_value();
 }
 
-bool MapBasedPredictionNode::isRelativelyLeft(
-  const TrackedObject & object)
+bool MapBasedPredictionNode::isRelativelyLeft(const TrackedObject & object)
 {
   lanelet::BasicPoint2d search_point(
     object.kinematics.pose_with_covariance.pose.position.x,
@@ -1444,14 +1444,23 @@ bool MapBasedPredictionNode::isRelativelyLeft(
 
   for (size_t t = 0; t < surrounding_lanelets.size(); t++) {
     for (size_t j = t + 1; j < surrounding_lanelets.size(); j++) {
-      prev_left_bound_dist = lanelet::geometry::distance2d(lanelet::utils::to2D(surrounding_lanelets[t].second.leftBound().basicLineString()),search_point);
-      prev_right_bound_dist = lanelet::geometry::distance2d(lanelet::utils::to2D(surrounding_lanelets[t].second.rightBound().basicLineString()),search_point);
-      next_left_bound_dist = lanelet::geometry::distance2d(lanelet::utils::to2D(surrounding_lanelets[j].second.leftBound().basicLineString()),search_point);
-      next_right_bound_dist = lanelet::geometry::distance2d(lanelet::utils::to2D(surrounding_lanelets[j].second.rightBound().basicLineString()),search_point);
-
+      prev_left_bound_dist = lanelet::geometry::distance2d(
+        lanelet::utils::to2D(surrounding_lanelets[t].second.leftBound().basicLineString()),
+        search_point);
+      prev_right_bound_dist = lanelet::geometry::distance2d(
+        lanelet::utils::to2D(surrounding_lanelets[t].second.rightBound().basicLineString()),
+        search_point);
+      next_left_bound_dist = lanelet::geometry::distance2d(
+        lanelet::utils::to2D(surrounding_lanelets[j].second.leftBound().basicLineString()),
+        search_point);
+      next_right_bound_dist = lanelet::geometry::distance2d(
+        lanelet::utils::to2D(surrounding_lanelets[j].second.rightBound().basicLineString()),
+        search_point);
     }
   }
-  if((prev_right_bound_dist < prev_left_bound_dist) && (next_left_bound_dist < next_right_bound_dist)){
+  if (
+    (prev_right_bound_dist < prev_left_bound_dist) &&
+    (next_left_bound_dist < next_right_bound_dist)) {
     return true;
   }
   return false;

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1171,12 +1171,12 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
             if (isLeft(transformed_object)) {
               predicted_path = path_generator_->generateShiftedPathForOnLaneVehicle(
                 yaw_fixed_transformed_object, predicted_path, prediction_time_horizon_.vehicle,
-                lateral_control_time_horizon_, bound_to_centerline/2, ref_path.speed_limit);
+                lateral_control_time_horizon_, bound_to_centerline / 2, ref_path.speed_limit);
 
             } else if (!isLeft(transformed_object)) {
               predicted_path = path_generator_->generateShiftedPathForOnLaneVehicle(
                 yaw_fixed_transformed_object, predicted_path, prediction_time_horizon_.vehicle,
-                lateral_control_time_horizon_, -bound_to_centerline/2, ref_path.speed_limit);
+                lateral_control_time_horizon_, -bound_to_centerline / 2, ref_path.speed_limit);
             }
           } else {
             predicted_path = path_generator_->generatePathForOnLaneVehicle(
@@ -1427,14 +1427,13 @@ bool MapBasedPredictionNode::isIntersecting(
   return intersection.has_value();
 }
 
-bool MapBasedPredictionNode::isLeft(
-  const TrackedObject & object)
+bool MapBasedPredictionNode::isLeft(const TrackedObject & object)
 {
   lanelet::BasicPoint2d search_point(
     object.kinematics.pose_with_covariance.pose.position.x,
     object.kinematics.pose_with_covariance.pose.position.y);
 
-  //find current lane
+  // find current lane
   const auto surrounding_lanelets = getCurrentLanelets(object);
   if (surrounding_lanelets.empty()) {
     return false;
@@ -1445,7 +1444,8 @@ bool MapBasedPredictionNode::isLeft(
 
   for (size_t t = 0; t < surrounding_lanelets.size(); t++) {
     const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-    const double lane_yaw = lanelet::utils::getLaneletAngle(surrounding_lanelets[t].lanelet, object.kinematics.pose_with_covariance.pose.position);
+    const double lane_yaw = lanelet::utils::getLaneletAngle(
+      surrounding_lanelets[t].lanelet, object.kinematics.pose_with_covariance.pose.position);
     const double delta_yaw = object_yaw - lane_yaw;
     const double normalized_delta_yaw = autoware::universe_utils::normalizeRadian(delta_yaw);
     const double abs_norm_delta = std::fabs(normalized_delta_yaw);

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -31,6 +31,21 @@ PathGenerator::PathGenerator(
 {
 }
 
+PredictedPath PathGenerator::shiftPath(const PredictedPath & path, const double shift_distance)
+{
+  //lateral shift of the path by shift_distance
+  PredictedPath shifted_path;
+  shifted_path.time_step = path.time_step;
+  shifted_path.confidence = path.confidence;
+  shifted_path.path.reserve(path.path.size());
+  for (const auto & pose : path.path) {
+    geometry_msgs::msg::Pose shifted_pose = pose;
+    shifted_pose.position.x += shift_distance;
+    shifted_path.path.push_back(shifted_pose);
+  }
+
+  return shifted_path;
+}
 void PathGenerator::setTimeKeeper(
   std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr)
 {

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -36,12 +36,12 @@ PredictedPath PathGenerator::shiftPath(const PosePath & ref_paths, const double 
   PredictedPath shifted_path;
   shifted_path.path.reserve(ref_paths.size());
   for (const auto & ref_path : ref_paths) {
-
     geometry_msgs::msg::Pose shifted_pose = ref_path;
 
     // Get yaw from quaternion
     tf2::Quaternion quat(
-      ref_path.orientation.x, ref_path.orientation.y, ref_path.orientation.z, ref_path.orientation.w);
+      ref_path.orientation.x, ref_path.orientation.y, ref_path.orientation.z,
+      ref_path.orientation.w);
     tf2::Matrix3x3 mat(quat);
     double roll, pitch, yaw;
     mat.getRPY(roll, pitch, yaw);

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -33,14 +33,27 @@ PathGenerator::PathGenerator(
 
 PredictedPath PathGenerator::shiftPath(const PredictedPath & path, const double shift_distance)
 {
-  // lateral shift of the path by shift_distance
   PredictedPath shifted_path;
   shifted_path.time_step = path.time_step;
   shifted_path.confidence = path.confidence;
   shifted_path.path.reserve(path.path.size());
   for (const auto & pose : path.path) {
     geometry_msgs::msg::Pose shifted_pose = pose;
-    shifted_pose.position.x += shift_distance;
+
+    // Get yaw from quaternion
+    tf2::Quaternion quat(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+    tf2::Matrix3x3 mat(quat);
+    double roll, pitch, yaw;
+    mat.getRPY(roll, pitch, yaw);
+
+    // Calculate the lateral shift
+    double delta_x = shift_distance * cos(yaw + M_PI_2);
+    double delta_y = shift_distance * sin(yaw + M_PI_2);
+
+    // Apply the shift
+    shifted_pose.position.x += delta_x;
+    shifted_pose.position.y += delta_y;
+
     shifted_path.path.push_back(shifted_pose);
   }
 

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -41,7 +41,8 @@ PredictedPath PathGenerator::shiftPath(const PredictedPath & path, const double 
     geometry_msgs::msg::Pose shifted_pose = pose;
 
     // Get yaw from quaternion
-    tf2::Quaternion quat(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+    tf2::Quaternion quat(
+      pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
     tf2::Matrix3x3 mat(quat);
     double roll, pitch, yaw;
     mat.getRPY(roll, pitch, yaw);

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -33,7 +33,7 @@ PathGenerator::PathGenerator(
 
 PredictedPath PathGenerator::shiftPath(const PredictedPath & path, const double shift_distance)
 {
-  //lateral shift of the path by shift_distance
+  // lateral shift of the path by shift_distance
   PredictedPath shifted_path;
   shifted_path.time_step = path.time_step;
   shifted_path.confidence = path.confidence;

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -203,6 +203,17 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   return generatePolynomialPath(object, ref_paths, duration, lateral_duration, speed_limit);
 }
 
+PredictedPath PathGenerator::generateShiftedPathForOnLaneVehicle(
+  const TrackedObject & object, const PredictedPath & predicted_path, const double duration,
+  const double lateral_duration, const double shift_length, const double speed_limit)
+{
+  if (predicted_path.path.size() < 2) {
+    return generateStraightPath(object, duration);
+  }
+  const PosePath & ref_path = shiftPath(predicted_path, shift_length).path;
+  return generatePolynomialPath(object, ref_path, duration, lateral_duration, speed_limit);
+}
+
 PredictedPath PathGenerator::generateStraightPath(
   const TrackedObject & object, const double longitudinal_duration) const
 {


### PR DESCRIPTION
## Description

fixes: https://github.com/autowarefoundation/autoware.universe/issues/8073
must merged: https://github.com/autowarefoundation/autoware_launch/pull/1141
## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/7689

<!-- ⬇️🟢
**Private Links:**


- [CompanyName internal link]()
⬆️🟢 -->

## New Approach
If the **right bound** id of the `prev_lanelet` is equal to the **left bound** id of the `next_lanelet` and the **left bound** id is equal to the **right bound** id of the next_lanelet, the lane is **bi-directional**.

prev_right_bound_id = next_left_bound_id
prev_left_bound_id = next_right_bound_id


![x](https://github.com/user-attachments/assets/6337e080-b486-4e70-8036-83a0b549fd35)



(prev_right_bound_dist < prev_left_bound_dist) && (next_left_bound_dist < next_right_bound_dist) -> shift left 
(prev_right_bound_dist > prev_left_bound_dist) && (next_left_bound_dist > next_right_bound_dist) -> shift right   

| Before  | After |   After |
| ------------- | ------------- | ------------- |
| <image src="https://github.com/user-attachments/assets/8edffa9b-0e6c-4018-a3a5-017adf500a99">  | <image src="https://github.com/user-attachments/assets/a5e34a7b-e6fe-4890-9785-5f3d6d631a8d">  | <image src="https://github.com/user-attachments/assets/f595bea5-980a-46ce-97eb-a76a66848e32">|


## How was this PR tested?

https://github.com/user-attachments/assets/1a8de069-3248-4d4b-a53e-b5925ae57be4


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
