### PR TITLE
fix(autoware_image_diagnostics): fix cppcheck warnings

### DIFF
--- a/sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp
+++ b/sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp
@@ -50,26 +50,19 @@ void ImageDiagNode::onImageDiagChecker(DiagnosticStatusWrapper & stat)
   stat.add("number backlight  regions ", std::to_string(params_.num_of_regions_backlight));
 
   auto level = DiagnosticStatusWrapper::OK;
+  std::string "OK";
+
   if (params_.diagnostic_status < 0) {
     level = DiagnosticStatusWrapper::STALE;
+    msg = "STALE";
   } else if (params_.diagnostic_status == 1) {
     level = DiagnosticStatusWrapper::WARN;
+    msg = "WARNING: abnormal state in image diagnostics";
   } else if (params_.diagnostic_status == 2) {
     level = DiagnosticStatusWrapper::ERROR;
-  } else {
-    level = DiagnosticStatusWrapper::OK;
+    msg = "ERROR: abnormal state in image diagnostics";
   }
 
-  std::string msg;
-  if (level == DiagnosticStatusWrapper::OK) {
-    msg = "OK";
-  } else if (level == DiagnosticStatusWrapper::WARN) {
-    msg = "WARNING: abnormal state in image diagnostics";
-  } else if (level == DiagnosticStatusWrapper::ERROR) {
-    msg = "ERROR: abnormal state in image diagnostics";
-  } else if (level == DiagnosticStatusWrapper::STALE) {
-    msg = "STALE";
-  }
   stat.summary(level, msg);
 }
 
@@ -101,7 +94,6 @@ void ImageDiagNode::ImageChecker(const sensor_msgs::msg::Image::ConstSharedPtr i
   img_gray.convertTo(img_gray_32b, CV_32FC1);
   cv::Mat imgDCT(size, CV_32FC1);
   imgDCT.setTo(0.0);
-  float region_freq_average = 0.0;
   cv::Mat imgDFT(size, CV_32FC1);
   imgDFT.setTo(0.0);
   // calculate the features of each small block in image
@@ -132,7 +124,7 @@ void ImageDiagNode::ImageChecker(const sensor_msgs::msg::Image::ConstSharedPtr i
       cv::Mat rect_tmp = img_gray_32b(roi);
       channelImg[0](original_roi).copyTo(rect_tmp);
       cv::log(rect_tmp, rect_tmp);
-      region_freq_average = cv::mean(rect_tmp)[0];
+      const float region_freq_average = cv::mean(rect_tmp)[0];
 
       region_average_vec.push_back(intensity_average);
       region_blockage_ratio_vec.push_back(roi_blockage_ratio);

--- a/sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp
+++ b/sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp
@@ -50,7 +50,7 @@ void ImageDiagNode::onImageDiagChecker(DiagnosticStatusWrapper & stat)
   stat.add("number backlight  regions ", std::to_string(params_.num_of_regions_backlight));
 
   auto level = DiagnosticStatusWrapper::OK;
-  std::string "OK";
+  std::string msg = "OK";
 
   if (params_.diagnostic_status < 0) {
     level = DiagnosticStatusWrapper::STALE;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantInitialization` and `unreadVariable` warnings

```
sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp:54:11: style: Redundant initialization for 'level'. The initialized value is overwritten before it is read. [redundantInitialization]
    level = DiagnosticStatusWrapper::STALE;
          ^
sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp:52:14: note: level is initialized
  auto level = DiagnosticStatusWrapper::OK;
             ^
sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp:54:11: note: level is overwritten
    level = DiagnosticStatusWrapper::STALE;
          ^
sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp:104:29: style: Variable 'region_freq_average' is assigned a value that is never used. [unreadVariable]
  float region_freq_average = 0.0;
                            ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
