### PR TITLE
fix(autoware_velocity_smoother): fix passedByValue

### DIFF
--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
@@ -45,8 +45,8 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   const std::vector<double> & times, const size_t start_index,
   TrajectoryPoints & output_trajectory);
 void updateStopVelocityStatus(
-  double v0, double a0, double jerk_acc, double jerk_dec, int type, const std::vector<double> & times,
-  double t, double & x, double & v, double & a, double & j);
+  double v0, double a0, double jerk_acc, double jerk_dec, int type,
+  const std::vector<double> & times, double t, double & x, double & v, double & a, double & j);
 double integ_x(double x0, double v0, double a0, double j0, double t);
 double integ_v(double v0, double a0, double j0, double t);
 double integ_a(double a0, double j0, double t);

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
@@ -45,7 +45,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   const std::vector<double> & times, const size_t start_index,
   TrajectoryPoints & output_trajectory);
 void updateStopVelocityStatus(
-  double v0, double a0, double jerk_acc, double jerk_dec, int type, std::vector<double> times,
+  double v0, double a0, double jerk_acc, double jerk_dec, int type, const std::vector<double> & times,
   double t, double & x, double & v, double & a, double & j);
 double integ_x(double x0, double v0, double a0, double j0, double t);
 double integ_v(double v0, double a0, double j0, double t);

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -271,8 +271,8 @@ bool calcStopVelocityWithConstantJerkAccLimit(
 }
 
 void updateStopVelocityStatus(
-  double v0, double a0, double jerk_acc, double jerk_dec, int type, const std::vector<double> & times,
-  double t, double & x, double & v, double & a, double & j)
+  double v0, double a0, double jerk_acc, double jerk_dec, int type,
+  const std::vector<double> & times, double t, double & x, double & v, double & a, double & j)
 {
   if (type == 1) {
     if (0 <= t && t < times.at(0)) {

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -271,7 +271,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
 }
 
 void updateStopVelocityStatus(
-  double v0, double a0, double jerk_acc, double jerk_dec, int type, std::vector<double> times,
+  double v0, double a0, double jerk_acc, double jerk_dec, int type, const std::vector<double> & times,
   double t, double & x, double & v, double & a, double & j)
 {
   if (type == 1) {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp:274:89: performance: Function parameter 'times' should be passed by const reference. [passedByValue]
  double v0, double a0, double jerk_acc, double jerk_dec, int type, std::vector<double> times,
                                                                                        ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
