### PR TITLE
fix(diagnostic_graph_aggregator): fix uninitMemberVar

### DIFF
--- a/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
@@ -18,10 +18,10 @@
 #include "data.hpp"
 #include "types.hpp"
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
-#include <limits>
 
 namespace diagnostic_graph_aggregator
 {

--- a/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
@@ -54,7 +54,7 @@ struct UnitConfig
   std::string path;
   LinkConfig * item = nullptr;
   std::vector<LinkConfig *> list;
-  size_t index = 0;
+  size_t index{};
 };
 
 struct FileConfig

--- a/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <limits>
 
 namespace diagnostic_graph_aggregator
 {
@@ -54,7 +55,7 @@ struct UnitConfig
   std::string path;
   LinkConfig * item = nullptr;
   std::vector<LinkConfig *> list;
-  size_t index{};
+  size_t index = std::numeric_limits<size_t>::max();
 };
 
 struct FileConfig

--- a/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
+++ b/system/diagnostic_graph_aggregator/src/common/graph/config.hpp
@@ -54,7 +54,7 @@ struct UnitConfig
   std::string path;
   LinkConfig * item = nullptr;
   std::vector<LinkConfig *> list;
-  size_t index;
+  size_t index = 0;
 };
 
 struct FileConfig


### PR DESCRIPTION
## Description
This is a fix based on cppcheck uninitMemberVar warnings.

```
system/diagnostic_graph_aggregator/src/common/graph/config.hpp:51:12: warning: Member variable 'UnitConfig::index' is not initialized in the constructor. [uninitMemberVar]
  explicit UnitConfig(const TreeData & data) : data(data) {}
           ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
