### PR TITLE
feat(start_planner): check current_pose and estimated_stop_pose for isPreventingRearVehicleFromPassingThrough

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
@@ -90,6 +90,9 @@ struct StartPlannerDebugData
   std::vector<Pose> start_pose_candidates;
   size_t selected_start_pose_candidate_index;
   double margin_for_start_pose_candidate;
+
+  // for isPreventingRearVehicleFromPassingThrough
+  std::optional<Pose> estimated_stop_pose;
 };
 
 struct StartPlannerParameters

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -229,7 +229,30 @@ private:
 
   bool isModuleRunning() const;
   bool isCurrentPoseOnMiddleOfTheRoad() const;
+
+  /**
+   * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.
+   *
+   * This function just call isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) with
+   * two poses. If rear vehicle is obstructed by ego vehicle at either of the two poses, it returns
+   * true.
+   *
+   * @return true if the ego vehicle is preventing the rear vehicle from passing through with the
+   * current pose or the pose if it stops.
+   */
   bool isPreventingRearVehicleFromPassingThrough() const;
+
+  /**
+    * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.
+    *
+    * This function measures the distance to the lane boundary from the current pose and the pose if
+it stops, and determines whether there is enough space for the rear vehicle to pass through. If
+    * it is obstructing at either of the two poses, it returns true.
+    *
+    * @return true if the ego vehicle is preventing the rear vehicle from passing through with given
+ego pose.
+    */
+  bool isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) const;
 
   bool isCloseToOriginalStartPose() const;
   bool hasArrivedAtGoal() const;


### PR DESCRIPTION
## Description

check current_pose and estimated_stop_pose for isPreventingRearVehicleFromPassingThrough.

Prevent the ego vehicle from getting stuck blocking other vehicles as a result of the stop. Use the predictive points of the stop to determine whether to block.

before this PR

https://github.com/user-attachments/assets/c778931b-edcb-46cb-bce4-1e3ab8220dd2



## Related links

**Parent Issue:**

- Link

**Private Links:**

- https://tier4.atlassian.net/browse/RT1-7072


## How was this PR tested?

- psim with rosbag reproducer 

check safety check does not work when it is not necessary


https://github.com/user-attachments/assets/b8dc995f-b18b-454c-b667-c082cc666116



- psim

check safety check works properly and do not over work

https://github.com/user-attachments/assets/4c17e7e6-0763-4d53-a5bd-663cdc9c9bac


- evaluator
2024/07/19 https://evaluation.tier4.jp/evaluation/reports/15d7d71b-ac76-5e76-b03a-9f0fd785c246/?project_id=prd_jt
## Notes for reviewers



None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
