### PR TITLE
fix(autoware_radar_object_tracker): fix redundantInitialization

### DIFF
--- a/perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
+++ b/perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
@@ -283,7 +283,8 @@ bool ConstantTurnRateMotionTracker::predict(const double dt, KalmanFilter & ekf)
   Q_xy_local << ekf_params_.q_cov_x, 0.0, 0.0, ekf_params_.q_cov_y;
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(2, 2);
   R << cos(yaw), -sin(yaw), sin(yaw), cos(yaw);
-  Q.block<2, 2>(IDX::X, IDX::X) = R * Q_xy_local * R.transpose();
+  Eigen::MatrixXd Q_xy_global = R * Q_xy_local * R.transpose();
+  Q.block<2, 2>(IDX::X, IDX::X) = Q_xy_global;
 
   Q(IDX::YAW, IDX::YAW) = ekf_params_.q_cov_yaw;
   Q(IDX::VX, IDX::VX) = ekf_params_.q_cov_vx;

--- a/perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
+++ b/perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
@@ -280,12 +280,10 @@ bool ConstantTurnRateMotionTracker::predict(const double dt, KalmanFilter & ekf)
   // Rotate the covariance matrix according to the vehicle yaw
   // because q_cov_x and y are in the vehicle coordinate system.
   Eigen::MatrixXd Q_xy_local = Eigen::MatrixXd::Zero(2, 2);
-  Eigen::MatrixXd Q_xy_global = Eigen::MatrixXd::Zero(2, 2);
   Q_xy_local << ekf_params_.q_cov_x, 0.0, 0.0, ekf_params_.q_cov_y;
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(2, 2);
   R << cos(yaw), -sin(yaw), sin(yaw), cos(yaw);
-  Q_xy_global = R * Q_xy_local * R.transpose();
-  Q.block<2, 2>(IDX::X, IDX::X) = Q_xy_global;
+  Q.block<2, 2>(IDX::X, IDX::X) = R * Q_xy_local * R.transpose();
 
   Q(IDX::YAW, IDX::YAW) = ekf_params_.q_cov_yaw;
   Q(IDX::VX, IDX::VX) = ekf_params_.q_cov_vx;
@@ -366,23 +364,21 @@ bool ConstantTurnRateMotionTracker::measureWithPose(
 
     // covariance need to be rotated since it is in the vehicle coordinate system
     Eigen::MatrixXd Rxy_local = Eigen::MatrixXd::Zero(2, 2);
-    Eigen::MatrixXd Rxy = Eigen::MatrixXd::Zero(2, 2);
     if (!object.kinematics.has_position_covariance) {
       // switch noise covariance in polar coordinate or cartesian coordinate
       const auto r_cov_y = use_polar_coordinate_in_measurement_noise_
                              ? depth * depth * ekf_params_.r_cov_x
                              : ekf_params_.r_cov_y;
       Rxy_local << ekf_params_.r_cov_x, 0, 0, r_cov_y;  // xy in base_link coordinate
-      Rxy = RotationBaseLink * Rxy_local * RotationBaseLink.transpose();
+      R_block_list.push_back(RotationBaseLink * Rxy_local * RotationBaseLink.transpose());
     } else {
       Rxy_local << object.kinematics.pose_with_covariance.covariance[XYZRPY_COV_IDX::X_X],
         object.kinematics.pose_with_covariance.covariance[XYZRPY_COV_IDX::X_Y],
         object.kinematics.pose_with_covariance.covariance[XYZRPY_COV_IDX::Y_X],
         object.kinematics.pose_with_covariance
           .covariance[XYZRPY_COV_IDX::Y_Y];  // xy in vehicle coordinate
-      Rxy = RotationYaw * Rxy_local * RotationYaw.transpose();
+      R_block_list.push_back(RotationYaw * Rxy_local * RotationYaw.transpose());
     }
-    R_block_list.push_back(Rxy);
   }
 
   // 2. add yaw measurement


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantInitialization` warning

```
perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp:287:15: style: Redundant initialization for 'Q_xy_global'. The initialized value is overwritten before it is read. [redundantInitialization]
  Q_xy_global = R * Q_xy_local * R.transpose();
              ^
perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp:283:31: note: Q_xy_global is initialized
  Eigen::MatrixXd Q_xy_global = Eigen::MatrixXd::Zero(2, 2);
                              ^
perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp:287:15: note: Q_xy_global is overwritten
  Q_xy_global = R * Q_xy_local * R.transpose();
              ^
perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp:376:11: style: Redundant initialization for 'Rxy'. The initialized value is overwritten before it is read. [redundantInitialization]
      Rxy = RotationBaseLink * Rxy_local * RotationBaseLink.transpose();
          ^
perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp:369:25: note: Rxy is initialized
    Eigen::MatrixXd Rxy = Eigen::MatrixXd::Zero(2, 2);
                        ^
perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp:376:11: note: Rxy is overwritten
      Rxy = RotationBaseLink * Rxy_local * RotationBaseLink.transpose();
          ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:329:5: style: Redundant initialization for 'Q'. The initialized value is overwritten before it is read. [redundantInitialization]
  Q = RotateCovMatrix * Q_local * RotateCovMatrix.transpose();
    ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:297:21: note: Q is initialized
  Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
                    ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:329:5: note: Q is overwritten
  Q = RotateCovMatrix * Q_local * RotateCovMatrix.transpose();
    ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:314:11: style: Redundant initialization for 'Q_local'. The initialized value is overwritten before it is read. [redundantInitialization]
  Q_local = q_diag_vector.asDiagonal();
          ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:298:27: note: Q_local is initialized
  Eigen::MatrixXd Q_local = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
                          ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:314:11: note: Q_local is overwritten
  Q_local = q_diag_vector.asDiagonal();
          ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:406:11: style: Redundant initialization for 'Rxy'. The initialized value is overwritten before it is read. [redundantInitialization]
      Rxy = RotationBaseLink * Rxy_local * RotationBaseLink.transpose();
          ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:399:25: note: Rxy is initialized
    Eigen::MatrixXd Rxy = Eigen::MatrixXd::Zero(2, 2);
                        ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:406:11: note: Rxy is overwritten
      Rxy = RotationBaseLink * Rxy_local * RotationBaseLink.transpose();
          ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:431:9: style: Redundant initialization for 'Vxy'. The initialized value is overwritten before it is read. [redundantInitialization]
    Vxy = RotationYaw * Vxy_local;
        ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:428:25: note: Vxy is initialized
    Eigen::MatrixXd Vxy = Eigen::MatrixXd::Zero(2, 1);
                        ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:431:9: note: Vxy is overwritten
    Vxy = RotationYaw * Vxy_local;
        ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:438:14: style: Redundant initialization for 'R_v_xy'. The initialized value is overwritten before it is read. [redundantInitialization]
      R_v_xy = RotationBaseLink * R_v_xy_local * RotationBaseLink.transpose();
             ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:435:28: note: R_v_xy is initialized
    Eigen::MatrixXd R_v_xy = Eigen::MatrixXd::Zero(2, 2);
                           ^
perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp:438:14: note: R_v_xy is overwritten
      R_v_xy = RotationBaseLink * R_v_xy_local * RotationBaseLink.transpose();
             ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
