### PR TITLE
fix(autoware_multi_object_tracker): missing parameter schema path fix

### DIFF
--- a/perception/autoware_multi_object_tracker/README.md
+++ b/perception/autoware_multi_object_tracker/README.md
@@ -65,16 +65,16 @@ Multiple inputs are pre-defined in the input channel parameters (described below
 
 ### Input Channel parameters
 
-{{ json_to_markdown("perception/multi_object_tracker/schema/input_channels.schema.json") }}
+{{ json_to_markdown("perception/autoware_multi_object_tracker/schema/input_channels.schema.json") }}
 
 ### Core Parameters
 
-{{ json_to_markdown("perception/multi_object_tracker/schema/multi_object_tracker_node.schema.json") }}
-{{ json_to_markdown("perception/multi_object_tracker/schema/data_association_matrix.schema.json") }}
+{{ json_to_markdown("perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json") }}
+{{ json_to_markdown("perception/autoware_multi_object_tracker/schema/data_association_matrix.schema.json") }}
 
 #### Simulation parameters
 
-{{ json_to_markdown("perception/multi_object_tracker/schema/simulation_tracker.schema.json") }}
+{{ json_to_markdown("perception/autoware_multi_object_tracker/schema/simulation_tracker.schema.json") }}
 
 ## Assumptions / Known limits
 


### PR DESCRIPTION
## Description
Fix missing transition to new package path

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
