### PR TITLE
fix(autoware_obstacle_stop_planner): fix passedByValue

### DIFF
--- a/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -748,7 +748,7 @@ void AdaptiveCruiseController::registerQueToVelocity(
   est_vel_que_.emplace_back(new_vel);
 }
 
-double AdaptiveCruiseController::getMedianVel(const std::vector<nav_msgs::msg::Odometry> vel_que)
+double AdaptiveCruiseController::getMedianVel(const std::vector<nav_msgs::msg::Odometry> & vel_que)
 {
   if (vel_que.size() == 0) {
     RCLCPP_WARN_STREAM(node_->get_logger(), "size of vel que is 0. Something has wrong.");

--- a/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
@@ -183,7 +183,7 @@ private:
   };
   Param param_;
 
-  double getMedianVel(const std::vector<nav_msgs::msg::Odometry> vel_que);
+  double getMedianVel(const std::vector<nav_msgs::msg::Odometry> & vel_que);
   double lowpass_filter(const double current_value, const double prev_value, const double gain);
   void calcDistanceToNearestPointOnPath(
     const TrajectoryPoints & trajectory, const int nearest_point_idx,

--- a/planning/autoware_obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/planner_utils.cpp
@@ -228,7 +228,7 @@ std::string jsonDumpsPose(const Pose & pose)
   return json_dumps_pose;
 }
 
-DiagnosticStatus makeStopReasonDiag(const std::string stop_reason, const Pose & stop_pose)
+DiagnosticStatus makeStopReasonDiag(const std::string & stop_reason, const Pose & stop_pose)
 {
   DiagnosticStatus stop_reason_diag;
   KeyValue stop_reason_diag_kv;

--- a/planning/autoware_obstacle_stop_planner/src/planner_utils.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/planner_utils.hpp
@@ -122,7 +122,7 @@ Polygon2d convertBoundingBoxObjectToGeometryPolygon(
 
 std::string jsonDumpsPose(const Pose & pose);
 
-DiagnosticStatus makeStopReasonDiag(const std::string stop_reason, const Pose & stop_pose);
+DiagnosticStatus makeStopReasonDiag(const std::string & stop_reason, const Pose & stop_pose);
 
 TrajectoryPoint getBackwardPointFromBasePoint(
   const TrajectoryPoint & p_from, const TrajectoryPoint & p_to, const TrajectoryPoint & p_base,


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp:751:90: performance: Function parameter 'vel_que' should be passed by const reference. [passedByValue]
double AdaptiveCruiseController::getMedianVel(const std::vector<nav_msgs::msg::Odometry> vel_que)
                                                                                         ^

planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp:186:66: performance: Function parameter 'vel_que' should be passed by const reference. [passedByValue]
  double getMedianVel(const std::vector<nav_msgs::msg::Odometry> vel_que);
                                                                 ^

planning/autoware_obstacle_stop_planner/src/planner_utils.hpp:125:55: performance: Function parameter 'stop_reason' should be passed by const reference. [passedByValue]
DiagnosticStatus makeStopReasonDiag(const std::string stop_reason, const Pose & stop_pose);
                                                      ^

planning/autoware_obstacle_stop_planner/src/planner_utils.cpp:231:55: performance: Function parameter 'stop_reason' should be passed by const reference. [passedByValue]
DiagnosticStatus makeStopReasonDiag(const std::string stop_reason, const Pose & stop_pose)
                                                      ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
