### PR TITLE
fix(autoware_vehicle_cmd_gate): fix functionConst

### DIFF
--- a/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.cpp
@@ -29,7 +29,7 @@ AdapiPauseInterface::AdapiPauseInterface(rclcpp::Node * node) : node_(node)
   publish();
 }
 
-bool AdapiPauseInterface::is_paused()
+bool AdapiPauseInterface::is_paused() const
 {
   return is_paused_;
 }

--- a/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.hpp
@@ -35,7 +35,7 @@ private:
 
 public:
   explicit AdapiPauseInterface(rclcpp::Node * node);
-  bool is_paused();
+  bool is_paused() const;
   void publish();
   void update(const Control & control);
 

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -75,7 +75,7 @@ public:
   static IsFilterActivated checkIsActivated(
     const Control & c1, const Control & c2, const double tol = 1.0e-3);
 
-  Control getPrevCmd() { return prev_cmd_; }
+  Control getPrevCmd() const { return prev_cmd_; }
 
 private:
   VehicleCmdFilterParam param_;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck constFunction warnings.

```
adapi_pause_interface.hpp:38:8: style: inconclusive: Technically the member function 'autoware::vehicle_cmd_gate::AdapiPauseInterface::is_paused' can be const. [functionConst]
  bool is_paused();
       ^
vehicle_cmd_filter.hpp:78:11: style: inconclusive: Technically the member function 'autoware::vehicle_cmd_gate::VehicleCmdFilter::getPrevCmd' can be const. [functionConst]
  Control getPrevCmd() { return prev_cmd_; }
          ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
