### PR TITLE
fix(autoware_behavior_velocity_intersection_module): fix functionConst

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp
@@ -248,7 +248,7 @@ public:
   std::vector<std::shared_ptr<ObjectInfo>> allObjects() const;
 
   const std::unordered_map<unique_identifier_msgs::msg::UUID, std::shared_ptr<ObjectInfo>> &
-  getObjectsMap()
+  getObjectsMap() const
   {
     return objects_info_;
   }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.hpp:251:3: style: inconclusive: Technically the member function 'autoware::behavior_velocity_planner::ObjectInfoManager::getObjectsMap' can be const. [functionConst]
  getObjectsMap()
  ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
