### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): fix functionConst

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp
@@ -202,17 +202,17 @@ struct dempsterShaferOccupancy
   }
 
   // calc conflict factor K
-  double calcK(const dempsterShaferOccupancy & other)
+  double calcK(const dempsterShaferOccupancy & other) const
   {
     return (occupied * other.empty + empty * other.occupied);
   }
   // calc sum of occupied probability mass
-  double calcOccupied(const dempsterShaferOccupancy & other)
+  double calcOccupied(const dempsterShaferOccupancy & other) const
   {
     return occupied * other.occupied + occupied * other.unknown + unknown * other.occupied;
   }
   // calc sum of empty probability mass
-  double calcEmpty(const dempsterShaferOccupancy & other)
+  double calcEmpty(const dempsterShaferOccupancy & other) const
   {
     return empty * other.empty + empty * other.unknown + unknown * other.empty;
   }
@@ -240,7 +240,7 @@ struct dempsterShaferOccupancy
   }
 
   // get occupancy probability via Pignistic Probability
-  double getPignisticProbability() { return occupied + unknown / 2.0; }
+  double getPignisticProbability() const { return occupied + unknown / 2.0; }
 };
 
 /**


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:205:10: style: inconclusive: Technically the member function 'autoware::occupancy_grid_map::fusion_policy::dempster_shafer_fusion::dempsterShaferOccupancy::calcK' can be const. [functionConst]
  double calcK(const dempsterShaferOccupancy & other)
         ^

perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:210:10: style: inconclusive: Technically the member function 'autoware::occupancy_grid_map::fusion_policy::dempster_shafer_fusion::dempsterShaferOccupancy::calcOccupied' can be const. [functionConst]
  double calcOccupied(const dempsterShaferOccupancy & other)
         ^

perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:215:10: style: inconclusive: Technically the member function 'autoware::occupancy_grid_map::fusion_policy::dempster_shafer_fusion::dempsterShaferOccupancy::calcEmpty' can be const. [functionConst]
  double calcEmpty(const dempsterShaferOccupancy & other)
         ^

perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp:243:10: style: inconclusive: Technically the member function 'autoware::occupancy_grid_map::fusion_policy::dempster_shafer_fusion::dempsterShaferOccupancy::getPignisticProbability' can be const. [functionConst]
  double getPignisticProbability() { return occupied + unknown / 2.0; }
         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
