### PR TITLE
fix(autoware_surround_obstacle_checker): fix passedByValue

### DIFF
--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -69,7 +69,7 @@ std::string jsonDumpsPose(const geometry_msgs::msg::Pose & pose)
 }
 
 diagnostic_msgs::msg::DiagnosticStatus makeStopReasonDiag(
-  const std::string no_start_reason, const geometry_msgs::msg::Pose & stop_pose)
+  const std::string & no_start_reason, const geometry_msgs::msg::Pose & stop_pose)
 {
   diagnostic_msgs::msg::DiagnosticStatus no_start_reason_diag;
   diagnostic_msgs::msg::KeyValue no_start_reason_diag_kv;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings
```
planning/autoware_surround_obstacle_checker/src/node.cpp:72:21: performance: Function parameter 'no_start_reason' should be passed by const reference. [passedByValue]
  const std::string no_start_reason, const geometry_msgs::msg::Pose & stop_pose)
                    ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
