### PR TITLE
perf(lane_change): cache lanelet polygons and expanded lanelets

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -24,6 +24,8 @@
 
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <boost/compute/detail/lru_cache.hpp>
+
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/Polygon.h>
 
@@ -277,6 +279,10 @@ using LCParamPtr = std::shared_ptr<Parameters>;
 using LanesPtr = std::shared_ptr<Lanes>;
 using LanesPolygonPtr = std::shared_ptr<LanesPolygon>;
 
+using LaneletsPolygonCache =
+  boost::compute::detail::lru_cache<lanelet::Ids, std::optional<lanelet::BasicPolygon2d>>;
+using LaneletsCache = boost::compute::detail::lru_cache<lanelet::Ids, lanelet::ConstLanelets>;
+
 struct CommonData
 {
   RouteHandlerPtr route_handler_ptr;
@@ -287,6 +293,14 @@ struct CommonData
   LanesPolygonPtr lanes_polygon_ptr;
   ModuleType lc_type;
   Direction direction;
+  mutable LaneletsPolygonCache lanelets_polygon_cache{100};
+  mutable LaneletsCache expanded_lanelets_polygon_cache{10};
+  mutable struct
+  {
+    Direction direction{};
+    double left_offset{};
+    double right_offset{};
+  } expanded_cache_parameters;
 
   [[nodiscard]] Pose get_ego_pose() const { return self_odometry_ptr->pose.pose; }
 


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
