### PR TITLE
fix(autoware_pointcloud_preprocessor): revert increase_size() in robin_hood

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
@@ -2495,6 +2495,7 @@ private:
 
       // unlikely that this evaluates to true
       if (ROBIN_HOOD_UNLIKELY(mNumElements >= mMaxNumElementsAllowed)) {
+        increase_size();
         continue;
       }
 


### PR DESCRIPTION
## Description

revert this PR https://github.com/autowarefoundation/autoware.universe/pull/8139

## Related links

**Parent Issue:**

- [TIER IV INTERNAL](https://star4.slack.com/archives/C4P0NSMB5/p1721700502159959)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
