### PR TITLE
fix(autoware_path_smoother): fix passedByValue

### DIFF
--- a/planning/autoware_path_smoother/include/autoware/path_smoother/utils/trajectory_utils.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/utils/trajectory_utils.hpp
@@ -116,10 +116,10 @@ size_t findEgoSegmentIndex(
 Path create_path(Path path_msg, const std::vector<TrajectoryPoint> & traj_points);
 
 std::vector<TrajectoryPoint> resampleTrajectoryPoints(
-  const std::vector<TrajectoryPoint> traj_points, const double interval);
+  const std::vector<TrajectoryPoint> & traj_points, const double interval);
 
 std::vector<TrajectoryPoint> resampleTrajectoryPointsWithoutStopPoint(
-  const std::vector<TrajectoryPoint> traj_points, const double interval);
+  const std::vector<TrajectoryPoint> & traj_points, const double interval);
 
 template <typename T>
 std::optional<size_t> updateFrontPointForFix(

--- a/planning/autoware_path_smoother/src/utils/trajectory_utils.cpp
+++ b/planning/autoware_path_smoother/src/utils/trajectory_utils.cpp
@@ -50,7 +50,7 @@ Path create_path(Path path_msg, const std::vector<TrajectoryPoint> & traj_points
 }
 
 std::vector<TrajectoryPoint> resampleTrajectoryPoints(
-  const std::vector<TrajectoryPoint> traj_points, const double interval)
+  const std::vector<TrajectoryPoint> & traj_points, const double interval)
 {
   constexpr bool enable_resampling_stop_point = true;
 
@@ -62,7 +62,7 @@ std::vector<TrajectoryPoint> resampleTrajectoryPoints(
 
 // NOTE: stop point will not be resampled
 std::vector<TrajectoryPoint> resampleTrajectoryPointsWithoutStopPoint(
-  const std::vector<TrajectoryPoint> traj_points, const double interval)
+  const std::vector<TrajectoryPoint> & traj_points, const double interval)
 {
   constexpr bool enable_resampling_stop_point = false;
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
planning/autoware_path_smoother/src/utils/trajectory_utils.cpp:53:38: performance: Function parameter 'traj_points' should be passed by const reference. [passedByValue]
  const std::vector<TrajectoryPoint> traj_points, const double interval)
                                     ^

planning/autoware_path_smoother/src/utils/trajectory_utils.cpp:65:38: performance: Function parameter 'traj_points' should be passed by const reference. [passedByValue]
  const std::vector<TrajectoryPoint> traj_points, const double interval)
                                     ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
