### PR TITLE
feat(psim)!: preapre settings to launch localization modules on psim

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -154,7 +154,8 @@
   </group>
 
   <group if="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;pose_twist_estimator&quot;')">
-    <group> <!-- start name space localization -->
+    <group>
+      <!-- start name space localization -->
       <push-ros-namespace namespace="localization"/>
       <group>
         <push-ros-namespace namespace="util"/>
@@ -180,7 +181,8 @@
         <push-ros-namespace namespace="pose_twist_fusion_filter"/>
         <include file="$(find-pkg-share tier4_localization_launch)/launch/pose_twist_fusion_filter/pose_twist_fusion_filter.launch.xml"/>
       </group>
-    </group> <!-- end name space localization -->
+    </group>
+    <!-- end name space localization -->
     <group>
       <push-ros-namespace namespace="sensing"/>
       <arg name="input_vehicle_velocity_topic" default="/vehicle/status/velocity_status"/>
@@ -210,12 +212,14 @@
   <!-- Simulator model -->
   <group if="$(var launch_dummy_vehicle)">
     <arg name="simulator_model" default="$(var vehicle_model_pkg)/config/simulator_model.param.yaml" description="path to the file of simulator model"/>
+    <let name="motion_publish_mode" value="pose_only" if="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;pose_twist_estimator&quot;')"/>
+    <let name="motion_publish_mode" value="full_motion" unless="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;pose_twist_estimator&quot;')"/>
     <include file="$(find-pkg-share simple_planning_simulator)/launch/simple_planning_simulator.launch.py">
       <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
       <arg name="simulator_model_param_file" value="$(var simulator_model)"/>
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
       <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
-      <arg name="launch_localization_for_sim_vehicle" value="$(var launch_localization_for_sim_vehicle)"/>
+      <arg name="motion_publish_mode" value="$(var motion_publish_mode)"/>
     </include>
   </group>
 </launch>

--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -16,7 +16,7 @@
   <arg name="launch_dummy_vehicle"/>
   <arg
     name="localization_sim_mode"
-    description="Select localization mode. Options are 'none' or 'api'. 'api' starts an external API for initial position estimation. 'none' does not start any localization-related process."
+    description="Select localization mode. Options are 'none', 'api' or 'pose_twist_estimator'. 'pose_twist_estimator' starts most of the localization modules except for the ndt_scan_matcher. 'api' starts an external API for initial position estimation. 'none' does not start any localization-related process."
   />
   <arg name="launch_dummy_doors"/>
   <arg name="launch_diagnostic_converter"/>

--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -5,7 +5,12 @@
   <arg name="laserscan_based_occupancy_grid_map_param_path"/>
   <arg name="occupancy_grid_map_updater"/>
   <arg name="occupancy_grid_map_updater_param_path"/>
+
+  <arg name="localization_error_monitor_param_path"/>
+  <arg name="ekf_localizer_param_path"/>
   <arg name="pose_initializer_param_path"/>
+  <arg name="twist2accel_param_path"/>
+
   <arg name="launch_simulator_perception_modules" default="true"/>
   <arg name="launch_dummy_perception"/>
   <arg name="launch_dummy_vehicle"/>
@@ -130,7 +135,7 @@
     </group>
   </group>
 
-  <!-- Dummy localization -->
+  <!-- localization -->
   <group if="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;none&quot;')">
     <!-- Do nothing -->
   </group>
@@ -146,6 +151,48 @@
       <arg name="stop_check_enabled" value="false"/>
       <arg name="config_file" value="$(var pose_initializer_param_path)"/>
     </include>
+  </group>
+
+  <group if="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;pose_twist_estimator&quot;')">
+    <group> <!-- start name space localization -->
+      <push-ros-namespace namespace="localization"/>
+      <group>
+        <push-ros-namespace namespace="util"/>
+        <include file="$(find-pkg-share pose_initializer)/launch/pose_initializer.launch.xml">
+          <arg name="user_defined_initial_pose/enable" value="false"/>
+          <arg name="user_defined_initial_pose/pose" value="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]"/>
+          <arg name="ndt_enabled" value="false"/>
+          <arg name="gnss_enabled" value="false"/>
+          <arg name="ekf_enabled" value="true"/>
+          <arg name="yabloc_enabled" value="false"/>
+          <arg name="stop_check_enabled" value="false"/>
+          <arg name="config_file" value="$(var pose_initializer_param_path)"/>
+        </include>
+      </group>
+
+      <group>
+        <push-ros-namespace namespace="twist_estimator"/>
+        <include file="$(find-pkg-share tier4_localization_launch)/launch/pose_twist_estimator/gyro_odometer.launch.xml"/>
+      </group>
+
+      <!-- pose_twist_fusion_filter module -->
+      <group>
+        <push-ros-namespace namespace="pose_twist_fusion_filter"/>
+        <include file="$(find-pkg-share tier4_localization_launch)/launch/pose_twist_fusion_filter/pose_twist_fusion_filter.launch.xml"/>
+      </group>
+    </group> <!-- end name space localization -->
+    <group>
+      <push-ros-namespace namespace="sensing"/>
+      <arg name="input_vehicle_velocity_topic" default="/vehicle/status/velocity_status"/>
+      <arg name="output_twist_with_covariance" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
+      <arg name="config_file" default="$(find-pkg-share vehicle_velocity_converter)/config/vehicle_velocity_converter.param.yaml"/>
+
+      <node pkg="vehicle_velocity_converter" exec="vehicle_velocity_converter_node" output="both">
+        <param from="$(var config_file)"/>
+        <remap from="velocity_status" to="$(var input_vehicle_velocity_topic)"/>
+        <remap from="twist_with_covariance" to="$(var output_twist_with_covariance)"/>
+      </node>
+    </group>
   </group>
 
   <!-- Dummy doors -->
@@ -168,6 +215,7 @@
       <arg name="simulator_model_param_file" value="$(var simulator_model)"/>
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
       <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
+      <arg name="launch_localization_for_sim_vehicle" value="$(var launch_localization_for_sim_vehicle)"/>
     </include>
   </group>
 </launch>

--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -212,6 +212,7 @@
   <!-- Simulator model -->
   <group if="$(var launch_dummy_vehicle)">
     <arg name="simulator_model" default="$(var vehicle_model_pkg)/config/simulator_model.param.yaml" description="path to the file of simulator model"/>
+    <!-- 'pose_only' mode publishes the pose topic as an alternative to ndt_localizer. 'full_motion' mode publishes the odometry and acceleration topics as an alternative to localization modules. -->
     <let name="motion_publish_mode" value="pose_only" if="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;pose_twist_estimator&quot;')"/>
     <let name="motion_publish_mode" value="full_motion" unless="$(eval '&quot;$(var localization_sim_mode)&quot;==&quot;pose_twist_estimator&quot;')"/>
     <include file="$(find-pkg-share simple_planning_simulator)/launch/simple_planning_simulator.launch.py">

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -137,7 +137,7 @@ private:
   rclcpp::Publisher<TurnIndicatorsReport>::SharedPtr pub_turn_indicators_report_;
   rclcpp::Publisher<HazardLightsReport>::SharedPtr pub_hazard_lights_report_;
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr pub_tf_;
-  rclcpp::Publisher<PoseStamped>::SharedPtr pub_current_pose_;
+  rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_current_pose_;
 
   rclcpp::Subscription<GearCommand>::SharedPtr sub_gear_cmd_;
   rclcpp::Subscription<GearCommand>::SharedPtr sub_manual_gear_cmd_;
@@ -345,6 +345,12 @@ private:
    * @param [in] odometry The odometry to publish
    */
   void publish_odometry(const Odometry & odometry);
+
+  /**
+   * @brief publish pose
+   * @param [in] odometry The odometry to publish its pose
+   */
+  void publish_pose(const Odometry & odometry);
 
   /**
    * @brief publish steering

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -41,6 +41,50 @@ def launch_setup(context, *args, **kwargs):
         param_file=simulator_model_param_path, allow_substs=True
     )
 
+    # Base remappings
+    remappings = [
+        ("input/vector_map", "/map/vector_map"),
+        ("input/initialpose", "/initialpose3d"),
+        ("input/ackermann_control_command", "/control/command/control_cmd"),
+        ("input/actuation_command", "/control/command/actuation_cmd"),
+        ("input/manual_ackermann_control_command", "/vehicle/command/manual_control_cmd"),
+        ("input/gear_command", "/control/command/gear_cmd"),
+        ("input/manual_gear_command", "/vehicle/command/manual_gear_command"),
+        ("input/turn_indicators_command", "/control/command/turn_indicators_cmd"),
+        ("input/hazard_lights_command", "/control/command/hazard_lights_cmd"),
+        ("input/trajectory", "/planning/scenario_planning/trajectory"),
+        ("input/engage", "/vehicle/engage"),
+        ("input/control_mode_request", "/control/control_mode_request"),
+        ("output/twist", "/vehicle/status/velocity_status"),
+        ("output/imu", "/sensing/imu/imu_data"),
+        ("output/steering", "/vehicle/status/steering_status"),
+        ("output/gear_report", "/vehicle/status/gear_status"),
+        ("output/turn_indicators_report", "/vehicle/status/turn_indicators_status"),
+        ("output/hazard_lights_report", "/vehicle/status/hazard_lights_status"),
+        ("output/control_mode_report", "/vehicle/status/control_mode"),
+    ]
+
+    # Additional remappings
+    if LaunchConfiguration("launch_localization_for_sim_vehicle").perform(context) == "true":
+        remappings.extend(
+            [
+                ("output/odometry", "/simulation/debug/localization/kinematic_state"),
+                ("output/acceleration", "/simulation/debug/localization/acceleration"),
+                ("output/pose", "/localization/pose_estimator/pose_with_covariance"),
+            ]
+        )
+    else:
+        remappings.extend(
+            [
+                ("output/odometry", "/localization/kinematic_state"),
+                ("output/acceleration", "/localization/acceleration"),
+                (
+                    "output/pose",
+                    "/simulation/debug/localization/pose_estimator/pose_with_covariance",
+                ),
+            ]
+        )
+
     simple_planning_simulator_node = Node(
         package="simple_planning_simulator",
         executable="simple_planning_simulator_exe",
@@ -55,29 +99,7 @@ def launch_setup(context, *args, **kwargs):
                 "initial_engage_state": LaunchConfiguration("initial_engage_state"),
             },
         ],
-        remappings=[
-            ("input/vector_map", "/map/vector_map"),
-            ("input/initialpose", "/initialpose3d"),
-            ("input/ackermann_control_command", "/control/command/control_cmd"),
-            ("input/actuation_command", "/control/command/actuation_cmd"),
-            ("input/manual_ackermann_control_command", "/vehicle/command/manual_control_cmd"),
-            ("input/gear_command", "/control/command/gear_cmd"),
-            ("input/manual_gear_command", "/vehicle/command/manual_gear_command"),
-            ("input/turn_indicators_command", "/control/command/turn_indicators_cmd"),
-            ("input/hazard_lights_command", "/control/command/hazard_lights_cmd"),
-            ("input/trajectory", "/planning/scenario_planning/trajectory"),
-            ("input/engage", "/vehicle/engage"),
-            ("input/control_mode_request", "/control/control_mode_request"),
-            ("output/twist", "/vehicle/status/velocity_status"),
-            ("output/odometry", "/localization/kinematic_state"),
-            ("output/acceleration", "/localization/acceleration"),
-            ("output/imu", "/sensing/imu/imu_data"),
-            ("output/steering", "/vehicle/status/steering_status"),
-            ("output/gear_report", "/vehicle/status/gear_status"),
-            ("output/turn_indicators_report", "/vehicle/status/turn_indicators_status"),
-            ("output/hazard_lights_report", "/vehicle/status/hazard_lights_status"),
-            ("output/control_mode_report", "/vehicle/status/control_mode"),
-        ],
+        remappings=remappings,
     )
 
     # Determine if we should launch raw_vehicle_cmd_converter based on the vehicle_model_type

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -84,10 +84,6 @@ def launch_setup(context, *args, **kwargs):
                 ),
             ]
         )
-    else:
-        raise ValueError(
-            "Invalid motion_publish_mode specified. Please choose 'pose_only' or 'full_motion'."
-        )
 
     simple_planning_simulator_node = Node(
         package="simple_planning_simulator",

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -65,7 +65,7 @@ def launch_setup(context, *args, **kwargs):
     ]
 
     # Additional remappings
-    if LaunchConfiguration("launch_localization_for_sim_vehicle").perform(context) == "true":
+    if LaunchConfiguration("motion_publish_mode").perform(context) == "pose_only":
         remappings.extend(
             [
                 ("output/odometry", "/simulation/debug/localization/kinematic_state"),
@@ -73,7 +73,7 @@ def launch_setup(context, *args, **kwargs):
                 ("output/pose", "/localization/pose_estimator/pose_with_covariance"),
             ]
         )
-    else:
+    elif LaunchConfiguration("motion_publish_mode").perform(context) == "full_motion":
         remappings.extend(
             [
                 ("output/odometry", "/localization/kinematic_state"),
@@ -83,6 +83,10 @@ def launch_setup(context, *args, **kwargs):
                     "/simulation/debug/localization/pose_estimator/pose_with_covariance",
                 ),
             ]
+        )
+    else:
+        raise ValueError(
+            "Invalid motion_publish_mode specified. Please choose 'pose_only' or 'full_motion'."
         )
 
     simple_planning_simulator_node = Node(


### PR DESCRIPTION
## Description
This PR is a part of the following issue:
https://github.com/autowarefoundation/autoware_launch/issues/1100

This PR allows localization and simple_planning_simulator to support launching the localization module in psim.
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1094

For more details, please see the launch PR and the issue page.

## How was this PR tested?
psim tests and scenario simulator

## Notes for reviewers

None.

## Interface changes

## Effects on system behavior

