### PR TITLE
perf(autoware_detected_object_validation): reduce lanelet_filter processing time 

### DIFF
--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
@@ -15,6 +15,7 @@
 #include "lanelet_filter.hpp"
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware_lanelet2_extension/utility/message_conversion.hpp"
 #include "autoware_lanelet2_extension/utility/query.hpp"
 #include "object_recognition_utils/object_recognition_utils.hpp"
@@ -22,8 +23,10 @@
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/disjoint.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
+#include <boost/geometry/index/rtree.hpp>
 
 #include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/geometry/LaneletMap.h>
 #include <lanelet2_core/geometry/Polygon.h>
 
@@ -100,18 +103,28 @@ void ObjectLaneletFilterNode::objectCallback(
     return;
   }
 
-  // calculate convex hull
-  const auto convex_hull = getConvexHull(transformed_objects);
+  if (transformed_objects.objects.size() > 0) {
+    // calculate convex hull
+    const auto convex_hull = getConvexHull(transformed_objects);
 
-  // get intersected lanelets
-  lanelet::ConstLanelets intersected_lanelets = getIntersectedLanelets(convex_hull);
+    // get intersected lanelets
+    std::vector<BoxAndLanelet> intersected_lanelets_with_bbox =
+      getIntersectedLanelets(convex_hull);
 
-  // filtering process
-  for (size_t index = 0; index < transformed_objects.objects.size(); ++index) {
-    const auto & transformed_object = transformed_objects.objects.at(index);
-    const auto & input_object = input_msg->objects.at(index);
-    filterObject(transformed_object, input_object, intersected_lanelets, output_object_msg);
+    // create R-Tree with intersected_lanelets for fast search
+    bgi::rtree<BoxAndLanelet, RtreeAlgo> local_rtree;
+    for (const auto& bbox_and_lanelet : intersected_lanelets_with_bbox) {
+      local_rtree.insert(bbox_and_lanelet);
+    }
+
+    // filtering process
+    for (size_t index = 0; index < transformed_objects.objects.size(); ++index) {
+      const auto & transformed_object = transformed_objects.objects.at(index);
+      const auto & input_object = input_msg->objects.at(index);
+      filterObject(transformed_object, input_object, local_rtree, output_object_msg);
+    }
   }
+
   object_pub_->publish(output_object_msg);
   published_time_publisher_->publish_if_subscribed(object_pub_, output_object_msg.header.stamp);
 
@@ -128,16 +141,21 @@ void ObjectLaneletFilterNode::objectCallback(
 bool ObjectLaneletFilterNode::filterObject(
   const autoware_perception_msgs::msg::DetectedObject & transformed_object,
   const autoware_perception_msgs::msg::DetectedObject & input_object,
-  const lanelet::ConstLanelets & intersected_lanelets,
+  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree,
   autoware_perception_msgs::msg::DetectedObjects & output_object_msg)
 {
   const auto & label = transformed_object.classification.front().label;
   if (filter_target_.isTarget(label)) {
+    // no tree, then no intersection
+    if (local_rtree.size() == 0) {
+      return false;
+    }
+
     bool filter_pass = true;
     // 1. is polygon overlap with road lanelets or shoulder lanelets
     if (filter_settings_.polygon_overlap_filter) {
       const bool is_polygon_overlap =
-        isObjectOverlapLanelets(transformed_object, intersected_lanelets);
+        isObjectOverlapLanelets(transformed_object, local_rtree);
       filter_pass = filter_pass && is_polygon_overlap;
     }
 
@@ -147,7 +165,7 @@ bool ObjectLaneletFilterNode::filterObject(
       autoware_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
     if (filter_settings_.lanelet_direction_filter && !orientation_not_available) {
       const bool is_same_direction =
-        isSameDirectionWithLanelets(intersected_lanelets, transformed_object);
+        isSameDirectionWithLanelets(transformed_object, local_rtree);
       filter_pass = filter_pass && is_same_direction;
     }
 
@@ -199,55 +217,75 @@ LinearRing2d ObjectLaneletFilterNode::getConvexHull(
       candidate_points.emplace_back(p.x + pos.x, p.y + pos.y);
     }
   }
+  LinearRing2d convex_hull;
+  bg::convex_hull(candidate_points, convex_hull);
+
+  return convex_hull;
+}
+
+LinearRing2d ObjectLaneletFilterNode::getConvexHullFromObjectFootprint(
+  const autoware_perception_msgs::msg::DetectedObject & object)
+{
+  MultiPoint2d candidate_points;
+  const auto & pos = object.kinematics.pose_with_covariance.pose.position;
+  const auto footprint = setFootprint(object);
+
+  for (const auto & p : footprint.points) {
+    candidate_points.emplace_back(p.x + pos.x, p.y + pos.y);
+  }
 
   LinearRing2d convex_hull;
-  boost::geometry::convex_hull(candidate_points, convex_hull);
+  bg::convex_hull(candidate_points, convex_hull);
 
   return convex_hull;
 }
 
 // fetch the intersected candidate lanelets with bounding box and then
 // check the intersections among the lanelets and the convex hull
-lanelet::ConstLanelets ObjectLaneletFilterNode::getIntersectedLanelets(
+std::vector<BoxAndLanelet> ObjectLaneletFilterNode::getIntersectedLanelets(
   const LinearRing2d & convex_hull)
 {
-  namespace bg = boost::geometry;
-
-  lanelet::ConstLanelets intersected_lanelets;
+  std::vector<BoxAndLanelet> intersected_lanelets_with_bbox;
 
   // convert convex_hull to a 2D bounding box for searching in the LaneletMap
-  bg::model::box<bg::model::d2::point_xy<double>> bbox2d_convex_hull;
-  bg::envelope(convex_hull, bbox2d_convex_hull);
-  lanelet::BoundingBox2d bbox2d(
+  bg::model::box<bg::model::d2::point_xy<double>> bbox_of_convex_hull;
+  bg::envelope(convex_hull, bbox_of_convex_hull);
+  const lanelet::BoundingBox2d bbox2d(
     lanelet::BasicPoint2d(
-      bg::get<bg::min_corner, 0>(bbox2d_convex_hull),
-      bg::get<bg::min_corner, 1>(bbox2d_convex_hull)),
+      bg::get<bg::min_corner, 0>(bbox_of_convex_hull),
+      bg::get<bg::min_corner, 1>(bbox_of_convex_hull)),
     lanelet::BasicPoint2d(
-      bg::get<bg::max_corner, 0>(bbox2d_convex_hull),
-      bg::get<bg::max_corner, 1>(bbox2d_convex_hull)));
+      bg::get<bg::max_corner, 0>(bbox_of_convex_hull),
+      bg::get<bg::max_corner, 1>(bbox_of_convex_hull)));
 
-  lanelet::Lanelets candidates_lanelets = lanelet_map_ptr_->laneletLayer.search(bbox2d);
-  for (const auto & lanelet : candidates_lanelets) {
+  const lanelet::Lanelets candidate_lanelets = lanelet_map_ptr_->laneletLayer.search(bbox2d);
+  for (const auto & lanelet : candidate_lanelets) {
     // only check the road lanelets and road shoulder lanelets
     if (
       lanelet.hasAttribute(lanelet::AttributeName::Subtype) &&
       (lanelet.attribute(lanelet::AttributeName::Subtype).value() ==
          lanelet::AttributeValueString::Road ||
        lanelet.attribute(lanelet::AttributeName::Subtype).value() == "road_shoulder")) {
-      if (boost::geometry::intersects(convex_hull, lanelet.polygon2d().basicPolygon())) {
-        intersected_lanelets.emplace_back(lanelet);
+      if (bg::intersects(convex_hull, lanelet.polygon2d().basicPolygon())) {
+        // create bbox using boost for making the R-tree in later phase
+        lanelet::BoundingBox2d lanelet_bbox = lanelet::geometry::boundingBox2d(lanelet);
+        Point2d min_corner(lanelet_bbox.min().x(), lanelet_bbox.min().y());
+        Point2d max_corner(lanelet_bbox.max().x(), lanelet_bbox.max().y());
+        Box boost_bbox(min_corner, max_corner);
+
+        intersected_lanelets_with_bbox.emplace_back(std::make_pair(boost_bbox, lanelet));
       }
     }
   }
 
-  return intersected_lanelets;
+  return intersected_lanelets_with_bbox;
 }
 
 bool ObjectLaneletFilterNode::isObjectOverlapLanelets(
   const autoware_perception_msgs::msg::DetectedObject & object,
-  const lanelet::ConstLanelets & intersected_lanelets)
+  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
 {
-  // if has bounding box, use polygon overlap
+  // if object has bounding box, use polygon overlap
   if (utils::hasBoundingBox(object)) {
     Polygon2d polygon;
     const auto footprint = setFootprint(object);
@@ -258,8 +296,17 @@ bool ObjectLaneletFilterNode::isObjectOverlapLanelets(
       polygon.outer().emplace_back(point_transformed.x, point_transformed.y);
     }
     polygon.outer().push_back(polygon.outer().front());
-    return isPolygonOverlapLanelets(polygon, intersected_lanelets);
+
+    return isPolygonOverlapLanelets(polygon, local_rtree);
   } else {
+    const LinearRing2d object_convex_hull = getConvexHullFromObjectFootprint(object);
+
+    // create bounding box to search in the rtree
+    std::vector<BoxAndLanelet> candidates;
+    bg::model::box<bg::model::d2::point_xy<double>> bbox;
+    bg::envelope(object_convex_hull, bbox);
+    local_rtree.query(bgi::intersects(bbox), std::back_inserter(candidates));
+
     // if object do not have bounding box, check each footprint is inside polygon
     for (const auto & point : object.shape.footprint.points) {
       const geometry_msgs::msg::Point32 point_transformed =
@@ -268,30 +315,40 @@ bool ObjectLaneletFilterNode::isObjectOverlapLanelets(
       geometry_msgs::msg::Pose point2d;
       point2d.position.x = point_transformed.x;
       point2d.position.y = point_transformed.y;
-      for (const auto & lanelet : intersected_lanelets) {
-        if (lanelet::utils::isInLanelet(point2d, lanelet, 0.0)) {
+
+      for (const auto & candidate : candidates) {
+        if (lanelet::utils::isInLanelet(point2d, candidate.second, 0.0)) {
           return true;
         }
       }
     }
+
     return false;
   }
 }
 
 bool ObjectLaneletFilterNode::isPolygonOverlapLanelets(
-  const Polygon2d & polygon, const lanelet::ConstLanelets & intersected_lanelets)
+  const Polygon2d & polygon,
+  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
 {
-  for (const auto & lanelet : intersected_lanelets) {
-    if (!boost::geometry::disjoint(polygon, lanelet.polygon2d().basicPolygon())) {
+  // create a bounding box from polygon for searching the local R-tree
+  std::vector<BoxAndLanelet> candidates;
+  bg::model::box<bg::model::d2::point_xy<double>> bbox_of_convex_hull;
+  bg::envelope(polygon, bbox_of_convex_hull);
+  local_rtree.query(bgi::intersects(bbox_of_convex_hull), std::back_inserter(candidates));
+
+  for (const auto & box_and_lanelet : candidates) {
+    if (!bg::disjoint(polygon, box_and_lanelet.second.polygon2d().basicPolygon())) {
       return true;
     }
   }
+
   return false;
 }
 
 bool ObjectLaneletFilterNode::isSameDirectionWithLanelets(
-  const lanelet::ConstLanelets & lanelets,
-  const autoware_perception_msgs::msg::DetectedObject & object)
+  const autoware_perception_msgs::msg::DetectedObject & object,
+  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
 {
   const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   const double object_velocity_norm = std::hypot(
@@ -305,14 +362,29 @@ bool ObjectLaneletFilterNode::isSameDirectionWithLanelets(
   if (object_velocity_norm < filter_settings_.lanelet_direction_filter_object_speed_threshold) {
     return true;
   }
-  for (const auto & lanelet : lanelets) {
+
+  // we can not query by points, so create a small bounding box
+  // eps is not determined by any specific criteria; just a guess
+  constexpr double eps = 1.0e-6;
+  std::vector<BoxAndLanelet> candidates;
+  const Point2d min_corner(object.kinematics.pose_with_covariance.pose.position.x-eps,
+    object.kinematics.pose_with_covariance.pose.position.y-eps);
+  const Point2d max_corner(object.kinematics.pose_with_covariance.pose.position.x+eps,
+    object.kinematics.pose_with_covariance.pose.position.y+eps);
+  const Box bbox(min_corner, max_corner);
+
+  local_rtree.query(bgi::intersects(bbox), std::back_inserter(candidates));
+
+  for (const auto & box_and_lanelet : candidates) {
     const bool is_in_lanelet =
-      lanelet::utils::isInLanelet(object.kinematics.pose_with_covariance.pose, lanelet, 0.0);
+      lanelet::utils::isInLanelet(object.kinematics.pose_with_covariance.pose,
+        box_and_lanelet.second, 0.0);
     if (!is_in_lanelet) {
       continue;
     }
+
     const double lane_yaw = lanelet::utils::getLaneletAngle(
-      lanelet, object.kinematics.pose_with_covariance.pose.position);
+      box_and_lanelet.second, object.kinematics.pose_with_covariance.pose.position);
     const double delta_yaw = object_velocity_yaw - lane_yaw;
     const double normalized_delta_yaw = autoware::universe_utils::normalizeRadian(delta_yaw);
     const double abs_norm_delta_yaw = std::fabs(normalized_delta_yaw);

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
@@ -103,7 +103,7 @@ void ObjectLaneletFilterNode::objectCallback(
     return;
   }
 
-  if (transformed_objects.objects.size() > 0) {
+  if (!transformed_objects.objects.empty()) {
     // calculate convex hull
     const auto convex_hull = getConvexHull(transformed_objects);
 
@@ -146,7 +146,7 @@ bool ObjectLaneletFilterNode::filterObject(
   const auto & label = transformed_object.classification.front().label;
   if (filter_target_.isTarget(label)) {
     // no tree, then no intersection
-    if (local_rtree.size() == 0) {
+    if (local_rtree.empty()) {
       return false;
     }
 

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
@@ -108,12 +108,11 @@ void ObjectLaneletFilterNode::objectCallback(
     const auto convex_hull = getConvexHull(transformed_objects);
 
     // get intersected lanelets
-    std::vector<BoxAndLanelet> intersected_lanelets_with_bbox =
-      getIntersectedLanelets(convex_hull);
+    std::vector<BoxAndLanelet> intersected_lanelets_with_bbox = getIntersectedLanelets(convex_hull);
 
     // create R-Tree with intersected_lanelets for fast search
     bgi::rtree<BoxAndLanelet, RtreeAlgo> local_rtree;
-    for (const auto& bbox_and_lanelet : intersected_lanelets_with_bbox) {
+    for (const auto & bbox_and_lanelet : intersected_lanelets_with_bbox) {
       local_rtree.insert(bbox_and_lanelet);
     }
 
@@ -154,8 +153,7 @@ bool ObjectLaneletFilterNode::filterObject(
     bool filter_pass = true;
     // 1. is polygon overlap with road lanelets or shoulder lanelets
     if (filter_settings_.polygon_overlap_filter) {
-      const bool is_polygon_overlap =
-        isObjectOverlapLanelets(transformed_object, local_rtree);
+      const bool is_polygon_overlap = isObjectOverlapLanelets(transformed_object, local_rtree);
       filter_pass = filter_pass && is_polygon_overlap;
     }
 
@@ -164,8 +162,7 @@ bool ObjectLaneletFilterNode::filterObject(
       transformed_object.kinematics.orientation_availability ==
       autoware_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
     if (filter_settings_.lanelet_direction_filter && !orientation_not_available) {
-      const bool is_same_direction =
-        isSameDirectionWithLanelets(transformed_object, local_rtree);
+      const bool is_same_direction = isSameDirectionWithLanelets(transformed_object, local_rtree);
       filter_pass = filter_pass && is_same_direction;
     }
 
@@ -328,8 +325,7 @@ bool ObjectLaneletFilterNode::isObjectOverlapLanelets(
 }
 
 bool ObjectLaneletFilterNode::isPolygonOverlapLanelets(
-  const Polygon2d & polygon,
-  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
+  const Polygon2d & polygon, const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
 {
   // create a bounding box from polygon for searching the local R-tree
   std::vector<BoxAndLanelet> candidates;
@@ -367,18 +363,19 @@ bool ObjectLaneletFilterNode::isSameDirectionWithLanelets(
   // eps is not determined by any specific criteria; just a guess
   constexpr double eps = 1.0e-6;
   std::vector<BoxAndLanelet> candidates;
-  const Point2d min_corner(object.kinematics.pose_with_covariance.pose.position.x-eps,
-    object.kinematics.pose_with_covariance.pose.position.y-eps);
-  const Point2d max_corner(object.kinematics.pose_with_covariance.pose.position.x+eps,
-    object.kinematics.pose_with_covariance.pose.position.y+eps);
+  const Point2d min_corner(
+    object.kinematics.pose_with_covariance.pose.position.x - eps,
+    object.kinematics.pose_with_covariance.pose.position.y - eps);
+  const Point2d max_corner(
+    object.kinematics.pose_with_covariance.pose.position.x + eps,
+    object.kinematics.pose_with_covariance.pose.position.y + eps);
   const Box bbox(min_corner, max_corner);
 
   local_rtree.query(bgi::intersects(bbox), std::back_inserter(candidates));
 
   for (const auto & box_and_lanelet : candidates) {
-    const bool is_in_lanelet =
-      lanelet::utils::isInLanelet(object.kinematics.pose_with_covariance.pose,
-        box_and_lanelet.second, 0.0);
+    const bool is_in_lanelet = lanelet::utils::isInLanelet(
+      object.kinematics.pose_with_covariance.pose, box_and_lanelet.second, 0.0);
     if (!is_in_lanelet) {
       continue;
     }

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
@@ -19,7 +19,6 @@
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/ros/debug_publisher.hpp"
 #include "autoware/universe_utils/ros/published_time_publisher.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 
 #include <boost/geometry/index/rtree.hpp>
@@ -86,7 +85,7 @@ private:
   bool filterObject(
     const autoware_perception_msgs::msg::DetectedObject & transformed_object,
     const autoware_perception_msgs::msg::DetectedObject & input_object,
-    const boost::geometry::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree,
+    const bg::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree,
     autoware_perception_msgs::msg::DetectedObjects & output_object_msg);
   LinearRing2d getConvexHull(const autoware_perception_msgs::msg::DetectedObjects &);
   LinearRing2d getConvexHullFromObjectFootprint(
@@ -94,7 +93,7 @@ private:
   std::vector<BoxAndLanelet> getIntersectedLanelets(const LinearRing2d &);
   bool isObjectOverlapLanelets(
     const autoware_perception_msgs::msg::DetectedObject & object,
-    const boost::geometry::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
+    const bg::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
   bool isPolygonOverlapLanelets(
   const Polygon2d & polygon,
   const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
@@ -21,14 +21,15 @@
 #include "autoware/universe_utils/ros/published_time_publisher.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 
-#include <boost/geometry/index/rtree.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_map_msgs/msg/lanelet_map_bin.hpp"
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 
-#include <lanelet2_core/geometry/Lanelet.h>
+#include <boost/geometry/index/rtree.hpp>
+
 #include <lanelet2_core/Forward.h>
+#include <lanelet2_core/geometry/Lanelet.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -95,8 +96,7 @@ private:
     const autoware_perception_msgs::msg::DetectedObject & object,
     const bg::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
   bool isPolygonOverlapLanelets(
-  const Polygon2d & polygon,
-  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
+    const Polygon2d & polygon, const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
   bool isSameDirectionWithLanelets(
     const autoware_perception_msgs::msg::DetectedObject & object,
     const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
@@ -19,19 +19,24 @@
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/ros/debug_publisher.hpp"
 #include "autoware/universe_utils/ros/published_time_publisher.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 
+#include <boost/geometry/index/rtree.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_map_msgs/msg/lanelet_map_bin.hpp"
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 
+#include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/Forward.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace autoware::detected_object_validation
 {
@@ -41,6 +46,13 @@ using autoware::universe_utils::LinearRing2d;
 using autoware::universe_utils::MultiPoint2d;
 using autoware::universe_utils::Point2d;
 using autoware::universe_utils::Polygon2d;
+
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+using Point2d = bg::model::point<double, 2, bg::cs::cartesian>;
+using Box = boost::geometry::model::box<Point2d>;
+using BoxAndLanelet = std::pair<Box, lanelet::Lanelet>;
+using RtreeAlgo = bgi::rstar<16>;
 
 class ObjectLaneletFilterNode : public rclcpp::Node
 {
@@ -74,17 +86,21 @@ private:
   bool filterObject(
     const autoware_perception_msgs::msg::DetectedObject & transformed_object,
     const autoware_perception_msgs::msg::DetectedObject & input_object,
-    const lanelet::ConstLanelets & intersected_lanelets,
+    const boost::geometry::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree,
     autoware_perception_msgs::msg::DetectedObjects & output_object_msg);
   LinearRing2d getConvexHull(const autoware_perception_msgs::msg::DetectedObjects &);
-  lanelet::ConstLanelets getIntersectedLanelets(const LinearRing2d &);
+  LinearRing2d getConvexHullFromObjectFootprint(
+    const autoware_perception_msgs::msg::DetectedObject & object);
+  std::vector<BoxAndLanelet> getIntersectedLanelets(const LinearRing2d &);
   bool isObjectOverlapLanelets(
     const autoware_perception_msgs::msg::DetectedObject & object,
-    const lanelet::ConstLanelets & intersected_lanelets);
-  bool isPolygonOverlapLanelets(const Polygon2d &, const lanelet::ConstLanelets &);
+    const boost::geometry::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
+  bool isPolygonOverlapLanelets(
+  const Polygon2d & polygon,
+  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
   bool isSameDirectionWithLanelets(
-    const lanelet::ConstLanelets & lanelets,
-    const autoware_perception_msgs::msg::DetectedObject & object);
+    const autoware_perception_msgs::msg::DetectedObject & object,
+    const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
   geometry_msgs::msg::Polygon setFootprint(const autoware_perception_msgs::msg::DetectedObject &);
 
   std::unique_ptr<autoware::universe_utils::PublishedTimePublisher> published_time_publisher_;


### PR DESCRIPTION
## Description
This PR is for speeding up the lanelet filtering process.
This PR will reduce the number of loops by using the inner R-tree of intersected lanelets.

Using the [TimeKeeper](https://github.com/autowarefoundation/autoware.universe/tree/main/common/autoware_universe_utils), I checked the bottleneck of lanelet filter node. The main bottleneck was the for-loop for the filtering for the objects that have no bounding box.

### processing times
Example of worst cases.

Before this PR
```Text
objectCallback: 136.19 [ms]
    ├── getConvexHull: 0.35 [ms]
    ├── getIntersectedLanelets: 1.62 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 2.24 [ms]
    │   └── isObjectOverlapLanelets: 2.24 [ms]
    │       └── non_bbox_filter: 2.24 [ms]
    ├── filterObject: 1.77 [ms]
    │   └── isObjectOverlapLanelets: 1.68 [ms]
    │       └── non_bbox_filter: 1.68 [ms]
    ├── filterObject: 1.60 [ms]
    │   └── isObjectOverlapLanelets: 1.60 [ms]
    │       └── non_bbox_filter: 1.60 [ms]
    ├── filterObject: 0.75 [ms]
    │   └── isObjectOverlapLanelets: 0.74 [ms]
    │       └── non_bbox_filter: 0.74 [ms]
    ├── filterObject: 1.11 [ms]
    │   └── isObjectOverlapLanelets: 1.11 [ms]
    │       └── non_bbox_filter: 1.11 [ms]
    ├── filterObject: 3.11 [ms]
    │   └── isObjectOverlapLanelets: 3.11 [ms]
    │       └── non_bbox_filter: 3.10 [ms]
    ├── filterObject: 1.29 [ms]
    │   └── isObjectOverlapLanelets: 1.29 [ms]
    │       └── non_bbox_filter: 1.28 [ms]
    ├── filterObject: 2.51 [ms]
    │   └── isObjectOverlapLanelets: 2.51 [ms]
    │       └── non_bbox_filter: 2.51 [ms]
    ├── filterObject: 1.55 [ms]
    │   └── isObjectOverlapLanelets: 1.55 [ms]
    │       └── non_bbox_filter: 1.55 [ms]
    ├── filterObject: 1.11 [ms]
    │   └── isObjectOverlapLanelets: 1.10 [ms]
    │       └── non_bbox_filter: 1.10 [ms]
    ├── filterObject: 0.54 [ms]
    │   └── isObjectOverlapLanelets: 0.54 [ms]
    │       └── non_bbox_filter: 0.54 [ms]
    ├── filterObject: 2.34 [ms]
    │   └── isObjectOverlapLanelets: 2.34 [ms]
    │       └── non_bbox_filter: 2.33 [ms]
   	...
```


After this PR
```Text
objectCallback: 12.90 [ms]
    ├── getConvexHull: 0.09 [ms]
    ├── getIntersectedLanelets: 0.32 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.00 [ms]
    ├── filterObject: 0.22 [ms]
    │   └── no bbox filter: pre process: 0.21 [ms]
    │       └── no bbox filter: main loop: 0.21 [ms]
    ├── filterObject: 0.58 [ms]
    │   └── no bbox filter: pre process: 0.57 [ms]
    │       └── no bbox filter: main loop: 0.57 [ms]
    ├── filterObject: 0.19 [ms]
    │   └── no bbox filter: pre process: 0.18 [ms]
    │       └── no bbox filter: main loop: 0.18 [ms]
    ├── filterObject: 0.01 [ms]
    │   └── no bbox filter: pre process: 0.01 [ms]
    │       └── no bbox filter: main loop: 0.00 [ms]
    ├── filterObject: 0.23 [ms]
    │   └── no bbox filter: pre process: 0.22 [ms]
    │       └── no bbox filter: main loop: 0.22 [ms]
    ├── filterObject: 0.20 [ms]
    │   └── no bbox filter: pre process: 0.20 [ms]
    │       └── no bbox filter: main loop: 0.20 [ms]
    ├── filterObject: 0.23 [ms]
    │   └── no bbox filter: pre process: 0.23 [ms]
    │       └── no bbox filter: main loop: 0.22 [ms]
    ├── filterObject: 0.18 [ms]
    │   └── no bbox filter: pre process: 0.17 [ms]
    │       └── no bbox filter: main loop: 0.17 [ms]
    ├── filterObject: 0.20 [ms]
    │   └── no bbox filter: pre process: 0.19 [ms]
    │       └── no bbox filter: main loop: 0.19 [ms]
    ├── filterObject: 0.12 [ms]
    │   └── no bbox filter: pre process: 0.12 [ms]
    │       └── no bbox filter: main loop: 0.12 [ms]
    ├── filterObject: 0.53 [ms]
    │   └── no bbox filter: pre process: 0.53 [ms]
    │       └── no bbox filter: main loop: 0.52 [ms]
    ├── filterObject: 0.17 [ms]
    │   └── no bbox filter: pre process: 0.16 [ms]
    │       └── no bbox filter: main loop: 0.16 [ms]
    ├── filterObject: 0.16 [ms]
    │   └── no bbox filter: pre process: 0.15 [ms]
    │       └── no bbox filter: main loop: 0.15 [ms]
    ├── filterObject: 0.05 [ms]
    │   └── no bbox filter: pre process: 0.04 [ms]
    │       └── no bbox filter: main loop: 0.04 [ms]
    ├── filterObject: 0.00 [ms]
    │   └── no bbox filter: pre process: 0.00 [ms]
    │       └── no bbox filter: main loop: 0.00 [ms]
    ├── filterObject: 0.13 [ms]
    │   └── no bbox filter: pre process: 0.13 [ms]
    │       └── no bbox filter: main loop: 0.13 [ms]
    ...
```

### VS. previous implementations
![compare_processing_time](https://github.com/user-attachments/assets/7beb6418-5bc3-4e56-b090-8af60ab0550d)

There is no guarantee the time is matching the actual time line or correspond to each other.

original: before https://github.com/autowarefoundation/autoware.universe/pull/8109
current: after https://github.com/autowarefoundation/autoware.universe/pull/8109 (before this PR)
optimized: after this PR

`play in x0.5` means, `bag play` with rate of 0.5.


##### mean processing time
original mean: `34.401` ms
current mean: `30.980` ms
optimized best comb. mean: `3.899` ms

(mean processing time was calculated with records that have more than 1 ms)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [TIER4 internal link](https://tier4.atlassian.net/browse/RT1-7219)
⬆️🟢 -->

## How was this PR tested?
#### Processing time
Processing time was gathered from TimeKeeper: https://github.com/autowarefoundation/autoware.universe/tree/main/common/autoware_universe_utils

#### Degradation 
Qualitative test is done by manually checking and comparing with the original implementation's detected and filtered unknown objects.

***No quantitative evaluation was done***.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
