### PR TITLE
fix(lidar_transfusion): commented tests were out of date

### DIFF
--- a/perception/autoware_lidar_transfusion/test/test_postprocess_kernel.cpp
+++ b/perception/autoware_lidar_transfusion/test/test_postprocess_kernel.cpp
@@ -26,15 +26,17 @@ void PostprocessKernelTest::SetUp()
 {
   cudaStreamCreate(&stream_);
 
+  auto cloud_capacity = 2000000;
   auto voxels_num = std::vector<int64_t>{1, 3, 5};
   auto point_cloud_range = std::vector<double>{-76.8, -76.8, -3.0, 76.8, 76.8, 5.0};
   auto voxel_size = std::vector<double>{0.3, 0.3, 8.0};
+  auto num_proposals = 500;
   auto score_threshold = 0.2f;
   auto circle_nms_dist_threshold = 0.5f;
   auto yaw_norm_thresholds = std::vector<double>{0.5, 0.5, 0.5};
   config_ptr_ = std::make_unique<TransfusionConfig>(
-    voxels_num, point_cloud_range, voxel_size, circle_nms_dist_threshold, yaw_norm_thresholds,
-    score_threshold);
+    cloud_capacity, voxels_num, point_cloud_range, voxel_size, num_proposals,
+    circle_nms_dist_threshold, yaw_norm_thresholds, score_threshold);
   post_ptr_ = std::make_unique<PostprocessCuda>(*config_ptr_, stream_);
 
   cls_size_ = config_ptr_->num_proposals_ * config_ptr_->num_classes_;

--- a/perception/autoware_lidar_transfusion/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_lidar_transfusion/test/test_preprocess_kernel.cpp
@@ -32,15 +32,17 @@ void PreprocessKernelTest::SetUp()
 {
   cudaStreamCreate(&stream_);
 
+  auto cloud_capacity = 2000000;
   auto voxels_num = std::vector<int64_t>{1, 3, 5};
   auto point_cloud_range = std::vector<double>{-76.8, -76.8, -3.0, 76.8, 76.8, 5.0};
   auto voxel_size = std::vector<double>{0.3, 0.3, 8.0};
+  auto num_proposals = 500;
   auto score_threshold = 0.2f;
   auto circle_nms_dist_threshold = 0.5f;
   auto yaw_norm_thresholds = std::vector<double>{0.5, 0.5, 0.5};
   config_ptr_ = std::make_unique<TransfusionConfig>(
-    voxels_num, point_cloud_range, voxel_size, circle_nms_dist_threshold, yaw_norm_thresholds,
-    score_threshold);
+    cloud_capacity, voxels_num, point_cloud_range, voxel_size, num_proposals,
+    circle_nms_dist_threshold, yaw_norm_thresholds, score_threshold);
   pre_ptr_ = std::make_unique<PreprocessCuda>(*config_ptr_, stream_);
 
   voxel_features_size_ = config_ptr_->max_voxels_ * config_ptr_->max_num_points_per_pillar_ *

--- a/perception/autoware_lidar_transfusion/test/test_voxel_generator.cpp
+++ b/perception/autoware_lidar_transfusion/test/test_voxel_generator.cpp
@@ -35,15 +35,17 @@ void VoxelGeneratorTest::SetUp()
   delta_pointcloud_x_ = 1.0;
   points_per_pointcloud_ = 300;
 
+  cloud_capacity_ = 2000000;
   voxels_num_ = std::vector<int64_t>{5000, 30000, 60000};
   point_cloud_range_ = std::vector<double>{-76.8, -76.8, -3.0, 76.8, 76.8, 5.0};
   voxel_size_ = std::vector<double>{0.3, 0.3, 8.0};
+  num_proposals_ = 500;
   score_threshold_ = 0.2f;
   circle_nms_dist_threshold_ = 0.5f;
   yaw_norm_thresholds_ = std::vector<double>{0.5, 0.5, 0.5};
   config_ptr_ = std::make_unique<TransfusionConfig>(
-    voxels_num_, point_cloud_range_, voxel_size_, circle_nms_dist_threshold_, yaw_norm_thresholds_,
-    score_threshold_);
+    cloud_capacity_, voxels_num_, point_cloud_range_, voxel_size_, num_proposals_,
+    circle_nms_dist_threshold_, yaw_norm_thresholds_, score_threshold_);
 
   cloud1_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
   cloud2_ = std::make_unique<sensor_msgs::msg::PointCloud2>();

--- a/perception/autoware_lidar_transfusion/test/test_voxel_generator.hpp
+++ b/perception/autoware_lidar_transfusion/test/test_voxel_generator.hpp
@@ -51,9 +51,11 @@ public:
   double delta_pointcloud_x_{};
   std::size_t points_per_pointcloud_{};
 
+  std::size_t cloud_capacity_{};
   std::vector<int64_t> voxels_num_{};
   std::vector<double> point_cloud_range_{};
   std::vector<double> voxel_size_{};
+  std::size_t num_proposals_{};
   float circle_nms_dist_threshold_{};
   std::vector<double> yaw_norm_thresholds_{};
   float score_threshold_{};


### PR DESCRIPTION
## Description
The commented out transfusion tests had not been updated to the latest headers so they did not compile. This PR just addressed that
## Related links

**Parent Issue:**


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
