### PR TITLE
fix(lane_change): skip path computation if len exceed dist to terminal start

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/interface.cpp
   src/manager.cpp
   src/scene.cpp
+  src/utils/calculation.cpp
   src/utils/markers.cpp
   src/utils/utils.cpp
 )

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -1,0 +1,45 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_
+#define AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_
+
+#include "autoware/behavior_path_lane_change_module/utils/data_structs.hpp"
+
+namespace autoware::behavior_path_planner::utils::lane_change::calculation
+{
+using behavior_path_planner::lane_change::CommonDataPtr;
+
+/**
+ * @brief Calculates the distance from the ego vehicle to the terminal point.
+ *
+ * This function computes the distance from the current position of the ego vehicle
+ * to either the goal pose or the end of the current lane, depending on whether
+ * the vehicle's current lane is within the goal section.
+ *
+ * @param common_data_ptr Shared pointer to a CommonData structure, which should include:
+ *  - Non null `lanes_ptr` that points to the current lanes data.
+ *  - Non null `self_odometry_ptr` that contains the current pose of the ego vehicle.
+ *  - Non null `route_handler_ptr` that contains the goal pose of the route.
+ *
+ * @return The distance to the terminal point (either the goal pose or the end of the current lane)
+ * in meters.
+ */
+double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr);
+
+double calc_dist_from_pose_to_terminal_end(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
+  const Pose & src_pose);
+}  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
+
+#endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -1,0 +1,45 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/behavior_path_lane_change_module/utils/calculation.hpp>
+#include <autoware/behavior_path_planner_common/utils/utils.hpp>
+
+namespace autoware::behavior_path_planner::utils::lane_change::calculation
+{
+double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr)
+{
+  const auto & lanes_ptr = common_data_ptr->lanes_ptr;
+  const auto & current_lanes = lanes_ptr->current;
+  const auto & current_pose = common_data_ptr->get_ego_pose();
+
+  return calc_dist_from_pose_to_terminal_end(common_data_ptr, current_lanes, current_pose);
+}
+
+double calc_dist_from_pose_to_terminal_end(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
+  const Pose & src_pose)
+{
+  if (lanes.empty()) {
+    return 0.0;
+  }
+
+  const auto & lanes_ptr = common_data_ptr->lanes_ptr;
+  const auto & goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
+
+  if (lanes_ptr->current_lane_in_goal_section) {
+    return utils::getSignedDistance(src_pose, goal_pose, lanes);
+  }
+  return utils::getDistanceToEndOfLane(src_pose, lanes);
+}
+}  // namespace autoware::behavior_path_planner::utils::lane_change::calculation


### PR DESCRIPTION
## Description

Lane change module evaluates the distance from preparation start to lane changing end at later phase.
Hence, if prepare path's lengths exceed distance to lane change terminal start, there will be unnecessary checks and computation before the evaluation.

This PR aims to fix this by skipping path computation if the prepare segment length exceed ego current distance to terminal start.

![diagram_for_PR (4)](https://github.com/user-attachments/assets/8a9ad9ad-7121-41aa-b3a6-34ce3247a698)

This PR also add `computation.hpp/cpp` to avoid `utils.hpp/cpp` file from having too many number of lines 

### After PR

```
[DEBUG 1722854092.480406897] [lane_change.NORMAL]: Reject: Prepare length exceed distance to terminal start. prep_len: 8.00000,  ego dist to terminal start: 7.83372 (getLaneChangePaths() at /home/zulfaqar/autoware/pilot-auto/src/autoware/universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp:1411)
[DEBUG 1722854092.480501893] [lane_change.NORMAL]: Prepare path satisfy constraints | prep_time: 4.00000 | lon_acc sampled: 0.80000, actual: 0.80000 | prep_len: 6.40000 (operator()() at /home/zulfaqar/autoware/pilot-auto/src/autoware/universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp:1422)
```

Path exceed ego dist to terminal  start is being  rejected.

## Related links

Depends on https://github.com/autowarefoundation/autoware.universe/pull/8358

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
