### PR TITLE
fix(autoware_accel_brake_map_calibrator): fix redundantInitialization

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -1326,15 +1326,12 @@ void AccelBrakeMapCalibrator::check_update_suggest(
   using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
   using CalibrationStatus = CalibrationStatus;
   CalibrationStatus accel_brake_map_status;
-  int8_t level = DiagStatus::OK;
-  std::string msg;
-
   accel_brake_map_status.target = CalibrationStatus::ACCEL_BRAKE_MAP;
-  if (is_default_map_) {
-    accel_brake_map_status.status = CalibrationStatus::NORMAL;
-    level = DiagStatus::OK;
-    msg = "OK";
-  } else {
+  accel_brake_map_status.status = CalibrationStatus::NORMAL;
+  int8_t level = DiagStatus::OK;
+  std::string msg = "OK";
+
+  if (!is_default_map_) {
     accel_brake_map_status.status = CalibrationStatus::UNAVAILABLE;
     level = DiagStatus::ERROR;
     msg = "Default map is not found in " + csv_default_map_dir_;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck `redundantInitialization` warning

```
vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp:1335:11: style: Redundant initialization for 'level'. The initialized value is overwritten before it is read. [redundantInitialization]
    level = DiagStatus::OK;
          ^
vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp:1329:16: note: level is initialized
  int8_t level = DiagStatus::OK;
               ^
vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp:1335:11: note: level is overwritten
    level = DiagStatus::OK;
          ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
