### PR TITLE
fix(autoware_behavior_path_planner_common): fix variableScope

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -283,9 +283,9 @@ std::optional<size_t> findIndexOutOfGoalSearchRange(
 
   // find goal index
   size_t min_dist_index;
-  double min_dist = std::numeric_limits<double>::max();
   {
     bool found = false;
+    double min_dist = std::numeric_limits<double>::max();
     for (size_t i = 0; i < points.size(); ++i) {
       const auto & lane_ids = points.at(i).lane_ids;
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck variableScope warnings

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:286:10: style: The scope of the variable 'min_dist' can be reduced. [variableScope]
  double min_dist = std::numeric_limits<double>::max();
         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
