### PR TITLE
fix(start/goal_planner): fix freespace planning error handling

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/freespace_pull_over.cpp
@@ -58,7 +58,12 @@ std::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
   const Pose end_pose =
     use_back_ ? goal_pose
               : autoware::universe_utils::calcOffsetPose(goal_pose, -straight_distance, 0.0, 0.0);
-  if (!planner_->makePlan(current_pose, end_pose)) {
+
+  try {
+    if (!planner_->makePlan(current_pose, end_pose)) {
+      return {};
+    }
+  } catch (const std::exception & e) {
     return {};
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -54,9 +54,12 @@ std::optional<PullOutPath> FreespacePullOut::plan(
 
   planner_->setMap(*planner_data_->costmap);
 
-  const bool found_path = planner_->makePlan(start_pose, end_pose);
-  if (!found_path) {
-    planner_debug_data.conditions_evaluation.emplace_back("no path found");
+  try {
+    if (!planner_->makePlan(start_pose, end_pose)) {
+      planner_debug_data.conditions_evaluation.emplace_back("no path found");
+      return {};
+    }
+  } catch (const std::exception & e) {
     return {};
   }
 


### PR DESCRIPTION
## Description

add error handling when freespace planning can not find path.

## Related links


https://github.com/autowarefoundation/autoware.universe/pull/8068

```
[openscenario_interpreter_node-3] [component_container_mt-33] terminate called after throwing an instance of 'std::logic_error'
[openscenario_interpreter_node-3] [component_container_mt-33]   what():  HA* failed to find path to goal
[openscenario_interpreter_node-3] [component_container_mt-33] *** Aborted at 1722248354 (unix time) try "date -d @1722248354" if you are using GNU date ***
```

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

wip: 2024/07/29 https://evaluation.tier4.jp/evaluation/reports/5e0d0571-2e37-5845-956e-62dc4f7dd810/?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
