### PR TITLE
fix(autoware_pointcloud_preprocessor): fix functionConst

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
@@ -1134,7 +1134,7 @@ private:
       map.deallocate(mData);
     }
 
-    void destroyDoNotDeallocate() noexcept { mData->~value_type(); }
+    void destroyDoNotDeallocate() const noexcept { mData->~value_type(); }
 
     value_type const * operator->() const noexcept { return mData; }
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h:1137:10: style: inconclusive: Technically the member function 'robin_hood::detail::Table::DataNode::destroyDoNotDeallocate' can be const. [functionConst]
    void destroyDoNotDeallocate() noexcept { mData->~value_type(); }
         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
