### PR TITLE
chore(codecov): ignore test directory in codecov

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,3 +26,7 @@ flag_management:
         type: patch
         target: 0% # Make CI always succeed
         threshold: 100% # Make CI always succeed
+
+ignore:
+  - "**/test/*"
+  - "**/test/**/*"


### PR DESCRIPTION
## Description

Currently, Codecov displays the coverage of test files, but I believe the coverage of the tests themselves is unnecessary. With this setting, we can exclude files under test/** from the coverage report.

## Related links

Same settings is tested in [here](https://github.com/yhisaki/ros2-unit-test-sample).

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
