### PR TITLE
fix(autoware_compare_map_segmentation): fix redundantInitialization warning

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/compare_elevation_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/compare_elevation_map_filter/node.cpp
@@ -72,9 +72,7 @@ void CompareElevationMapFilterComponent::filter(
 {
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
-  std::string output_frame = map_frame_;
 
-  output_frame = elevation_map_.getFrameId();
   elevation_map_.setTimestamp(input->header.stamp.nanosec);
   pcl::fromROSMsg(*input, *pcl_input);
   pcl_output->points.reserve(pcl_input->points.size());
@@ -92,7 +90,7 @@ void CompareElevationMapFilterComponent::filter(
 
   pcl::toROSMsg(*pcl_output, output);
   output.header.stamp = input->header.stamp;
-  output.header.frame_id = output_frame;
+  output.header.frame_id = elevation_map_.getFrameId();
 }
 }  // namespace autoware::compare_map_segmentation
 


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantInitialization` warning

```
perception/autoware_compare_map_segmentation/src/compare_elevation_map_filter/node.cpp:77:16: style: Redundant initialization for 'output_frame'. The initialized value is overwritten before it is read. [redundantInitialization]
  output_frame = elevation_map_.getFrameId();
               ^
perception/autoware_compare_map_segmentation/src/compare_elevation_map_filter/node.cpp:75:28: note: output_frame is initialized
  std::string output_frame = map_frame_;
                           ^
perception/autoware_compare_map_segmentation/src/compare_elevation_map_filter/node.cpp:77:16: note: output_frame is overwritten
  output_frame = elevation_map_.getFrameId();
               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
