### PR TITLE
fix(lane_departure_checker): fix uninitialized variables

### DIFF
--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
@@ -60,18 +60,18 @@ typedef boost::geometry::index::rtree<Segment2d, boost::geometry::index::rstar<1
 
 struct Param
 {
-  double footprint_margin_scale;
-  double footprint_extra_margin;
-  double resample_interval;
-  double max_deceleration;
-  double delay_time;
-  double max_lateral_deviation;
-  double max_longitudinal_deviation;
-  double max_yaw_deviation_deg;
-  double min_braking_distance;
+  double footprint_margin_scale{0.0};
+  double footprint_extra_margin{0.0};
+  double resample_interval{0.0};
+  double max_deceleration{0.0};
+  double delay_time{0.0};
+  double max_lateral_deviation{0.0};
+  double max_longitudinal_deviation{0.0};
+  double max_yaw_deviation_deg{0.0};
+  double min_braking_distance{0.0};
   // nearest search to ego
-  double ego_nearest_dist_threshold;
-  double ego_nearest_yaw_threshold;
+  double ego_nearest_dist_threshold{0.0};
+  double ego_nearest_yaw_threshold{0.0};
 };
 
 struct Input


### PR DESCRIPTION
## Description

related to https://github.com/autowarefoundation/autoware.universe/pull/8449, better to set initial value for when forgetting set in user side.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

none

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
