### PR TITLE
fix(autoware_mpc_lateral_controller): add timestamp and frame ID to published trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -804,8 +804,10 @@ Trajectory MPC::calculatePredictedTrajectory(
     const auto frenet = m_vehicle_model_ptr->calculatePredictedTrajectoryInFrenetCoordinate(
       mpc_matrix.Aex, mpc_matrix.Bex, mpc_matrix.Cex, mpc_matrix.Wex, x0, Uex, reference_trajectory,
       dt);
-    const auto frenet_clipped = MPCUtils::convertToAutowareTrajectory(
+    auto frenet_clipped = MPCUtils::convertToAutowareTrajectory(
       MPCUtils::clipTrajectoryByLength(frenet, predicted_length));
+    frenet_clipped.header.stamp = m_clock->now();
+    frenet_clipped.header.frame_id = "map";
     m_debug_frenet_predicted_trajectory_pub->publish(frenet_clipped);
   }
 


### PR DESCRIPTION
## Description

In this [PR](https://github.com/autowarefoundation/autoware.universe/pull/5576), predicted path calculated using the Frenet coordinate system were added for debug purpose, but they couldn't be visualized in rviz due to missing header information. 
added the necessary header information with following modification to resolve this issue.

```
    frenet_clipped.header.stamp = m_clock->now();
    frenet_clipped.header.frame_id = "map";
```

## How was this PR tested?
tested in psim and confirmed visualization
![Screenshot from 2024-07-23 20-28-54](https://github.com/user-attachments/assets/257f9eba-3b08-446f-9df4-3cf49b202e3f)


## Effects on system behavior

None.
