### PR TITLE
feat(traffic_light_roi_visualizer): add an option to use normal publisher instead of image tranport in traffic light roi visualizer

### DIFF
--- a/perception/autoware_traffic_light_visualization/config/traffic_light_visualization.param.yaml
+++ b/perception/autoware_traffic_light_visualization/config/traffic_light_visualization.param.yaml
@@ -1,3 +1,4 @@
 /**:
   ros__parameters:
     enable_fine_detection: false
+    use_image_transport: true

--- a/perception/autoware_traffic_light_visualization/launch/traffic_light_roi_visualizer.launch.xml
+++ b/perception/autoware_traffic_light_visualization/launch/traffic_light_roi_visualizer.launch.xml
@@ -5,6 +5,7 @@
   <arg name="input/traffic_signals" default="~/input/traffic_signals"/>
   <arg name="output/image" default="~/debug/rois"/>
   <arg name="enable_fine_detection" default="false"/>
+  <arg name="use_image_transport" default="true"/>
 
   <node pkg="autoware_traffic_light_visualization" exec="traffic_light_visualization_node" name="traffic_light_visualization">
     <remap from="~/input/image" to="$(var input/image)"/>
@@ -13,5 +14,6 @@
     <remap from="~/input/traffic_signals" to="$(var input/traffic_signals)"/>
     <remap from="~/output/image" to="$(var output/image)"/>
     <param name="enable_fine_detection" value="$(var enable_fine_detection)"/>
+    <param name="use_image_transport" value="$(var use_image_transport)"/>
   </node>
 </launch>

--- a/perception/autoware_traffic_light_visualization/schema/traffic_light_visualization.schema.json
+++ b/perception/autoware_traffic_light_visualization/schema/traffic_light_visualization.schema.json
@@ -10,9 +10,14 @@
           "type": "boolean",
           "description": "whether to visualize result of the traffic light fine detection",
           "default": "false"
+        },
+        "use_image_transport": {
+          "type": "boolean",
+          "description": "whether to apply image transport to compress the output debugging image in the traffic light fine detection",
+          "default": "true"
         }
       },
-      "required": ["enable_fine_detection"]
+      "required": ["enable_fine_detection", "use_image_transport"]
     }
   },
   "properties": {

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp
@@ -31,7 +31,8 @@ TrafficLightRoiVisualizerNode::TrafficLightRoiVisualizerNode(const rclcpp::NodeO
   using std::placeholders::_2;
   using std::placeholders::_3;
   using std::placeholders::_4;
-  enable_fine_detection_ = this->declare_parameter<bool>("enable_fine_detection");
+  enable_fine_detection_ = this->declare_parameter<bool>("enable_fine_detection", false);
+  use_image_transport_ = this->declare_parameter<bool>("use_image_transport", false);
 
   if (enable_fine_detection_) {
     sync_with_rough_roi_.reset(new SyncWithRoughRoi(
@@ -48,13 +49,24 @@ TrafficLightRoiVisualizerNode::TrafficLightRoiVisualizerNode(const rclcpp::NodeO
   timer_ = rclcpp::create_timer(
     this, get_clock(), 100ms, std::bind(&TrafficLightRoiVisualizerNode::connectCb, this));
 
-  image_pub_ =
-    image_transport::create_publisher(this, "~/output/image", rclcpp::QoS{1}.get_rmw_qos_profile());
+  if (use_image_transport_) {
+    image_pub_ = image_transport::create_publisher(
+      this, "~/output/image", rclcpp::QoS{1}.get_rmw_qos_profile());
+  } else {
+    auto qos = rclcpp::QoS(1);
+    simple_image_pub_ = this->create_publisher<sensor_msgs::msg::Image>("~/output/image", qos);
+  }
 }
 
 void TrafficLightRoiVisualizerNode::connectCb()
 {
-  if (image_pub_.getNumSubscribers() == 0) {
+  int num_subscribers = 0;
+  if (use_image_transport_) {
+    num_subscribers = image_pub_.getNumSubscribers();
+  } else {
+    num_subscribers = simple_image_pub_->get_subscription_count();
+  }
+  if (num_subscribers == 0) {
     image_sub_.unsubscribe();
     traffic_signals_sub_.unsubscribe();
     roi_sub_.unsubscribe();
@@ -143,7 +155,11 @@ void TrafficLightRoiVisualizerNode::imageRoiCallback(
     RCLCPP_ERROR(
       get_logger(), "Could not convert from '%s' to 'rgb8'.", input_image_msg->encoding.c_str());
   }
-  image_pub_.publish(cv_ptr->toImageMsg());
+  if (use_image_transport_) {
+    image_pub_.publish(cv_ptr->toImageMsg());
+  } else {
+    simple_image_pub_->publish(*cv_ptr->toImageMsg());
+  }
 }
 
 bool TrafficLightRoiVisualizerNode::getClassificationResult(
@@ -220,7 +236,11 @@ void TrafficLightRoiVisualizerNode::imageRoughRoiCallback(
     RCLCPP_ERROR(
       get_logger(), "Could not convert from '%s' to 'rgb8'.", input_image_msg->encoding.c_str());
   }
-  image_pub_.publish(cv_ptr->toImageMsg());
+  if (use_image_transport_) {
+    image_pub_.publish(cv_ptr->toImageMsg());
+  } else {
+    simple_image_pub_->publish(*cv_ptr->toImageMsg());
+  }
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp
@@ -31,8 +31,8 @@ TrafficLightRoiVisualizerNode::TrafficLightRoiVisualizerNode(const rclcpp::NodeO
   using std::placeholders::_2;
   using std::placeholders::_3;
   using std::placeholders::_4;
-  enable_fine_detection_ = this->declare_parameter<bool>("enable_fine_detection", false);
-  use_image_transport_ = this->declare_parameter<bool>("use_image_transport", false);
+  enable_fine_detection_ = this->declare_parameter<bool>("enable_fine_detection");
+  use_image_transport_ = this->declare_parameter<bool>("use_image_transport");
 
   if (enable_fine_detection_) {
     sync_with_rough_roi_.reset(new SyncWithRoughRoi(

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.hpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.hpp
@@ -121,6 +121,8 @@ private:
   message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightRoiArray> rough_roi_sub_;
   message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightArray> traffic_signals_sub_;
   image_transport::Publisher image_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr simple_image_pub_;
+
   typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::msg::Image, tier4_perception_msgs::msg::TrafficLightRoiArray,
     tier4_perception_msgs::msg::TrafficLightArray>
@@ -136,6 +138,7 @@ private:
   std::shared_ptr<SyncWithRoughRoi> sync_with_rough_roi_;
 
   bool enable_fine_detection_;
+  bool use_image_transport_;
 };
 
 }  // namespace autoware::traffic_light


### PR DESCRIPTION
## Description
Adding an option to use normal image publisher instead of image transport in traffic light roi visualizer.

### History
Originally, the traffic_light_roi_visualizer used image_transport to simultaneously publish raw images and compressed images (especially compressed images for internal logging).

### Motivation
1. `traffic_light_roi_visualizer` is usually running on nvidia/cuda devices.
2. `image_transport` by default uses CPU for image compression.
3. We have new packages to conduct image compression with GPU or NVEncoder.

### Updates
Adding an optional argument in the launch file, with a default behavior of preserving the original codes.

If we provide with `use_image_transport=false`, it will not use image_tranport and just output raw images.

## Related links

https://github.com/tier4/ros2_v4l2_camera/pull/14

## How was this PR tested?

For now, it was tested with bag logging.

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Removed | Pub | `output/image/compressedDepth` | `sensor_msgs/CompressedImage`   | Willl be removed if use_image_transport=false |
| Removed | Pub | `output/image/compressed` | `sensor_msgs/CompressedImage`   | Willl be removed if use_image_transport=false |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `use_image_transport`   | `bool` | `true`         | Whether to use image transport and preserve the original behavior |

## Effects on system behavior

None.
