### PR TITLE
fix(diagnostic_graph_aggregator): fix functionConst

### DIFF
--- a/system/diagnostic_graph_aggregator/src/common/graph/graph.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/graph.cpp
@@ -37,7 +37,7 @@ void Graph::create(const std::string & file, const std::string & id)
   id_ = id;
 }
 
-void Graph::update(const rclcpp::Time & stamp)
+void Graph::update(const rclcpp::Time & stamp) const
 {
   for (const auto & diag : diags_) diag->on_time(stamp);
 }

--- a/system/diagnostic_graph_aggregator/src/common/graph/graph.cpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/graph.cpp
@@ -37,7 +37,7 @@ void Graph::create(const std::string & file, const std::string & id)
   id_ = id;
 }
 
-void Graph::update(const rclcpp::Time & stamp) const
+void Graph::update(const rclcpp::Time & stamp)
 {
   for (const auto & diag : diags_) diag->on_time(stamp);
 }

--- a/system/diagnostic_graph_aggregator/src/common/graph/graph.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/graph.hpp
@@ -31,7 +31,7 @@ class Graph
 {
 public:
   void create(const std::string & file, const std::string & id = "");
-  void update(const rclcpp::Time & stamp); // cppcheck-suppress functionConst
+  void update(const rclcpp::Time & stamp);  // cppcheck-suppress functionConst
   bool update(const rclcpp::Time & stamp, const DiagnosticStatus & status);
   const auto & nodes() const { return nodes_; }
   const auto & diags() const { return diags_; }

--- a/system/diagnostic_graph_aggregator/src/common/graph/graph.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/graph.hpp
@@ -31,7 +31,7 @@ class Graph
 {
 public:
   void create(const std::string & file, const std::string & id = "");
-  void update(const rclcpp::Time & stamp);
+  void update(const rclcpp::Time & stamp) const;
   bool update(const rclcpp::Time & stamp, const DiagnosticStatus & status);
   const auto & nodes() const { return nodes_; }
   const auto & diags() const { return diags_; }

--- a/system/diagnostic_graph_aggregator/src/common/graph/graph.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/graph.hpp
@@ -31,7 +31,7 @@ class Graph
 {
 public:
   void create(const std::string & file, const std::string & id = "");
-  void update(const rclcpp::Time & stamp) const;
+  void update(const rclcpp::Time & stamp); // cppcheck-suppress functionConst
   bool update(const rclcpp::Time & stamp, const DiagnosticStatus & status);
   const auto & nodes() const { return nodes_; }
   const auto & diags() const { return diags_; }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
system/diagnostic_graph_aggregator/src/common/graph/graph.hpp:34:8: style: inconclusive: Technically the member function 'diagnostic_graph_aggregator::Graph::update' can be const. [functionConst]
  void update(const rclcpp::Time & stamp);
       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
