### PR TITLE
fix(bytetrack): No need to throw exception when idx is out of range

### DIFF
--- a/perception/bytetrack/include/bytetrack/bytetrack_visualizer_node.hpp
+++ b/perception/bytetrack/include/bytetrack/bytetrack_visualizer_node.hpp
@@ -31,7 +31,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -54,10 +53,7 @@ public:
 
   cv::Scalar operator()(size_t idx)
   {
-    if (kColorNum <= idx) {
-      throw std::runtime_error("idx should be between [0, 255]");
-    }
-    return color_table_.at<cv::Vec3b>(0, idx);
+    return color_table_.at<cv::Vec3b>(0, idx % kColorNum);
   }
 
 protected:


### PR DESCRIPTION
Since ColorMapper just returns a unique color to the caller, we simply use modulo to get a valid color index.
In such a way there is no need to check the index validity and throw a runtime exception.

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
