### PR TITLE
fix(autoware_behavior_velocity_crosswalk_module): fix passedByValue

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
@@ -86,7 +86,7 @@ std::vector<lanelet::BasicPolygon2d> calculate_detection_areas(
 
 std::vector<autoware_perception_msgs::msg::PredictedObject> select_and_inflate_objects(
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & objects,
-  const std::vector<double> velocity_thresholds, const double inflate_size)
+  const std::vector<double> & velocity_thresholds, const double inflate_size)
 {
   std::vector<autoware_perception_msgs::msg::PredictedObject> selected_objects;
   for (const auto & o : objects) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
@@ -80,7 +80,7 @@ double calculate_detection_range(
 /// @return selected and inflated objects
 std::vector<autoware_perception_msgs::msg::PredictedObject> select_and_inflate_objects(
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & objects,
-  const double velocity_threshold, const bool skip_pedestrians, const double inflate_size);
+  const double & velocity_threshold, const bool skip_pedestrians, const double inflate_size);
 
 /// @brief clear occlusions behind the given objects
 /// @details masks behind the object assuming rays from the center of the grid map

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
@@ -80,7 +80,7 @@ double calculate_detection_range(
 /// @return selected and inflated objects
 std::vector<autoware_perception_msgs::msg::PredictedObject> select_and_inflate_objects(
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & objects,
-  const double & velocity_threshold, const bool skip_pedestrians, const double inflate_size);
+  const double velocity_threshold, const bool skip_pedestrians, const double inflate_size);
 
 /// @brief clear occlusions behind the given objects
 /// @details masks behind the object assuming rays from the center of the grid map

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -145,7 +145,7 @@ std::vector<Polygon2d> calcOverlappingPoints(const Polygon2d & polygon1, const P
 
 StopFactor createStopFactor(
   const geometry_msgs::msg::Pose & stop_pose,
-  const std::vector<geometry_msgs::msg::Point> stop_factor_points = {})
+  const std::vector<geometry_msgs::msg::Point> & stop_factor_points = {})
 {
   StopFactor stop_factor;
   stop_factor.stop_factor_points = stop_factor_points;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constParameterReference warnings

```
planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp:89:29: performance: Function parameter 'velocity_thresholds' should be passed by const reference. [passedByValue]
  const std::vector<double> velocity_thresholds, const double inflate_size)
                            ^

planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp:148:48: performance: Function parameter 'stop_factor_points' should be passed by const reference. [passedByValue]
  const std::vector<geometry_msgs::msg::Point> stop_factor_points = {})
                                               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
