### PR TITLE
fix(autoware_vehicle_cmd_gate): fix uninitMemberVar

### DIFF
--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
@@ -20,7 +20,7 @@
 namespace autoware::vehicle_cmd_gate
 {
 
-VehicleCmdFilter::VehicleCmdFilter()
+VehicleCmdFilter::VehicleCmdFilter() : param_()
 {
 }
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck uninitMemberVar warnings.

```
control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp:23:19: warning: Member variable 'VehicleCmdFilter::param_' is not initialized in the constructor. [uninitMemberVar]
VehicleCmdFilter::VehicleCmdFilter()
                  ^

```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
