### PR TITLE
feat(autonomous_emergency_braking): enable AEB emergency stop

### DIFF
--- a/system/system_diagnostic_monitor/config/autoware-psim.yaml
+++ b/system/system_diagnostic_monitor/config/autoware-psim.yaml
@@ -8,4 +8,3 @@ edits:
   - { type: remove, path: /autoware/localization/sensor_fusion_status }
   - { type: remove, path: /autoware/localization/topic_rate_check/pose_twist_fusion }
   - { type: remove, path: /autoware/perception/topic_rate_check/pointcloud }
-  - { type: remove, path: /autoware/control/emergency_braking }


### PR DESCRIPTION
## Description
Enable emergency stop for AEB module
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
