### PR TITLE
refactor(tensorrt_yolox): move utils into perception_utils

### DIFF
--- a/common/perception_utils/CMakeLists.txt
+++ b/common/perception_utils/CMakeLists.txt
@@ -5,3 +5,13 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ament_auto_package()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/run_length_encoder.cpp
+)
+
+find_package(OpenCV REQUIRED)
+target_link_libraries(${PROJECT_NAME}
+  ${OpenCV_LIBS}
+)
+

--- a/common/perception_utils/CMakeLists.txt
+++ b/common/perception_utils/CMakeLists.txt
@@ -14,4 +14,3 @@ find_package(OpenCV REQUIRED)
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBS}
 )
-

--- a/common/perception_utils/include/perception_utils/run_length_encoder.hpp
+++ b/common/perception_utils/include/perception_utils/run_length_encoder.hpp
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TENSORRT_YOLOX__UTILS_HPP_
-#define AUTOWARE__TENSORRT_YOLOX__UTILS_HPP_
+#ifndef PERCEPTION_UTILS__RUN_LENGTH_ENCODER_HPP_
+
+#define PERCEPTION_UTILS__RUN_LENGTH_ENCODER_HPP_
 #include <opencv2/opencv.hpp>
 
 #include <utility>
 #include <vector>
 
-namespace autoware::tensorrt_yolox
+namespace perception_utils
 {
 std::vector<std::pair<uint8_t, int>> runLengthEncoder(const cv::Mat & mask);
 cv::Mat runLengthDecoder(const std::vector<uint8_t> & rle_data, const int rows, const int cols);
-}  // namespace autoware::tensorrt_yolox
+}  // namespace perception_utils
 
-#endif  // AUTOWARE__TENSORRT_YOLOX__UTILS_HPP_
+#endif  // PERCEPTION_UTILS__RUN_LENGTH_ENCODER_HPP_

--- a/common/perception_utils/package.xml
+++ b/common/perception_utils/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
 
   <export>

--- a/common/perception_utils/src/run_length_encoder.cpp
+++ b/common/perception_utils/src/run_length_encoder.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/tensorrt_yolox/utils.hpp"
+#include "perception_utils/run_length_encoder.hpp"
 
-namespace autoware::tensorrt_yolox
+namespace perception_utils
 {
 
 std::vector<std::pair<uint8_t, int>> runLengthEncoder(const cv::Mat & image)
@@ -62,4 +62,4 @@ cv::Mat runLengthDecoder(const std::vector<uint8_t> & rle_data, const int rows, 
   return mask;
 }
 
-}  // namespace autoware::tensorrt_yolox
+}  // namespace perception_utils

--- a/perception/autoware_tensorrt_yolox/CMakeLists.txt
+++ b/perception/autoware_tensorrt_yolox/CMakeLists.txt
@@ -143,7 +143,6 @@ rclcpp_components_register_node(yolox_single_image_inference_node
 )
 
 ament_auto_add_library(${PROJECT_NAME}_node SHARED
-  src/utils.cpp
   src/tensorrt_yolox_node.cpp
 )
 

--- a/perception/autoware_tensorrt_yolox/package.xml
+++ b/perception/autoware_tensorrt_yolox/package.xml
@@ -24,6 +24,7 @@
   <depend>image_transport</depend>
   <depend>libopencv-dev</depend>
   <depend>object_recognition_utils</depend>
+  <depend>perception_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -14,8 +14,8 @@
 
 #include "autoware/tensorrt_yolox/tensorrt_yolox_node.hpp"
 
-#include "autoware/tensorrt_yolox/utils.hpp"
 #include "object_recognition_utils/object_classification.hpp"
+#include "perception_utils/run_length_encoder.hpp"
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 
@@ -184,7 +184,7 @@ void TrtYoloXNode::onImage(const sensor_msgs::msg::Image::ConstSharedPtr msg)
         .toImageMsg();
     out_mask_msg->header = msg->header;
 
-    std::vector<std::pair<uint8_t, int>> compressed_data = runLengthEncoder(mask);
+    std::vector<std::pair<uint8_t, int>> compressed_data = perception_utils::runLengthEncoder(mask);
     int step = sizeof(uint8_t) + sizeof(int);
     out_mask_msg->data.resize(static_cast<int>(compressed_data.size()) * step);
     for (size_t i = 0; i < compressed_data.size(); ++i) {


### PR DESCRIPTION
## Description

- This to move out run_length compression in `utils` from `tensorrt_yolox` to avoid `cuda`, `cudnn` [required during CI build](https://github.com/autowarefoundation/autoware.universe/actions/runs/10312758044/job/28548491995?pr=7909) when it is used in other package such as `image_projection_based_fusion`. 
- There no change in algorimth.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
