### PR TITLE
feat(start_planner): add time_keeper

### DIFF
--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
@@ -139,9 +139,8 @@ public:
     const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
     const size_t end_index);
 
-  bool isOutOfLane(
-    const lanelet::ConstLanelets & candidate_lanelets,
-    const LinearRing2d & vehicle_footprint) const;
+  static bool isOutOfLane(
+    const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint);
 
 private:
   Param param_;

--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/geometry/pose_deviation.hpp>
+#include <autoware/universe_utils/system/time_keeper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rosidl_runtime_cpp/message_initialization.hpp>
 
@@ -101,6 +102,12 @@ struct Output
 class LaneDepartureChecker
 {
 public:
+  LaneDepartureChecker(
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper =
+      std::make_shared<universe_utils::TimeKeeper>())
+  : time_keeper_(time_keeper)
+  {
+  }
   Output update(const Input & input);
 
   void setParam(const Param & param, const autoware::vehicle_info_utils::VehicleInfo vehicle_info)
@@ -132,8 +139,9 @@ public:
     const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
     const size_t end_index);
 
-  static bool isOutOfLane(
-    const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint);
+  bool isOutOfLane(
+    const lanelet::ConstLanelets & candidate_lanelets,
+    const LinearRing2d & vehicle_footprint) const;
 
 private:
   Param param_;
@@ -156,9 +164,9 @@ private:
   static std::vector<LinearRing2d> createVehiclePassingAreas(
     const std::vector<LinearRing2d> & vehicle_footprints);
 
-  static bool willLeaveLane(
+  bool willLeaveLane(
     const lanelet::ConstLanelets & candidate_lanelets,
-    const std::vector<LinearRing2d> & vehicle_footprints);
+    const std::vector<LinearRing2d> & vehicle_footprints) const;
 
   double calcMaxSearchLengthForBoundaries(const Trajectory & trajectory) const;
 
@@ -166,9 +174,11 @@ private:
     const lanelet::LaneletMap & lanelet_map, const geometry_msgs::msg::Point & ego_point,
     const double max_search_length, const std::vector<std::string> & boundary_types_to_detect);
 
-  static bool willCrossBoundary(
+  bool willCrossBoundary(
     const std::vector<LinearRing2d> & vehicle_footprints,
-    const SegmentRtree & uncrossable_segments);
+    const SegmentRtree & uncrossable_segments) const;
+
+  mutable std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
 };
 }  // namespace autoware::lane_departure_checker
 

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -397,7 +397,7 @@ PathWithLaneId LaneDepartureChecker::cropPointsOutsideOfLanes(
   const auto vehicle_footprints = createVehicleFootprints(path);
 
   {
-    universe_utils::ScopedTimeTrack st(
+    universe_utils::ScopedTimeTrack st2(
       "check if footprint is within fused_lanlets_polygon", *time_keeper_);
 
     size_t idx = 0;

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -160,6 +160,8 @@ Output LaneDepartureChecker::update(const Input & input)
 bool LaneDepartureChecker::checkPathWillLeaveLane(
   const lanelet::ConstLanelets & lanelets, const PathWithLaneId & path) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   std::vector<LinearRing2d> vehicle_footprints = createVehicleFootprints(path);
   lanelet::ConstLanelets candidate_lanelets = getCandidateLanelets(lanelets, vehicle_footprints);
   return willLeaveLane(candidate_lanelets, vehicle_footprints);
@@ -290,8 +292,10 @@ std::vector<LinearRing2d> LaneDepartureChecker::createVehiclePassingAreas(
 
 bool LaneDepartureChecker::willLeaveLane(
   const lanelet::ConstLanelets & candidate_lanelets,
-  const std::vector<LinearRing2d> & vehicle_footprints)
+  const std::vector<LinearRing2d> & vehicle_footprints) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   for (const auto & vehicle_footprint : vehicle_footprints) {
     if (isOutOfLane(candidate_lanelets, vehicle_footprint)) {
       return true;
@@ -304,6 +308,8 @@ bool LaneDepartureChecker::willLeaveLane(
 std::vector<std::pair<double, lanelet::Lanelet>> LaneDepartureChecker::getLaneletsFromPath(
   const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   // Get Footprint Hull basic polygon
   std::vector<LinearRing2d> vehicle_footprints = createVehicleFootprints(path);
   LinearRing2d footprint_hull = createHullFromFootprints(vehicle_footprints);
@@ -326,6 +332,8 @@ std::optional<autoware::universe_utils::Polygon2d>
 LaneDepartureChecker::getFusedLaneletPolygonForPath(
   const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const auto lanelets_distance_pair = getLaneletsFromPath(lanelet_map_ptr, path);
   auto to_polygon2d =
     [](const lanelet::BasicPolygon2d & poly) -> autoware::universe_utils::Polygon2d {
@@ -365,6 +373,8 @@ LaneDepartureChecker::getFusedLaneletPolygonForPath(
 bool LaneDepartureChecker::checkPathWillLeaveLane(
   const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   // check if the footprint is not fully contained within the fused lanelets polygon
   const std::vector<LinearRing2d> vehicle_footprints = createVehicleFootprints(path);
   const auto fused_lanelets_polygon = getFusedLaneletPolygonForPath(lanelet_map_ptr, path);
@@ -379,25 +389,36 @@ bool LaneDepartureChecker::checkPathWillLeaveLane(
 PathWithLaneId LaneDepartureChecker::cropPointsOutsideOfLanes(
   const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path, const size_t end_index)
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   PathWithLaneId temp_path;
   const auto fused_lanelets_polygon = getFusedLaneletPolygonForPath(lanelet_map_ptr, path);
   if (path.points.empty() || !fused_lanelets_polygon) return temp_path;
   const auto vehicle_footprints = createVehicleFootprints(path);
-  size_t idx = 0;
-  std::for_each(vehicle_footprints.begin(), vehicle_footprints.end(), [&](const auto & footprint) {
-    if (idx > end_index || boost::geometry::within(footprint, fused_lanelets_polygon.value())) {
-      temp_path.points.push_back(path.points.at(idx));
-    }
-    ++idx;
-  });
+
+  {
+    universe_utils::ScopedTimeTrack st(
+      "check if footprint is within fused_lanlets_polygon", *time_keeper_);
+
+    size_t idx = 0;
+    std::for_each(
+      vehicle_footprints.begin(), vehicle_footprints.end(), [&](const auto & footprint) {
+        if (idx > end_index || boost::geometry::within(footprint, fused_lanelets_polygon.value())) {
+          temp_path.points.push_back(path.points.at(idx));
+        }
+        ++idx;
+      });
+  }
   PathWithLaneId cropped_path = path;
   cropped_path.points = temp_path.points;
   return cropped_path;
 }
 
 bool LaneDepartureChecker::isOutOfLane(
-  const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint)
+  const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   for (const auto & point : vehicle_footprint) {
     if (!isInAnyLane(candidate_lanelets, point)) {
       return true;
@@ -449,8 +470,11 @@ SegmentRtree LaneDepartureChecker::extractUncrossableBoundaries(
 }
 
 bool LaneDepartureChecker::willCrossBoundary(
-  const std::vector<LinearRing2d> & vehicle_footprints, const SegmentRtree & uncrossable_segments)
+  const std::vector<LinearRing2d> & vehicle_footprints,
+  const SegmentRtree & uncrossable_segments) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   for (const auto & footprint : vehicle_footprints) {
     std::vector<Segment2d> intersection_result;
     uncrossable_segments.query(

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -415,10 +415,8 @@ PathWithLaneId LaneDepartureChecker::cropPointsOutsideOfLanes(
 }
 
 bool LaneDepartureChecker::isOutOfLane(
-  const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint) const
+  const lanelet::ConstLanelets & candidate_lanelets, const LinearRing2d & vehicle_footprint)
 {
-  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   for (const auto & point : vehicle_footprint) {
     if (!isInAnyLane(candidate_lanelets, point)) {
       return true;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/freespace_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/freespace_pull_out.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__BEHAVIOR_PATH_START_PLANNER_MODULE__FREESPACE_PULL_OUT_HPP_
 
 #include "autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 
 #include <autoware/freespace_planning_algorithms/abstract_algorithm.hpp>
 #include <autoware/freespace_planning_algorithms/astar_search.hpp>
@@ -36,7 +37,8 @@ class FreespacePullOut : public PullOutPlannerBase
 public:
   FreespacePullOut(
     rclcpp::Node & node, const StartPlannerParameters & parameters,
-    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper);
 
   PlannerType getPlannerType() const override { return PlannerType::FREESPACE; }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -18,6 +18,7 @@
 #include "autoware/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp"
 #include "autoware/behavior_path_start_planner_module/pull_out_path.hpp"
 #include "autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 
 #include <autoware/lane_departure_checker/lane_departure_checker.hpp>
 
@@ -33,7 +34,8 @@ public:
   explicit GeometricPullOut(
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     const std::shared_ptr<autoware::lane_departure_checker::LaneDepartureChecker>
-      lane_departure_checker);
+      lane_departure_checker,
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper);
 
   PlannerType getPlannerType() const override { return PlannerType::GEOMETRIC; };
   std::optional<PullOutPath> plan(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/behavior_path_start_planner_module/pull_out_path.hpp"
 #include "autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 
 #include <autoware/lane_departure_checker/lane_departure_checker.hpp>
 
@@ -34,7 +35,8 @@ class ShiftPullOut : public PullOutPlannerBase
 public:
   explicit ShiftPullOut(
     rclcpp::Node & node, const StartPlannerParameters & parameters,
-    std::shared_ptr<LaneDepartureChecker> & lane_departure_checker);
+    std::shared_ptr<LaneDepartureChecker> & lane_departure_checker,
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper);
 
   PlannerType getPlannerType() const override { return PlannerType::SHIFT; };
   std::optional<PullOutPath> plan(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -28,8 +28,10 @@ namespace autoware::behavior_path_planner
 {
 FreespacePullOut::FreespacePullOut(
   rclcpp::Node & node, const StartPlannerParameters & parameters,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
-: PullOutPlannerBase{node, parameters}, velocity_{parameters.freespace_planner_velocity}
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  std::shared_ptr<universe_utils::TimeKeeper> time_keeper)
+: PullOutPlannerBase{node, parameters, time_keeper},
+  velocity_{parameters.freespace_planner_velocity}
 {
   autoware::freespace_planning_algorithms::VehicleShape vehicle_shape(
     vehicle_info, parameters.vehicle_shape_margin);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -33,8 +33,9 @@ using start_planner_utils::getPullOutLanes;
 GeometricPullOut::GeometricPullOut(
   rclcpp::Node & node, const StartPlannerParameters & parameters,
   const std::shared_ptr<autoware::lane_departure_checker::LaneDepartureChecker>
-    lane_departure_checker)
-: PullOutPlannerBase{node, parameters},
+    lane_departure_checker,
+  std::shared_ptr<universe_utils::TimeKeeper> time_keeper)
+: PullOutPlannerBase{node, parameters, time_keeper},
   parallel_parking_parameters_{parameters.parallel_parking_parameters},
   lane_departure_checker_(lane_departure_checker)
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -37,8 +37,9 @@ using start_planner_utils::getPullOutLanes;
 
 ShiftPullOut::ShiftPullOut(
   rclcpp::Node & node, const StartPlannerParameters & parameters,
-  std::shared_ptr<LaneDepartureChecker> & lane_departure_checker)
-: PullOutPlannerBase{node, parameters}, lane_departure_checker_{lane_departure_checker}
+  std::shared_ptr<LaneDepartureChecker> & lane_departure_checker,
+  std::shared_ptr<universe_utils::TimeKeeper> time_keeper)
+: PullOutPlannerBase{node, parameters, time_keeper}, lane_departure_checker_{lane_departure_checker}
 {
 }
 
@@ -62,6 +63,8 @@ std::optional<PullOutPath> ShiftPullOut::plan(
 
   // get safe path
   for (auto & pull_out_path : pull_out_paths) {
+    universe_utils::ScopedTimeTrack st("get safe path", *time_keeper_);
+
     // shift path is not separate but only one.
     auto & shift_path = pull_out_path.partial_paths.front();
     // check lane_departure with path between pull_out_start to pull_out_end
@@ -215,6 +218,8 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & road_lanes,
   const Pose & start_pose, const Pose & goal_pose)
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   std::vector<PullOutPath> candidate_paths{};
 
   if (road_lanes.empty()) {

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -65,7 +65,7 @@ StartPlannerModule::StartPlannerModule(
   vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
   is_freespace_planner_cb_running_{false}
 {
-  lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
+  lane_departure_checker_ = std::make_shared<LaneDepartureChecker>(time_keeper_);
   lane_departure_checker_->setVehicleInfo(vehicle_info_);
   autoware::lane_departure_checker::Param lane_departure_checker_params{};
   lane_departure_checker_params.footprint_extra_margin =
@@ -76,18 +76,19 @@ StartPlannerModule::StartPlannerModule(
   // set enabled planner
   if (parameters_->enable_shift_pull_out) {
     start_planners_.push_back(
-      std::make_shared<ShiftPullOut>(node, *parameters, lane_departure_checker_));
+      std::make_shared<ShiftPullOut>(node, *parameters, lane_departure_checker_, time_keeper_));
   }
   if (parameters_->enable_geometric_pull_out) {
     start_planners_.push_back(
-      std::make_shared<GeometricPullOut>(node, *parameters, lane_departure_checker_));
+      std::make_shared<GeometricPullOut>(node, *parameters, lane_departure_checker_, time_keeper_));
   }
   if (start_planners_.empty()) {
     RCLCPP_ERROR(getLogger(), "Not found enabled planner");
   }
 
   if (parameters_->enable_freespace_planner) {
-    freespace_planner_ = std::make_unique<FreespacePullOut>(node, *parameters, vehicle_info_);
+    freespace_planner_ =
+      std::make_unique<FreespacePullOut>(node, *parameters, vehicle_info_, time_keeper_);
     const auto freespace_planner_period_ns = rclcpp::Rate(1.0).period();
     freespace_planner_timer_cb_group_ =
       node.create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -211,6 +212,8 @@ void StartPlannerModule::updateObjectsFilteringParams(
 
 void StartPlannerModule::updateData()
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   // The method PlannerManager::run() calls SceneModuleInterface::setData and
   // SceneModuleInterface::setPreviousModuleOutput() before this module's run() method is called
   // with module_ptr->run(). Then module_ptr->run() invokes StartPlannerModule::updateData and,
@@ -368,6 +371,8 @@ bool StartPlannerModule::isCurrentPoseOnMiddleOfTheRoad() const
 
 bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   // prepare poses for preventing check
   // - current_pose
   // - estimated_stop_pose (The position assumed when stopped with the minimum stop distance,
@@ -397,6 +402,8 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
 
 bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const auto & dynamic_object = planner_data_->dynamic_object;
   const auto & route_handler = planner_data_->route_handler;
   const Pose start_pose = planner_data_->route_handler->getOriginalStartPose();
@@ -646,6 +653,8 @@ bool StartPlannerModule::canTransitSuccessState()
 
 BehaviorModuleOutput StartPlannerModule::plan()
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (isWaitingApproval()) {
     clearWaitingApproval();
     resetPathCandidate();
@@ -662,6 +671,8 @@ BehaviorModuleOutput StartPlannerModule::plan()
   }
 
   const auto path = std::invoke([&]() {
+    universe_utils::ScopedTimeTrack st("plan path", *time_keeper_);
+
     if (!status_.driving_forward && !status_.backward_driving_complete) {
       return status_.backward_path;
     }
@@ -775,6 +786,8 @@ PathWithLaneId StartPlannerModule::getFullPath() const
 
 BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   updatePullOutStatus();
 
   if (!status_.found_pull_out_path) {
@@ -868,6 +881,8 @@ void StartPlannerModule::planWithPriority(
   const std::vector<Pose> & start_pose_candidates, const Pose & refined_start_pose,
   const Pose & goal_pose, const std::string & search_priority)
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (start_pose_candidates.empty()) return;
 
   auto get_accumulated_debug_stream = [](const std::vector<PlannerDebugData> & debug_data_vector) {
@@ -884,18 +899,22 @@ void StartPlannerModule::planWithPriority(
     determinePriorityOrder(search_priority, start_pose_candidates.size());
 
   std::vector<PlannerDebugData> debug_data_vector;
-  for (const auto & collision_check_margin : parameters_->collision_check_margins) {
-    for (const auto & [index, planner] : order_priority) {
-      if (findPullOutPath(
-            start_pose_candidates[index], planner, refined_start_pose, goal_pose,
-            collision_check_margin, debug_data_vector)) {
-        debug_data_.selected_start_pose_candidate_index = index;
-        debug_data_.margin_for_start_pose_candidate = collision_check_margin;
-        if (parameters_->print_debug_info) {
-          const auto ss = get_accumulated_debug_stream(debug_data_vector);
-          DEBUG_PRINT("\nPull out path search results:\n%s", ss.str().c_str());
+  {  // create a scope for the scoped time track
+    universe_utils::ScopedTimeTrack st("findPullOutPaths", *time_keeper_);
+
+    for (const auto & collision_check_margin : parameters_->collision_check_margins) {
+      for (const auto & [index, planner] : order_priority) {
+        if (findPullOutPath(
+              start_pose_candidates[index], planner, refined_start_pose, goal_pose,
+              collision_check_margin, debug_data_vector)) {
+          debug_data_.selected_start_pose_candidate_index = index;
+          debug_data_.margin_for_start_pose_candidate = collision_check_margin;
+          if (parameters_->print_debug_info) {
+            const auto ss = get_accumulated_debug_stream(debug_data_vector);
+            DEBUG_PRINT("\nPull out path search results:\n%s", ss.str().c_str());
+          }
+          return;
         }
-        return;
       }
     }
   }
@@ -910,6 +929,8 @@ void StartPlannerModule::planWithPriority(
 PriorityOrder StartPlannerModule::determinePriorityOrder(
   const std::string & search_priority, const size_t start_pose_candidates_num)
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   PriorityOrder order_priority;
   if (search_priority == "efficient_path") {
     for (const auto & planner : start_planners_) {
@@ -1080,6 +1101,8 @@ std::vector<DrivableLanes> StartPlannerModule::generateDrivableLanes(
 
 void StartPlannerModule::updatePullOutStatus()
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   // skip updating if enough time has not passed for preventing chattering between back and
   // start_planner
   if (!receivedNewRoute()) {
@@ -1148,6 +1171,8 @@ void StartPlannerModule::updateStatusAfterBackwardDriving()
 
 PathWithLaneId StartPlannerModule::calcBackwardPathFromStartPose() const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const Pose start_pose = planner_data_->route_handler->getOriginalStartPose();
   const auto pull_out_lanes = start_planner_utils::getPullOutLanes(
     planner_data_, planner_data_->parameters.backward_path_length + parameters_->max_back_distance);
@@ -1175,6 +1200,8 @@ PathWithLaneId StartPlannerModule::calcBackwardPathFromStartPose() const
 std::vector<Pose> StartPlannerModule::searchPullOutStartPoseCandidates(
   const PathWithLaneId & back_path_from_start_pose) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   std::vector<Pose> pull_out_start_pose_candidates{};
   const auto start_pose = planner_data_->route_handler->getOriginalStartPose();
   const auto local_vehicle_footprint = vehicle_info_.createFootprint();
@@ -1239,6 +1266,8 @@ PredictedObjects StartPlannerModule::filterStopObjectsInPullOutLanes(
   const double velocity_threshold, const double object_check_forward_distance,
   const double object_check_backward_distance) const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const auto stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     *planner_data_->dynamic_object, velocity_threshold);
 
@@ -1388,6 +1417,8 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo()
 
 bool StartPlannerModule::isSafePath() const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   // TODO(Sugahara): should safety check for backward path
 
   const auto pull_out_path = getCurrentPath();
@@ -1518,6 +1549,8 @@ std::optional<PullOutStatus> StartPlannerModule::planFreespacePath(
   const StartPlannerParameters & parameters,
   const std::shared_ptr<const PlannerData> & planner_data, const PullOutStatus & pull_out_status)
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const Pose & current_pose = planner_data->self_odometry->pose.pose;
   const auto & route_handler = planner_data->route_handler;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1549,8 +1549,6 @@ std::optional<PullOutStatus> StartPlannerModule::planFreespacePath(
   const StartPlannerParameters & parameters,
   const std::shared_ptr<const PlannerData> & planner_data, const PullOutStatus & pull_out_status)
 {
-  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   const Pose & current_pose = planner_data->self_odometry->pose.pose;
   const auto & route_handler = planner_data->route_handler;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -671,7 +671,7 @@ BehaviorModuleOutput StartPlannerModule::plan()
   }
 
   const auto path = std::invoke([&]() {
-    universe_utils::ScopedTimeTrack st("plan path", *time_keeper_);
+    universe_utils::ScopedTimeTrack st2("plan path", *time_keeper_);
 
     if (!status_.driving_forward && !status_.backward_driving_complete) {
       return status_.backward_path;
@@ -900,7 +900,7 @@ void StartPlannerModule::planWithPriority(
 
   std::vector<PlannerDebugData> debug_data_vector;
   {  // create a scope for the scoped time track
-    universe_utils::ScopedTimeTrack st("findPullOutPaths", *time_keeper_);
+    universe_utils::ScopedTimeTrack st2("findPullOutPaths", *time_keeper_);
 
     for (const auto & collision_check_margin : parameters_->collision_check_margins) {
       for (const auto & [index, planner] : order_priority) {


### PR DESCRIPTION
## Description

Added a time_keeper to start_planner to track the processing time.
The following is the result where there is a front parked vehicle.
```
⏰ Worst Case Execution Time ⏰
start_planner=>run: 41.71 [ms]
    ├── updateData: 0.04 [ms]
    └── planWaitingApproval: 41.56 [ms]
        ├── updatePullOutStatus: 36.69 [ms]
        │   ├── calcBackwardPathFromStartPose: 1.37 [ms]
        │   ├── searchPullOutStartPoseCandidates: 1.81 [ms]
        │   │   ├── filterStopObjectsInPullOutLanes: 0.17 [ms]
        │   │   └── filterStopObjectsInPullOutLanes: 1.03 [ms]
        │   └── planWithPriority: 33.13 [ms]
        │       ├── determinePriorityOrder: 0.00 [ms]
        │       └── findPullOutPaths: 33.12 [ms]
        │           ├── calcPullOutPaths: 4.09 [ms]
        │           ├── get safe path: 11.02 [ms]
        │           │   ├── checkPathWillLeaveLane: 0.50 [ms]
        │           │   │   └── getFusedLaneletPolygonForPath: 0.33 [ms]
        │           │   │       └── getLaneletsFromPath: 0.23 [ms]
        │           │   ├── cropPointsOutsideOfLanes: 9.64 [ms]
        │           │   │   ├── getFusedLaneletPolygonForPath: 9.24 [ms]
        │           │   │   │   └── getLaneletsFromPath: 1.43 [ms]
        │           │   │   └── check if footprint is within fused_lanlets_polygon: 0.22 [ms]
        │           │   └── isPullOutPathCollided: 0.77 [ms]
        │           ├── get safe path: 8.93 [ms]
        │           │   ├── checkPathWillLeaveLane: 0.39 [ms]
        │           │   │   └── getFusedLaneletPolygonForPath: 0.21 [ms]
        │           │   │       └── getLaneletsFromPath: 0.12 [ms]
        │           │   ├── cropPointsOutsideOfLanes: 7.90 [ms]
        │           │   │   ├── getFusedLaneletPolygonForPath: 7.62 [ms]
        │           │   │   │   └── getLaneletsFromPath: 1.71 [ms]
        │           │   │   └── check if footprint is within fused_lanlets_polygon: 0.15 [ms]
        │           │   └── isPullOutPathCollided: 0.59 [ms]
        │           └── get safe path: 8.82 [ms]
        │               ├── checkPathWillLeaveLane: 0.22 [ms]
        │               │   └── getFusedLaneletPolygonForPath: 0.12 [ms]
        │               │       └── getLaneletsFromPath: 0.06 [ms]
        │               ├── cropPointsOutsideOfLanes: 7.95 [ms]
        │               │   ├── getFusedLaneletPolygonForPath: 7.65 [ms]
        │               │   │   └── getLaneletsFromPath: 1.51 [ms]
        │               │   └── check if footprint is within fused_lanlets_polygon: 0.15 [ms]
        │               └── isPullOutPathCollided: 0.57 [ms]
        ├── isPreventingRearVehicleFromPassingThrough: 0.41 [ms]
        │   ├── isPreventingRearVehicleFromPassingThrough: 0.49 [ms]
        │   └── isPreventingRearVehicleFromPassingThrough: 0.41 [ms]
        └── isSafePath: 0.62 [ms]

isPreventingRearVehicleFromPassingThrough: 0.25 [ms]
    ├── isPreventingRearVehicleFromPassingThrough: 0.33 [ms]
    └── isPreventingRearVehicleFromPassingThrough: 0.25 [ms]

isSafePath: 0.41 [ms]
```
## Related links


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
