### PR TITLE
fix(autoware_obstacle_stop_planner): register obstacle stop planner node with autoware scoping

### DIFF
--- a/common/qp_interface/src/osqp_interface.cpp
+++ b/common/qp_interface/src/osqp_interface.cpp
@@ -354,9 +354,7 @@ std::vector<double> OSQPInterface::optimizeImpl()
   osqp_solve(work_.get());
 
   double * sol_x = work_->solution->x;
-  double * sol_y = work_->solution->y;
   std::vector<double> sol_primal(sol_x, sol_x + param_n_);
-  std::vector<double> sol_lagrange_multiplier(sol_y, sol_y + data_->m);
 
   latest_work_info_ = *(work_->info);
 

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2404,7 +2404,13 @@ std::vector<PosePath> MapBasedPredictionNode::convertPathType(
 
           const double lane_yaw = std::atan2(
             current_p.position.y - prev_p.position.y, current_p.position.x - prev_p.position.x);
-          current_p.orientation = autoware::universe_utils::createQuaternionFromYaw(lane_yaw);
+          const double sin_yaw_half = std::sin(lane_yaw / 2.0);
+          const double cos_yaw_half = std::cos(lane_yaw / 2.0);
+          current_p.orientation.x = 0.0;
+          current_p.orientation.y = 0.0;
+          current_p.orientation.z = sin_yaw_half;
+          current_p.orientation.w = cos_yaw_half;
+
           converted_path.push_back(current_p);
           prev_p = current_p;
         }
@@ -2435,15 +2441,27 @@ std::vector<PosePath> MapBasedPredictionNode::convertPathType(
 
         const double lane_yaw = std::atan2(
           current_p.position.y - prev_p.position.y, current_p.position.x - prev_p.position.x);
-        current_p.orientation = autoware::universe_utils::createQuaternionFromYaw(lane_yaw);
+        const double sin_yaw_half = std::sin(lane_yaw / 2.0);
+        const double cos_yaw_half = std::cos(lane_yaw / 2.0);
+        current_p.orientation.x = 0.0;
+        current_p.orientation.y = 0.0;
+        current_p.orientation.z = sin_yaw_half;
+        current_p.orientation.w = cos_yaw_half;
+
         converted_path.push_back(current_p);
         prev_p = current_p;
       }
     }
 
     // Resample Path
-    const auto resampled_converted_path =
-      autoware::motion_utils::resamplePoseVector(converted_path, reference_path_resolution_);
+    const bool use_akima_spline_for_xy = true;
+    const bool use_lerp_for_z = true;
+    // the options use_akima_spline_for_xy and use_lerp_for_z are set to true
+    // but the implementation of use_akima_spline_for_xy in resamplePoseVector and
+    // resamplePointVector is opposite to the options so the options are set to true to use linear
+    // interpolation for xy
+    const auto resampled_converted_path = autoware::motion_utils::resamplePoseVector(
+      converted_path, reference_path_resolution_, use_akima_spline_for_xy, use_lerp_for_z);
     converted_paths.push_back(resampled_converted_path);
   }
 

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/fusion_policy/fusion_policy.cpp
@@ -218,7 +218,7 @@ struct dempsterShaferOccupancy
   }
 
   // Dempster-Shafer fusion
-  dempsterShaferOccupancy operator+(const dempsterShaferOccupancy & other)
+  dempsterShaferOccupancy operator+(const dempsterShaferOccupancy & other) const
   {
     dempsterShaferOccupancy result;
     double K = calcK(other);

--- a/perception/autoware_radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/autoware_radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -271,8 +271,8 @@ TwistWithCovariance RadarFusionToDetectedObject::estimateTwist(
 
   // calculate twist for radar data with target_value * average
   Eigen::Vector2d vec_target_value_average(0.0, 0.0);
-  double sum_target_value = 0.0;
   if (param_.velocity_weight_target_value_average > 0.0) {
+    double sum_target_value = 0.0;
     for (const auto & radar : (*radars)) {
       vec_target_value_average += (toVector2d(radar.twist_with_covariance) * radar.target_value);
       sum_target_value += radar.target_value;

--- a/perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.hpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/occlusion_predictor.hpp
@@ -75,12 +75,12 @@ private:
     const pcl::PointCloud<pcl::PointXYZ> & cloud_in, const std::vector<pcl::PointXYZ> & roi_tls,
     const std::vector<pcl::PointXYZ> & roi_brs, pcl::PointCloud<pcl::PointXYZ> & cloud_out) const;
 
-  void sampleTrafficLightRoi(
+  static void sampleTrafficLightRoi(
     const pcl::PointXYZ & top_left, const pcl::PointXYZ & bottom_right,
     uint32_t horizontal_sample_num, uint32_t vertical_sample_num,
     pcl::PointCloud<pcl::PointXYZ> & cloud_out);
 
-  void calcRoiVector3D(
+  static void calcRoiVector3D(
     const tier4_perception_msgs::msg::TrafficLightRoi & roi,
     const image_geometry::PinholeCameraModel & pinhole_model,
     const std::map<lanelet::Id, tf2::Vector3> & traffic_light_position_map,

--- a/planning/autoware_obstacle_stop_planner/CMakeLists.txt
+++ b/planning/autoware_obstacle_stop_planner/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "motion_planning::ObstacleStopPlannerNode"
+  PLUGIN "autoware::motion_planning::ObstacleStopPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -26,6 +26,11 @@
       min_longitudinal_acc: -1.0
       max_longitudinal_acc: 1.0
 
+      skip_process:
+        longitudinal_distance_diff_threshold:
+          prepare: 0.5
+          lane_changing: 0.5
+
       # safety check
       safety_check:
         allow_loose_check_for_cancel: true

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -82,7 +82,7 @@ public:
   PathSafetyStatus evaluateApprovedPathWithUnsafeHysteresis(
     PathSafetyStatus approved_path_safety_status) override;
 
-  bool isRequiredStop(const bool is_object_coming_from_rear) override;
+  bool isRequiredStop(const bool is_trailing_object) override;
 
   bool isNearEndOfCurrentLanes(
     const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
@@ -120,19 +120,16 @@ protected:
     const lanelet::ConstLanelets & current_lanes,
     const lanelet::ConstLanelets & target_lanes) const;
 
-  ExtendedPredictedObjects getTargetObjects(
-    const LaneChangeLanesFilteredObjects & predicted_objects,
+  lane_change::TargetObjects getTargetObjects(
+    const FilteredByLanesExtendedObjects & predicted_objects,
     const lanelet::ConstLanelets & current_lanes) const;
 
-  LaneChangeLanesFilteredObjects filterObjects() const;
+  FilteredByLanesExtendedObjects filterObjects() const;
 
   void filterOncomingObjects(PredictedObjects & objects) const;
 
-  void filterObjectsByLanelets(
-    const PredictedObjects & objects, const PathWithLaneId & current_lanes_ref_path,
-    std::vector<PredictedObject> & current_lane_objects,
-    std::vector<PredictedObject> & target_lane_objects,
-    std::vector<PredictedObject> & other_lane_objects) const;
+  FilteredByLanesObjects filterObjectsByLanelets(
+    const PredictedObjects & objects, const PathWithLaneId & current_lanes_ref_path) const;
 
   PathWithLaneId getPrepareSegment(
     const lanelet::ConstLanelets & current_lanes, const double backward_path_length,
@@ -170,7 +167,7 @@ protected:
 
   PathSafetyStatus isLaneChangePathSafe(
     const LaneChangePath & lane_change_path,
-    const ExtendedPredictedObjects & collision_check_objects,
+    const lane_change::TargetObjects & collision_check_objects,
     const utils::path_safety_checker::RSSparams & rss_params,
     CollisionCheckDebugMap & debug_data) const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -99,7 +99,7 @@ public:
 
   virtual bool isEgoOnPreparePhase() const = 0;
 
-  virtual bool isRequiredStop(const bool is_object_coming_from_rear) = 0;
+  virtual bool isRequiredStop(const bool is_trailing_object) = 0;
 
   virtual PathSafetyStatus isApprovedPathSafe() const = 0;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -215,11 +215,33 @@ struct Info
   double terminal_lane_changing_velocity{0.0};
 };
 
+template <typename Object>
 struct LanesObjects
 {
-  ExtendedPredictedObjects current_lane{};
-  ExtendedPredictedObjects target_lane{};
-  ExtendedPredictedObjects other_lane{};
+  Object current_lane{};
+  Object target_lane_leading{};
+  Object target_lane_trailing{};
+  Object other_lane{};
+
+  LanesObjects() = default;
+  LanesObjects(
+    Object current_lane, Object target_lane_leading, Object target_lane_trailing, Object other_lane)
+  : current_lane(std::move(current_lane)),
+    target_lane_leading(std::move(target_lane_leading)),
+    target_lane_trailing(std::move(target_lane_trailing)),
+    other_lane(std::move(other_lane))
+  {
+  }
+};
+
+struct TargetObjects
+{
+  ExtendedPredictedObjects leading;
+  ExtendedPredictedObjects trailing;
+  TargetObjects(ExtendedPredictedObjects leading, ExtendedPredictedObjects trailing)
+  : leading(std::move(leading)), trailing(std::move(trailing))
+  {
+  }
 };
 
 enum class ModuleType {
@@ -231,7 +253,13 @@ enum class ModuleType {
 struct PathSafetyStatus
 {
   bool is_safe{true};
-  bool is_object_coming_from_rear{false};
+  bool is_trailing_object{false};
+
+  PathSafetyStatus() = default;
+  PathSafetyStatus(const bool is_safe, const bool is_trailing_object)
+  : is_safe(is_safe), is_trailing_object(is_trailing_object)
+  {
+  }
 };
 
 struct LanesPolygon
@@ -280,12 +308,15 @@ using CommonDataPtr = std::shared_ptr<CommonData>;
 
 namespace autoware::behavior_path_planner
 {
+using autoware_perception_msgs::msg::PredictedObject;
+using utils::path_safety_checker::ExtendedPredictedObjects;
 using LaneChangeModuleType = lane_change::ModuleType;
 using LaneChangeParameters = lane_change::Parameters;
 using LaneChangeStates = lane_change::States;
 using LaneChangePhaseInfo = lane_change::PhaseInfo;
 using LaneChangeInfo = lane_change::Info;
-using LaneChangeLanesFilteredObjects = lane_change::LanesObjects;
+using FilteredByLanesObjects = lane_change::LanesObjects<std::vector<PredictedObject>>;
+using FilteredByLanesExtendedObjects = lane_change::LanesObjects<ExtendedPredictedObjects>;
 using LateralAccelerationMap = lane_change::LateralAccelerationMap;
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -124,6 +124,9 @@ struct Parameters
   double min_longitudinal_acc{-1.0};
   double max_longitudinal_acc{1.0};
 
+  double skip_process_lon_diff_th_prepare{0.5};
+  double skip_process_lon_diff_th_lane_changing{1.0};
+
   // collision check
   bool enable_collision_check_for_prepare_phase_in_general_lanes{false};
   bool enable_collision_check_for_prepare_phase_in_intersection{true};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/debug_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/debug_structs.hpp
@@ -35,7 +35,7 @@ struct Debug
   LaneChangePaths valid_paths;
   CollisionCheckDebugMap collision_check_objects;
   CollisionCheckDebugMap collision_check_objects_after_approval;
-  LaneChangeLanesFilteredObjects filtered_objects;
+  FilteredByLanesExtendedObjects filtered_objects;
   geometry_msgs::msg::Polygon execution_area;
   geometry_msgs::msg::Pose ego_pose;
   lanelet::ConstLanelets current_lanes;
@@ -55,7 +55,8 @@ struct Debug
     collision_check_objects.clear();
     collision_check_objects_after_approval.clear();
     filtered_objects.current_lane.clear();
-    filtered_objects.target_lane.clear();
+    filtered_objects.target_lane_leading.clear();
+    filtered_objects.target_lane_trailing.clear();
     filtered_objects.other_lane.clear();
     execution_area.points.clear();
     current_lanes.clear();

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/markers.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/markers.hpp
@@ -29,6 +29,7 @@
 
 namespace marker_utils::lane_change_markers
 {
+using autoware::behavior_path_planner::FilteredByLanesExtendedObjects;
 using autoware::behavior_path_planner::LaneChangePath;
 using autoware::behavior_path_planner::lane_change::Debug;
 using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObjects;
@@ -39,9 +40,7 @@ MarkerArray createLaneChangingVirtualWallMarker(
   const geometry_msgs::msg::Pose & lane_changing_pose, const std::string & module_name,
   const rclcpp::Time & now, const std::string & ns);
 MarkerArray showFilteredObjects(
-  const ExtendedPredictedObjects & current_lane_objects,
-  const ExtendedPredictedObjects & target_lane_objects,
-  const ExtendedPredictedObjects & other_lane_objects, const std::string & ns);
+  const FilteredByLanesExtendedObjects & filtered_objects, const std::string & ns);
 MarkerArray createExecutionArea(const geometry_msgs::msg::Polygon & execution_area);
 MarkerArray showExecutionInfo(const Debug & debug_data, const geometry_msgs::msg::Pose & ego_pose);
 MarkerArray createDebugMarkerArray(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -312,6 +312,10 @@ bool is_before_terminal(
   const PredictedObject & object);
 
 double calc_angle_to_lanelet_segment(const lanelet::ConstLanelets & lanelets, const Pose & pose);
+
+ExtendedPredictedObjects transform_to_extended_objects(
+  const CommonDataPtr & common_data_ptr, const std::vector<PredictedObject> & objects,
+  const bool check_prepare_phase);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 
 namespace autoware::behavior_path_planner::utils::lane_change::debug

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -307,7 +307,7 @@ bool LaneChangeInterface::canTransitFailureState()
     return false;
   }
 
-  if (module_type_->isRequiredStop(post_process_safety_status_.is_object_coming_from_rear)) {
+  if (module_type_->isRequiredStop(post_process_safety_status_.is_trailing_object)) {
     log_debug_throttled("Module require stopping");
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -355,6 +355,13 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
   }
 
   {
+    const std::string ns = "lane_change.skip_process.longitudinal_distance_diff_threshold.";
+    updateParam<double>(parameters, ns + "prepare", p->skip_process_lon_diff_th_prepare);
+    updateParam<double>(
+      parameters, ns + "lane_changing", p->skip_process_lon_diff_th_lane_changing);
+  }
+
+  {
     const std::string ns = "lane_change.safety_check.lane_expansion.";
     updateParam<double>(parameters, ns + "left_offset", p->lane_expansion_left_offset);
     updateParam<double>(parameters, ns + "right_offset", p->lane_expansion_right_offset);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -465,7 +465,8 @@ void NormalLaneChange::insertStopPoint(
     //    [ego]>          | <--- lane change margin --->  [obj]>
     //  ----------------------------------------------------------
     const bool has_blocking_target_lane_obj = std::any_of(
-      target_objects.target_lane.begin(), target_objects.target_lane.end(), [&](const auto & o) {
+      target_objects.target_lane_leading.begin(), target_objects.target_lane_leading.end(),
+      [&](const auto & o) {
         const auto v = std::abs(o.initial_twist.twist.linear.x);
         if (v > lane_change_parameters_->stop_velocity_threshold) {
           return false;
@@ -973,32 +974,32 @@ PathWithLaneId NormalLaneChange::getPrepareSegment(
   return prepare_segment;
 }
 
-ExtendedPredictedObjects NormalLaneChange::getTargetObjects(
-  const LaneChangeLanesFilteredObjects & filtered_objects,
+lane_change::TargetObjects NormalLaneChange::getTargetObjects(
+  const FilteredByLanesExtendedObjects & filtered_objects,
   const lanelet::ConstLanelets & current_lanes) const
 {
-  ExtendedPredictedObjects target_objects = filtered_objects.target_lane;
+  ExtendedPredictedObjects leading_objects = filtered_objects.target_lane_leading;
   const auto is_stuck = isVehicleStuck(current_lanes);
   const auto chk_obj_in_curr_lanes = lane_change_parameters_->check_objects_on_current_lanes;
   if (chk_obj_in_curr_lanes || is_stuck) {
-    target_objects.insert(
-      target_objects.end(), filtered_objects.current_lane.begin(),
+    leading_objects.insert(
+      leading_objects.end(), filtered_objects.current_lane.begin(),
       filtered_objects.current_lane.end());
   }
 
   const auto chk_obj_in_other_lanes = lane_change_parameters_->check_objects_on_other_lanes;
   if (chk_obj_in_other_lanes) {
-    target_objects.insert(
-      target_objects.end(), filtered_objects.other_lane.begin(), filtered_objects.other_lane.end());
+    leading_objects.insert(
+      leading_objects.end(), filtered_objects.other_lane.begin(),
+      filtered_objects.other_lane.end());
   }
 
-  return target_objects;
+  return {leading_objects, filtered_objects.target_lane_trailing};
 }
 
-LaneChangeLanesFilteredObjects NormalLaneChange::filterObjects() const
+FilteredByLanesExtendedObjects NormalLaneChange::filterObjects() const
 {
   const auto & route_handler = getRouteHandler();
-  const auto & common_parameters = planner_data_->parameters;
   auto objects = *planner_data_->dynamic_object;
   utils::path_safety_checker::filterObjectsByClass(
     objects, lane_change_parameters_->object_types_to_check);
@@ -1019,10 +1020,6 @@ LaneChangeLanesFilteredObjects NormalLaneChange::filterObjects() const
     return {};
   }
 
-  std::vector<PredictedObject> target_lane_objects;
-  std::vector<PredictedObject> current_lane_objects;
-  std::vector<PredictedObject> other_lane_objects;
-
   const auto & target_lanes = get_target_lanes();
 
   if (target_lanes.empty()) {
@@ -1032,8 +1029,7 @@ LaneChangeLanesFilteredObjects NormalLaneChange::filterObjects() const
   const auto path =
     route_handler->getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
 
-  filterObjectsByLanelets(
-    objects, path, current_lane_objects, target_lane_objects, other_lane_objects);
+  auto filtered_by_lanes_objects = filterObjectsByLanelets(objects, path);
 
   const auto is_within_vel_th = [](const auto & object) -> bool {
     constexpr double min_vel_th = 1.0;
@@ -1042,14 +1038,12 @@ LaneChangeLanesFilteredObjects NormalLaneChange::filterObjects() const
   };
 
   utils::path_safety_checker::filterObjects(
-    target_lane_objects, [&](const PredictedObject & object) {
-      const auto ahead_of_ego = utils::lane_change::is_ahead_of_ego(common_data_ptr_, path, object);
-      return is_within_vel_th(object) || ahead_of_ego;
-    });
+    filtered_by_lanes_objects.target_lane_trailing,
+    [&](const PredictedObject & object) { return is_within_vel_th(object); });
 
   if (lane_change_parameters_->check_objects_on_other_lanes) {
     utils::path_safety_checker::filterObjects(
-      other_lane_objects, [&](const PredictedObject & object) {
+      filtered_by_lanes_objects.other_lane, [&](const PredictedObject & object) {
         const auto ahead_of_ego =
           utils::lane_change::is_ahead_of_ego(common_data_ptr_, path, object);
         return is_within_vel_th(object) && ahead_of_ego;
@@ -1057,34 +1051,27 @@ LaneChangeLanesFilteredObjects NormalLaneChange::filterObjects() const
   }
 
   utils::path_safety_checker::filterObjects(
-    current_lane_objects, [&](const PredictedObject & object) {
+    filtered_by_lanes_objects.current_lane, [&](const PredictedObject & object) {
       const auto ahead_of_ego = utils::lane_change::is_ahead_of_ego(common_data_ptr_, path, object);
       return is_within_vel_th(object) && ahead_of_ego;
     });
 
-  LaneChangeLanesFilteredObjects lane_change_target_objects;
-
   const auto is_check_prepare_phase = check_prepare_phase();
-  std::for_each(target_lane_objects.begin(), target_lane_objects.end(), [&](const auto & object) {
-    auto extended_predicted_object = utils::lane_change::transform(
-      object, common_parameters, *lane_change_parameters_, is_check_prepare_phase);
-    lane_change_target_objects.target_lane.push_back(extended_predicted_object);
-  });
+  const auto target_lane_leading_extended_objects =
+    utils::lane_change::transform_to_extended_objects(
+      common_data_ptr_, filtered_by_lanes_objects.target_lane_leading, is_check_prepare_phase);
+  const auto target_lane_trailing_extended_objects =
+    utils::lane_change::transform_to_extended_objects(
+      common_data_ptr_, filtered_by_lanes_objects.target_lane_trailing, is_check_prepare_phase);
+  const auto current_lane_extended_objects = utils::lane_change::transform_to_extended_objects(
+    common_data_ptr_, filtered_by_lanes_objects.current_lane, is_check_prepare_phase);
+  const auto other_lane_extended_objects = utils::lane_change::transform_to_extended_objects(
+    common_data_ptr_, filtered_by_lanes_objects.other_lane, is_check_prepare_phase);
 
-  std::for_each(current_lane_objects.begin(), current_lane_objects.end(), [&](const auto & object) {
-    auto extended_predicted_object = utils::lane_change::transform(
-      object, common_parameters, *lane_change_parameters_, is_check_prepare_phase);
-    lane_change_target_objects.current_lane.push_back(extended_predicted_object);
-  });
-
-  std::for_each(other_lane_objects.begin(), other_lane_objects.end(), [&](const auto & object) {
-    auto extended_predicted_object = utils::lane_change::transform(
-      object, common_parameters, *lane_change_parameters_, is_check_prepare_phase);
-    lane_change_target_objects.other_lane.push_back(extended_predicted_object);
-  });
-
+  FilteredByLanesExtendedObjects lane_change_target_objects(
+    current_lane_extended_objects, target_lane_leading_extended_objects,
+    target_lane_trailing_extended_objects, other_lane_extended_objects);
   lane_change_debug_.filtered_objects = lane_change_target_objects;
-
   return lane_change_target_objects;
 }
 
@@ -1115,12 +1102,14 @@ void NormalLaneChange::filterOncomingObjects(PredictedObjects & objects) const
   });
 }
 
-void NormalLaneChange::filterObjectsByLanelets(
-  const PredictedObjects & objects, const PathWithLaneId & current_lanes_ref_path,
-  std::vector<PredictedObject> & current_lane_objects,
-  std::vector<PredictedObject> & target_lane_objects,
-  std::vector<PredictedObject> & other_lane_objects) const
+FilteredByLanesObjects NormalLaneChange::filterObjectsByLanelets(
+  const PredictedObjects & objects, const PathWithLaneId & current_lanes_ref_path) const
 {
+  std::vector<PredictedObject> target_lane_leading_objects;
+  std::vector<PredictedObject> target_lane_trailing_objects;
+  std::vector<PredictedObject> current_lane_objects;
+  std::vector<PredictedObject> other_lane_objects;
+
   const auto & current_pose = getEgoPose();
   const auto & current_lanes = common_data_ptr_->lanes_ptr->current;
   const auto & target_lanes = common_data_ptr_->lanes_ptr->target;
@@ -1152,12 +1141,11 @@ void NormalLaneChange::filterObjectsByLanelets(
   const auto dist_ego_to_current_lanes_center =
     lanelet::utils::getLateralDistanceToClosestLanelet(current_lanes, current_pose);
 
-  {
-    const auto reserve_size = objects.objects.size();
-    current_lane_objects.reserve(reserve_size);
-    target_lane_objects.reserve(reserve_size);
-    other_lane_objects.reserve(reserve_size);
-  }
+  const auto reserve_size = objects.objects.size();
+  current_lane_objects.reserve(reserve_size);
+  target_lane_leading_objects.reserve(reserve_size);
+  target_lane_trailing_objects.reserve(reserve_size);
+  other_lane_objects.reserve(reserve_size);
 
   for (const auto & object : objects.objects) {
     const auto is_lateral_far = std::invoke([&]() -> bool {
@@ -1176,7 +1164,13 @@ void NormalLaneChange::filterObjectsByLanelets(
     if (
       check_optional_polygon(object, lanes_polygon.expanded_target) && is_lateral_far &&
       is_before_terminal()) {
-      target_lane_objects.push_back(object);
+      const auto ahead_of_ego =
+        utils::lane_change::is_ahead_of_ego(common_data_ptr_, current_lanes_ref_path, object);
+      if (ahead_of_ego) {
+        target_lane_leading_objects.push_back(object);
+      } else {
+        target_lane_trailing_objects.push_back(object);
+      }
       continue;
     }
 
@@ -1191,7 +1185,7 @@ void NormalLaneChange::filterObjectsByLanelets(
 
     // check if the object intersects with target backward lanes
     if (is_overlap_target_backward) {
-      target_lane_objects.push_back(object);
+      target_lane_trailing_objects.push_back(object);
       continue;
     }
 
@@ -1203,6 +1197,10 @@ void NormalLaneChange::filterObjectsByLanelets(
 
     other_lane_objects.push_back(object);
   }
+
+  return {
+    current_lane_objects, target_lane_leading_objects, target_lane_trailing_objects,
+    other_lane_objects};
 }
 
 PathWithLaneId NormalLaneChange::getTargetSegment(
@@ -1629,7 +1627,7 @@ bool NormalLaneChange::getLaneChangePaths(
 
         if (
           !is_stuck && !utils::lane_change::passed_parked_objects(
-                         common_data_ptr_, *candidate_path, filtered_objects.target_lane,
+                         common_data_ptr_, *candidate_path, filtered_objects.target_lane_leading,
                          lane_change_buffer, lane_change_debug_.collision_check_objects)) {
           debug_print_lat(
             "Reject: parking vehicle exists in the target lane, and the ego is not in stuck. Skip "
@@ -1642,7 +1640,7 @@ bool NormalLaneChange::getLaneChangePaths(
           return false;
         }
 
-        const auto [is_safe, is_object_coming_from_rear] = isLaneChangePathSafe(
+        const auto [is_safe, is_trailing_object] = isLaneChangePathSafe(
           *candidate_path, target_objects, rss_params, lane_change_debug_.collision_check_objects);
 
         if (is_safe) {
@@ -1820,7 +1818,7 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
     common_data_ptr_->route_handler_ptr->getLateralIntervalsToPreferredLane(current_lanes.back()));
 
   const auto has_passed_parked_objects = utils::lane_change::passed_parked_objects(
-    common_data_ptr_, path, filtered_objects.target_lane, min_lc_length, debug_data);
+    common_data_ptr_, path, filtered_objects.target_lane_leading, min_lc_length, debug_data);
 
   if (!has_passed_parked_objects) {
     RCLCPP_DEBUG(logger_, "Lane change has been delayed.");
@@ -1908,13 +1906,13 @@ bool NormalLaneChange::isValidPath(const PathWithLaneId & path) const
   return true;
 }
 
-bool NormalLaneChange::isRequiredStop(const bool is_object_coming_from_rear)
+bool NormalLaneChange::isRequiredStop(const bool is_trailing_object)
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   const auto threshold = lane_change_parameters_->backward_length_buffer_for_end_of_lane;
   if (
     isNearEndOfCurrentLanes(get_current_lanes(), get_target_lanes(), threshold) &&
-    isAbleToStopSafely() && is_object_coming_from_rear) {
+    isAbleToStopSafely() && is_trailing_object) {
     current_lane_change_state_ = LaneChangeStates::Stop;
     return true;
   }
@@ -2064,16 +2062,18 @@ bool NormalLaneChange::calcAbortPath()
 }
 
 PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
-  const LaneChangePath & lane_change_path, const ExtendedPredictedObjects & collision_check_objects,
+  const LaneChangePath & lane_change_path,
+  const lane_change::TargetObjects & collision_check_objects,
   const utils::path_safety_checker::RSSparams & rss_params,
   CollisionCheckDebugMap & debug_data) const
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-  PathSafetyStatus path_safety_status;
+  constexpr auto is_safe = true;
+  constexpr auto is_object_behind_ego = true;
 
-  if (collision_check_objects.empty()) {
+  if (collision_check_objects.leading.empty() && collision_check_objects.trailing.empty()) {
     RCLCPP_DEBUG(logger_, "There is nothing to check.");
-    return path_safety_status;
+    return {is_safe, !is_object_behind_ego};
   }
 
   const auto & path = lane_change_path.path;
@@ -2082,11 +2082,10 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
   const auto current_twist = getEgoTwist();
 
   if (path.points.empty()) {
-    path_safety_status.is_safe = false;
-    return path_safety_status;
+    return {!is_safe, !is_object_behind_ego};
   }
 
-  const double & time_resolution = lane_change_parameters_->prediction_time_resolution;
+  const auto time_resolution = lane_change_parameters_->prediction_time_resolution;
 
   const auto ego_predicted_path = utils::lane_change::convertToPredictedPath(
     lane_change_path, current_twist, current_pose, common_parameters, *lane_change_parameters_,
@@ -2099,7 +2098,7 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
 
   constexpr double collision_check_yaw_diff_threshold{M_PI};
 
-  for (const auto & obj : collision_check_objects) {
+  const auto check_collision = [&](const ExtendedPredictedObject & obj) {
     auto current_debug_data = utils::path_safety_checker::createObjectDebug(obj);
     const auto obj_predicted_paths = utils::path_safety_checker::getPredictedPathFromObj(
       obj, lane_change_parameters_->use_all_predicted_path);
@@ -2132,21 +2131,28 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
         continue;
       }
 
-      is_safe = false;
-      path_safety_status.is_safe = false;
       utils::path_safety_checker::updateCollisionCheckDebugMap(
-        debug_data, current_debug_data, is_safe);
-      const auto & obj_pose = obj.initial_pose.pose;
-      const auto obj_polygon = autoware::universe_utils::toPolygon2d(obj_pose, obj.shape);
-      path_safety_status.is_object_coming_from_rear |=
-        !utils::path_safety_checker::isTargetObjectFront(
-          path, current_pose, common_parameters.vehicle_info, obj_polygon);
+        debug_data, current_debug_data, !is_safe);
+      return !is_safe;
     }
     utils::path_safety_checker::updateCollisionCheckDebugMap(
       debug_data, current_debug_data, is_safe);
+    return is_safe;
+  };
+
+  for (const auto & obj : collision_check_objects.trailing) {
+    if (!check_collision(obj)) {
+      return {!is_safe, is_object_behind_ego};
+    }
   }
 
-  return path_safety_status;
+  for (const auto & obj : collision_check_objects.leading) {
+    if (!check_collision(obj)) {
+      return {!is_safe, !is_object_behind_ego};
+    }
+  }
+
+  return {is_safe, !is_object_behind_ego};
 }
 
 // Check if the ego vehicle is in stuck by a stationary obstacle or by the terminal of current lanes

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1338,6 +1338,23 @@ double calc_angle_to_lanelet_segment(const lanelet::ConstLanelets & lanelets, co
   const auto closest_pose = lanelet::utils::getClosestCenterPose(closest_lanelet, pose.position);
   return std::abs(autoware::universe_utils::calcYawDeviation(closest_pose, pose));
 }
+
+ExtendedPredictedObjects transform_to_extended_objects(
+  const CommonDataPtr & common_data_ptr, const std::vector<PredictedObject> & objects,
+  const bool check_prepare_phase)
+{
+  ExtendedPredictedObjects extended_objects;
+  extended_objects.reserve(objects.size());
+
+  const auto & bpp_param = *common_data_ptr->bpp_param_ptr;
+  const auto & lc_param = *common_data_ptr->lc_param_ptr;
+  std::transform(
+    objects.begin(), objects.end(), std::back_inserter(extended_objects), [&](const auto & object) {
+      return utils::lane_change::transform(object, bpp_param, lc_param, check_prepare_phase);
+    });
+
+  return extended_objects;
+}
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 
 namespace autoware::behavior_path_planner::utils::lane_change::debug

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -987,11 +987,6 @@ BehaviorModuleOutput StaticObstacleAvoidanceModule::plan()
     spline_shift_path = helper_->getPreviousSplineShiftPath();
   }
 
-  // post processing
-  {
-    postProcess();  // remove old shift points
-  }
-
   BehaviorModuleOutput output;
 
   const auto is_ignore_signal = [this](const UUID & uuid) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -772,6 +772,46 @@ bool isObviousAvoidanceTarget(
     }
   }
 
+  if (object.behavior == ObjectData::Behavior::MERGING) {
+    object.info = ObjectInfo::MERGING_TO_EGO_LANE;
+    if (
+      isOnRight(object) && !object.is_on_ego_lane &&
+      object.overhang_points.front().first < parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(logger_namespace),
+        "merging vehicle. but overhang distance is less than threshold.");
+      return true;
+    }
+    if (
+      !isOnRight(object) && !object.is_on_ego_lane &&
+      object.overhang_points.front().first > -1.0 * parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(logger_namespace),
+        "merging vehicle. but overhang distance is less than threshold.");
+      return true;
+    }
+  }
+
+  if (object.behavior == ObjectData::Behavior::DEVIATING) {
+    object.info = ObjectInfo::DEVIATING_FROM_EGO_LANE;
+    if (
+      isOnRight(object) && !object.is_on_ego_lane &&
+      object.overhang_points.front().first < parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(logger_namespace),
+        "deviating vehicle. but overhang distance is less than threshold.");
+      return true;
+    }
+    if (
+      !isOnRight(object) && !object.is_on_ego_lane &&
+      object.overhang_points.front().first > -1.0 * parameters->th_overhang_distance) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger(logger_namespace),
+        "deviating vehicle. but overhang distance is less than threshold.");
+      return true;
+    }
+  }
+
   if (!object.is_parked) {
     object.info = ObjectInfo::IS_NOT_PARKING_OBJECT;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -2282,10 +2282,9 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
   Pose p_reference_ego_front = reference_path.points.front().point.pose;
   Pose p_spline_ego_front = spline_path.points.front().point.pose;
   double next_longitudinal_distance = parameters->resample_interval_for_output;
+  const auto offset = arc_length_array.at(ego_idx);
   for (size_t i = 0; i < points_size; ++i) {
-    const auto distance_from_ego =
-      autoware::motion_utils::calcSignedArcLength(reference_path.points, ego_idx, i);
-    if (distance_from_ego > object_check_forward_distance) {
+    if (arc_length_array.at(i) > object_check_forward_distance + offset) {
       break;
     }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
@@ -9,6 +9,7 @@
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
@@ -30,22 +30,21 @@ namespace autoware::motion_velocity_planner::out_of_lane
 /// @param [in] object_front_overhang extra distance to cut ahead of the stop line
 void cut_predicted_path_beyond_line(
   autoware_perception_msgs::msg::PredictedPath & predicted_path,
-  const lanelet::BasicLineString2d & stop_line, const double object_front_overhang);
+  const universe_utils::LineString2d & stop_line, const double object_front_overhang);
 
 /// @brief find the next red light stop line along the given path
 /// @param [in] path predicted path to check for a stop line
-/// @param [in] planner_data planner data with stop line information
+/// @param [in] ego_data ego data with the stop lines information
 /// @return the first red light stop line found along the path (if any)
-std::optional<const lanelet::BasicLineString2d> find_next_stop_line(
-  const autoware_perception_msgs::msg::PredictedPath & path,
-  const std::shared_ptr<const PlannerData> planner_data);
+std::optional<universe_utils::LineString2d> find_next_stop_line(
+  const autoware_perception_msgs::msg::PredictedPath & path, const EgoData & ego_data);
 
 /// @brief cut predicted path beyond stop lines of red lights
 /// @param [inout] predicted_path predicted path to cut
-/// @param [in] planner_data planner data to get the map and traffic light information
+/// @param [in] ego_data ego data with the stop lines information
 void cut_predicted_path_beyond_red_lights(
-  autoware_perception_msgs::msg::PredictedPath & predicted_path,
-  const std::shared_ptr<const PlannerData> planner_data, const double object_front_overhang);
+  autoware_perception_msgs::msg::PredictedPath & predicted_path, const EgoData & ego_data,
+  const double object_front_overhang);
 
 /// @brief filter predicted objects and their predicted paths
 /// @param [in] planner_data planner data

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -25,13 +25,19 @@
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/motion_velocity_planner_common/planner_data.hpp>
+#include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/ros/parameter.hpp>
 #include <autoware/universe_utils/ros/update_param.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
+#include <traffic_light_utils/traffic_light_utils.hpp>
 
+#include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 
-#include <lanelet2_core/geometry/LaneletMap.h>
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/Polygon.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <map>
 #include <memory>
@@ -155,6 +161,42 @@ void OutOfLaneModule::update_parameters(const std::vector<rclcpp::Parameter> & p
   updateParam(parameters, ns_ + ".ego.extra_right_offset", pp.extra_right_offset);
 }
 
+void prepare_stop_lines_rtree(
+  out_of_lane::EgoData & ego_data, const PlannerData & planner_data, const double search_distance)
+{
+  std::vector<out_of_lane::StopLineNode> rtree_nodes;
+  const auto bbox = lanelet::BoundingBox2d(
+    lanelet::BasicPoint2d{
+      ego_data.pose.position.x - search_distance, ego_data.pose.position.y - search_distance},
+    lanelet::BasicPoint2d{
+      ego_data.pose.position.x + search_distance, ego_data.pose.position.y + search_distance});
+  out_of_lane::StopLineNode stop_line_node;
+  for (const auto & ll :
+       planner_data.route_handler->getLaneletMapPtr()->laneletLayer.search(bbox)) {
+    for (const auto & element : ll.regulatoryElementsAs<lanelet::TrafficLight>()) {
+      const auto traffic_signal_stamped = planner_data.get_traffic_signal(element->id());
+      if (
+        traffic_signal_stamped.has_value() && element->stopLine().has_value() &&
+        traffic_light_utils::isTrafficSignalStop(ll, traffic_signal_stamped.value().signal)) {
+        stop_line_node.second.stop_line.clear();
+        for (const auto & p : element->stopLine()->basicLineString()) {
+          stop_line_node.second.stop_line.emplace_back(p.x(), p.y());
+        }
+        // use a longer stop line to also cut predicted paths that slightly go around the stop line
+        const auto diff =
+          stop_line_node.second.stop_line.back() - stop_line_node.second.stop_line.front();
+        stop_line_node.second.stop_line.front() -= diff * 0.5;
+        stop_line_node.second.stop_line.back() += diff * 0.5;
+        stop_line_node.second.lanelets = planner_data.route_handler->getPreviousLanelets(ll);
+        stop_line_node.first =
+          boost::geometry::return_envelope<universe_utils::Box2d>(stop_line_node.second.stop_line);
+        rtree_nodes.push_back(stop_line_node);
+      }
+    }
+  }
+  ego_data.stop_lines_rtree = {rtree_nodes.begin(), rtree_nodes.end()};
+}
+
 VelocityPlanningResult OutOfLaneModule::plan(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & ego_trajectory_points,
   const std::shared_ptr<const PlannerData> planner_data)
@@ -169,6 +211,10 @@ VelocityPlanningResult OutOfLaneModule::plan(
     autoware::motion_utils::findNearestSegmentIndex(ego_trajectory_points, ego_data.pose.position);
   ego_data.velocity = planner_data->current_odometry.twist.twist.linear.x;
   ego_data.max_decel = planner_data->velocity_smoother_->getMinDecel();
+  stopwatch.tic("preprocessing");
+  prepare_stop_lines_rtree(ego_data, *planner_data, 100.0);
+  const auto preprocessing_us = stopwatch.toc("preprocessing");
+
   stopwatch.tic("calculate_trajectory_footprints");
   const auto current_ego_footprint =
     out_of_lane::calculate_current_ego_footprint(ego_data, params_, true);
@@ -289,6 +335,7 @@ VelocityPlanningResult OutOfLaneModule::plan(
   RCLCPP_DEBUG(
     logger_,
     "Total time = %2.2fus\n"
+    "\tpreprocessing = %2.0fus\n"
     "\tcalculate_lanelets = %2.0fus\n"
     "\tcalculate_trajectory_footprints = %2.0fus\n"
     "\tcalculate_overlapping_ranges = %2.0fus\n"
@@ -296,7 +343,7 @@ VelocityPlanningResult OutOfLaneModule::plan(
     "\tcalculate_decisions = %2.0fus\n"
     "\tcalc_slowdown_points = %2.0fus\n"
     "\tinsert_slowdown_points = %2.0fus\n",
-    total_time_us, calculate_lanelets_us, calculate_trajectory_footprints_us,
+    preprocessing_us, total_time_us, calculate_lanelets_us, calculate_trajectory_footprints_us,
     calculate_overlapping_ranges_us, filter_predicted_objects_us, calculate_decisions_us,
     calc_slowdown_points_us, insert_slowdown_points_us);
   debug_publisher_->publish(out_of_lane::debug::create_debug_marker_array(debug_data_));
@@ -304,6 +351,7 @@ VelocityPlanningResult OutOfLaneModule::plan(
     out_of_lane::debug::create_virtual_walls(debug_data_, params_));
   virtual_wall_publisher_->publish(virtual_wall_marker_creator.create_markers(clock_->now()));
   std::map<std::string, double> processing_times;
+  processing_times["preprocessing"] = preprocessing_us / 1000;
   processing_times["calculate_lanelets"] = calculate_lanelets_us / 1000;
   processing_times["calculate_trajectory_footprints"] = calculate_trajectory_footprints_us / 1000;
   processing_times["calculate_overlapping_ranges"] = calculate_overlapping_ranges_us / 1000;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/test/test_filter_predicted_objects.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/test/test_filter_predicted_objects.cpp
@@ -25,7 +25,7 @@ TEST(TestCollisionDistance, CutPredictedPathBeyondLine)
 {
   using autoware::motion_velocity_planner::out_of_lane::cut_predicted_path_beyond_line;
   autoware_perception_msgs::msg::PredictedPath predicted_path;
-  lanelet::BasicLineString2d stop_line;
+  autoware::universe_utils::LineString2d stop_line;
   double object_front_overhang = 0.0;
   const auto eps = 1e-9;
 

--- a/sensing/livox/autoware_livox_tag_filter/src/livox_tag_filter_node.cpp
+++ b/sensing/livox/autoware_livox_tag_filter/src/livox_tag_filter_node.cpp
@@ -22,10 +22,10 @@
 
 struct EIGEN_ALIGN16 LivoxPoint
 {
-  float x;
-  float y;
-  float z;
-  float intensity;
+  float x;          // cppcheck-suppress unusedStructMember
+  float y;          // cppcheck-suppress unusedStructMember
+  float z;          // cppcheck-suppress unusedStructMember
+  float intensity;  // cppcheck-suppress unusedStructMember
   std::uint8_t tag;
   std::uint8_t line;
 };


### PR DESCRIPTION
## Description
This PR updates the name of the composable node registration in `CMakeLists.txt` to include `autoware::` scoping as specified in the node source file.

This change is fixes #8437 .


**Parent Issue:**

- [Link](https://github.com/autowarefoundation/autoware.universe/issues/8437)

## How was this PR tested?
A composable node from an xml launch file was created as stated in the linked issue and the launch file was used to start the obstacle stop planner node.

The node started as expected in the component container and the expected obstacle slow down and obstacle stopping behaviors were visualized on RViz.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
