### PR TITLE
perf(static_obstacle_avoidance): improve logic to reduce computational cost

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -987,11 +987,6 @@ BehaviorModuleOutput StaticObstacleAvoidanceModule::plan()
     spline_shift_path = helper_->getPreviousSplineShiftPath();
   }
 
-  // post processing
-  {
-    postProcess();  // remove old shift points
-  }
-
   BehaviorModuleOutput output;
 
   const auto is_ignore_signal = [this](const UUID & uuid) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -2282,10 +2282,9 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
   Pose p_reference_ego_front = reference_path.points.front().point.pose;
   Pose p_spline_ego_front = spline_path.points.front().point.pose;
   double next_longitudinal_distance = parameters->resample_interval_for_output;
+  const auto offset = arc_length_array.at(ego_idx);
   for (size_t i = 0; i < points_size; ++i) {
-    const auto distance_from_ego =
-      autoware::motion_utils::calcSignedArcLength(reference_path.points, ego_idx, i);
-    if (distance_from_ego > object_check_forward_distance) {
+    if (arc_length_array.at(i) > object_check_forward_distance + offset) {
       break;
     }
 


### PR DESCRIPTION
## Description

### 272846b0923cfb6efe98367c38918c3c8ec5324c

Since the process of yaw deviation check is heavy, I fixed it in order to check object within/without target lane first.

![image](https://github.com/user-attachments/assets/d7b1c333-576f-4690-985d-63c4e4eb14e6)

### d638d088c772fb0cf9542e551dffc5aa0a8e5b95

The `postProcess()` function is automatically called in **[this](https://github.com/autowarefoundation/autoware.universe/blob/7f96352a42062a97090acc27d40a6377e3513dfc/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp#L749)** line.

### 7ba2c3d586fffa3a1b21c67a7e3b4fd45a1e092d

Don't use heavy process `calcSignedArcLength()`.

![image](https://github.com/user-attachments/assets/2d7478f3-5d08-421b-b23b-d0052ae307d9)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/1318a52e-607f-5539-ba19-b95d8f3e2af8?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
