### PR TITLE
fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix uninitMemberVar

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp
@@ -46,9 +46,9 @@ struct ObstacleParameters
   double dynamic_obstacles_buffer{};
   double dynamic_obstacles_min_vel{};
   std::vector<std::string> static_map_tags{};
-  bool filter_envelope;
-  bool ignore_on_path;
-  double ignore_extra_distance;
+  bool filter_envelope{};
+  bool ignore_on_path{};
+  double ignore_extra_distance{};
   size_t rtree_min_points{};
   size_t rtree_min_segments{};
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck uninitMemberVar warnings.
```
planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp:55:3: warning: Member variable 'ObstacleParameters::filter_envelope' is not initialized in the constructor. [uninitMemberVar]
  ObstacleParameters() = default;
  ^

planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp:55:3: warning: Member variable 'ObstacleParameters::ignore_on_path' is not initialized in the constructor. [uninitMemberVar]
  ObstacleParameters() = default;
  ^

planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp:55:3: warning: Member variable 'ObstacleParameters::ignore_extra_distance' is not initialized in the constructor. [uninitMemberVar]
  ObstacleParameters() = default;
  ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
