### PR TITLE
fix(autoware_image_projection_based_fusion): fix passedByValue

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
@@ -80,7 +80,7 @@ void closest_cluster(
 
 void updateOutputFusedObjects(
   std::vector<DetectedObjectWithFeature> & output_objs, std::vector<PointCloud2> & clusters,
-  const std::vector<size_t> clusters_data_size, const PointCloud2 & in_cloud,
+  const std::vector<size_t> & clusters_data_size, const PointCloud2 & in_cloud,
   const std_msgs::msg::Header & in_roi_header, const tf2_ros::Buffer & tf_buffer,
   const int min_cluster_size, const int max_cluster_size, const float cluster_2d_tolerance,
   std::vector<DetectedObjectWithFeature> & output_fused_objects);

--- a/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
@@ -118,7 +118,7 @@ void closest_cluster(
 
 void updateOutputFusedObjects(
   std::vector<DetectedObjectWithFeature> & output_objs, std::vector<PointCloud2> & clusters,
-  const std::vector<size_t> clusters_data_size, const PointCloud2 & in_cloud,
+  const std::vector<size_t> & clusters_data_size, const PointCloud2 & in_cloud,
   const std_msgs::msg::Header & in_roi_header, const tf2_ros::Buffer & tf_buffer,
   const int min_cluster_size, const int max_cluster_size, const float cluster_2d_tolerance,
   std::vector<DetectedObjectWithFeature> & output_fused_objects)


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
perception/image_projection_based_fusion/src/utils/utils.cpp:121:29: performance: Function parameter 'clusters_data_size' should be passed by const reference. [passedByValue]
  const std::vector<size_t> clusters_data_size, const PointCloud2 & in_cloud,
                            ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
