### PR TITLE
fix(autoware_multi_object_tracker): fix functionConst

### DIFF
--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -91,8 +91,8 @@ public:
   void endMeasurementTime(const rclcpp::Time & now);
   void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
-  void checkDelay(
-    diagnostic_updater::DiagnosticStatusWrapper & stat);  // cppcheck-suppress functionConst
+  // cppcheck-suppress functionConst
+  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   // Debug object
   void setObjectChannels(const std::vector<std::string> & channels)


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionConst warnings.

```
perception/autoware_multi_object_tracker/src/debugger/debugger.hpp:94:8: style: inconclusive: Technically the member function 'autoware::multi_object_tracker::TrackerDebugger::checkDelay' can be const. [functionConst]
  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat);
       ^
```

This is a re-publication of a [previous PR](https://github.com/autowarefoundation/autoware.universe/pull/8290) that was corrected in this PR, but was not properly suppressed in the comments.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/8290

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
