### PR TITLE
fix(autoware_elevation_map_loader): fix functionConst

### DIFF
--- a/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.hpp
+++ b/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.hpp
@@ -45,7 +45,7 @@ class DataManager
 {
 public:
   DataManager() = default;
-  bool isInitialized()
+  bool isInitialized() const
   {
     if (use_lane_filter_) {
       return static_cast<bool>(elevation_map_path_) && static_cast<bool>(map_pcl_ptr_) &&


### PR DESCRIPTION
## Description

This is a fix based on cppcheck functionConst warnings.

```
elevation_map_loader_node.hpp:48:8: style: inconclusive: Technically the member function 'autoware::elevation_map_loader::DataManager::isInitialized' can be const. [functionConst]
  bool isInitialized()
       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
