### PR TITLE
refactor(autoware_map_based_prediction): map based pred time keeper ptr

### DIFF
--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -50,3 +50,8 @@
       consider_only_routable_neighbours: false
 
     reference_path_resolution: 0.5 #[m]
+
+    # debug parameters
+    publish_processing_time: false
+    publish_processing_time_detail: false
+    publish_debug_markers: false

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -252,8 +252,7 @@ private:
   std::unique_ptr<autoware::universe_utils::PublishedTimePublisher> published_time_publisher_;
   rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
     detailed_processing_time_publisher_;
-  mutable autoware::universe_utils::TimeKeeper time_keeper_;
-  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   // Member Functions
   void mapCallback(const LaneletMapBin::ConstSharedPtr msg);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -344,6 +344,10 @@ private:
     const TrackedObject & object, const LaneletData & current_lanelet_data,
     const double object_detected_time);
 
+  void publish(
+    const PredictedObjects & output,
+    const visualization_msgs::msg::MarkerArray & debug_markers) const;
+
   // NOTE: This function is copied from the motion_velocity_smoother package.
   // TODO(someone): Consolidate functions and move them to a common
   inline std::vector<double> calcTrajectoryCurvatureFrom3Points(

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -253,6 +253,7 @@ private:
   rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
     detailed_processing_time_publisher_;
   mutable autoware::universe_utils::TimeKeeper time_keeper_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr_;
 
   // Member Functions
   void mapCallback(const LaneletMapBin::ConstSharedPtr msg);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -122,7 +122,7 @@ private:
   bool use_vehicle_acceleration_;
   double acceleration_exponential_half_life_;
 
-  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object, const double duration) const;

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -16,6 +16,7 @@
 #define MAP_BASED_PREDICTION__PATH_GENERATOR_HPP_
 
 #include <Eigen/Eigen>
+#include <autoware/universe_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -82,6 +83,8 @@ class PathGenerator
 public:
   PathGenerator(const double sampling_time_interval, const double min_crosswalk_user_velocity);
 
+  void setTimeKeeper(std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr);
+
   PredictedPath generatePathForNonVehicleObject(
     const TrackedObject & object, const double duration) const;
 
@@ -118,6 +121,8 @@ private:
   double min_crosswalk_user_velocity_;
   bool use_vehicle_acceleration_;
   double acceleration_exponential_half_life_;
+
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr_;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object, const double duration) const;

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -870,9 +870,9 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
     detailed_processing_time_publisher_ =
       this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
         "~/debug/processing_time_detail_ms", 1);
-    time_keeper_ = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
-    time_keeper_ptr_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper_);
-    path_generator_->setTimeKeeper(time_keeper_ptr_);
+    auto time_keeper = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
+    time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper);
+    path_generator_->setTimeKeeper(time_keeper_);
   }
 
   if (use_debug_marker) {
@@ -962,7 +962,7 @@ void MapBasedPredictionNode::trafficSignalsCallback(
   const TrafficLightGroupArray::ConstSharedPtr msg)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   traffic_signal_id_map_.clear();
   for (const auto & signal : msg->traffic_light_groups) {
@@ -973,7 +973,7 @@ void MapBasedPredictionNode::trafficSignalsCallback(
 void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPtr in_objects)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   if (stop_watch_ptr_) stop_watch_ptr_->toc("processing_time", true);
 
@@ -1265,7 +1265,7 @@ void MapBasedPredictionNode::publish(
   const PredictedObjects & output, const visualization_msgs::msg::MarkerArray & debug_markers) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   pub_objects_->publish(output);
   if (published_time_publisher_)
@@ -1277,7 +1277,7 @@ void MapBasedPredictionNode::updateCrosswalkUserHistory(
   const std_msgs::msg::Header & header, const TrackedObject & object, const std::string & object_id)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   CrosswalkUserData crosswalk_user_data;
   crosswalk_user_data.header = header;
@@ -1295,7 +1295,7 @@ std::string MapBasedPredictionNode::tryMatchNewObjectToDisappeared(
   const std::string & object_id, std::unordered_map<std::string, TrackedObject> & current_users)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   const auto known_match_opt = [&]() -> std::optional<std::string> {
     if (!known_matches_.count(object_id)) {
@@ -1355,7 +1355,7 @@ std::string MapBasedPredictionNode::tryMatchNewObjectToDisappeared(
 bool MapBasedPredictionNode::doesPathCrossAnyFence(const PredictedPath & predicted_path)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   lanelet::BasicLineString2d predicted_path_ls;
   for (const auto & p : predicted_path.path)
@@ -1374,7 +1374,7 @@ bool MapBasedPredictionNode::doesPathCrossFence(
   const PredictedPath & predicted_path, const lanelet::ConstLineString3d & fence_line)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // check whether the predicted path cross with fence
   for (size_t i = 0; i < predicted_path.path.size() - 1; ++i) {
@@ -1394,7 +1394,7 @@ bool MapBasedPredictionNode::isIntersecting(
   const lanelet::ConstPoint3d & point3, const lanelet::ConstPoint3d & point4)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   const auto p1 = autoware::universe_utils::createPoint(point1.x, point1.y, 0.0);
   const auto p2 = autoware::universe_utils::createPoint(point2.x, point2.y, 0.0);
@@ -1408,7 +1408,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
   const TrackedObject & object)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   auto predicted_object = convertToPredictedObject(object);
   {
@@ -1563,7 +1563,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
 void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   if (
     object.kinematics.orientation_availability ==
@@ -1632,7 +1632,7 @@ void MapBasedPredictionNode::removeStaleTrafficLightInfo(
 LaneletsData MapBasedPredictionNode::getCurrentLanelets(const TrackedObject & object)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // obstacle point
   lanelet::BasicPoint2d search_point(
@@ -1725,7 +1725,7 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
   const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // Step1. If we only have one point in the centerline, we will ignore the lanelet
   if (lanelet.second.centerline().size() <= 1) {
@@ -1774,7 +1774,7 @@ float MapBasedPredictionNode::calculateLocalLikelihood(
   const lanelet::Lanelet & current_lanelet, const TrackedObject & object) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   const auto & obj_point = object.kinematics.pose_with_covariance.pose.position;
 
@@ -1812,7 +1812,7 @@ void MapBasedPredictionNode::updateRoadUsersHistory(
   const LaneletsData & current_lanelets_data)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   std::string object_id = autoware::universe_utils::toHexString(object.object_id);
   const auto current_lanelets = getLanelets(current_lanelets_data);
@@ -1856,7 +1856,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
   const double object_detected_time, const double time_horizon)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   const double obj_vel = std::hypot(
     object.kinematics.twist_with_covariance.twist.linear.x,
@@ -2021,7 +2021,7 @@ Maneuver MapBasedPredictionNode::predictObjectManeuver(
   const double object_detected_time)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // calculate maneuver
   const auto current_maneuver = [&]() {
@@ -2074,7 +2074,7 @@ Maneuver MapBasedPredictionNode::predictObjectManeuverByTimeToLaneChange(
   const double /*object_detected_time*/)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // Step1. Check if we have the object in the buffer
   const std::string object_id = autoware::universe_utils::toHexString(object.object_id);
@@ -2148,7 +2148,7 @@ Maneuver MapBasedPredictionNode::predictObjectManeuverByLatDiffDistance(
   const double /*object_detected_time*/)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // Step1. Check if we have the object in the buffer
   const std::string object_id = autoware::universe_utils::toHexString(object.object_id);
@@ -2313,7 +2313,7 @@ void MapBasedPredictionNode::updateFuturePossibleLanelets(
   const TrackedObject & object, const lanelet::routing::LaneletPaths & paths)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   std::string object_id = autoware::universe_utils::toHexString(object.object_id);
   if (road_users_history.count(object_id) == 0) {
@@ -2340,7 +2340,7 @@ void MapBasedPredictionNode::addReferencePaths(
   const double speed_limit)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   if (!candidate_paths.empty()) {
     updateFuturePossibleLanelets(object, candidate_paths);
@@ -2362,7 +2362,7 @@ ManeuverProbability MapBasedPredictionNode::calculateManeuverProbability(
   const lanelet::routing::LaneletPaths & center_paths)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   float left_lane_change_probability = 0.0;
   float right_lane_change_probability = 0.0;
@@ -2427,7 +2427,7 @@ std::vector<PosePath> MapBasedPredictionNode::convertPathType(
   const lanelet::routing::LaneletPaths & paths) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   if (lru_cache_of_convert_path_type_.contains(paths)) {
     return *lru_cache_of_convert_path_type_.get(paths);
@@ -2574,7 +2574,7 @@ std::optional<TrafficLightElement> MapBasedPredictionNode::getTrafficSignalEleme
   const lanelet::Id & id)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   if (traffic_signal_id_map_.count(id) != 0) {
     const auto & signal_elements = traffic_signal_id_map_.at(id).elements;
@@ -2593,7 +2593,7 @@ bool MapBasedPredictionNode::calcIntentionToCrossWithTrafficSignal(
   const lanelet::Id & signal_id)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   const auto signal_color = [&] {
     const auto elem_opt = getTrafficSignalElement(signal_id);

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1235,15 +1235,26 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
   }
 
   // Publish Results
-  pub_objects_->publish(output);
-  published_time_publisher_->publish_if_subscribed(pub_objects_, output.header.stamp);
-  pub_debug_markers_->publish(debug_markers);
+  publish(output, debug_markers);
+
+  // Publish Processing Time
   const auto processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
   const auto cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
   processing_time_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", cyclic_time_ms);
   processing_time_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", processing_time_ms);
+}
+
+void MapBasedPredictionNode::publish(
+  const PredictedObjects & output, const visualization_msgs::msg::MarkerArray & debug_markers) const
+{
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+
+  pub_objects_->publish(output);
+  published_time_publisher_->publish_if_subscribed(pub_objects_, output.header.stamp);
+  pub_debug_markers_->publish(debug_markers);
 }
 
 void MapBasedPredictionNode::updateCrosswalkUserHistory(

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -52,6 +52,7 @@
 
 namespace autoware::map_based_prediction
 {
+using autoware::universe_utils::ScopedTimeTrack;
 
 namespace
 {
@@ -919,7 +920,8 @@ PredictedObject MapBasedPredictionNode::convertToPredictedObject(
 
 void MapBasedPredictionNode::mapCallback(const LaneletMapBin::ConstSharedPtr msg)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   RCLCPP_DEBUG(get_logger(), "[Map Based Prediction]: Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
@@ -948,7 +950,8 @@ void MapBasedPredictionNode::mapCallback(const LaneletMapBin::ConstSharedPtr msg
 void MapBasedPredictionNode::trafficSignalsCallback(
   const TrafficLightGroupArray::ConstSharedPtr msg)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   traffic_signal_id_map_.clear();
   for (const auto & signal : msg->traffic_light_groups) {
@@ -958,7 +961,8 @@ void MapBasedPredictionNode::trafficSignalsCallback(
 
 void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPtr in_objects)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   stop_watch_ptr_->toc("processing_time", true);
 
@@ -1245,7 +1249,8 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
 void MapBasedPredictionNode::updateCrosswalkUserHistory(
   const std_msgs::msg::Header & header, const TrackedObject & object, const std::string & object_id)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   CrosswalkUserData crosswalk_user_data;
   crosswalk_user_data.header = header;
@@ -1262,7 +1267,8 @@ void MapBasedPredictionNode::updateCrosswalkUserHistory(
 std::string MapBasedPredictionNode::tryMatchNewObjectToDisappeared(
   const std::string & object_id, std::unordered_map<std::string, TrackedObject> & current_users)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const auto known_match_opt = [&]() -> std::optional<std::string> {
     if (!known_matches_.count(object_id)) {
@@ -1321,7 +1327,8 @@ std::string MapBasedPredictionNode::tryMatchNewObjectToDisappeared(
 
 bool MapBasedPredictionNode::doesPathCrossAnyFence(const PredictedPath & predicted_path)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   lanelet::BasicLineString2d predicted_path_ls;
   for (const auto & p : predicted_path.path)
@@ -1339,7 +1346,8 @@ bool MapBasedPredictionNode::doesPathCrossAnyFence(const PredictedPath & predict
 bool MapBasedPredictionNode::doesPathCrossFence(
   const PredictedPath & predicted_path, const lanelet::ConstLineString3d & fence_line)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // check whether the predicted path cross with fence
   for (size_t i = 0; i < predicted_path.path.size() - 1; ++i) {
@@ -1369,7 +1377,8 @@ bool MapBasedPredictionNode::isIntersecting(
 PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
   const TrackedObject & object)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   auto predicted_object = convertToPredictedObject(object);
   {
@@ -1523,7 +1532,8 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
 
 void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   if (
     object.kinematics.orientation_availability ==
@@ -1575,7 +1585,8 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
 void MapBasedPredictionNode::removeStaleTrafficLightInfo(
   const TrackedObjects::ConstSharedPtr in_objects)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   for (auto it = stopped_times_against_green_.begin(); it != stopped_times_against_green_.end();) {
     const bool isDisappeared = std::none_of(
@@ -1593,7 +1604,8 @@ void MapBasedPredictionNode::removeStaleTrafficLightInfo(
 
 LaneletsData MapBasedPredictionNode::getCurrentLanelets(const TrackedObject & object)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // obstacle point
   lanelet::BasicPoint2d search_point(
@@ -1685,7 +1697,8 @@ LaneletsData MapBasedPredictionNode::getCurrentLanelets(const TrackedObject & ob
 bool MapBasedPredictionNode::checkCloseLaneletCondition(
   const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // Step1. If we only have one point in the centerline, we will ignore the lanelet
   if (lanelet.second.centerline().size() <= 1) {
@@ -1733,7 +1746,8 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
 float MapBasedPredictionNode::calculateLocalLikelihood(
   const lanelet::Lanelet & current_lanelet, const TrackedObject & object) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const auto & obj_point = object.kinematics.pose_with_covariance.pose.position;
 
@@ -1770,7 +1784,8 @@ void MapBasedPredictionNode::updateRoadUsersHistory(
   const std_msgs::msg::Header & header, const TrackedObject & object,
   const LaneletsData & current_lanelets_data)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   std::string object_id = autoware::universe_utils::toHexString(object.object_id);
   const auto current_lanelets = getLanelets(current_lanelets_data);
@@ -1813,7 +1828,8 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
   const TrackedObject & object, const LaneletsData & current_lanelets_data,
   const double object_detected_time, const double time_horizon)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const double obj_vel = std::hypot(
     object.kinematics.twist_with_covariance.twist.linear.x,
@@ -1977,7 +1993,8 @@ Maneuver MapBasedPredictionNode::predictObjectManeuver(
   const TrackedObject & object, const LaneletData & current_lanelet_data,
   const double object_detected_time)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // calculate maneuver
   const auto current_maneuver = [&]() {
@@ -2029,7 +2046,8 @@ Maneuver MapBasedPredictionNode::predictObjectManeuverByTimeToLaneChange(
   const TrackedObject & object, const LaneletData & current_lanelet_data,
   const double /*object_detected_time*/)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // Step1. Check if we have the object in the buffer
   const std::string object_id = autoware::universe_utils::toHexString(object.object_id);
@@ -2102,7 +2120,8 @@ Maneuver MapBasedPredictionNode::predictObjectManeuverByLatDiffDistance(
   const TrackedObject & object, const LaneletData & current_lanelet_data,
   const double /*object_detected_time*/)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // Step1. Check if we have the object in the buffer
   const std::string object_id = autoware::universe_utils::toHexString(object.object_id);
@@ -2247,7 +2266,8 @@ geometry_msgs::msg::Pose MapBasedPredictionNode::compensateTimeDelay(
 double MapBasedPredictionNode::calcRightLateralOffset(
   const lanelet::ConstLineString2d & boundary_line, const geometry_msgs::msg::Pose & search_pose)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   std::vector<geometry_msgs::msg::Point> boundary_path(boundary_line.size());
   for (size_t i = 0; i < boundary_path.size(); ++i) {
@@ -2268,7 +2288,8 @@ double MapBasedPredictionNode::calcLeftLateralOffset(
 void MapBasedPredictionNode::updateFuturePossibleLanelets(
   const TrackedObject & object, const lanelet::routing::LaneletPaths & paths)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   std::string object_id = autoware::universe_utils::toHexString(object.object_id);
   if (road_users_history.count(object_id) == 0) {
@@ -2294,7 +2315,8 @@ void MapBasedPredictionNode::addReferencePaths(
   const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths,
   const double speed_limit)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   if (!candidate_paths.empty()) {
     updateFuturePossibleLanelets(object, candidate_paths);
@@ -2315,7 +2337,8 @@ ManeuverProbability MapBasedPredictionNode::calculateManeuverProbability(
   const lanelet::routing::LaneletPaths & right_paths,
   const lanelet::routing::LaneletPaths & center_paths)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   float left_lane_change_probability = 0.0;
   float right_lane_change_probability = 0.0;
@@ -2379,7 +2402,8 @@ ManeuverProbability MapBasedPredictionNode::calculateManeuverProbability(
 std::vector<PosePath> MapBasedPredictionNode::convertPathType(
   const lanelet::routing::LaneletPaths & paths) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   if (lru_cache_of_convert_path_type_.contains(paths)) {
     return *lru_cache_of_convert_path_type_.get(paths);
@@ -2476,7 +2500,8 @@ bool MapBasedPredictionNode::isDuplicated(
   const std::pair<double, lanelet::ConstLanelet> & target_lanelet,
   const LaneletsData & lanelets_data)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const double CLOSE_LANELET_THRESHOLD = 0.1;
   for (const auto & lanelet_data : lanelets_data) {
@@ -2495,7 +2520,8 @@ bool MapBasedPredictionNode::isDuplicated(
 bool MapBasedPredictionNode::isDuplicated(
   const PredictedPath & predicted_path, const std::vector<PredictedPath> & predicted_paths)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const double CLOSE_PATH_THRESHOLD = 0.1;
   for (const auto & prev_predicted_path : predicted_paths) {
@@ -2513,7 +2539,8 @@ bool MapBasedPredictionNode::isDuplicated(
 std::optional<lanelet::Id> MapBasedPredictionNode::getTrafficSignalId(
   const lanelet::ConstLanelet & way_lanelet)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const auto traffic_light_reg_elems =
     way_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
@@ -2531,7 +2558,8 @@ std::optional<lanelet::Id> MapBasedPredictionNode::getTrafficSignalId(
 std::optional<TrafficLightElement> MapBasedPredictionNode::getTrafficSignalElement(
   const lanelet::Id & id)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   if (traffic_signal_id_map_.count(id) != 0) {
     const auto & signal_elements = traffic_signal_id_map_.at(id).elements;
@@ -2549,7 +2577,8 @@ bool MapBasedPredictionNode::calcIntentionToCrossWithTrafficSignal(
   const TrackedObject & object, const lanelet::ConstLanelet & crosswalk,
   const lanelet::Id & signal_id)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const auto signal_color = [&] {
     const auto elem_opt = getTrafficSignalElement(signal_id);

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -858,6 +858,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
       "~/debug/processing_time_detail_ms", 1);
   time_keeper_ = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
   time_keeper_ptr_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper_);
+  path_generator_->setTimeKeeper(time_keeper_ptr_);
 
   set_param_res_ = this->add_on_set_parameters_callback(
     std::bind(&MapBasedPredictionNode::onParam, this, std::placeholders::_1));

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -934,9 +934,6 @@ PredictedObject MapBasedPredictionNode::convertToPredictedObject(
 
 void MapBasedPredictionNode::mapCallback(const LaneletMapBin::ConstSharedPtr msg)
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   RCLCPP_DEBUG(get_logger(), "[Map Based Prediction]: Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
@@ -1396,6 +1393,9 @@ bool MapBasedPredictionNode::isIntersecting(
   const geometry_msgs::msg::Point & point1, const geometry_msgs::msg::Point & point2,
   const lanelet::ConstPoint3d & point3, const lanelet::ConstPoint3d & point4)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+
   const auto p1 = autoware::universe_utils::createPoint(point1.x, point1.y, 0.0);
   const auto p2 = autoware::universe_utils::createPoint(point2.x, point2.y, 0.0);
   const auto p3 = autoware::universe_utils::createPoint(point3.x(), point3.y(), 0.0);
@@ -1615,9 +1615,6 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
 void MapBasedPredictionNode::removeStaleTrafficLightInfo(
   const TrackedObjects::ConstSharedPtr in_objects)
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   for (auto it = stopped_times_against_green_.begin(); it != stopped_times_against_green_.end();) {
     const bool isDisappeared = std::none_of(
       in_objects->objects.begin(), in_objects->objects.end(),
@@ -2296,9 +2293,6 @@ geometry_msgs::msg::Pose MapBasedPredictionNode::compensateTimeDelay(
 double MapBasedPredictionNode::calcRightLateralOffset(
   const lanelet::ConstLineString2d & boundary_line, const geometry_msgs::msg::Pose & search_pose)
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   std::vector<geometry_msgs::msg::Point> boundary_path(boundary_line.size());
   for (size_t i = 0; i < boundary_path.size(); ++i) {
     const double x = boundary_line[i].x();
@@ -2530,9 +2524,6 @@ bool MapBasedPredictionNode::isDuplicated(
   const std::pair<double, lanelet::ConstLanelet> & target_lanelet,
   const LaneletsData & lanelets_data)
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   const double CLOSE_LANELET_THRESHOLD = 0.1;
   for (const auto & lanelet_data : lanelets_data) {
     const auto target_lanelet_end_p = target_lanelet.second.centerline2d().back();
@@ -2550,9 +2541,6 @@ bool MapBasedPredictionNode::isDuplicated(
 bool MapBasedPredictionNode::isDuplicated(
   const PredictedPath & predicted_path, const std::vector<PredictedPath> & predicted_paths)
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   const double CLOSE_PATH_THRESHOLD = 0.1;
   for (const auto & prev_predicted_path : predicted_paths) {
     const auto prev_path_end = prev_predicted_path.path.back().position;
@@ -2569,9 +2557,6 @@ bool MapBasedPredictionNode::isDuplicated(
 std::optional<lanelet::Id> MapBasedPredictionNode::getTrafficSignalId(
   const lanelet::ConstLanelet & way_lanelet)
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   const auto traffic_light_reg_elems =
     way_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
   if (traffic_light_reg_elems.empty()) {

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -29,15 +29,25 @@ PathGenerator::PathGenerator(
 {
 }
 
+void PathGenerator::setTimeKeeper(
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr)
+{
+  time_keeper_ptr_ = std::move(time_keeper_ptr);
+}
+
 PredictedPath PathGenerator::generatePathForNonVehicleObject(
   const TrackedObject & object, const double duration) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   return generateStraightPath(object, duration);
 }
 
 PredictedPath PathGenerator::generatePathToTargetPoint(
   const TrackedObject & object, const Eigen::Vector2d & point) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   PredictedPath predicted_path{};
   const double ep = 0.001;
 
@@ -77,6 +87,8 @@ PredictedPath PathGenerator::generatePathForCrosswalkUser(
   const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk,
   const double duration) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   PredictedPath predicted_path{};
   const double ep = 0.001;
 
@@ -135,6 +147,8 @@ PredictedPath PathGenerator::generatePathForCrosswalkUser(
 PredictedPath PathGenerator::generatePathForLowSpeedVehicle(
   const TrackedObject & object, const double duration) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   PredictedPath path;
   path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
   const double ep = 0.001;
@@ -148,6 +162,8 @@ PredictedPath PathGenerator::generatePathForLowSpeedVehicle(
 PredictedPath PathGenerator::generatePathForOffLaneVehicle(
   const TrackedObject & object, const double duration) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   return generateStraightPath(object, duration);
 }
 
@@ -155,6 +171,8 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   const TrackedObject & object, const PosePath & ref_paths, const double duration,
   const double lateral_duration, const double speed_limit) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   if (ref_paths.size() < 2) {
     return generateStraightPath(object, duration);
   }
@@ -165,6 +183,8 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
 PredictedPath PathGenerator::generateStraightPath(
   const TrackedObject & object, const double longitudinal_duration) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   const auto & object_pose = object.kinematics.pose_with_covariance.pose;
   const auto & object_twist = object.kinematics.twist_with_covariance.twist;
   constexpr double ep = 0.001;
@@ -186,6 +206,8 @@ PredictedPath PathGenerator::generatePolynomialPath(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
   const double lateral_duration, const double speed_limit) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   // Get current Frenet Point
   const double ref_path_len = autoware::motion_utils::calcArcLength(ref_path);
   const auto current_point = getFrenetPoint(object, ref_path, duration, speed_limit);
@@ -219,6 +241,8 @@ FrenetPath PathGenerator::generateFrenetPath(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length,
   const double duration, const double lateral_duration) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   FrenetPath path;
 
   // Compute Lateral and Longitudinal Coefficients to generate the trajectory
@@ -259,6 +283,8 @@ FrenetPath PathGenerator::generateFrenetPath(
 Eigen::Vector3d PathGenerator::calcLatCoefficients(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   // Lateral Path Calculation
   // Quintic polynomial for d
   // A = np.array([[T**3, T**4, T**5],
@@ -285,6 +311,8 @@ Eigen::Vector3d PathGenerator::calcLatCoefficients(
 Eigen::Vector2d PathGenerator::calcLonCoefficients(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   // Longitudinal Path Calculation
   // Quadric polynomial
   // A_inv = np.matrix([[1/(T**2), -1/(3*T)],
@@ -303,6 +331,8 @@ Eigen::Vector2d PathGenerator::calcLonCoefficients(
 PosePath PathGenerator::interpolateReferencePath(
   const PosePath & base_path, const FrenetPath & frenet_predicted_path) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   PosePath interpolated_path;
   const size_t interpolate_num = frenet_predicted_path.size();
   if (interpolate_num < 2) {
@@ -361,6 +391,8 @@ PredictedPath PathGenerator::convertToPredictedPath(
   const TrackedObject & object, const FrenetPath & frenet_predicted_path,
   const PosePath & ref_path) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   PredictedPath predicted_path;
   predicted_path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
   predicted_path.path.resize(ref_path.size());
@@ -392,6 +424,8 @@ FrenetPoint PathGenerator::getFrenetPoint(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
   const double speed_limit) const
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+
   FrenetPoint frenet_point;
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;
 

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -191,9 +191,6 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
 PredictedPath PathGenerator::generateStraightPath(
   const TrackedObject & object, const double longitudinal_duration) const
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   const auto & object_pose = object.kinematics.pose_with_covariance.pose;
   const auto & object_twist = object.kinematics.twist_with_covariance.twist;
   constexpr double ep = 0.001;
@@ -294,9 +291,6 @@ FrenetPath PathGenerator::generateFrenetPath(
 Eigen::Vector3d PathGenerator::calcLatCoefficients(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   // Lateral Path Calculation
   // Quintic polynomial for d
   // A = np.array([[T**3, T**4, T**5],
@@ -323,9 +317,6 @@ Eigen::Vector3d PathGenerator::calcLatCoefficients(
 Eigen::Vector2d PathGenerator::calcLonCoefficients(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const
 {
-  std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
-
   // Longitudinal Path Calculation
   // Quadric polynomial
   // A_inv = np.matrix([[1/(T**2), -1/(3*T)],

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -34,14 +34,14 @@ PathGenerator::PathGenerator(
 void PathGenerator::setTimeKeeper(
   std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_ptr)
 {
-  time_keeper_ptr_ = std::move(time_keeper_ptr);
+  time_keeper_ = std::move(time_keeper_ptr);
 }
 
 PredictedPath PathGenerator::generatePathForNonVehicleObject(
   const TrackedObject & object, const double duration) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   return generateStraightPath(object, duration);
 }
@@ -50,7 +50,7 @@ PredictedPath PathGenerator::generatePathToTargetPoint(
   const TrackedObject & object, const Eigen::Vector2d & point) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   PredictedPath predicted_path{};
   const double ep = 0.001;
@@ -92,7 +92,7 @@ PredictedPath PathGenerator::generatePathForCrosswalkUser(
   const double duration) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   PredictedPath predicted_path{};
   const double ep = 0.001;
@@ -153,7 +153,7 @@ PredictedPath PathGenerator::generatePathForLowSpeedVehicle(
   const TrackedObject & object, const double duration) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   PredictedPath path;
   path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
@@ -169,7 +169,7 @@ PredictedPath PathGenerator::generatePathForOffLaneVehicle(
   const TrackedObject & object, const double duration) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   return generateStraightPath(object, duration);
 }
@@ -179,7 +179,7 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   const double lateral_duration, const double speed_limit) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   if (ref_paths.size() < 2) {
     return generateStraightPath(object, duration);
@@ -213,7 +213,7 @@ PredictedPath PathGenerator::generatePolynomialPath(
   const double lateral_duration, const double speed_limit) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   // Get current Frenet Point
   const double ref_path_len = autoware::motion_utils::calcArcLength(ref_path);
@@ -249,7 +249,7 @@ FrenetPath PathGenerator::generateFrenetPath(
   const double duration, const double lateral_duration) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   FrenetPath path;
 
@@ -336,7 +336,7 @@ PosePath PathGenerator::interpolateReferencePath(
   const PosePath & base_path, const FrenetPath & frenet_predicted_path) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   PosePath interpolated_path;
   const size_t interpolate_num = frenet_predicted_path.size();
@@ -397,7 +397,7 @@ PredictedPath PathGenerator::convertToPredictedPath(
   const PosePath & ref_path) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   PredictedPath predicted_path;
   predicted_path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
@@ -431,7 +431,7 @@ FrenetPoint PathGenerator::getFrenetPoint(
   const double speed_limit) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
-  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   FrenetPoint frenet_point;
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -22,6 +22,8 @@
 
 namespace autoware::map_based_prediction
 {
+using autoware::universe_utils::ScopedTimeTrack;
+
 PathGenerator::PathGenerator(
   const double sampling_time_interval, const double min_crosswalk_user_velocity)
 : sampling_time_interval_(sampling_time_interval),
@@ -38,7 +40,8 @@ void PathGenerator::setTimeKeeper(
 PredictedPath PathGenerator::generatePathForNonVehicleObject(
   const TrackedObject & object, const double duration) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   return generateStraightPath(object, duration);
 }
@@ -46,7 +49,8 @@ PredictedPath PathGenerator::generatePathForNonVehicleObject(
 PredictedPath PathGenerator::generatePathToTargetPoint(
   const TrackedObject & object, const Eigen::Vector2d & point) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   PredictedPath predicted_path{};
   const double ep = 0.001;
@@ -87,7 +91,8 @@ PredictedPath PathGenerator::generatePathForCrosswalkUser(
   const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk,
   const double duration) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   PredictedPath predicted_path{};
   const double ep = 0.001;
@@ -147,7 +152,8 @@ PredictedPath PathGenerator::generatePathForCrosswalkUser(
 PredictedPath PathGenerator::generatePathForLowSpeedVehicle(
   const TrackedObject & object, const double duration) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   PredictedPath path;
   path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
@@ -162,7 +168,8 @@ PredictedPath PathGenerator::generatePathForLowSpeedVehicle(
 PredictedPath PathGenerator::generatePathForOffLaneVehicle(
   const TrackedObject & object, const double duration) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   return generateStraightPath(object, duration);
 }
@@ -171,7 +178,8 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   const TrackedObject & object, const PosePath & ref_paths, const double duration,
   const double lateral_duration, const double speed_limit) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   if (ref_paths.size() < 2) {
     return generateStraightPath(object, duration);
@@ -183,7 +191,8 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
 PredictedPath PathGenerator::generateStraightPath(
   const TrackedObject & object, const double longitudinal_duration) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   const auto & object_pose = object.kinematics.pose_with_covariance.pose;
   const auto & object_twist = object.kinematics.twist_with_covariance.twist;
@@ -206,7 +215,8 @@ PredictedPath PathGenerator::generatePolynomialPath(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
   const double lateral_duration, const double speed_limit) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // Get current Frenet Point
   const double ref_path_len = autoware::motion_utils::calcArcLength(ref_path);
@@ -241,7 +251,8 @@ FrenetPath PathGenerator::generateFrenetPath(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length,
   const double duration, const double lateral_duration) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   FrenetPath path;
 
@@ -283,7 +294,8 @@ FrenetPath PathGenerator::generateFrenetPath(
 Eigen::Vector3d PathGenerator::calcLatCoefficients(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // Lateral Path Calculation
   // Quintic polynomial for d
@@ -311,7 +323,8 @@ Eigen::Vector3d PathGenerator::calcLatCoefficients(
 Eigen::Vector2d PathGenerator::calcLonCoefficients(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   // Longitudinal Path Calculation
   // Quadric polynomial
@@ -331,7 +344,8 @@ Eigen::Vector2d PathGenerator::calcLonCoefficients(
 PosePath PathGenerator::interpolateReferencePath(
   const PosePath & base_path, const FrenetPath & frenet_predicted_path) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   PosePath interpolated_path;
   const size_t interpolate_num = frenet_predicted_path.size();
@@ -391,7 +405,8 @@ PredictedPath PathGenerator::convertToPredictedPath(
   const TrackedObject & object, const FrenetPath & frenet_predicted_path,
   const PosePath & ref_path) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   PredictedPath predicted_path;
   predicted_path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
@@ -424,7 +439,8 @@ FrenetPoint PathGenerator::getFrenetPoint(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
   const double speed_limit) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_ptr_);
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_ptr_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_ptr_);
 
   FrenetPoint frenet_point;
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;


### PR DESCRIPTION
## Description

1. Implementing the time keeper by pointer.
  a. Can be implemented to sub-module by passing the pointer of the time keeper
  b. enable or disable the measurement
2. Add configuration for on/off debug message processes
  a. If the debugging process is heavy/not-needed, it can be turned off.

This PR do not contain any logic change.

## Related links

- Link

This PR should be merged first. 
https://github.com/autowarefoundation/autoware_launch/pull/1118

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested in a local recompute environment. 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
