### PR TITLE
perf(ndt_scan_matcher): change the temperature of multi_ndt_score to 0.05

### DIFF
--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -117,7 +117,7 @@
         initial_pose_offset_model_y: [0.5, -0.5, 0.0, 0.0, 0.0, 0.0]
 
         # In MULTI_NDT_SCORE, the parameter that adjusts the estimated 2D covariance
-        temperature: 0.1
+        temperature: 0.05
 
         # Scale value for adjusting the estimated covariance by a constant multiplication
         scale_factor: 1.0

--- a/localization/ndt_scan_matcher/schema/sub/covariance_covariance_estimation.json
+++ b/localization/ndt_scan_matcher/schema/sub/covariance_covariance_estimation.json
@@ -25,7 +25,7 @@
         "temperature": {
           "type": "number",
           "description": "In MULTI_NDT_SCORE, the parameter that adjusts the estimated 2D covariance",
-          "default": 0.1,
+          "default": 0.05,
           "exclusiveMinimum": 0
         },
         "scale_factor": {


### PR DESCRIPTION
## Description

Change the default parameter values ​​to improve the accuracy of online covariance estimation in NDT.

## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1096

## How was this PR tested?
Driving Log Replayer is executed for 28 data.

![compare_result](https://github.com/user-attachments/assets/9bdfebf8-713c-4e1c-8d5a-63f80c7f26ec)

For data with an error of 50 cm or less, the performance is almost the same as when the covariance is fixed.

As for other data with large errors, it is expected that there will be large fluctuations due to some degree of randomness.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
