### PR TITLE
fix(autoware_vehicle_cmd_gate): fix passedByValue

### DIFF
--- a/control/autoware_vehicle_cmd_gate/src/marker_helper.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/marker_helper.hpp
@@ -96,7 +96,7 @@ inline visualization_msgs::msg::Marker createMarker(
 inline visualization_msgs::msg::Marker createStringMarker(
   const std::string & frame_id, const std::string & ns, const int32_t id, const int32_t type,
   geometry_msgs::msg::Point point, geometry_msgs::msg::Vector3 scale,
-  const std_msgs::msg::ColorRGBA & color, const std::string text)
+  const std_msgs::msg::ColorRGBA & color, const std::string & text)
 {
   visualization_msgs::msg::Marker marker;
 

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
@@ -40,43 +40,43 @@ bool VehicleCmdFilter::setParameterWithValidation(const VehicleCmdFilterParam & 
   param_ = p;
   return true;
 }
-void VehicleCmdFilter::setSteerLim(LimitArray v)
+void VehicleCmdFilter::setSteerLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.steer_lim = v;
   setParameterWithValidation(tmp);
 }
-void VehicleCmdFilter::setSteerRateLim(LimitArray v)
+void VehicleCmdFilter::setSteerRateLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.steer_rate_lim = v;
   setParameterWithValidation(tmp);
 }
-void VehicleCmdFilter::setLonAccLim(LimitArray v)
+void VehicleCmdFilter::setLonAccLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.lon_acc_lim = v;
   setParameterWithValidation(tmp);
 }
-void VehicleCmdFilter::setLonJerkLim(LimitArray v)
+void VehicleCmdFilter::setLonJerkLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.lon_jerk_lim = v;
   setParameterWithValidation(tmp);
 }
-void VehicleCmdFilter::setLatAccLim(LimitArray v)
+void VehicleCmdFilter::setLatAccLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.lat_acc_lim = v;
   setParameterWithValidation(tmp);
 }
-void VehicleCmdFilter::setLatJerkLim(LimitArray v)
+void VehicleCmdFilter::setLatJerkLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.lat_jerk_lim = v;
   setParameterWithValidation(tmp);
 }
-void VehicleCmdFilter::setActualSteerDiffLim(LimitArray v)
+void VehicleCmdFilter::setActualSteerDiffLim(const LimitArray & v)
 {
   auto tmp = param_;
   tmp.actual_steer_diff_lim = v;

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -49,13 +49,13 @@ public:
 
   void setWheelBase(double v) { param_.wheel_base = v; }
   void setVelLim(double v) { param_.vel_lim = v; }
-  void setSteerLim(LimitArray v);
-  void setSteerRateLim(LimitArray v);
-  void setLonAccLim(LimitArray v);
-  void setLonJerkLim(LimitArray v);
-  void setLatAccLim(LimitArray v);
-  void setLatJerkLim(LimitArray v);
-  void setActualSteerDiffLim(LimitArray v);
+  void setSteerLim(const LimitArray & v);
+  void setSteerRateLim(const LimitArray & v);
+  void setLonAccLim(const LimitArray & v);
+  void setLonJerkLim(const LimitArray & v);
+  void setLatAccLim(const LimitArray & v);
+  void setLatJerkLim(const LimitArray & v);
+  void setActualSteerDiffLim(const LimitArray & v);
   void setCurrentSpeed(double v) { current_speed_ = v; }
   void setParam(const VehicleCmdFilterParam & p);
   VehicleCmdFilterParam getParam() const;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck passedByValue warnings.

```
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:43:47: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setSteerLim(LimitArray v)
                                              ^
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:49:51: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setSteerRateLim(LimitArray v)
                                                  ^
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:55:48: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setLonAccLim(LimitArray v)
                                               ^
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:61:49: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setLonJerkLim(LimitArray v)
                                                ^
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:67:48: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setLatAccLim(LimitArray v)
                                               ^
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:73:49: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setLatJerkLim(LimitArray v)
                                                ^
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:79:57: performance: Function parameter 'v' should be passed by const reference. [passedByValue]
void VehicleCmdFilter::setActualSteerDiffLim(LimitArray v)
                                                        ^
control/autoware_vehicle_cmd_gate/src/marker_helper.hpp:99:61: performance: Function parameter 'text' should be passed by const reference. [passedByValue]
  const std_msgs::msg::ColorRGBA & color, const std::string text)
                                                            ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
