### PR TITLE
fix(autoware_traffic_light_classifier): fix passedByValue

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -195,7 +195,7 @@ bool CNNClassifier::readLabelfile(std::string filepath, std::vector<std::string>
   return true;
 }
 
-bool CNNClassifier::isColorLabel(const std::string label)
+bool CNNClassifier::isColorLabel(const std::string & label)
 {
   using tier4_perception_msgs::msg::TrafficLight;
   if (

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
@@ -63,7 +63,7 @@ private:
   void postProcess(
     int class_index, float prob, tier4_perception_msgs::msg::TrafficLight & traffic_signal);
   bool readLabelfile(std::string filepath, std::vector<std::string> & labels);
-  bool isColorLabel(const std::string label);
+  bool isColorLabel(const std::string & label);
   void outputDebugImage(
     cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal);
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck passedByValue warnings

```
perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp:198:52: performance: Function parameter 'label' should be passed by const reference. [passedByValue]
bool CNNClassifier::isColorLabel(const std::string label)
                                                   ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
