### PR TITLE
fix(autoware_pid_longitudinal_controller): correct the PID controller

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -36,7 +36,7 @@ public:
    * @throw std::runtime_error if gains or limits have not been set
    */
   double calculate(
-    const double error, const double dt, const bool is_integrated,
+    const double error, const double dt,
     std::vector<double> & pid_contributions);
   /**
    * @brief set the coefficients for the P (proportional) I (integral) D (derivative) terms

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -83,7 +83,6 @@ private:
   Params m_params;
 
   // state variables
-  double m_error_integral;
   double m_prev_error;
   bool m_is_gains_set;
   bool m_is_limits_set;

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -30,7 +30,8 @@ public:
    * @brief calculate the output of this PID
    * @param [in] error previous error
    * @param [in] dt time step [s]
-   * @param [in] is_integrated if true, will use the integral component for calculation
+   * @param [in] erase_integral if true, will erase the calculated integral (P (proportional) and I
+   * (integral))
    * @param [out] pid_contributions values of the proportional, integral, and derivative components
    * @return PID output
    * @throw std::runtime_error if gains or limits have not been set

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -85,7 +85,6 @@ private:
   // state variables
   double m_error_integral;
   double m_prev_error;
-  bool m_is_first_time;
   bool m_is_gains_set;
   bool m_is_limits_set;
 };

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -36,7 +36,7 @@ public:
    * @throw std::runtime_error if gains or limits have not been set
    */
   double calculate(
-    const double error, const double dt,
+    const double error, const double dt, const bool erase_integration,
     std::vector<double> & pid_contributions);
   /**
    * @brief set the coefficients for the P (proportional) I (integral) D (derivative) terms

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -83,6 +83,8 @@ private:
   Params m_params;
 
   // state variables
+  double m_virtual_displacement_error;
+  double m_virtual_displacement_error_integral;
   double m_prev_error;
   bool m_is_gains_set;
   bool m_is_limits_set;

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -30,14 +30,14 @@ public:
    * @brief calculate the output of this PID
    * @param [in] error previous error
    * @param [in] dt time step [s]
-   * @param [in] erase_integral if true, will erase the calculated integral (P (proportional) and I
+   * @param [in] is_integrated if false, will erase the calculated integral (P (proportional) and I
    * (integral))
    * @param [out] pid_contributions values of the proportional, integral, and derivative components
    * @return PID output
    * @throw std::runtime_error if gains or limits have not been set
    */
   double calculate(
-    const double error, const double dt, const bool erase_integral,
+    const double error, const double dt, const bool is_integrated,
     std::vector<double> & pid_contributions);
   /**
    * @brief set the coefficients for the P (proportional) I (integral) D (derivative) terms

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid.hpp
@@ -36,7 +36,7 @@ public:
    * @throw std::runtime_error if gains or limits have not been set
    */
   double calculate(
-    const double error, const double dt, const bool erase_integration,
+    const double error, const double dt, const bool erase_integral,
     std::vector<double> & pid_contributions);
   /**
    * @brief set the coefficients for the P (proportional) I (integral) D (derivative) terms

--- a/control/autoware_pid_longitudinal_controller/param/longitudinal_controller_defaults.param.yaml
+++ b/control/autoware_pid_longitudinal_controller/param/longitudinal_controller_defaults.param.yaml
@@ -20,17 +20,17 @@
     emergency_state_traj_rot_dev: 0.7854
 
     # drive state
-    kp: 1.0
-    ki: 0.1
-    kd: 0.0
+    kp: 0.1 # kp > 0 (stability proof) for third-order
+    ki: 0.0 # ki > 0 && Ki < kp * kd (stability proof) for third-order
+    kd: 1.0 # kd > 0 (stability proof) for third-order
     max_out: 1.0
     min_out: -1.0
-    max_p_effort: 1.0
-    min_p_effort: -1.0
-    max_i_effort: 0.3
-    min_i_effort: -0.3
-    max_d_effort: 0.0
-    min_d_effort: 0.0
+    max_p_effort: 15.0
+    min_p_effort: -15.0
+    max_i_effort: 4.0
+    min_i_effort: -4.0
+    max_d_effort: 50.0
+    min_d_effort: -50.0
     lpf_vel_error_gain: 0.9
     enable_integration_at_low_speed: false
     current_vel_threshold_pid_integration: 0.5

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -30,7 +30,7 @@ PIDController::PIDController()
 }
 
 double PIDController::calculate(
-  const double error, const double dt, const bool enable_integration,
+  const double error, const double dt,
   std::vector<double> & pid_contributions)
 {
   if (!m_is_gains_set || !m_is_limits_set) {
@@ -49,7 +49,7 @@ double PIDController::calculate(
   static double virtual_displacement_error_integral {0.0};
   virtual_displacement_error_integral += virtual_displacement_error * dt;
   
-  const double ret_i = enable_integration ? std::min(std::max(p.ki *virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i) : 0.0;
+  const double ret_i = std::min(std::max(p.ki *virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
   std::cerr << "ret_i: " << ret_i << ", max: " << p.max_ret_i << ", min: " << p.min_ret_i << std::endl;
 
   double ret_d = p.kd * error;

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -48,9 +48,8 @@ double PIDController::calculate(
 
   static double virtual_displacement_error_integral {0.0};
   virtual_displacement_error_integral += virtual_displacement_error * dt;
-  virtual_displacement_error_integral = std::min(std::max(virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
   
-  const double ret_i = enable_integration ? p.ki * virtual_displacement_error_integral : 0.0;
+  const double ret_i = enable_integration ? std::min(std::max(p.ki *virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i) : 0.0;
   std::cerr << "ret_i: " << ret_i << ", max: " << p.max_ret_i << ", min: " << p.min_ret_i << std::endl;
 
   double ret_d = p.kd * error;

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -67,7 +67,10 @@ double PIDController::calculate(
   pid_contributions.at(1) = ret_i;
   pid_contributions.at(2) = ret_d;
 
-  double ret = ret_p + ret_i + ret_d;
+  double ret_before_integration = ret_p + ret_i + ret_d;
+
+  static double ret {0.0};
+  ret += ret_before_integration;
   ret = std::min(std::max(ret, p.min_ret), p.max_ret);
 
   return ret;

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -32,7 +32,7 @@ PIDController::PIDController()
 }
 
 double PIDController::calculate(
-  const double error, const double dt,
+  const double error, const double dt, const bool erase_integration,
   std::vector<double> & pid_contributions)
 {
   if (!m_is_gains_set || !m_is_limits_set) {
@@ -41,12 +41,12 @@ double PIDController::calculate(
 
   const auto & p = m_params;
 
-  m_virtual_displacement_error += error * dt ;
+  m_virtual_displacement_error = erase_integration? 0.0 : m_virtual_displacement_error + error * dt ;
 
   double ret_p = p.kp * m_virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
-  m_virtual_displacement_error_integral += m_virtual_displacement_error * dt;
+  m_virtual_displacement_error_integral = erase_integration? 0.0 : m_virtual_displacement_error_integral + m_virtual_displacement_error * dt;
 
   const double ret_i = std::min(std::max(p.ki * m_virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
 

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -25,7 +25,6 @@ namespace autoware::motion::control::pid_longitudinal_controller
 PIDController::PIDController()
 : m_error_integral(0.0),
   m_prev_error(0.0),
-  m_is_first_time(true),
   m_is_gains_set(false),
   m_is_limits_set(false)
 {
@@ -50,14 +49,7 @@ double PIDController::calculate(
   }
   const double ret_i = p.ki * m_error_integral;
 
-  double error_differential;
-  if (m_is_first_time) {
-    error_differential = 0;
-    m_is_first_time = false;
-  } else {
-    error_differential = (error - m_prev_error) / dt;
-  }
-  double ret_d = p.kd * error_differential;
+  double ret_d = p.kd * error;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);
 
   m_prev_error = error;
@@ -67,10 +59,7 @@ double PIDController::calculate(
   pid_contributions.at(1) = ret_i;
   pid_contributions.at(2) = ret_d;
 
-  double ret_before_integration = ret_p + ret_i + ret_d;
-
-  static double ret {0.0};
-  ret += ret_before_integration * dt;
+  double ret = ret_p + ret_i + ret_d;
   ret = std::min(std::max(ret, p.min_ret), p.max_ret);
 
   return ret;
@@ -103,6 +92,5 @@ void PIDController::reset()
 {
   m_error_integral = 0.0;
   m_prev_error = 0.0;
-  m_is_first_time = true;
 }
 }  // namespace autoware::motion::control::pid_longitudinal_controller

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -94,6 +94,8 @@ void PIDController::setLimits(
 
 void PIDController::reset()
 {
+  m_virtual_displacement_error = 0.0;
+  m_virtual_displacement_error_integral = 0.0;
   m_prev_error = 0.0;
 }
 }  // namespace autoware::motion::control::pid_longitudinal_controller

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -70,7 +70,7 @@ double PIDController::calculate(
   double ret_before_integration = ret_p + ret_i + ret_d;
 
   static double ret {0.0};
-  ret += ret_before_integration;
+  ret += ret_before_integration * dt;
   ret = std::min(std::max(ret, p.min_ret), p.max_ret);
 
   return ret;

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -40,7 +40,10 @@ double PIDController::calculate(
 
   const auto & p = m_params;
 
-  double ret_p = p.kp * error;
+  static double virtual_displacement_error {0.0};
+  virtual_displacement_error += error * dt ;
+
+  double ret_p = p.kp * virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
   if (enable_integration) {

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -48,10 +48,10 @@ double PIDController::calculate(
 
   static double virtual_displacement_error_integral {0.0};
   virtual_displacement_error_integral += virtual_displacement_error * dt;
-  virtual_displacement_error_integral = std::min(std::max(virtual_displacement_error_integral, p.min_ret_i / p.ki), p.max_ret_i / p.ki);
+  virtual_displacement_error_integral = std::min(std::max(virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
   
   const double ret_i = enable_integration ? p.ki * virtual_displacement_error_integral : 0.0;
-  std::cerr << "ret_i: " << ret_i << ", max: " << p.max_ret_i / p.ki << ", min: " << p.min_ret_i / p.ki << std::endl;
+  std::cerr << "ret_i: " << ret_i << ", max: " << p.max_ret_i << ", min: " << p.min_ret_i << std::endl;
 
   double ret_d = p.kd * error;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -47,7 +47,7 @@ double PIDController::calculate(
 
   static double virtual_displacement_error_integral {0.0};
   virtual_displacement_error_integral += virtual_displacement_error * dt;
-  
+
   const double ret_i = std::min(std::max(p.ki *virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
 
   double ret_d = p.kd * error;

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -23,7 +23,9 @@
 namespace autoware::motion::control::pid_longitudinal_controller
 {
 PIDController::PIDController()
-: m_prev_error(0.0),
+: m_virtual_displacement_error(0.0),
+  m_virtual_displacement_error_integral(0.0),
+  m_prev_error(0.0),
   m_is_gains_set(false),
   m_is_limits_set(false)
 {
@@ -39,16 +41,14 @@ double PIDController::calculate(
 
   const auto & p = m_params;
 
-  static double virtual_displacement_error {0.0};
-  virtual_displacement_error += error * dt ;
+  m_virtual_displacement_error += error * dt ;
 
-  double ret_p = p.kp * virtual_displacement_error;
+  double ret_p = p.kp * m_virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
-  static double virtual_displacement_error_integral {0.0};
-  virtual_displacement_error_integral += virtual_displacement_error * dt;
+  m_virtual_displacement_error_integral += m_virtual_displacement_error * dt;
 
-  const double ret_i = std::min(std::max(p.ki *virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
+  const double ret_i = std::min(std::max(p.ki * m_virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
 
   double ret_d = p.kd * error;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -47,7 +47,7 @@ double PIDController::calculate(
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
   if (enable_integration) {
-    m_error_integral += error * dt;
+    m_error_integral += virtual_displacement_error * dt;
     m_error_integral = std::min(std::max(m_error_integral, p.min_ret_i / p.ki), p.max_ret_i / p.ki);
   }
   const double ret_i = p.ki * m_error_integral;

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -32,7 +32,7 @@ PIDController::PIDController()
 }
 
 double PIDController::calculate(
-  const double error, const double dt, const bool erase_integration,
+  const double error, const double dt, const bool erase_integral,
   std::vector<double> & pid_contributions)
 {
   if (!m_is_gains_set || !m_is_limits_set) {
@@ -41,14 +41,17 @@ double PIDController::calculate(
 
   const auto & p = m_params;
 
-  m_virtual_displacement_error = erase_integration? 0.0 : m_virtual_displacement_error + error * dt ;
+  m_virtual_displacement_error = erase_integral ? 0.0 : m_virtual_displacement_error + error * dt;
 
   double ret_p = p.kp * m_virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
-  m_virtual_displacement_error_integral = erase_integration? 0.0 : m_virtual_displacement_error_integral + m_virtual_displacement_error * dt;
+  m_virtual_displacement_error_integral =
+    erase_integral ? 0.0
+                   : m_virtual_displacement_error_integral + m_virtual_displacement_error * dt;
 
-  const double ret_i = std::min(std::max(p.ki * m_virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
+  const double ret_i =
+    std::min(std::max(p.ki * m_virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
 
   double ret_d = p.kd * error;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -32,7 +32,7 @@ PIDController::PIDController()
 }
 
 double PIDController::calculate(
-  const double error, const double dt, const bool erase_integral,
+  const double error, const double dt, const bool enable_integration,
   std::vector<double> & pid_contributions)
 {
   if (!m_is_gains_set || !m_is_limits_set) {
@@ -41,14 +41,15 @@ double PIDController::calculate(
 
   const auto & p = m_params;
 
-  m_virtual_displacement_error = erase_integral ? 0.0 : m_virtual_displacement_error + error * dt;
+  m_virtual_displacement_error =
+    enable_integration ? m_virtual_displacement_error + error * dt : 0.0;
 
   double ret_p = p.kp * m_virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
   m_virtual_displacement_error_integral =
-    erase_integral ? 0.0
-                   : m_virtual_displacement_error_integral + m_virtual_displacement_error * dt;
+    enable_integration ? m_virtual_displacement_error_integral + m_virtual_displacement_error * dt
+                       : 0.0;
 
   const double ret_i =
     std::min(std::max(p.ki * m_virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "autoware/pid_longitudinal_controller/pid.hpp"
-
+#include <iostream>
 #include <algorithm>
 #include <memory>
 #include <stdexcept>
@@ -44,15 +44,18 @@ double PIDController::calculate(
 
   double ret_p = p.kp * virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
+  std::cerr << "ret_p: " << ret_p << ", max: " << p.max_ret_p << ", min: " << p.min_ret_p << std::endl;
 
   static double virtual_displacement_error_integral {0.0};
   virtual_displacement_error_integral += virtual_displacement_error * dt;
   virtual_displacement_error_integral = std::min(std::max(virtual_displacement_error_integral, p.min_ret_i / p.ki), p.max_ret_i / p.ki);
   
   const double ret_i = enable_integration ? p.ki * virtual_displacement_error_integral : 0.0;
+  std::cerr << "ret_i: " << ret_i << ", max: " << p.max_ret_i / p.ki << ", min: " << p.min_ret_i / p.ki << std::endl;
 
   double ret_d = p.kd * error;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);
+  std::cerr << "ret_d: " << ret_d << ", max: " << p.max_ret_d << ", min: " << p.min_ret_d << std::endl;
 
   m_prev_error = error;
 

--- a/control/autoware_pid_longitudinal_controller/src/pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "autoware/pid_longitudinal_controller/pid.hpp"
-#include <iostream>
+
 #include <algorithm>
 #include <memory>
 #include <stdexcept>
@@ -44,17 +44,14 @@ double PIDController::calculate(
 
   double ret_p = p.kp * virtual_displacement_error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
-  std::cerr << "ret_p: " << ret_p << ", max: " << p.max_ret_p << ", min: " << p.min_ret_p << std::endl;
 
   static double virtual_displacement_error_integral {0.0};
   virtual_displacement_error_integral += virtual_displacement_error * dt;
   
   const double ret_i = std::min(std::max(p.ki *virtual_displacement_error_integral, p.min_ret_i), p.max_ret_i);
-  std::cerr << "ret_i: " << ret_i << ", max: " << p.max_ret_i << ", min: " << p.min_ret_i << std::endl;
 
   double ret_d = p.kd * error;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);
-  std::cerr << "ret_d: " << ret_d << ", max: " << p.max_ret_d << ", min: " << p.min_ret_d << std::endl;
 
   m_prev_error = error;
 

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1115,9 +1115,6 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2 * ff_scale;
 
   const double feedback_acc = ff_acc + pid_acc;
-  std::cerr << "feedback_acc: " << feedback_acc << std::endl;
-  std::cerr << "ff_acc: " << ff_acc << std::endl;
-  std::cerr << "pid_acc: " << pid_acc << std::endl;
 
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PID_APPLIED, feedback_acc);
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL_FILTERED, error_vel_filtered);

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1110,8 +1110,11 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
   std::vector<double> pid_contributions(3);
-  const double pid_acc =
+  const double pid_acc_before_integration =
     m_pid_vel.calculate(error_vel_filtered, control_data.dt, enable_integration, pid_contributions);
+  
+  static double pid_acc {0.0};
+  pid_acc += pid_acc_before_integration;
 
   // Feedforward scaling:
   // This is for the coordinate conversion where feedforward is applied, from Time to Arclength.

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1095,25 +1095,25 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};
   const double diff_vel = (target_motion.vel - current_vel) * vel_sign;
-  const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&	
-                                m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;	
+  const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
+                                m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
 
-  const bool vehicle_is_moving = std::abs(current_vel) > m_current_vel_threshold_pid_integrate;	
-  const double time_under_control = getTimeUnderControl();	
-  const bool vehicle_is_stuck =	
-    !vehicle_is_moving && time_under_control > m_time_threshold_before_pid_integrate;	
+  const bool vehicle_is_moving = std::abs(current_vel) > m_current_vel_threshold_pid_integrate;
+  const double time_under_control = getTimeUnderControl();
+  const bool vehicle_is_stuck =
+    !vehicle_is_moving && time_under_control > m_time_threshold_before_pid_integrate;
 
-  const bool enable_integration =	
-    (vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&	
+  const bool enable_integration =
+    (vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&
     is_under_control;
-  
-  const bool erase_integration = !enable_integration;
+
+  const bool erase_integral = !enable_integration;
 
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
   std::vector<double> pid_contributions(3);
   const double pid_acc =
-    m_pid_vel.calculate(error_vel_filtered, control_data.dt, erase_integration, pid_contributions);
+    m_pid_vel.calculate(error_vel_filtered, control_data.dt, erase_integral, pid_contributions);
 
   // Feedforward scaling:
   // This is for the coordinate conversion where feedforward is applied, from Time to Arclength.

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1110,11 +1110,8 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
   std::vector<double> pid_contributions(3);
-  const double pid_acc_before_integration =
+  const double pid_acc =
     m_pid_vel.calculate(error_vel_filtered, control_data.dt, enable_integration, pid_contributions);
-  
-  static double pid_acc {0.0};
-  pid_acc += pid_acc_before_integration;
 
   // Feedforward scaling:
   // This is for the coordinate conversion where feedforward is applied, from Time to Arclength.

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1095,23 +1095,12 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};
   const double diff_vel = (target_motion.vel - current_vel) * vel_sign;
-  const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
-                                m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
-
-  const bool vehicle_is_moving = std::abs(current_vel) > m_current_vel_threshold_pid_integrate;
-  const double time_under_control = getTimeUnderControl();
-  const bool vehicle_is_stuck =
-    !vehicle_is_moving && time_under_control > m_time_threshold_before_pid_integrate;
-
-  const bool enable_integration = 1 ||
-    ((vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&
-    is_under_control);
 
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
   std::vector<double> pid_contributions(3);
   const double pid_acc =
-    m_pid_vel.calculate(error_vel_filtered, control_data.dt, enable_integration, pid_contributions);
+    m_pid_vel.calculate(error_vel_filtered, control_data.dt, pid_contributions);
 
   // Feedforward scaling:
   // This is for the coordinate conversion where feedforward is applied, from Time to Arclength.

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1103,9 +1103,9 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
   const bool vehicle_is_stuck =
     !vehicle_is_moving && time_under_control > m_time_threshold_before_pid_integrate;
 
-  const bool enable_integration =
-    (vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&
-    is_under_control;
+  const bool enable_integration = 1 ||
+    ((vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&
+    is_under_control);
 
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1126,6 +1126,9 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2 * ff_scale;
 
   const double feedback_acc = ff_acc + pid_acc;
+  std::cerr << "feedback_acc: " << feedback_acc << std::endl;
+  std::cerr << "ff_acc: " << ff_acc << std::endl;
+  std::cerr << "pid_acc: " << pid_acc << std::endl;
 
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PID_APPLIED, feedback_acc);
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL_FILTERED, error_vel_filtered);

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1095,12 +1095,25 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};
   const double diff_vel = (target_motion.vel - current_vel) * vel_sign;
+  const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&	
+                                m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;	
+
+  const bool vehicle_is_moving = std::abs(current_vel) > m_current_vel_threshold_pid_integrate;	
+  const double time_under_control = getTimeUnderControl();	
+  const bool vehicle_is_stuck =	
+    !vehicle_is_moving && time_under_control > m_time_threshold_before_pid_integrate;	
+
+  const bool enable_integration =	
+    (vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&	
+    is_under_control;
+  
+  const bool erase_integration = !enable_integration;
 
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
   std::vector<double> pid_contributions(3);
   const double pid_acc =
-    m_pid_vel.calculate(error_vel_filtered, control_data.dt, pid_contributions);
+    m_pid_vel.calculate(error_vel_filtered, control_data.dt, erase_integration, pid_contributions);
 
   // Feedforward scaling:
   // This is for the coordinate conversion where feedforward is applied, from Time to Arclength.

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1107,13 +1107,11 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     (vehicle_is_moving || (m_enable_integration_at_low_speed && vehicle_is_stuck)) &&
     is_under_control;
 
-  const bool erase_integral = !enable_integration;
-
   const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
   std::vector<double> pid_contributions(3);
   const double pid_acc =
-    m_pid_vel.calculate(error_vel_filtered, control_data.dt, erase_integral, pid_contributions);
+    m_pid_vel.calculate(error_vel_filtered, control_data.dt, enable_integration, pid_contributions);
 
   // Feedforward scaling:
   // This is for the coordinate conversion where feedforward is applied, from Time to Arclength.

--- a/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
@@ -24,19 +24,18 @@ TEST(TestPID, calculate_pid_output)
   const double dt = 1.0;
   double target = 10.0;
   double current = 0.0;
-  bool enable_integration = false;
 
   PIDController pid;
 
   // Cannot calculate before initializing gains and limits
-  EXPECT_THROW(pid.calculate(0.0, dt, enable_integration, contributions), std::runtime_error);
+  EXPECT_THROW(pid.calculate(0.0, dt, contributions), std::runtime_error);
 
   pid.setGains(1.0, 1.0, 1.0);
   pid.setLimits(10.0, 0.0, 10.0, 0.0, 10.0, 0.0, 10.0, 0.0);
   double error = target - current;
   double prev_error = error;
   while (current != target) {
-    current = pid.calculate(error, dt, enable_integration, contributions);
+    current = pid.calculate(error, dt, contributions);
     EXPECT_EQ(contributions[0], error);
     EXPECT_EQ(contributions[1], 0.0);  // integration is deactivated
     EXPECT_EQ(contributions[2], error - prev_error);
@@ -47,21 +46,20 @@ TEST(TestPID, calculate_pid_output)
 
   pid.setGains(100.0, 100.0, 100.0);
   pid.setLimits(10.0, -10.0, 10.0, -10.0, 10.0, -10.0, 10.0, -10.0);
-  enable_integration = true;
 
   // High errors to force each component to its upper limit
-  EXPECT_EQ(pid.calculate(0.0, dt, enable_integration, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, contributions), 0.0);
   for (double error = 100.0; error < 1000.0; error += 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, enable_integration, contributions), 10.0);
+    EXPECT_EQ(pid.calculate(error, dt, contributions), 10.0);
     EXPECT_EQ(contributions[0], 10.0);
     EXPECT_EQ(contributions[1], 10.0);  // integration is activated
     EXPECT_EQ(contributions[2], 10.0);
   }
 
   // Low errors to force each component to its lower limit
-  EXPECT_EQ(pid.calculate(0.0, dt, enable_integration, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, contributions), 0.0);
   for (double error = -100.0; error > -1000.0; error -= 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, enable_integration, contributions), -10.0);
+    EXPECT_EQ(pid.calculate(error, dt, contributions), -10.0);
     EXPECT_EQ(contributions[0], -10.0);
     EXPECT_EQ(contributions[1], -10.0);  // integration is activated
     EXPECT_EQ(contributions[2], -10.0);

--- a/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
@@ -34,13 +34,11 @@ TEST(TestPID, calculate_pid_output)
   pid.setGains(1.0, 1.0, 1.0);
   pid.setLimits(10.0, 0.0, 10.0, 0.0, 10.0, 0.0, 10.0, 0.0);
   double error = target - current;
-  double prev_error = error;
   while (current != target) {
     current = pid.calculate(error, dt, erase_integral, contributions);
-    EXPECT_EQ(contributions[0], error);
-    EXPECT_EQ(contributions[1], 0.0);  // integration is deactivated
-    EXPECT_EQ(contributions[2], error - prev_error);
-    prev_error = error;
+    EXPECT_EQ(contributions[0], 0.0);  // integral is erased
+    EXPECT_EQ(contributions[1], 0.0);  // double integral is erased
+    EXPECT_EQ(contributions[2], error);
     error = target - current;
   }
   pid.reset();
@@ -53,17 +51,18 @@ TEST(TestPID, calculate_pid_output)
   EXPECT_EQ(pid.calculate(0.0, dt, erase_integral, contributions), 0.0);
   for (double error = 100.0; error < 1000.0; error += 100.0) {
     EXPECT_EQ(pid.calculate(error, dt, erase_integral, contributions), 10.0);
-    EXPECT_EQ(contributions[0], 10.0);
-    EXPECT_EQ(contributions[1], 10.0);  // integration is activated
+    EXPECT_EQ(contributions[0], 10.0);  // integral is not erased
+    EXPECT_EQ(contributions[1], 10.0);  // double integral is not erased
     EXPECT_EQ(contributions[2], 10.0);
   }
+  pid.reset();
 
   // Low errors to force each component to its lower limit
   EXPECT_EQ(pid.calculate(0.0, dt, erase_integral, contributions), 0.0);
   for (double error = -100.0; error > -1000.0; error -= 100.0) {
     EXPECT_EQ(pid.calculate(error, dt, erase_integral, contributions), -10.0);
-    EXPECT_EQ(contributions[0], -10.0);
-    EXPECT_EQ(contributions[1], -10.0);  // integration is activated
+    EXPECT_EQ(contributions[0], -10.0);  // integral is not erased
+    EXPECT_EQ(contributions[1], -10.0);  // double integral is not erased
     EXPECT_EQ(contributions[2], -10.0);
   }
 }

--- a/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
@@ -24,18 +24,18 @@ TEST(TestPID, calculate_pid_output)
   const double dt = 1.0;
   double target = 10.0;
   double current = 0.0;
-  bool erase_integral = true;
+  bool enable_integration = false;
 
   PIDController pid;
 
   // Cannot calculate before initializing gains and limits
-  EXPECT_THROW(pid.calculate(0.0, dt, erase_integral, contributions), std::runtime_error);
+  EXPECT_THROW(pid.calculate(0.0, dt, enable_integration, contributions), std::runtime_error);
 
   pid.setGains(1.0, 1.0, 1.0);
   pid.setLimits(10.0, 0.0, 10.0, 0.0, 10.0, 0.0, 10.0, 0.0);
   double error = target - current;
   while (current != target) {
-    current = pid.calculate(error, dt, erase_integral, contributions);
+    current = pid.calculate(error, dt, enable_integration, contributions);
     EXPECT_EQ(contributions[0], 0.0);  // integral is erased
     EXPECT_EQ(contributions[1], 0.0);  // double integral is erased
     EXPECT_EQ(contributions[2], error);
@@ -45,12 +45,12 @@ TEST(TestPID, calculate_pid_output)
 
   pid.setGains(100.0, 100.0, 100.0);
   pid.setLimits(10.0, -10.0, 10.0, -10.0, 10.0, -10.0, 10.0, -10.0);
-  erase_integral = false;
+  enable_integration = true;
 
   // High errors to force each component to its upper limit
-  EXPECT_EQ(pid.calculate(0.0, dt, erase_integral, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, enable_integration, contributions), 0.0);
   for (double error = 100.0; error < 1000.0; error += 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, erase_integral, contributions), 10.0);
+    EXPECT_EQ(pid.calculate(error, dt, enable_integration, contributions), 10.0);
     EXPECT_EQ(contributions[0], 10.0);  // integral is not erased
     EXPECT_EQ(contributions[1], 10.0);  // double integral is not erased
     EXPECT_EQ(contributions[2], 10.0);
@@ -58,9 +58,9 @@ TEST(TestPID, calculate_pid_output)
   pid.reset();
 
   // Low errors to force each component to its lower limit
-  EXPECT_EQ(pid.calculate(0.0, dt, erase_integral, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, enable_integration, contributions), 0.0);
   for (double error = -100.0; error > -1000.0; error -= 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, erase_integral, contributions), -10.0);
+    EXPECT_EQ(pid.calculate(error, dt, enable_integration, contributions), -10.0);
     EXPECT_EQ(contributions[0], -10.0);  // integral is not erased
     EXPECT_EQ(contributions[1], -10.0);  // double integral is not erased
     EXPECT_EQ(contributions[2], -10.0);

--- a/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
@@ -24,18 +24,19 @@ TEST(TestPID, calculate_pid_output)
   const double dt = 1.0;
   double target = 10.0;
   double current = 0.0;
+  bool erase_integration = true;
 
   PIDController pid;
 
   // Cannot calculate before initializing gains and limits
-  EXPECT_THROW(pid.calculate(0.0, dt, contributions), std::runtime_error);
+  EXPECT_THROW(pid.calculate(0.0, dt, erase_integration, contributions), std::runtime_error);
 
   pid.setGains(1.0, 1.0, 1.0);
   pid.setLimits(10.0, 0.0, 10.0, 0.0, 10.0, 0.0, 10.0, 0.0);
   double error = target - current;
   double prev_error = error;
   while (current != target) {
-    current = pid.calculate(error, dt, contributions);
+    current = pid.calculate(error, dt, erase_integration, contributions);
     EXPECT_EQ(contributions[0], error);
     EXPECT_EQ(contributions[1], 0.0);  // integration is deactivated
     EXPECT_EQ(contributions[2], error - prev_error);
@@ -46,20 +47,21 @@ TEST(TestPID, calculate_pid_output)
 
   pid.setGains(100.0, 100.0, 100.0);
   pid.setLimits(10.0, -10.0, 10.0, -10.0, 10.0, -10.0, 10.0, -10.0);
+  erase_integration = false;
 
   // High errors to force each component to its upper limit
-  EXPECT_EQ(pid.calculate(0.0, dt, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, erase_integration, contributions), 0.0);
   for (double error = 100.0; error < 1000.0; error += 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, contributions), 10.0);
+    EXPECT_EQ(pid.calculate(error, dt, erase_integration, contributions), 10.0);
     EXPECT_EQ(contributions[0], 10.0);
     EXPECT_EQ(contributions[1], 10.0);  // integration is activated
     EXPECT_EQ(contributions[2], 10.0);
   }
 
   // Low errors to force each component to its lower limit
-  EXPECT_EQ(pid.calculate(0.0, dt, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, erase_integration, contributions), 0.0);
   for (double error = -100.0; error > -1000.0; error -= 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, contributions), -10.0);
+    EXPECT_EQ(pid.calculate(error, dt, erase_integration, contributions), -10.0);
     EXPECT_EQ(contributions[0], -10.0);
     EXPECT_EQ(contributions[1], -10.0);  // integration is activated
     EXPECT_EQ(contributions[2], -10.0);

--- a/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid.cpp
@@ -24,19 +24,19 @@ TEST(TestPID, calculate_pid_output)
   const double dt = 1.0;
   double target = 10.0;
   double current = 0.0;
-  bool erase_integration = true;
+  bool erase_integral = true;
 
   PIDController pid;
 
   // Cannot calculate before initializing gains and limits
-  EXPECT_THROW(pid.calculate(0.0, dt, erase_integration, contributions), std::runtime_error);
+  EXPECT_THROW(pid.calculate(0.0, dt, erase_integral, contributions), std::runtime_error);
 
   pid.setGains(1.0, 1.0, 1.0);
   pid.setLimits(10.0, 0.0, 10.0, 0.0, 10.0, 0.0, 10.0, 0.0);
   double error = target - current;
   double prev_error = error;
   while (current != target) {
-    current = pid.calculate(error, dt, erase_integration, contributions);
+    current = pid.calculate(error, dt, erase_integral, contributions);
     EXPECT_EQ(contributions[0], error);
     EXPECT_EQ(contributions[1], 0.0);  // integration is deactivated
     EXPECT_EQ(contributions[2], error - prev_error);
@@ -47,21 +47,21 @@ TEST(TestPID, calculate_pid_output)
 
   pid.setGains(100.0, 100.0, 100.0);
   pid.setLimits(10.0, -10.0, 10.0, -10.0, 10.0, -10.0, 10.0, -10.0);
-  erase_integration = false;
+  erase_integral = false;
 
   // High errors to force each component to its upper limit
-  EXPECT_EQ(pid.calculate(0.0, dt, erase_integration, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, erase_integral, contributions), 0.0);
   for (double error = 100.0; error < 1000.0; error += 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, erase_integration, contributions), 10.0);
+    EXPECT_EQ(pid.calculate(error, dt, erase_integral, contributions), 10.0);
     EXPECT_EQ(contributions[0], 10.0);
     EXPECT_EQ(contributions[1], 10.0);  // integration is activated
     EXPECT_EQ(contributions[2], 10.0);
   }
 
   // Low errors to force each component to its lower limit
-  EXPECT_EQ(pid.calculate(0.0, dt, erase_integration, contributions), 0.0);
+  EXPECT_EQ(pid.calculate(0.0, dt, erase_integral, contributions), 0.0);
   for (double error = -100.0; error > -1000.0; error -= 100.0) {
-    EXPECT_EQ(pid.calculate(error, dt, erase_integration, contributions), -10.0);
+    EXPECT_EQ(pid.calculate(error, dt, erase_integral, contributions), -10.0);
     EXPECT_EQ(contributions[0], -10.0);
     EXPECT_EQ(contributions[1], -10.0);  // integration is activated
     EXPECT_EQ(contributions[2], -10.0);


### PR DESCRIPTION
## Description


The previous PID controller in Autoware is actually equivalent to a PD/PI controller.
This PR corrects the utilization of and upgrades to the PID controller.

**N.B. Without specific reasons, the parameters adopted in the previous PD/PI controller are adopted in [another PR](https://github.com/autowarefoundation/autoware_launch/pull/1083). And the parameters in that PR are equivalent to the PD/PI controller.**

**Before change:**
[Screencast from 07-19-2024 02_05_57 PM.webm](https://github.com/user-attachments/assets/2031b80b-a813-4b93-8398-77013562c9e7)

**After change:**
[Screencast from 07-19-2024 02_37_49 PM.webm](https://github.com/user-attachments/assets/3e0602fd-ce76-4abf-81a1-323c9931e1ea)

---

Note that one of the benefits of using implementing PID controllers is being robust to the external noise (e.g., driving on an ice road). Therefore, a noise was introduced artificially to test the PD/PI controller (before) and PID controller (after). 

**Noise definition**: a constant acceleration (+1.0 m/s2), that is `return feedback_acc + 1.0;`.
Also, note the PID output constraint has been relaxted to `max_out: 2.0`, `min_out: -2.0` in the analysis.


**Before change:**
[Screencast from 07-19-2024 02_15_43 PM.webm](https://github.com/user-attachments/assets/15116f58-1373-422a-a481-23a9b6ea6a69)


**After change (with new parameters below)**
```
kp: 1.5 # kp > 0 (stability proof) for third-order
ki: 0.8 # ki > 0 && Ki < kp * kd (stability proof) for third-order
kd: 2.5 # kd > 0 (stability proof) for third-order
```
[Screencast from 07-19-2024 04_26_14 PM.webm](https://github.com/user-attachments/assets/23b87cbd-15d2-4cad-a79d-3c5219481951)

**N.B. In the parameter PR, we picked the parameters equivalent to the PI/PD controller.**
It means that it will also show limit robustness to the external noise.

---

**Conclusions:**

1. The previous PI/PD controller shows the [logical error ](https://github.com/HansOersted/Autonomous_PID_controller_parameters), which is fixed in this PR.
2. The updated PID controller (this PR) works as expected in the normal case.
3. The previous PI/PD controller can fail to track the reference once the external disturbance in introduced.
4. The previous PI/PD controller successfully tracks the reference for some introduced external disturbances.

---

**Further steps:**

1. The user may change the coefficients of the PID controller based on the concentrations and missions.
2. The max P, I, and D constraints can be adjusted.
3. The coefficients of the PID controller for a robust tracking performances can be analyzed.

---

**Discussions:**

1. Honestly, erasing the integration when and only when the car is controlled manually is personally preferred. If latecomers have interests on this topic, do not hesitate to contact me.
2. If you are trying to implement Discussion 1, consider using `reset()`.



## Tests performed



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
