### PR TITLE
fix(autoware_radar_fusion_to_detected_object): fix functionConst

### DIFF
--- a/perception/autoware_radar_fusion_to_detected_object/src/include/radar_fusion_to_detected_object.hpp
+++ b/perception/autoware_radar_fusion_to_detected_object/src/include/radar_fusion_to_detected_object.hpp
@@ -99,9 +99,9 @@ private:
   // std::vector<DetectedObject> splitObject(
   //   const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars);
   TwistWithCovariance estimateTwist(
-    const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars);
+    const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars) const;
   bool isQualified(
-    const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars);
+    const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars) const;
   TwistWithCovariance convertDopplerToTwist(
     const DetectedObject & object, const TwistWithCovariance & twist_with_covariance);
   static bool isYawCorrect(

--- a/perception/autoware_radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/autoware_radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -205,7 +205,7 @@ RadarFusionToDetectedObject::filterRadarWithinObject(
 // (Target value is amplitude if using radar pointcloud. Target value is probability if using radar
 // objects).
 TwistWithCovariance RadarFusionToDetectedObject::estimateTwist(
-  const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars)
+  const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars) const
 {
   if (!radars || (*radars).empty()) {
     TwistWithCovariance output{};
@@ -298,7 +298,7 @@ TwistWithCovariance RadarFusionToDetectedObject::estimateTwist(
 
 // Judge whether low confidence objects that do not have some radar points/objects or not.
 bool RadarFusionToDetectedObject::isQualified(
-  const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars)
+  const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars) const
 {
   if (object.existence_probability > param_.threshold_probability) {
     return true;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
perception/autoware_radar_fusion_to_detected_object/src/include/radar_fusion_to_detected_object.hpp:101:23: style: inconclusive: Technically the member function 'autoware::radar_fusion_to_detected_object::RadarFusionToDetectedObject::estimateTwist' can be const. [functionConst]
  TwistWithCovariance estimateTwist(
                      ^

perception/autoware_radar_fusion_to_detected_object/src/include/radar_fusion_to_detected_object.hpp:103:8: style: inconclusive: Technically the member function 'autoware::radar_fusion_to_detected_object::RadarFusionToDetectedObject::isQualified' can be const. [functionConst]
  bool isQualified(
       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
