### PR TITLE
fix(reaction_analyzer): fix variableScope

### DIFF
--- a/tools/reaction_analyzer/src/utils.cpp
+++ b/tools/reaction_analyzer/src/utils.cpp
@@ -222,9 +222,8 @@ size_t get_index_after_distance(
   const TrajectoryPoint & curr_p = traj.points.at(curr_id);
 
   size_t target_id = curr_id;
-  double current_distance = 0.0;
   for (size_t traj_id = curr_id + 1; traj_id < traj.points.size(); ++traj_id) {
-    current_distance = autoware::universe_utils::calcDistance3d(traj.points.at(traj_id), curr_p);
+    const double current_distance = autoware::universe_utils::calcDistance3d(traj.points.at(traj_id), curr_p);
     if (current_distance >= distance) {
       break;
     }

--- a/tools/reaction_analyzer/src/utils.cpp
+++ b/tools/reaction_analyzer/src/utils.cpp
@@ -223,7 +223,8 @@ size_t get_index_after_distance(
 
   size_t target_id = curr_id;
   for (size_t traj_id = curr_id + 1; traj_id < traj.points.size(); ++traj_id) {
-    const double current_distance = autoware::universe_utils::calcDistance3d(traj.points.at(traj_id), curr_p);
+    const double current_distance =
+      autoware::universe_utils::calcDistance3d(traj.points.at(traj_id), curr_p);
     if (current_distance >= distance) {
       break;
     }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck variableScope warnings

```
tools/reaction_analyzer/src/utils.cpp:225:10: style: The scope of the variable 'current_distance' can be reduced. [variableScope]
  double current_distance = 0.0;
         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
