### PR TITLE
ci(pr-agent): disable newly added default review labels

### DIFF
--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -36,3 +36,5 @@ jobs:
           config.max_model_tokens: 64000
           pr_code_suggestions.max_context_tokens: 12000
           pr_code_suggestions.commitable_code_suggestions: true
+          pr_reviewer.enable_review_labels_effort: false
+          pr_reviewer.enable_review_labels_security: false


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/623694d6-85a9-453c-becc-0253fd87dab7)
- https://github.com/autowarefoundation/autoware.universe/pull/7951#event-13488709181

## Related links

**Cause:**

- https://github.com/Codium-ai/pr-agent/pull/620/commits

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
