### PR TITLE
fix(autoware_multi_object_tracker): fix passedByValue

### DIFF
--- a/perception/autoware_multi_object_tracker/src/debugger/debug_object.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debug_object.cpp
@@ -51,7 +51,7 @@ int32_t uuidToInt(const boost::uuids::uuid & uuid)
 namespace autoware::multi_object_tracker
 {
 
-TrackerObjectDebugger::TrackerObjectDebugger(std::string frame_id)
+TrackerObjectDebugger::TrackerObjectDebugger(const std::string & frame_id)
 {
   // set frame id
   frame_id_ = frame_id;
@@ -173,7 +173,7 @@ void TrackerObjectDebugger::process()
 }
 
 void TrackerObjectDebugger::draw(
-  const std::vector<std::vector<ObjectData>> object_data_groups,
+  const std::vector<std::vector<ObjectData>> & object_data_groups,
   visualization_msgs::msg::MarkerArray & marker_array) const
 {
   // initialize markers

--- a/perception/autoware_multi_object_tracker/src/debugger/debug_object.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debug_object.hpp
@@ -65,7 +65,7 @@ struct ObjectData
 class TrackerObjectDebugger
 {
 public:
-  explicit TrackerObjectDebugger(std::string frame_id);
+  explicit TrackerObjectDebugger(const std::string & frame_id);
 
 private:
   bool is_initialized_{false};
@@ -96,7 +96,7 @@ public:
 
   void reset();
   void draw(
-    const std::vector<std::vector<ObjectData>> object_data_groups,
+    const std::vector<std::vector<ObjectData>> & object_data_groups,
     visualization_msgs::msg::MarkerArray & marker_array) const;
   void process();
   void getMessage(visualization_msgs::msg::MarkerArray & marker_array) const;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
perception/autoware_multi_object_tracker/src/debugger/debug_object.cpp:54:58: performance: Function parameter 'frame_id' should be passed by const reference. [passedByValue]
TrackerObjectDebugger::TrackerObjectDebugger(std::string frame_id)
                                                         ^

perception/autoware_multi_object_tracker/src/debugger/debug_object.cpp:176:46: performance: Function parameter 'object_data_groups' should be passed by const reference. [passedByValue]
  const std::vector<std::vector<ObjectData>> object_data_groups,
                                             ^

perception/autoware_multi_object_tracker/src/debugger/debug_object.hpp:99:48: performance: Function parameter 'object_data_groups' should be passed by const reference. [passedByValue]
    const std::vector<std::vector<ObjectData>> object_data_groups,
                                               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
