### PR TITLE
fix(lane_change): skip generating path if longitudinal distance difference is less than threshold

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -26,6 +26,11 @@
       min_longitudinal_acc: -1.0
       max_longitudinal_acc: 1.0
 
+      skip_process:
+        longitudinal_distance_diff_threshold:
+          prepare: 0.5
+          lane_changing: 0.5
+
       # safety check
       safety_check:
         allow_loose_check_for_cancel: true

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -124,6 +124,9 @@ struct Parameters
   double min_longitudinal_acc{-1.0};
   double max_longitudinal_acc{1.0};
 
+  double skip_process_lon_diff_th_prepare{0.5};
+  double skip_process_lon_diff_th_lane_changing{1.0};
+
   // collision check
   bool enable_collision_check_for_prepare_phase_in_general_lanes{false};
   bool enable_collision_check_for_prepare_phase_in_intersection{true};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -355,6 +355,13 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
   }
 
   {
+    const std::string ns = "lane_change.skip_process.longitudinal_distance_diff_threshold.";
+    updateParam<double>(parameters, ns + "prepare", p->skip_process_lon_diff_th_prepare);
+    updateParam<double>(
+      parameters, ns + "lane_changing", p->skip_process_lon_diff_th_lane_changing);
+  }
+
+  {
     const std::string ns = "lane_change.safety_check.lane_expansion.";
     updateParam<double>(parameters, ns + "left_offset", p->lane_expansion_left_offset);
     updateParam<double>(parameters, ns + "right_offset", p->lane_expansion_right_offset);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1500,6 +1500,8 @@ bool NormalLaneChange::getLaneChangePaths(
           const auto lc_length_diff =
             candidate_paths->back().info.length.lane_changing - lane_changing_length;
 
+          // We only check lc_length_diff if and only if the current prepare_length is equal to the
+          // previous prepare_length.
           if (
             std::abs(prev_prep_diff) < eps &&
             std::abs(lc_length_diff) <

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1417,6 +1417,13 @@ bool NormalLaneChange::getLaneChangePaths(
         continue;
       }
 
+      if (!candidate_paths->empty()) {
+        const auto prev_prep_diff = candidate_paths->back().info.length.prepare - prepare_length;
+        if (std::abs(prev_prep_diff) < lane_change_parameters_->skip_process_lon_diff_th_prepare) {
+          RCLCPP_DEBUG(logger_, "Skip: Change in prepare length is less than threshold.");
+          continue;
+        }
+      }
       auto prepare_segment = getPrepareSegment(current_lanes, backward_path_length, prepare_length);
 
       const auto debug_print = [&](const auto & s) {
@@ -1488,6 +1495,19 @@ bool NormalLaneChange::getLaneChangePaths(
             lane_changing_time, sampled_longitudinal_acc, longitudinal_acc_on_lane_changing,
             lane_changing_length);
         };
+        if (!candidate_paths->empty()) {
+          const auto prev_prep_diff = candidate_paths->back().info.length.prepare - prepare_length;
+          const auto lc_length_diff =
+            candidate_paths->back().info.length.lane_changing - lane_changing_length;
+
+          if (
+            std::abs(prev_prep_diff) < eps &&
+            std::abs(lc_length_diff) <
+              lane_change_parameters_->skip_process_lon_diff_th_lane_changing) {
+            RCLCPP_DEBUG(logger_, "Skip: Change in lane changing length is less than threshold.");
+            continue;
+          }
+        }
 
         if (lane_changing_length + prepare_length > dist_to_end_of_current_lanes) {
           debug_print_lat("Reject: length of lane changing path is longer than length to goal!!");


### PR DESCRIPTION
## Description

**Current behavior:**

The number of lane change  samples increases as ego vehicle approaches terminal start, due to the greater number of longitudinal acceleration samples.

The increase in lane change samples also leads to higher computational costs, as each sample generates a candidate path and undergoes various validations.

**Proposed behavior:**

Each lane change sample is computed based on the corresponding longitudinal acceleration sample.

As the ego vehicle approaches the terminal start, the distance differences between each lane change sample become smaller. 

In this case, if the distance difference is small and the previous path is unsafe, it's likely that the new path with a small distance difference will also be unsafe. Therefore, it is feasible to skip generating paths with small distance differences and focus on those with larger differences instead.

Following are the illustrations of the **proposed behavior**

![prepare_diff_th](https://github.com/user-attachments/assets/dc0384f4-dc82-4e49-8b31-4d99a20d4535)

![lc_diff_th](https://github.com/user-attachments/assets/d7ba5729-0d03-4d2e-ba2b-3c9e1368bf49)

**Before PR**

Has more number of candidate path (5 samples) and processing time is between 7~10ms. 

https://github.com/user-attachments/assets/17b3b757-57ef-432d-9668-6c80e0f0f43c

**After PR**

Has less number of candidate path (3 sample) and processing time is between 5~8ms. 

https://github.com/user-attachments/assets/10d88bad-07f4-454d-a7cd-15475303f551

## Related links
Required https://github.com/autowarefoundation/autoware.universe/pull/8362
Required launcher: https://github.com/autowarefoundation/autoware_launch/pull/1108
**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
