### PR TITLE
perf(map_based_prediction): use linear interpolation for path conversion

### DIFF
--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2395,9 +2395,15 @@ std::vector<PosePath> MapBasedPredictionNode::convertPathType(
             continue;
           }
 
-          const double lane_yaw = std::atan2(
-            current_p.position.y - prev_p.position.y, current_p.position.x - prev_p.position.x);
-          current_p.orientation = autoware::universe_utils::createQuaternionFromYaw(lane_yaw);
+          const double dx = current_p.position.x - prev_p.position.x;
+          const double dy = current_p.position.y - prev_p.position.y;
+          const double sin_yaw_half = dy / (std::sqrt(dx * dx + dy * dy) + dx);
+          const double cos_yaw_half = std::sqrt(1 - sin_yaw_half * sin_yaw_half);
+          current_p.orientation.x = 0.0;
+          current_p.orientation.y = 0.0;
+          current_p.orientation.z = sin_yaw_half;
+          current_p.orientation.w = cos_yaw_half;
+
           converted_path.push_back(current_p);
           prev_p = current_p;
         }
@@ -2426,9 +2432,15 @@ std::vector<PosePath> MapBasedPredictionNode::convertPathType(
           }
         }
 
-        const double lane_yaw = std::atan2(
-          current_p.position.y - prev_p.position.y, current_p.position.x - prev_p.position.x);
-        current_p.orientation = autoware::universe_utils::createQuaternionFromYaw(lane_yaw);
+        const double dx = current_p.position.x - prev_p.position.x;
+        const double dy = current_p.position.y - prev_p.position.y;
+        const double sin_yaw_half = dy / (std::sqrt(dx * dx + dy * dy) + dx);
+        const double cos_yaw_half = std::sqrt(1 - sin_yaw_half * sin_yaw_half);
+        current_p.orientation.x = 0.0;
+        current_p.orientation.y = 0.0;
+        current_p.orientation.z = sin_yaw_half;
+        current_p.orientation.w = cos_yaw_half;
+        
         converted_path.push_back(current_p);
         prev_p = current_p;
       }

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2440,15 +2440,21 @@ std::vector<PosePath> MapBasedPredictionNode::convertPathType(
         current_p.orientation.y = 0.0;
         current_p.orientation.z = sin_yaw_half;
         current_p.orientation.w = cos_yaw_half;
-        
+
         converted_path.push_back(current_p);
         prev_p = current_p;
       }
     }
 
     // Resample Path
-    const auto resampled_converted_path =
-      autoware::motion_utils::resamplePoseVector(converted_path, reference_path_resolution_);
+    const bool use_akima_spline_for_xy = true;
+    const bool use_lerp_for_z = true;
+    // the options use_akima_slpine_for_xy and use_lerp_for_z are set to true
+    // but the implementation of use_akima_slpine_for_xy in resamplePoseVector and
+    // resamplePointVector is opposite to the options so the options are set to true to use linear
+    // interpolation for xy
+    const auto resampled_converted_path = autoware::motion_utils::resamplePoseVector(
+      converted_path, reference_path_resolution_, use_akima_spline_for_xy, use_lerp_for_z);
     converted_paths.push_back(resampled_converted_path);
   }
 


### PR DESCRIPTION
## Description
CPU usage of the map based prediction is high.
One of the reason is to using spline interpolation in predicted path conversion.

1. using linear interpolation
2. simplify quaternion calculation only for yaw


In the worst cases, `convertPathType` is increasing. Therefore, this part should be improved.

## Related links

- Link
Another performance improvement PR https://github.com/autowarefoundation/autoware.universe/pull/8388

## How was this PR tested?
Tested in a local environment and the relative performance was measured using modified [autoware_debug_tool](https://github.com/autowarefoundation/autoware_tools/pull/92).



With the linear interpolation, the average time is reduced from 0.41 to 0.28 [ms] avg..


* before
```
⏰ Worst Case Execution Time ⏰
100.00% objectsCallback: total 110.49 [ms], avg. 110.49 [ms], run count: 1
    ├── 0.01% trafficSignalsCallback: total 0.01 [ms], avg. 0.01 [ms], run count: 1
    ├── 0.00% removeStaleTrafficLightInfo: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── 0.02% updateObjectData: total 0.02 [ms], avg. 0.00 [ms], run count: 21
    ├── 4.35% getCurrentLanelets: total 4.80 [ms], avg. 0.23 [ms], run count: 21
    │   ├── 1.09% checkCloseLaneletCondition: total 1.21 [ms], avg. 0.01 [ms], run count: 210
    │   ├── 0.00% isDuplicated: total 0.00 [ms], avg. 0.00 [ms], run count: 36
    │   ├── 0.21% calculateLocalLikelihood: total 0.23 [ms], avg. 0.01 [ms], run count: 22
    │   └── 3.04% rest: 3.36 [ms]
    ├── 9.55% updateRoadUsersHistory: total 10.56 [ms], avg. 0.50 [ms], run count: 21
    ├── 35.12% getPredictedReferencePath: total 38.80 [ms], avg. 2.77 [ms], run count: 14
    │   ├── 0.47% predictObjectManeuver: total 0.52 [ms], avg. 0.03 [ms], run count: 15
    │   │   ├── 0.41% predictObjectManeuverByLatDiffDistance: total 0.46 [ms], avg. 0.03 [ms], run count: 15
    │   │   │   ├── 0.05% calcRightLateralOffset: total 0.05 [ms], avg. 0.00 [ms], run count: 52
    │   │   │   └── 0.36% rest: 0.40 [ms]
    │   │   └── 0.05% rest: 0.06 [ms]
    │   ├── 0.01% calculateManeuverProbability: total 0.02 [ms], avg. 0.00 [ms], run count: 15
    │   ├── 30.21% addReferencePaths: total 33.38 [ms], avg. 0.74 [ms], run count: 45
    │   │   ├── 0.10% updateFuturePossibleLanelets: total 0.12 [ms], avg. 0.00 [ms], run count: 26
    │   │   ├── 29.54% convertPathType: total 32.64 [ms], avg. 1.26 [ms], run count: 26
    │   │   └── 0.56% rest: 0.62 [ms]
    │   └── 4.43% rest: 4.89 [ms]
    ├── 0.02% updateCrosswalkUserHistory: total 0.02 [ms], avg. 0.00 [ms], run count: 6
    ├── 27.04% getPredictedObjectAsCrosswalkUser: total 29.88 [ms], avg. 4.98 [ms], run count: 6
    │   ├── 0.06% getTrafficSignalId: total 0.07 [ms], avg. 0.00 [ms], run count: 852
    │   ├── 1.16% calcIntentionToCrossWithTrafficSignal: total 1.28 [ms], avg. 0.00 [ms], run count: 570
    │   │   ├── 0.02% getTrafficSignalElement: total 0.02 [ms], avg. 0.00 [ms], run count: 570
    │   │   └── 1.14% rest: 1.26 [ms]
    │   ├── 10.97% doesPathCrossAnyFence: total 12.12 [ms], avg. 2.02 [ms], run count: 6
    │   └── 14.85% rest: 16.41 [ms]
    └── 23.89% rest: 26.40 [ms]

🌲 Total Processing Time Tree 🌲
100.00% objectsCallback: total 14453.88 [ms], avg. 26.23 [ms], run count: 551
    ├── 0.05% trafficSignalsCallback: total 7.55 [ms], avg. 0.01 [ms], run count: 551
    ├── 0.00% removeStaleTrafficLightInfo: total 0.35 [ms], avg. 0.00 [ms], run count: 551
    ├── 0.04% updateObjectData: total 5.23 [ms], avg. 0.00 [ms], run count: 7411
    ├── 11.84% getCurrentLanelets: total 1710.88 [ms], avg. 0.23 [ms], run count: 7411
    │   ├── 3.82% checkCloseLaneletCondition: total 552.58 [ms], avg. 0.01 [ms], run count: 74110
    │   ├── 0.02% isDuplicated: total 2.29 [ms], avg. 0.00 [ms], run count: 11331
    │   ├── 0.94% calculateLocalLikelihood: total 136.12 [ms], avg. 0.02 [ms], run count: 6915
    │   └── 7.06% rest: 1019.89 [ms]
    ├── 0.70% updateRoadUsersHistory: total 101.20 [ms], avg. 0.01 [ms], run count: 7411
    ├── 0.03% updateCrosswalkUserHistory: total 4.74 [ms], avg. 0.00 [ms], run count: 1480
    ├── 17.12% getPredictedObjectAsCrosswalkUser: total 2475.08 [ms], avg. 1.67 [ms], run count: 1480
    │   ├── 0.21% getTrafficSignalId: total 29.89 [ms], avg. 0.00 [ms], run count: 210160
    │   ├── 1.86% calcIntentionToCrossWithTrafficSignal: total 268.13 [ms], avg. 0.00 [ms], run count: 140600
    │   │   ├── 0.06% getTrafficSignalElement: total 8.84 [ms], avg. 0.00 [ms], run count: 140600
    │   │   └── 1.79% rest: 259.29 [ms]
    │   ├── 6.43% doesPathCrossAnyFence: total 929.93 [ms], avg. 1.75 [ms], run count: 530
    │   └── 8.63% rest: 1247.13 [ms]
    ├── 32.25% getPredictedReferencePath: total 4661.87 [ms], avg. 1.10 [ms], run count: 4251
    │   ├── 1.27% predictObjectManeuver: total 183.22 [ms], avg. 0.04 [ms], run count: 4400
    │   │   ├── 1.15% predictObjectManeuverByLatDiffDistance: total 166.86 [ms], avg. 0.04 [ms], run count: 4400
    │   │   │   ├── 0.19% calcRightLateralOffset: total 27.61 [ms], avg. 0.00 [ms], run count: 13824
    │   │   │   └── 0.96% rest: 139.25 [ms]
    │   │   └── 0.11% rest: 16.36 [ms]
    │   ├── 0.02% calculateManeuverProbability: total 2.72 [ms], avg. 0.00 [ms], run count: 4400
    │   ├── 28.95% addReferencePaths: total 4184.06 [ms], avg. 0.32 [ms], run count: 13200
    │   │   ├── 0.22% updateFuturePossibleLanelets: total 31.13 [ms], avg. 0.00 [ms], run count: 8459
    │   │   ├── 27.12% convertPathType: total 3920.45 [ms], avg. 0.46 [ms], run count: 8459
    │   │   └── 1.61% rest: 232.48 [ms]
    │   └── 2.02% rest: 291.87 [ms]
    └── 37.96% rest: 5486.99 [ms]

```

* after ped cross search (PR 8388)
```
⏰ Worst Case Execution Time ⏰
100.00% objectsCallback: total 121.33 [ms], avg. 121.33 [ms], run count: 1
    ├── 0.01% trafficSignalsCallback: total 0.02 [ms], avg. 0.02 [ms], run count: 1
    ├── 0.00% removeStaleTrafficLightInfo: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── 0.03% updateObjectData: total 0.04 [ms], avg. 0.00 [ms], run count: 8
    ├── 9.70% getCurrentLanelets: total 11.78 [ms], avg. 1.47 [ms], run count: 8
    │   ├── 2.59% checkCloseLaneletCondition: total 3.14 [ms], avg. 0.04 [ms], run count: 80
    │   ├── 0.01% isDuplicated: total 0.01 [ms], avg. 0.00 [ms], run count: 13
    │   ├── 0.36% calculateLocalLikelihood: total 0.43 [ms], avg. 0.06 [ms], run count: 7
    │   └── 6.75% rest: 8.20 [ms]
    ├── 0.25% updateRoadUsersHistory: total 0.30 [ms], avg. 0.04 [ms], run count: 8
    ├── 38.91% getPredictedReferencePath: total 47.21 [ms], avg. 7.87 [ms], run count: 6
    │   ├── 6.51% predictObjectManeuver: total 7.90 [ms], avg. 1.32 [ms], run count: 6
    │   │   ├── 6.46% predictObjectManeuverByLatDiffDistance: total 7.83 [ms], avg. 1.31 [ms], run count: 6
    │   │   │   ├── 0.10% calcRightLateralOffset: total 0.12 [ms], avg. 0.00 [ms], run count: 24
    │   │   │   └── 6.36% rest: 7.71 [ms]
    │   │   └── 0.06% rest: 0.07 [ms]
    │   ├── 0.01% calculateManeuverProbability: total 0.01 [ms], avg. 0.00 [ms], run count: 6
    │   ├── 31.51% addReferencePaths: total 38.23 [ms], avg. 2.12 [ms], run count: 18
    │   │   ├── 0.11% updateFuturePossibleLanelets: total 0.13 [ms], avg. 0.01 [ms], run count: 12
    │   │   ├── 30.93% convertPathType: total 37.52 [ms], avg. 3.13 [ms], run count: 12
    │   │   └── 0.47% rest: 0.57 [ms]
    │   └── 0.88% rest: 1.06 [ms]
    ├── 0.02% updateCrosswalkUserHistory: total 0.03 [ms], avg. 0.01 [ms], run count: 4
    ├── 4.71% getPredictedObjectAsCrosswalkUser: total 5.71 [ms], avg. 1.43 [ms], run count: 4
    └── 46.36% rest: 56.25 [ms]

🌲 Total Processing Time Tree 🌲
100.00% objectsCallback: total 13432.69 [ms], avg. 22.92 [ms], run count: 586
    ├── 0.06% trafficSignalsCallback: total 8.65 [ms], avg. 0.01 [ms], run count: 586
    ├── 0.00% removeStaleTrafficLightInfo: total 0.46 [ms], avg. 0.00 [ms], run count: 586
    ├── 0.07% updateObjectData: total 8.76 [ms], avg. 0.00 [ms], run count: 8907
    ├── 14.62% getCurrentLanelets: total 1964.45 [ms], avg. 0.22 [ms], run count: 8907
    │   ├── 5.06% checkCloseLaneletCondition: total 679.85 [ms], avg. 0.01 [ms], run count: 89070
    │   ├── 0.03% isDuplicated: total 4.48 [ms], avg. 0.00 [ms], run count: 12791
    │   ├── 1.16% calculateLocalLikelihood: total 155.60 [ms], avg. 0.02 [ms], run count: 7960
    │   └── 8.37% rest: 1124.52 [ms]
    ├── 0.81% updateRoadUsersHistory: total 108.44 [ms], avg. 0.01 [ms], run count: 8907
    ├── 35.17% getPredictedReferencePath: total 4724.37 [ms], avg. 1.02 [ms], run count: 4615
    │   ├── 1.90% predictObjectManeuver: total 255.00 [ms], avg. 0.05 [ms], run count: 4844
    │   │   ├── 1.71% predictObjectManeuverByLatDiffDistance: total 230.25 [ms], avg. 0.05 [ms], run count: 4844
    │   │   │   ├── 0.20% calcRightLateralOffset: total 26.30 [ms], avg. 0.00 [ms], run count: 14748
    │   │   │   └── 1.52% rest: 203.95 [ms]
    │   │   └── 0.18% rest: 24.75 [ms]
    │   ├── 0.03% calculateManeuverProbability: total 3.85 [ms], avg. 0.00 [ms], run count: 4844
    │   ├── 29.87% addReferencePaths: total 4012.35 [ms], avg. 0.28 [ms], run count: 14532
    │   │   ├── 0.26% updateFuturePossibleLanelets: total 35.39 [ms], avg. 0.00 [ms], run count: 9213
    │   │   ├── 27.97% convertPathType: total 3756.88 [ms], avg. 0.41 [ms], run count: 9213
    │   │   └── 1.64% rest: 220.08 [ms]
    │   └── 3.37% rest: 453.16 [ms]
    ├── 0.08% updateCrosswalkUserHistory: total 11.20 [ms], avg. 0.01 [ms], run count: 1871
    ├── 3.85% getPredictedObjectAsCrosswalkUser: total 517.24 [ms], avg. 0.28 [ms], run count: 1871
    │   ├── 0.02% getTrafficSignalId: total 2.56 [ms], avg. 0.00 [ms], run count: 2036
    │   ├── 0.05% calcIntentionToCrossWithTrafficSignal: total 7.22 [ms], avg. 0.00 [ms], run count: 2036
    │   │   ├── 0.00% getTrafficSignalElement: total 0.60 [ms], avg. 0.00 [ms], run count: 2036
    │   │   └── 0.05% rest: 6.62 [ms]
    │   ├── 0.10% doesPathCrossAnyFence: total 12.83 [ms], avg. 0.02 [ms], run count: 670
    │   └── 3.68% rest: 494.63 [ms]
    └── 45.33% rest: 6089.13 [ms]
```

* after linear interpolation (this PR)
```
⏰ Worst Case Execution Time ⏰
100.00% objectsCallback: total 94.21 [ms], avg. 94.21 [ms], run count: 1
    ├── 0.02% trafficSignalsCallback: total 0.02 [ms], avg. 0.02 [ms], run count: 1
    ├── 0.00% removeStaleTrafficLightInfo: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── 0.04% updateObjectData: total 0.03 [ms], avg. 0.00 [ms], run count: 15
    ├── 14.64% getCurrentLanelets: total 13.79 [ms], avg. 0.92 [ms], run count: 15
    │   ├── 12.45% checkCloseLaneletCondition: total 11.73 [ms], avg. 0.08 [ms], run count: 150
    │   ├── 0.01% isDuplicated: total 0.01 [ms], avg. 0.00 [ms], run count: 30
    │   ├── 0.28% calculateLocalLikelihood: total 0.27 [ms], avg. 0.02 [ms], run count: 14
    │   └── 1.90% rest: 1.79 [ms]
    ├── 0.46% updateRoadUsersHistory: total 0.44 [ms], avg. 0.03 [ms], run count: 15
    ├── 50.71% getPredictedReferencePath: total 47.77 [ms], avg. 3.41 [ms], run count: 14
    │   ├── 0.65% predictObjectManeuver: total 0.62 [ms], avg. 0.04 [ms], run count: 14
    │   │   ├── 0.60% predictObjectManeuverByLatDiffDistance: total 0.56 [ms], avg. 0.04 [ms], run count: 14
    │   │   │   ├── 0.06% calcRightLateralOffset: total 0.05 [ms], avg. 0.00 [ms], run count: 40
    │   │   │   └── 0.54% rest: 0.51 [ms]
    │   │   └── 0.06% rest: 0.06 [ms]
    │   ├── 0.02% calculateManeuverProbability: total 0.02 [ms], avg. 0.00 [ms], run count: 14
    │   ├── 46.51% addReferencePaths: total 43.81 [ms], avg. 1.04 [ms], run count: 42
    │   │   ├── 0.18% updateFuturePossibleLanelets: total 0.17 [ms], avg. 0.01 [ms], run count: 30
    │   │   ├── 40.36% convertPathType: total 38.02 [ms], avg. 1.27 [ms], run count: 30
    │   │   └── 5.97% rest: 5.62 [ms]
    │   └── 3.53% rest: 3.33 [ms]
    ├── 0.00% updateCrosswalkUserHistory: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── 0.20% getPredictedObjectAsCrosswalkUser: total 0.18 [ms], avg. 0.18 [ms], run count: 1
    └── 33.92% rest: 31.96 [ms]

🌲 Total Processing Time Tree 🌲
100.00% objectsCallback: total 10145.53 [ms], avg. 17.28 [ms], run count: 587
    ├── 0.06% trafficSignalsCallback: total 6.59 [ms], avg. 0.01 [ms], run count: 587
    ├── 0.00% removeStaleTrafficLightInfo: total 0.37 [ms], avg. 0.00 [ms], run count: 587
    ├── 0.04% updateObjectData: total 4.39 [ms], avg. 0.00 [ms], run count: 9050
    ├── 15.73% getCurrentLanelets: total 1596.15 [ms], avg. 0.18 [ms], run count: 9050
    │   ├── 5.89% checkCloseLaneletCondition: total 597.74 [ms], avg. 0.01 [ms], run count: 90500
    │   ├── 0.01% isDuplicated: total 1.08 [ms], avg. 0.00 [ms], run count: 12926
    │   ├── 1.10% calculateLocalLikelihood: total 111.33 [ms], avg. 0.01 [ms], run count: 8002
    │   └── 8.73% rest: 886.01 [ms]
    ├── 0.79% updateRoadUsersHistory: total 79.87 [ms], avg. 0.01 [ms], run count: 9050
    ├── 33.03% getPredictedReferencePath: total 3351.41 [ms], avg. 0.72 [ms], run count: 4654
    │   ├── 2.00% predictObjectManeuver: total 203.07 [ms], avg. 0.04 [ms], run count: 4878
    │   │   ├── 1.87% predictObjectManeuverByLatDiffDistance: total 189.57 [ms], avg. 0.04 [ms], run count: 4878
    │   │   │   ├── 0.16% calcRightLateralOffset: total 16.60 [ms], avg. 0.00 [ms], run count: 14784
    │   │   │   └── 1.70% rest: 172.97 [ms]
    │   │   └── 0.13% rest: 13.50 [ms]
    │   ├── 0.02% calculateManeuverProbability: total 2.31 [ms], avg. 0.00 [ms], run count: 4878
    │   ├── 27.62% addReferencePaths: total 2802.01 [ms], avg. 0.19 [ms], run count: 14634
    │   │   ├── 0.22% updateFuturePossibleLanelets: total 21.95 [ms], avg. 0.00 [ms], run count: 9298
    │   │   ├── 25.80% convertPathType: total 2617.62 [ms], avg. 0.28 [ms], run count: 9298
    │   │   └── 1.60% rest: 162.44 [ms]
    │   └── 3.39% rest: 344.02 [ms]
    ├── 0.08% updateCrosswalkUserHistory: total 8.04 [ms], avg. 0.00 [ms], run count: 1874
    ├── 3.74% getPredictedObjectAsCrosswalkUser: total 379.11 [ms], avg. 0.20 [ms], run count: 1874
    │   ├── 0.01% getTrafficSignalId: total 1.11 [ms], avg. 0.00 [ms], run count: 2057
    │   ├── 0.04% calcIntentionToCrossWithTrafficSignal: total 4.25 [ms], avg. 0.00 [ms], run count: 2055
    │   │   ├── 0.00% getTrafficSignalElement: total 0.35 [ms], avg. 0.00 [ms], run count: 2055
    │   │   └── 0.04% rest: 3.90 [ms]
    │   ├── 0.08% doesPathCrossAnyFence: total 8.53 [ms], avg. 0.01 [ms], run count: 652
    │   └── 3.60% rest: 365.22 [ms]
    └── 46.52% rest: 4719.59 [ms]
```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
