### PR TITLE
feat(rtc_inteface): add function to check force deactivate

### DIFF
--- a/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
+++ b/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
@@ -60,6 +60,7 @@ public:
   void clearCooperateStatus();
   bool isActivated(const UUID & uuid) const;
   bool isForceActivated(const UUID & uuid) const;
+  bool isForceDeactivated(const UUID & UUID) const;
   bool isRegistered(const UUID & uuid) const;
   bool isRTCEnabled(const UUID & uuid) const;
   bool isTerminated(const UUID & uuid) const;

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -370,6 +370,30 @@ bool RTCInterface::isForceActivated(const UUID & uuid) const
   return false;
 }
 
+bool RTCInterface::isForceDeactivated(const UUID & uuid) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto itr = std::find_if(
+    registered_status_.statuses.begin(), registered_status_.statuses.end(),
+    [uuid](const auto & s) { return s.uuid == uuid; });
+
+  if (itr != registered_status_.statuses.end()) {
+    if (itr->state.type != State::RUNNING) {
+      return false;
+    }
+    if (itr->command_status.type == Command::DEACTIVATE && itr->safe && !itr->auto_mode) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  RCLCPP_WARN_STREAM(
+    getLogger(),
+    "[isForceDeactivated] uuid : " << uuid_to_string(uuid) << " is not found" << std::endl);
+  return false;
+}
+
 bool RTCInterface::isRegistered(const UUID & uuid) const
 {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
## Description
Current rtc interface could not judge whether cooperateStatus was force deactivated or not.
This PR enables to judge force deactivation (ex. deactivation from human operators).

## Related links

## How was this PR tested?
[TIER IV internal test](https://evaluation.tier4.jp/evaluation/reports/2ab7653e-934b-51d5-b94e-05e2d10d3664?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
