### PR TITLE
fix(autoware_compare_map_segmentation): fix passedByValue

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
@@ -224,7 +224,7 @@ public:
   }
   inline void updateDifferentialMapCells(
     const std::vector<autoware_map_msgs::msg::PointCloudMapCellWithID> & map_cells_to_add,
-    std::vector<std::string> map_cell_ids_to_remove)
+    const std::vector<std::string> & map_cell_ids_to_remove)
   {
     for (const auto & map_cell_to_add : map_cells_to_add) {
       addMapCellAndFilter(map_cell_to_add);
@@ -271,7 +271,7 @@ public:
     (*mutex_ptr_).unlock();
   }
 
-  inline void removeMapCell(const std::string map_cell_id_to_remove)
+  inline void removeMapCell(const std::string & map_cell_id_to_remove)
   {
     (*mutex_ptr_).lock();
     current_voxel_grid_dict_.erase(map_cell_id_to_remove);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
perception/compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp:227:30: performance: Function parameter 'map_cell_ids_to_remove' should be passed by const reference. [passedByValue]
    std::vector<std::string> map_cell_ids_to_remove)
                             ^

perception/compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp:274:47: performance: Function parameter 'map_cell_id_to_remove' should be passed by const reference. [passedByValue]
  inline void removeMapCell(const std::string map_cell_id_to_remove)
                                              ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
