### PR TITLE
fix(lane_change): moving object is filtered in the extended target lanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1201,7 +1201,8 @@ FilteredByLanesObjects NormalLaneChange::filterObjectsByLanelets(
       is_before_terminal()) {
       const auto ahead_of_ego =
         utils::lane_change::is_ahead_of_ego(common_data_ptr_, current_lanes_ref_path, object);
-      if (object.kinematics.initial_twist_with_covariance.twist.linear.x < 1.0) {
+      constexpr double stopped_obj_vel_th = 1.0;
+      if (object.kinematics.initial_twist_with_covariance.twist.linear.x < stopped_obj_vel_th) {
         if (ahead_of_ego) {
           target_lane_leading_objects.push_back(object);
           continue;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1184,7 +1184,7 @@ FilteredByLanesObjects NormalLaneChange::filterObjectsByLanelets(
     };
 
     if (
-      check_optional_polygon(object, lanes_polygon.expanded_target) && is_lateral_far &&
+      check_optional_polygon(object, lanes_polygon.target) && is_lateral_far &&
       is_before_terminal()) {
       const auto ahead_of_ego =
         utils::lane_change::is_ahead_of_ego(common_data_ptr_, current_lanes_ref_path, object);
@@ -1194,6 +1194,19 @@ FilteredByLanesObjects NormalLaneChange::filterObjectsByLanelets(
         target_lane_trailing_objects.push_back(object);
       }
       continue;
+    }
+
+    if (
+      check_optional_polygon(object, lanes_polygon.expanded_target) && is_lateral_far &&
+      is_before_terminal()) {
+      const auto ahead_of_ego =
+        utils::lane_change::is_ahead_of_ego(common_data_ptr_, current_lanes_ref_path, object);
+      if (object.kinematics.initial_twist_with_covariance.twist.linear.x < 1.0) {
+        if (ahead_of_ego) {
+          target_lane_leading_objects.push_back(object);
+          continue;
+        }
+      }
     }
 
     const auto is_overlap_target_backward = std::invoke([&]() -> bool {


### PR DESCRIPTION
## Description

When filtering  lane change target objects, the objects that is close to target lanes' bound is considered as target objects. This is to prevent ego from lane change too near to the object. However, if the object is not moving, we don't really need to consider them as the target object.

### Before PR

https://github.com/user-attachments/assets/b43c0da5-de38-4d80-82ff-67628d6ef968

### After PR

https://github.com/user-attachments/assets/5631fe31-0d5b-4e07-ac45-6a769657401e

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
