### PR TITLE
fix(autoware_traffic_light_occlusion_predictor): fix functionConst

### DIFF
--- a/perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.cpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.cpp
@@ -148,7 +148,7 @@ void CloudOcclusionPredictor::calcRoiVector3D(
 
 void CloudOcclusionPredictor::filterCloud(
   const pcl::PointCloud<pcl::PointXYZ> & cloud_in, const std::vector<pcl::PointXYZ> & roi_tls,
-  const std::vector<pcl::PointXYZ> & roi_brs, pcl::PointCloud<pcl::PointXYZ> & cloud_out)
+  const std::vector<pcl::PointXYZ> & roi_brs, pcl::PointCloud<pcl::PointXYZ> & cloud_out) const
 {
   float min_x = 0, max_x = 0, min_y = 0, max_y = 0, min_z = 0, max_z = 0;
   for (const auto & pt : roi_tls) {

--- a/perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.hpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.hpp
@@ -73,7 +73,7 @@ private:
 
   void filterCloud(
     const pcl::PointCloud<pcl::PointXYZ> & cloud_in, const std::vector<pcl::PointXYZ> & roi_tls,
-    const std::vector<pcl::PointXYZ> & roi_brs, pcl::PointCloud<pcl::PointXYZ> & cloud_out);
+    const std::vector<pcl::PointXYZ> & roi_brs, pcl::PointCloud<pcl::PointXYZ> & cloud_out) const;
 
   void sampleTrafficLightRoi(
     const pcl::PointXYZ & top_left, const pcl::PointXYZ & bottom_right,


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.hpp:74:8: style: inconclusive: Technically the member function 'autoware::traffic_light::CloudOcclusionPredictor::filterCloud' can be const. [functionConst]
  void filterCloud(
       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
