### PR TITLE
feat(ndt_scan_matcher): add scale_factor to covariance_estimation

### DIFF
--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -119,6 +119,9 @@
         # In MULTI_NDT_SCORE, the parameter that adjusts the estimated 2D covariance
         temperature: 0.1
 
+        # Scale value for adjusting the estimated covariance by a constant multiplication
+        scale_factor: 1.0
+
 
     dynamic_map_loading:
       # Dynamic map loading distance

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/hyper_parameters.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/hyper_parameters.hpp
@@ -91,6 +91,7 @@ struct HyperParameters
       std::vector<double> initial_pose_offset_model_x{};
       std::vector<double> initial_pose_offset_model_y{};
       double temperature{};
+      double scale_factor{};
     } covariance_estimation{};
   } covariance{};
 
@@ -178,6 +179,8 @@ public:
     }
     covariance.covariance_estimation.temperature =
       node->declare_parameter<double>("covariance.covariance_estimation.temperature");
+    covariance.covariance_estimation.scale_factor =
+      node->declare_parameter<double>("covariance.covariance_estimation.scale_factor");
 
     dynamic_map_loading.update_distance =
       node->declare_parameter<double>("dynamic_map_loading.update_distance");

--- a/localization/ndt_scan_matcher/schema/sub/covariance_covariance_estimation.json
+++ b/localization/ndt_scan_matcher/schema/sub/covariance_covariance_estimation.json
@@ -27,13 +27,21 @@
           "description": "In MULTI_NDT_SCORE, the parameter that adjusts the estimated 2D covariance",
           "default": 0.1,
           "exclusiveMinimum": 0
+        },
+        "scale_factor": {
+          "type": "number",
+          "description": "Scale value for adjusting the estimated covariance by a constant multiplication",
+          "default": 1.0,
+          "exclusiveMinimum": 0
         }
       },
 
       "required": [
         "covariance_estimation_type",
         "initial_pose_offset_model_x",
-        "initial_pose_offset_model_y"
+        "initial_pose_offset_model_y",
+        "temperature",
+        "scale_factor"
       ],
       "additionalProperties": false
     }

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -584,8 +584,10 @@ bool NDTScanMatcher::callback_sensor_points_main(
     CovarianceEstimationType::FIXED_VALUE) {
     const Eigen::Matrix2d estimated_covariance_2d =
       estimate_covariance(ndt_result, initial_pose_matrix, sensor_ros_time);
-    const Eigen::Matrix2d estimated_covariance_2d_adj =
-      pclomp::adjust_diagonal_covariance(estimated_covariance_2d, ndt_result.pose, 0.0225, 0.0225);
+    const Eigen::Matrix2d estimated_covariance_2d_scaled =
+      estimated_covariance_2d * param_.covariance.covariance_estimation.scale_factor;
+    const Eigen::Matrix2d estimated_covariance_2d_adj = pclomp::adjust_diagonal_covariance(
+      estimated_covariance_2d_scaled, ndt_result.pose, 0.0225, 0.0225);
     ndt_covariance[0 + 6 * 0] = estimated_covariance_2d_adj(0, 0);
     ndt_covariance[1 + 6 * 1] = estimated_covariance_2d_adj(1, 1);
     ndt_covariance[1 + 6 * 0] = estimated_covariance_2d_adj(1, 0);


### PR DESCRIPTION
## Description
The current online covariance estimator is not perfect either, so sometimes a better estimate can be obtained by adjusting the magnitude by multiplying it by a constant. To make this easier, I add a parameter "scale_factor".

Related PR:
* 

## How was this PR tested?
I have confirmed that logging_simulator works well and `scale_factor` changes the magnitude of the estimated covariance.

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `covariance.covariance_estimation.scale_factor`   | `double` | `1.0`         | Scale value for adjusting the estimated covariance by a constant multiplication |

## Effects on system behavior

The default behavior remains unchanged.
