### PR TITLE
fix(autoware_pointcloud_preprocessor): fix passedByValue

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
@@ -1932,7 +1932,7 @@ public:
   }
 
   template <typename... Args>
-  iterator emplace_hint(const_iterator position, Args &&... args)
+  iterator emplace_hint(const const_iterator & position, Args &&... args)
   {
     (void)position;
     return emplace(std::forward<Args>(args)...).first;
@@ -1951,14 +1951,14 @@ public:
   }
 
   template <typename... Args>
-  iterator try_emplace(const_iterator hint, const key_type & key, Args &&... args)
+  iterator try_emplace(const const_iterator & hint, const key_type & key, Args &&... args)
   {
     (void)hint;
     return try_emplace_impl(key, std::forward<Args>(args)...).first;
   }
 
   template <typename... Args>
-  iterator try_emplace(const_iterator hint, key_type && key, Args &&... args)
+  iterator try_emplace(const const_iterator & hint, key_type && key, Args &&... args)
   {
     (void)hint;
     return try_emplace_impl(std::move(key), std::forward<Args>(args)...).first;
@@ -1977,14 +1977,14 @@ public:
   }
 
   template <typename Mapped>
-  iterator insert_or_assign(const_iterator hint, const key_type & key, Mapped && obj)
+  iterator insert_or_assign(const const_iterator & hint, const key_type & key, Mapped && obj)
   {
     (void)hint;
     return insertOrAssignImpl(key, std::forward<Mapped>(obj)).first;
   }
 
   template <typename Mapped>
-  iterator insert_or_assign(const_iterator hint, key_type && key, Mapped && obj)
+  iterator insert_or_assign(const const_iterator & hint, key_type && key, Mapped && obj)
   {
     (void)hint;
     return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj)).first;
@@ -1996,7 +1996,7 @@ public:
     return emplace(keyval);
   }
 
-  iterator insert(const_iterator hint, const value_type & keyval)
+  iterator insert(const const_iterator & hint, const value_type & keyval)
   {
     (void)hint;
     return emplace(keyval).first;
@@ -2004,7 +2004,7 @@ public:
 
   std::pair<iterator, bool> insert(value_type && keyval) { return emplace(std::move(keyval)); }
 
-  iterator insert(const_iterator hint, value_type && keyval)
+  iterator insert(const const_iterator & hint, value_type && keyval)
   {
     (void)hint;
     return emplace(std::move(keyval)).first;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1935:40: performance: inconclusive: Function parameter 'position' should be passed by const reference. [passedByValue]
  iterator emplace_hint(const_iterator position, Args &&... args)
                                       ^

sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1954:39: performance: inconclusive: Function parameter 'hint' should be passed by const reference. [passedByValue]
  iterator try_emplace(const_iterator hint, const key_type & key, Args &&... args)
                                      ^

sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1961:39: performance: inconclusive: Function parameter 'hint' should be passed by const reference. [passedByValue]
  iterator try_emplace(const_iterator hint, key_type && key, Args &&... args)
                                      ^

sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1980:44: performance: inconclusive: Function parameter 'hint' should be passed by const reference. [passedByValue]
  iterator insert_or_assign(const_iterator hint, const key_type & key, Mapped && obj)
                                           ^

sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1987:44: performance: inconclusive: Function parameter 'hint' should be passed by const reference. [passedByValue]
  iterator insert_or_assign(const_iterator hint, key_type && key, Mapped && obj)
                                           ^

sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1999:34: performance: inconclusive: Function parameter 'hint' should be passed by const reference. [passedByValue]
  iterator insert(const_iterator hint, const value_type & keyval)
                                 ^

sensing/pointcloud_preprocessor/src/downsample_filter/robin_hood.h:2007:34: performance: inconclusive: Function parameter 'hint' should be passed by const reference. [passedByValue]
  iterator insert(const_iterator hint, value_type && keyval)
                                 ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
