### PR TITLE
fix(lidar_apollo_instance_segmentation): fixed preprocessing

### DIFF
--- a/perception/autoware_lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/src/detector.cpp
@@ -17,9 +17,12 @@
 #include "autoware/lidar_apollo_instance_segmentation/feature_map.hpp"
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <NvInfer.h>
-#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/PointIndices.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 
 #include <functional>
 #include <memory>
@@ -83,7 +86,6 @@ bool LidarApolloInstanceSegmentation::transformCloud(
   const sensor_msgs::msg::PointCloud2 & input, sensor_msgs::msg::PointCloud2 & transformed_cloud,
   float z_offset)
 {
-  // TODO(mitsudome-r): remove conversion once pcl_ros transform are available.
   // transform pointcloud to target_frame
   if (target_frame_ != input.header.frame_id) {
     try {
@@ -119,7 +121,6 @@ bool LidarApolloInstanceSegmentation::detectDynamicObjects(
 
   // convert from ros to pcl
   pcl::PointCloud<pcl::PointXYZI>::Ptr pcl_pointcloud_raw_ptr(new pcl::PointCloud<pcl::PointXYZI>);
-  // pcl::fromROSMsg(transformed_cloud, *pcl_pointcloud_raw_ptr);
 
   auto & pcl_pointcloud_raw = *pcl_pointcloud_raw_ptr;
   pcl_pointcloud_raw.width = transformed_cloud.width;


### PR DESCRIPTION
During the point cloud type transition, I performed a manual conversion to cast intensities into floats.
However, there was a transformation step that is not compatible with the new type so addressed those issues in this PR

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
