### PR TITLE
fix(lane_change): do not cancel when approaching terminal start

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -92,6 +92,8 @@ public:
 
   bool isAbleToReturnCurrentLane() const override;
 
+  bool is_near_terminal() const final;
+
   bool isEgoOnPreparePhase() const override;
 
   bool isAbleToStopSafely() const override;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -93,6 +93,8 @@ public:
 
   virtual bool isAbleToReturnCurrentLane() const = 0;
 
+  virtual bool is_near_terminal() const = 0;
+
   virtual LaneChangePath getLaneChangePath() const = 0;
 
   virtual BehaviorModuleOutput getTerminalLaneChangePath() const = 0;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -19,6 +19,7 @@
 namespace autoware::behavior_path_planner::utils::lane_change::calculation
 {
 using behavior_path_planner::lane_change::CommonDataPtr;
+using behavior_path_planner::lane_change::LCParamPtr;
 
 /**
  * @brief Calculates the distance from the ego vehicle to the terminal point.
@@ -40,6 +41,23 @@ double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr);
 double calc_dist_from_pose_to_terminal_end(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
   const Pose & src_pose);
+
+/**
+ * @brief Calculates the backward buffer distance required for safe lane changing.
+ *
+ * This function computes the minimum required backward buffer distance based on the
+ * minimum lane changing velocity and the minimum longitudinal acceleration. It then
+ * compares this calculated distance with a pre-defined backward length buffer parameter
+ * and returns the larger of the two values to ensure safe lane changing.
+ *
+ * @param lc_param_ptr Shared pointer to an LCParam structure, which should include:
+ *  - `minimum_lane_changing_velocity`: The minimum velocity required for lane changing.
+ *  - `min_longitudinal_acc`: The minimum longitudinal acceleration used for deceleration.
+ *  - `backward_length_buffer_for_end_of_lane`: A predefined backward buffer length parameter.
+ *
+ * @return The required backward buffer distance in meters.
+ */
+double calc_backward_buffer(const LCParamPtr & lc_param_ptr);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -43,9 +43,9 @@ double calc_dist_from_pose_to_terminal_end(
   const Pose & src_pose);
 
 /**
- * @brief Calculates the backward buffer distance required for safe lane changing.
+ * @brief Calculates the minimum stopping distance to terminal start.
  *
- * This function computes the minimum required backward buffer distance based on the
+ * This function computes the minimum stopping distance to terminal start based on the
  * minimum lane changing velocity and the minimum longitudinal acceleration. It then
  * compares this calculated distance with a pre-defined backward length buffer parameter
  * and returns the larger of the two values to ensure safe lane changing.
@@ -57,7 +57,7 @@ double calc_dist_from_pose_to_terminal_end(
  *
  * @return The required backward buffer distance in meters.
  */
-double calc_backward_buffer(const LCParamPtr & lc_param_ptr);
+double calc_stopping_distance(const LCParamPtr & lc_param_ptr);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -265,6 +265,11 @@ bool LaneChangeInterface::canTransitFailureState()
     return true;
   }
 
+  if (module_type_->is_near_terminal()) {
+    log_debug_throttled("Unsafe, but ego is approaching terminal. Continue lane change");
+    return false;
+  }
+
   if (module_type_->isCancelEnabled() && module_type_->isEgoOnPreparePhase()) {
     if (module_type_->isStoppedAtRedTrafficLight()) {
       log_debug_throttled("Stopping at traffic light while in prepare phase. Cancel lane change");

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -295,6 +295,11 @@ bool LaneChangeInterface::canTransitFailureState()
 
     if (post_process_safety_status_.is_safe) {
       log_debug_throttled("Can't transit to failure state. Ego is on prepare, and it's safe.");
+
+      if (module_type_->isRequiredStop(post_process_safety_status_.is_object_coming_from_rear)) {
+        log_debug_throttled("Module require stopping");
+      }
+
       return false;
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -267,6 +267,10 @@ bool LaneChangeInterface::canTransitFailureState()
 
   if (module_type_->is_near_terminal()) {
     log_debug_throttled("Unsafe, but ego is approaching terminal. Continue lane change");
+
+    if (module_type_->isRequiredStop(post_process_safety_status_.is_trailing_object)) {
+      log_debug_throttled("Module require stopping");
+    }
     return false;
   }
 
@@ -295,11 +299,6 @@ bool LaneChangeInterface::canTransitFailureState()
 
     if (post_process_safety_status_.is_safe) {
       log_debug_throttled("Can't transit to failure state. Ego is on prepare, and it's safe.");
-
-      if (module_type_->isRequiredStop(post_process_safety_status_.is_object_coming_from_rear)) {
-        log_debug_throttled("Module require stopping");
-      }
-
       return false;
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -768,6 +768,31 @@ bool NormalLaneChange::isAbleToReturnCurrentLane() const
   return true;
 }
 
+bool NormalLaneChange::is_near_terminal() const
+{
+  const auto & current_lanes = common_data_ptr_->lanes_ptr->current;
+
+  if (current_lanes.empty()) {
+    return true;
+  }
+
+  const auto & current_lanes_terminal = current_lanes.back();
+  const auto & lc_param_ptr = common_data_ptr_->lc_param_ptr;
+  const auto direction = common_data_ptr_->direction;
+  const auto & route_handler_ptr = common_data_ptr_->route_handler_ptr;
+  const auto min_lane_changing_distance = calcMinimumLaneChangeLength(
+    route_handler_ptr, current_lanes_terminal, *lc_param_ptr, direction);
+
+  const auto backward_buffer = calculation::calc_backward_buffer(lc_param_ptr);
+
+  const auto min_lc_dist_with_buffer =
+    backward_buffer + min_lane_changing_distance + lc_param_ptr->lane_change_finish_judge_buffer;
+  const auto dist_from_ego_to_terminal_end =
+    calculation::calc_ego_dist_to_terminal_end(common_data_ptr_);
+
+  return dist_from_ego_to_terminal_end < min_lc_dist_with_buffer;
+}
+
 bool NormalLaneChange::isEgoOnPreparePhase() const
 {
   const auto & start_position = status_.lane_change_path.info.shift_line.start.position;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -783,7 +783,7 @@ bool NormalLaneChange::is_near_terminal() const
   const auto min_lane_changing_distance = calcMinimumLaneChangeLength(
     route_handler_ptr, current_lanes_terminal, *lc_param_ptr, direction);
 
-  const auto backward_buffer = calculation::calc_backward_buffer(lc_param_ptr);
+  const auto backward_buffer = calculation::calc_stopping_distance(lc_param_ptr);
 
   const auto min_lc_dist_with_buffer =
     backward_buffer + min_lane_changing_distance + lc_param_ptr->lane_change_finish_judge_buffer;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -44,7 +44,7 @@ double calc_dist_from_pose_to_terminal_end(
   return utils::getDistanceToEndOfLane(src_pose, lanes);
 }
 
-double calc_backward_buffer(const LCParamPtr & lc_param_ptr)
+double calc_stopping_distance(const LCParamPtr & lc_param_ptr)
 {
   // v^2 = u^2 + 2ad
   const auto min_lc_vel = lc_param_ptr->minimum_lane_changing_velocity;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -1,3 +1,4 @@
+
 // Copyright 2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,5 +42,16 @@ double calc_dist_from_pose_to_terminal_end(
     return utils::getSignedDistance(src_pose, goal_pose, lanes);
   }
   return utils::getDistanceToEndOfLane(src_pose, lanes);
+}
+
+double calc_backward_buffer(const LCParamPtr & lc_param_ptr)
+{
+  // v^2 = u^2 + 2ad
+  const auto min_lc_vel = lc_param_ptr->minimum_lane_changing_velocity;
+  const auto min_lon_acc = lc_param_ptr->min_longitudinal_acc;
+  const auto min_back_dist = std::abs((min_lc_vel * min_lc_vel) / (2 * min_lon_acc));
+
+  const auto param_back_dist = lc_param_ptr->backward_length_buffer_for_end_of_lane;
+  return std::max(min_back_dist, param_back_dist);
 }
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation


### PR DESCRIPTION
## Description

Lane change module will cancel unsafe path unless ego has passed terminal start point.
However, as ego vehicle approaching terminal end, cancelling lane change path might result in difficulties in re-attempting lane change.

This PR aims to fix this, by not cancelling lane change if ego has already near terminal start.

## Related links

None

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
