### PR TITLE
fix(autoware_freespace_planning_algorithms): fix functionConst

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/astar_search.hpp
+++ b/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/astar_search.hpp
@@ -79,7 +79,7 @@ struct AstarNode
 
 struct NodeComparison
 {
-  bool operator()(const AstarNode * lhs, const AstarNode * rhs) { return lhs->fc > rhs->fc; }
+  bool operator()(const AstarNode * lhs, const AstarNode * rhs) const { return lhs->fc > rhs->fc; }
 };
 
 struct NodeUpdate

--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -155,7 +155,7 @@ void AstarSearch::setCollisionFreeDistanceMap()
   using Entry = std::pair<IndexXY, double>;
   struct CompareEntry
   {
-    bool operator()(const Entry & a, const Entry & b) { return a.second > b.second; }
+    bool operator()(const Entry & a, const Entry & b) const { return a.second > b.second; }
   };
   std::priority_queue<Entry, std::vector<Entry>, CompareEntry> heap;
   std::vector<bool> closed(col_free_distance_map_.size(), false);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
planning/autoware_freespace_planning_algorithms/src/astar_search.cpp:158:10: style: inconclusive: Technically the member function 'autoware::freespace_planning_algorithms::setCollisionFreeDistanceMap::CompareEntry::operator()' can be const. [functionConst]
    bool operator()(const Entry & a, const Entry & b) { return a.second > b.second; }
         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
