### PR TITLE
feat(static_obstacle_avoidance): force deactivation

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -243,6 +243,8 @@
       # For cancel maneuver
       cancel:
         enable: true                                    # [-]
+        force:
+          duration_time: 2.0                            # [s]
 
       # For yield maneuver
       yield:

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -107,6 +107,8 @@ struct AvoidanceParameters
   // if this param is true, it reverts avoidance path when the path is no longer needed.
   bool enable_cancel_maneuver{false};
 
+  double force_deactivate_duration_time{0.0};
+
   // enable avoidance for all parking vehicle
   std::string policy_ambiguous_vehicle{"ignore"};
 
@@ -580,6 +582,8 @@ struct AvoidancePlanningData
   bool yield_required{false};
 
   bool found_avoidance_path{false};
+
+  bool force_deactivated{false};
 
   double to_stop_line{std::numeric_limits<double>::max()};
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
@@ -301,6 +301,7 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
   {
     const std::string ns = "avoidance.cancel.";
     p.enable_cancel_maneuver = getOrDeclareParameter<bool>(*node, ns + "enable");
+    p.force_deactivate_duration_time = getOrDeclareParameter<double>(*node, ns + "force.duration_time");
   }
 
   // yield

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
@@ -301,7 +301,8 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
   {
     const std::string ns = "avoidance.cancel.";
     p.enable_cancel_maneuver = getOrDeclareParameter<bool>(*node, ns + "enable");
-    p.force_deactivate_duration_time = getOrDeclareParameter<double>(*node, ns + "force.duration_time");
+    p.force_deactivate_duration_time =
+      getOrDeclareParameter<double>(*node, ns + "force.duration_time");
   }
 
   // yield

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -480,7 +480,6 @@ private:
 
   bool force_deactivated_{false};
   rclcpp::Time last_deactivation_triggered_time_;
-
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -477,6 +477,10 @@ private:
   mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;
 
   mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
+
+  bool force_deactivated_{false};
+  rclcpp::Time last_deactivation_triggered_time_;
+
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
@@ -1263,6 +1263,16 @@
               "type": "boolean",
               "description": "Flag to enable cancel maneuver.",
               "default": "true"
+            },
+            "force": {
+              "type": "object",
+              "properties": {
+                "duration_time": {
+                  "type": "number",
+                  "description": "force deactive duration time",
+                  "default": 2.0
+                }
+              }
             }
           },
           "required": ["enable"],

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
@@ -1269,7 +1269,7 @@
               "properties": {
                 "duration_time": {
                   "type": "number",
-                  "description": "force deactive duration time",
+                  "description": "force deactivate duration time",
                   "default": 2.0
                 }
               }

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
@@ -183,6 +183,11 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
   }
 
   {
+    const std::string ns = "avoidance.cancel.";
+    updateParam<double>(parameters, ns + "force.duration_time", p->force_deactivate_duration_time);
+  }
+
+  {
     const std::string ns = "avoidance.stop.";
     updateParam<double>(parameters, ns + "max_distance", p->stop_max_distance);
     updateParam<double>(parameters, ns + "stop_buffer", p->stop_buffer);

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -570,6 +570,23 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
+  auto registered_sl_force_deactivated =
+    [&](const std::string & direction, const RegisteredShiftLineArray shift_line_array) {
+      return std::any_of(
+        shift_line_array.begin(), shift_line_array.end(), [&](const auto & shift_line) {
+          return rtc_interface_ptr_map_.at(direction)->isForceDeactivated(shift_line.uuid);
+        });
+    };
+
+  auto is_force_deactivated = registered_sl_force_deactivated("left", left_shift_array_) || registered_sl_force_deactivated("right", right_shift_array_);
+  if(is_force_deactivated && can_yield_maneuver) {
+    data.yield_required = true;
+    data.safe_shift_line = data.new_shift_line;
+    data.force_deactivated = true;
+    RCLCPP_INFO(getLogger(), "this module is force deactivated. wait until reactivation");
+    return;
+  }
+
   /**
    * If the avoidance path is safe, use unapproved_new_sl for avoidance path generation.
    */
@@ -754,6 +771,10 @@ bool StaticObstacleAvoidanceModule::isSafePath(
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   const auto & p = planner_data_->parameters;
+
+  if (force_deactivated_) {
+    return false;
+  }
 
   if (!parameters_->enable_safety_check) {
     return true;  // if safety check is disabled, it always return safe.
@@ -1371,6 +1392,18 @@ void StaticObstacleAvoidanceModule::updateData()
   }
 
   safe_ = avoid_data_.safe;
+
+  if(!force_deactivated_) {
+    last_deactivation_triggered_time_ = clock_->now();
+    force_deactivated_ = avoid_data_.force_deactivated;
+    return;
+  }
+  
+  if((clock_->now() - last_deactivation_triggered_time_).seconds() > parameters_->force_deactivate_duration_time) {
+    RCLCPP_INFO(getLogger(), "The force deactivation is released");
+    force_deactivated_ = false;
+  }
+ 
 }
 
 void StaticObstacleAvoidanceModule::processOnEntry()

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -578,8 +578,9 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
         });
     };
 
-  auto is_force_deactivated = registered_sl_force_deactivated("left", left_shift_array_) || registered_sl_force_deactivated("right", right_shift_array_);
-  if(is_force_deactivated && can_yield_maneuver) {
+  auto is_force_deactivated = registered_sl_force_deactivated("left", left_shift_array_) ||
+                              registered_sl_force_deactivated("right", right_shift_array_);
+  if (is_force_deactivated && can_yield_maneuver) {
     data.yield_required = true;
     data.safe_shift_line = data.new_shift_line;
     data.force_deactivated = true;
@@ -1393,17 +1394,18 @@ void StaticObstacleAvoidanceModule::updateData()
 
   safe_ = avoid_data_.safe;
 
-  if(!force_deactivated_) {
+  if (!force_deactivated_) {
     last_deactivation_triggered_time_ = clock_->now();
     force_deactivated_ = avoid_data_.force_deactivated;
     return;
   }
-  
-  if((clock_->now() - last_deactivation_triggered_time_).seconds() > parameters_->force_deactivate_duration_time) {
+
+  if (
+    (clock_->now() - last_deactivation_triggered_time_).seconds() >
+    parameters_->force_deactivate_duration_time) {
     RCLCPP_INFO(getLogger(), "The force deactivation is released");
     force_deactivated_ = false;
   }
- 
 }
 
 void StaticObstacleAvoidanceModule::processOnEntry()

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -570,7 +570,7 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
-  auto registered_sl_force_deactivated =
+  const auto registered_sl_force_deactivated =
     [&](const std::string & direction, const RegisteredShiftLineArray shift_line_array) {
       return std::any_of(
         shift_line_array.begin(), shift_line_array.end(), [&](const auto & shift_line) {
@@ -578,8 +578,8 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
         });
     };
 
-  auto is_force_deactivated = registered_sl_force_deactivated("left", left_shift_array_) ||
-                              registered_sl_force_deactivated("right", right_shift_array_);
+  const auto is_force_deactivated = registered_sl_force_deactivated("left", left_shift_array_) ||
+                                    registered_sl_force_deactivated("right", right_shift_array_);
   if (is_force_deactivated && can_yield_maneuver) {
     data.yield_required = true;
     data.safe_shift_line = data.new_shift_line;


### PR DESCRIPTION
## Description
Previously the static obstacle avoidance continuously activated even when the shift point was force deactivated by human operation via RTC. 
This PR enables force deactivation when yield maneuver could be applied, and after a certain time (this is parameterized) the avoidance would reactivate.

## Related links
Please merge [this PR](https://github.com/autowarefoundation/autoware_launch/pull/1101) first.

## How was this PR tested?
Before:
[Can't cancel](https://github.com/user-attachments/assets/53fb4361-9c8d-4b53-9f0e-6e00bbbfc9b1)
After:
[Duration time 2 second](https://github.com/user-attachments/assets/71f87f3e-0aa2-4904-83d2-349ed090b8d2)
[Duration time 10 second](https://github.com/user-attachments/assets/be528dad-42e8-4a6f-a4f4-483f0bbf03a0)

No degrade in [TIER IV internal scenario test](https://evaluation.tier4.jp/evaluation/reports/57af72fc-d3c4-52e3-88b3-587b54cdd9cd?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
