### PR TITLE
fix(autoware_multi_object_tracker): fix functionConst

### DIFF
--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -94,7 +94,7 @@ void TrackerDebugger::publishTentativeObjects(
 
 // Time measurement functions
 
-void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat) const
 {
   if (!is_initialized_) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Measurement time is not set.");

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -94,7 +94,7 @@ void TrackerDebugger::publishTentativeObjects(
 
 // Time measurement functions
 
-void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat) const
+void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if (!is_initialized_) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Measurement time is not set.");

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -91,7 +91,7 @@ public:
   void endMeasurementTime(const rclcpp::Time & now);
   void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
-  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat) const;
+  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat); // cppcheck-suppress functionConst
 
   // Debug object
   void setObjectChannels(const std::vector<std::string> & channels)

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -91,7 +91,7 @@ public:
   void endMeasurementTime(const rclcpp::Time & now);
   void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
-  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat) const;
 
   // Debug object
   void setObjectChannels(const std::vector<std::string> & channels)

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -91,7 +91,8 @@ public:
   void endMeasurementTime(const rclcpp::Time & now);
   void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
-  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat); // cppcheck-suppress functionConst
+  void checkDelay(
+    diagnostic_updater::DiagnosticStatusWrapper & stat);  // cppcheck-suppress functionConst
 
   // Debug object
   void setObjectChannels(const std::vector<std::string> & channels)

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
@@ -60,7 +60,7 @@ public:
   void getObjectsOlderThan(
     const rclcpp::Time & object_latest_time, const rclcpp::Time & object_oldest_time,
     ObjectsList & objects_list);
-  void getNames(std::string & long_name, std::string & short_name)
+  void getNames(std::string & long_name, std::string & short_name) const
   {
     long_name = long_name_;
     short_name = short_name_;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
perception/autoware_multi_object_tracker/src/debugger/debugger.hpp:94:8: style: inconclusive: Technically the member function 'autoware::multi_object_tracker::TrackerDebugger::checkDelay' can be const. [functionConst]
  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat);
       ^

perception/autoware_multi_object_tracker/src/processor/input_manager.hpp:63:8: style: inconclusive: Technically the member function 'autoware::multi_object_tracker::InputStream::getNames' can be const. [functionConst]
  void getNames(std::string & long_name, std::string & short_name)
       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
