### PR TITLE
fix(autoware_behavior_velocity_run_out_module): fix functionConst

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.cpp
@@ -202,7 +202,7 @@ autoware::motion_utils::VirtualWalls RunOutDebug::createVirtualWalls()
 }
 
 visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArrayFromDebugData(
-  const builtin_interfaces::msg::Time & current_time)
+  const builtin_interfaces::msg::Time & current_time) const
 {
   visualization_msgs::msg::MarkerArray msg;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.hpp
@@ -127,7 +127,7 @@ public:
 
 private:
   visualization_msgs::msg::MarkerArray createVisualizationMarkerArrayFromDebugData(
-    const builtin_interfaces::msg::Time & current_time);
+    const builtin_interfaces::msg::Time & current_time) const;
   void clearDebugMarker();
 
   rclcpp::Node & node_;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.hpp:129:40: style: inconclusive: Technically the member function 'autoware::behavior_velocity_planner::RunOutDebug::createVisualizationMarkerArrayFromDebugData' can be const. [functionConst]
  visualization_msgs::msg::MarkerArray createVisualizationMarkerArrayFromDebugData(
                                       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
