### PR TITLE
fix(bpp): fix approved request search 

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -340,7 +340,7 @@ private:
         }
 
         if (rtc.second->isTerminated(uuid_map_.at(rtc.first))) {
-          return true;
+          return false;
         }
 
         return rtc.second->isActivated(uuid_map_.at(rtc.first));


### PR DESCRIPTION
## Description
With the change made in the related link, existApprovedRequest function returned true value even when all cooperateStatus has terminated. Due to this change, some modules in the behavior path planner was not approved under appropriate condition. This PR reverts the existApprovedRequest function return value.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/7743

## How was this PR tested?
[TIER IV internal test](https://evaluation.tier4.jp/evaluation/reports/2cc549ca-985d-5095-af3a-dd810ac8342f/tests/05e2ce34-0e97-58bd-a8fa-6a6db6f01477/bfcc5be5-4d0e-5a91-b2c7-cfbf68b971ec/f5fa29cf-6d53-57e1-b339-ab904359f326?project_id=prd_jt)

## Notes for reviewers
The state transition around terminated cooperate status would be considered once again, and would be implemented in future PR.

## Interface changes
None.

## Effects on system behavior
None.
