### PR TITLE
fix(autoware_ground_segmentation): fix functionConst

### DIFF
--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp
@@ -128,18 +128,18 @@ private:
 
     float getAverageSlope() { return std::atan2(height_avg, radius_avg); }
 
-    float getAverageHeight() { return height_avg; }
+    float getAverageHeight() const { return height_avg; }
 
-    float getAverageRadius() { return radius_avg; }
+    float getAverageRadius() const { return radius_avg; }
 
-    float getMaxHeight() { return height_max; }
+    float getMaxHeight() const { return height_max; }
 
-    float getMinHeight() { return height_min; }
+    float getMinHeight() const { return height_min; }
 
-    uint16_t getGridId() { return grid_id; }
+    uint16_t getGridId() const { return grid_id; }
 
-    pcl::PointIndices getIndices() { return pcl_indices; }
-    std::vector<float> getHeightList() { return height_list; }
+    pcl::PointIndices getIndices() const { return pcl_indices; }
+    std::vector<float> getHeightList() const { return height_list; }
 
     pcl::PointIndices & getIndicesRef() { return pcl_indices; }
     std::vector<float> & getHeightListRef() { return height_list; }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.
```
perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:131:11: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getAverageHeight' can be const. [functionConst]
    float getAverageHeight() { return height_avg; }
          ^

perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:133:11: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getAverageRadius' can be const. [functionConst]
    float getAverageRadius() { return radius_avg; }
          ^

perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:135:11: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getMaxHeight' can be const. [functionConst]
    float getMaxHeight() { return height_max; }
          ^

perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:137:11: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getMinHeight' can be const. [functionConst]
    float getMinHeight() { return height_min; }
          ^

perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:139:14: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getGridId' can be const. [functionConst]
    uint16_t getGridId() { return grid_id; }
             ^

perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:141:23: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getIndices' can be const. [functionConst]
    pcl::PointIndices getIndices() { return pcl_indices; }
                      ^

perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp:142:24: style: inconclusive: Technically the member function 'autoware::ground_segmentation::ScanGroundFilterComponent::PointsCentroid::getHeightList' can be const. [functionConst]
    std::vector<float> getHeightList() { return height_list; }
                       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
