### PR TITLE
feat: perception objects pointcloud better visualization

### DIFF
--- a/common/autoware_perception_rviz_plugin/include/autoware_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_perception_rviz_plugin/include/autoware_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -32,6 +32,13 @@
 #include <geometry_msgs/msg/twist_with_covariance.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/strategies/buffer.hpp>
+#include <boost/geometry/strategies/transform.hpp>
+#include <boost/polygon/polygon.hpp>
+
 #include <algorithm>
 #include <map>
 #include <string>
@@ -193,6 +200,10 @@ AUTOWARE_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_orientation_line_l
   std::vector<geometry_msgs::msg::Point> & points);
 
 AUTOWARE_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_bounding_box_bottom_line_list(
+  const autoware_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_bounding_box_bottom_triangle_list(
   const autoware_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);
 


### PR DESCRIPTION
## Description
From the previous [PR](https://github.com/autowarefoundation/autoware.universe/pull/7095), there was a bug related to the implementation of the Pointcloud attached to the objects which caused RViz to crash regularly/randomly, i have not been able to fix the pcl implementation and for that i created a separate PR for just the 2d bottom visualization of the object such as this instead of the bounding boxes

![image](https://github.com/user-attachments/assets/f1302ad0-3b15-4999-b4bb-89b9af3914f5)

![image](https://github.com/user-attachments/assets/702f8100-b684-4a63-9bd6-67e8bd7100aa)


## Related links

- https://github.com/autowarefoundation/autoware.universe/pull/7095

## Effects on system behavior

None.
