### PR TITLE
fix(autoware_behavior_path_planner_common): fix passedByValue

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/marker_utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/marker_utils/utils.hpp
@@ -67,7 +67,7 @@ MarkerArray createFootprintMarkerArray(
   const std::string && ns, const int32_t & id, const float & r, const float & g, const float & b);
 
 MarkerArray createPointsMarkerArray(
-  const std::vector<Point> points, const std::string & ns, const int32_t id, const float r,
+  const std::vector<Point> & points, const std::string & ns, const int32_t id, const float r,
   const float g, const float b);
 
 MarkerArray createPoseMarkerArray(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -87,7 +87,7 @@ bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double 
 
 // only two points is supported
 std::vector<double> splineTwoPoints(
-  const std::vector<double> & base_s, std::vector<double> & base_x, const double begin_diff,
+  const std::vector<double> & base_s, const std::vector<double> & base_x, const double begin_diff,
   const double end_diff, const std::vector<double> & new_s);
 
 std::vector<Pose> interpolatePose(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -79,7 +79,7 @@ PathWithLaneId convertWayPointsToPathWithLaneId(
 std::vector<size_t> getReversingIndices(const PathWithLaneId & path);
 
 std::vector<PathWithLaneId> dividePath(
-  const PathWithLaneId & path, const std::vector<size_t> indices);
+  const PathWithLaneId & path, const std::vector<size_t> & indices);
 
 void correctDividedPathVelocity(std::vector<PathWithLaneId> & divided_paths);
 
@@ -87,8 +87,8 @@ bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double 
 
 // only two points is supported
 std::vector<double> splineTwoPoints(
-  std::vector<double> base_s, std::vector<double> base_x, const double begin_diff,
-  const double end_diff, std::vector<double> new_s);
+  std::vector<double> & base_s, std::vector<double> & base_x, const double begin_diff,
+  const double end_diff, std::vector<double> & new_s);
 
 std::vector<Pose> interpolatePose(
   const Pose & start_pose, const Pose & end_pose, const double resample_interval);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -87,8 +87,8 @@ bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double 
 
 // only two points is supported
 std::vector<double> splineTwoPoints(
-  std::vector<double> & base_s, std::vector<double> & base_x, const double begin_diff,
-  const double end_diff, std::vector<double> & new_s);
+  const std::vector<double> & base_s, std::vector<double> & base_x, const double begin_diff,
+  const double end_diff, const std::vector<double> & new_s);
 
 std::vector<Pose> interpolatePose(
   const Pose & start_pose, const Pose & end_pose, const double resample_interval);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
@@ -79,7 +79,7 @@ MarkerArray createFootprintMarkerArray(
 }
 
 MarkerArray createPointsMarkerArray(
-  const std::vector<Point> points, const std::string & ns, const int32_t id, const float r,
+  const std::vector<Point> & points, const std::string & ns, const int32_t id, const float r,
   const float g, const float b)
 {
   auto marker = createDefaultMarker(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -445,8 +445,8 @@ bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double 
 
 // only two points is supported
 std::vector<double> splineTwoPoints(
-  std::vector<double> & base_s, std::vector<double> & base_x, const double begin_diff,
-  const double end_diff, std::vector<double> & new_s)
+  const std::vector<double> & base_s, const std::vector<double> & base_x, const double begin_diff,
+  const double end_diff, const std::vector<double> & new_s)
 {
   assert(base_s.size() == 2 && base_x.size() == 2);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -376,7 +376,7 @@ std::vector<size_t> getReversingIndices(const PathWithLaneId & path)
 }
 
 std::vector<PathWithLaneId> dividePath(
-  const PathWithLaneId & path, const std::vector<size_t> indices)
+  const PathWithLaneId & path, const std::vector<size_t> & indices)
 {
   std::vector<PathWithLaneId> divided_paths;
 
@@ -445,8 +445,8 @@ bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double 
 
 // only two points is supported
 std::vector<double> splineTwoPoints(
-  std::vector<double> base_s, std::vector<double> base_x, const double begin_diff,
-  const double end_diff, std::vector<double> new_s)
+  std::vector<double> & base_s, std::vector<double> & base_x, const double begin_diff,
+  const double end_diff, std::vector<double> & new_s)
 {
   assert(base_s.size() == 2 && base_x.size() == 2);
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp:82:28: performance: Function parameter 'points' should be passed by const reference. [passedByValue]
  const std::vector<Point> points, const std::string & ns, const int32_t id, const float r,
                           ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:379:58: performance: Function parameter 'indices' should be passed by const reference. [passedByValue]
  const PathWithLaneId & path, const std::vector<size_t> indices)
                                                         ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:448:23: performance: Function parameter 'base_s' should be passed by const reference. [passedByValue]
  std::vector<double> base_s, std::vector<double> base_x, const double begin_diff,
                      ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:448:51: performance: Function parameter 'base_x' should be passed by const reference. [passedByValue]
  std::vector<double> base_s, std::vector<double> base_x, const double begin_diff,
                                                  ^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:449:46: performance: Function parameter 'new_s' should be passed by const reference. [passedByValue]
  const double end_diff, std::vector<double> new_s)
                                             ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
