### PR TITLE
fix(autoware_object_merger): fix passedByValue

### DIFF
--- a/perception/autoware_object_merger/src/object_association_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_association_merger_node.cpp
@@ -36,8 +36,8 @@ bool isUnknownObjectOverlapped(
   const autoware_perception_msgs::msg::DetectedObject & unknown_object,
   const autoware_perception_msgs::msg::DetectedObject & known_object,
   const double precision_threshold, const double recall_threshold,
-  std::map<int, double> distance_threshold_map,
-  const std::map<int, double> generalized_iou_threshold_map)
+  const std::map<int, double> & distance_threshold_map,
+  const std::map<int, double> & generalized_iou_threshold_map)
 {
   const double generalized_iou_threshold = generalized_iou_threshold_map.at(
     object_recognition_utils::getHighestProbLabel(known_object.classification));


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
perception/autoware_object_merger/src/object_association_merger_node.cpp:39:25: performance: Function parameter 'distance_threshold_map' should be passed by const reference. [passedByValue]
  std::map<int, double> distance_threshold_map,
                        ^

perception/autoware_object_merger/src/object_association_merger_node.cpp:40:31: performance: Function parameter 'generalized_iou_threshold_map' should be passed by const reference. [passedByValue]
  const std::map<int, double> generalized_iou_threshold_map)
                              ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
