### PR TITLE
perf(autoware_map_based_prediction): enhance speed by removing unnecessary calculation

### DIFF
--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -411,8 +411,8 @@ bool withinRoadLanelet(
 
 boost::optional<CrosswalkEdgePoints> isReachableCrosswalkEdgePoints(
   const TrackedObject & object, const lanelet::ConstLanelets & surrounding_lanelets,
-  const lanelet::ConstLanelets & external_surrounding_crosswalks,
-  const CrosswalkEdgePoints & edge_points, const double time_horizon, const double min_object_vel)
+  const lanelet::ConstLanelets & surrounding_crosswalks, const CrosswalkEdgePoints & edge_points,
+  const double time_horizon, const double min_object_vel)
 {
   using Point = boost::geometry::model::d2::point_xy<double>;
 
@@ -439,10 +439,10 @@ boost::optional<CrosswalkEdgePoints> isReachableCrosswalkEdgePoints(
   const auto is_stop_object = estimated_velocity < stop_velocity_th;
   const auto velocity = std::max(min_object_vel, estimated_velocity);
 
-  const auto isAcrossAnyRoad = [&surrounding_lanelets, &external_surrounding_crosswalks](
+  const auto isAcrossAnyRoad = [&surrounding_lanelets, &surrounding_crosswalks](
                                  const Point & p_src, const Point & p_dst) {
-    const auto withinAnyCrosswalk = [&external_surrounding_crosswalks](const Point & p) {
-      for (const auto & crosswalk : external_surrounding_crosswalks) {
+    const auto withinAnyCrosswalk = [&surrounding_crosswalks](const Point & p) {
+      for (const auto & crosswalk : surrounding_crosswalks) {
         if (boost::geometry::within(p, crosswalk.polygon2d().basicPolygon())) {
           return true;
         }
@@ -1388,7 +1388,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
     lanelet_map_ptr_->laneletLayer, lanelet::BasicPoint2d{obj_pos.x, obj_pos.y},
     prediction_time_horizon_.pedestrian * velocity);
   lanelet::ConstLanelets surrounding_lanelets;
-  lanelet::ConstLanelets external_surrounding_crosswalks;
+  lanelet::ConstLanelets surrounding_crosswalks;
   for (const auto & [dist, lanelet] : surrounding_lanelets_with_dist) {
     surrounding_lanelets.push_back(lanelet);
     const auto attr = lanelet.attribute(lanelet::AttributeName::Subtype);
@@ -1396,10 +1396,9 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
       attr.value() == lanelet::AttributeValueString::Crosswalk ||
       attr.value() == lanelet::AttributeValueString::Walkway) {
       const auto & crosswalk = lanelet;
+      surrounding_crosswalks.push_back(crosswalk);
       if (withinLanelet(object, crosswalk)) {
         crossing_crosswalk = crosswalk;
-      } else {
-        external_surrounding_crosswalks.push_back(crosswalk);
       }
     }
   }
@@ -1463,7 +1462,10 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
 
   // try to find the edge points for other surrounding crosswalks and generate path to the crosswalk
   // edge
-  for (const auto & crosswalk : external_surrounding_crosswalks) {
+  for (const auto & crosswalk : surrounding_crosswalks) {
+    if (crossing_crosswalk && crossing_crosswalk.get() == crosswalk) {
+      continue;
+    }
     const auto crosswalk_signal_id_opt = getTrafficSignalId(crosswalk);
     if (crosswalk_signal_id_opt.has_value() && use_crosswalk_signal_) {
       if (!calcIntentionToCrossWithTrafficSignal(
@@ -1488,7 +1490,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
     }
 
     const auto reachable_crosswalk = isReachableCrosswalkEdgePoints(
-      object, surrounding_lanelets, external_surrounding_crosswalks, edge_points,
+      object, surrounding_lanelets, surrounding_crosswalks, edge_points,
       prediction_time_horizon_.pedestrian, min_crosswalk_user_velocity_);
 
     if (!reachable_crosswalk) {

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -1426,7 +1426,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
       attr.value() == lanelet::AttributeValueString::Walkway) {
       const auto & crosswalk = lanelet;
       surrounding_crosswalks.push_back(crosswalk);
-      if (withinLanelet(object, crosswalk)) {
+      if (std::abs(dist) < 1e-5) {
         crossing_crosswalk = crosswalk;
       }
     }

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -358,28 +358,6 @@ CrosswalkEdgePoints getCrosswalkEdgePoints(const lanelet::ConstLanelet & crosswa
                              back_center_point,  r_p_back,  l_p_back};
 }
 
-bool withinLanelet(
-  const TrackedObject & object, const lanelet::ConstLanelet & lanelet,
-  const bool use_yaw_information = false, const float yaw_threshold = 0.6)
-{
-  using Point = boost::geometry::model::d2::point_xy<double>;
-
-  const auto & obj_pos = object.kinematics.pose_with_covariance.pose.position;
-  const Point p_object{obj_pos.x, obj_pos.y};
-
-  auto polygon = lanelet.polygon2d().basicPolygon();
-  boost::geometry::correct(polygon);
-  bool with_in_polygon = boost::geometry::within(p_object, polygon);
-
-  if (!use_yaw_information) return with_in_polygon;
-
-  // use yaw angle to compare
-  const double abs_yaw_diff = calcAbsYawDiffBetweenLaneletAndObject(object, lanelet);
-  if (abs_yaw_diff < yaw_threshold) return with_in_polygon;
-
-  return false;
-}
-
 bool withinRoadLanelet(
   const TrackedObject & object, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const bool use_yaw_information = false)
@@ -391,9 +369,12 @@ bool withinRoadLanelet(
   const auto surrounding_lanelets =
     lanelet::geometry::findNearest(lanelet_map_ptr->laneletLayer, search_point, search_radius);
 
-  for (const auto & lanelet : surrounding_lanelets) {
-    if (lanelet.second.hasAttribute(lanelet::AttributeName::Subtype)) {
-      lanelet::Attribute attr = lanelet.second.attribute(lanelet::AttributeName::Subtype);
+  for (const auto & lanelet_with_dist : surrounding_lanelets) {
+    const auto & dist = lanelet_with_dist.first;
+    const auto & lanelet = lanelet_with_dist.second;
+
+    if (lanelet.hasAttribute(lanelet::AttributeName::Subtype)) {
+      lanelet::Attribute attr = lanelet.attribute(lanelet::AttributeName::Subtype);
       if (
         attr.value() == lanelet::AttributeValueString::Crosswalk ||
         attr.value() == lanelet::AttributeValueString::Walkway) {
@@ -401,7 +382,13 @@ bool withinRoadLanelet(
       }
     }
 
-    if (withinLanelet(object, lanelet.second, use_yaw_information)) {
+    constexpr float yaw_threshold = 0.6;
+    bool within_lanelet = std::abs(dist) < 1e-5;
+    if (use_yaw_information) {
+      within_lanelet =
+        within_lanelet && calcAbsYawDiffBetweenLaneletAndObject(object, lanelet) < yaw_threshold;
+    }
+    if (within_lanelet) {
       return true;
     }
   }
@@ -1397,7 +1384,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
       attr.value() == lanelet::AttributeValueString::Walkway) {
       const auto & crosswalk = lanelet;
       surrounding_crosswalks.push_back(crosswalk);
-      if (withinLanelet(object, crosswalk)) {
+      if (std::abs(dist) < 1e-5) {
         crossing_crosswalk = crosswalk;
       }
     }


### PR DESCRIPTION
## Description

Multiple places were found where `boost::geometry::within(...)` was used immediately after `auto [dist, lanelet] = lanelet::geometry::findNearest(...)` (especially in places using `withinLanelet`). However, since `dist` being 0 and `boost::geometry::within(...)` returning true are equivalent, the redundant processing was eliminated.

https://wandbox.org/permlink/u3KhRExZACGjSf5Z

This change slightly improves performance.
*before*

```
⏰ Worst Case Execution Time ⏰
objectsCallback: total 7.75 [ms], avg. 7.75 [ms], run count: 1
    ├── trafficSignalsCallback: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── removeStaleTrafficLightInfo: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── updateObjectData: total 0.00 [ms], avg. 0.00 [ms], run count: 19
    ├── getCurrentLanelets: total 1.17 [ms], avg. 0.06 [ms], run count: 19
    │   ├── checkCloseLaneletCondition: total 0.40 [ms], avg. 0.00 [ms], run count: 190
    │   ├── isDuplicated: total 0.00 [ms], avg. 0.00 [ms], run count: 18
    │   └── calculateLocalLikelihood: total 0.06 [ms], avg. 0.00 [ms], run count: 15
    ├── updateRoadUsersHistory: total 0.06 [ms], avg. 0.00 [ms], run count: 19
    ├── getPredictedReferencePath: total 0.29 [ms], avg. 0.06 [ms], run count: 5
    │   ├── predictObjectManeuver: total 0.07 [ms], avg. 0.01 [ms], run count: 6
    │   │   └── predictObjectManeuverByLatDiffDistance: total 0.06 [ms], avg. 0.01 [ms], run count: 6
    │   │       └── calcRightLateralOffset: total 0.00 [ms], avg. 0.00 [ms], run count: 8
    │   ├── calculateManeuverProbability: total 0.00 [ms], avg. 0.00 [ms], run count: 6
    │   └── addReferencePaths: total 0.10 [ms], avg. 0.01 [ms], run count: 18
    │       ├── updateFuturePossibleLanelets: total 0.00 [ms], avg. 0.00 [ms], run count: 9
    │       └── convertPathType: total 0.05 [ms], avg. 0.01 [ms], run count: 9
    ├── updateCrosswalkUserHistory: total 0.00 [ms], avg. 0.00 [ms], run count: 54
    └── getPredictedObjectAsCrosswalkUser: total 5.19 [ms], avg. 0.10 [ms], run count: 54
        ├── getTrafficSignalId: total 0.00 [ms], avg. 0.00 [ms], run count: 113
        ├── calcIntentionToCrossWithTrafficSignal: total 0.11 [ms], avg. 0.00 [ms], run count: 113
        │   └── getTrafficSignalElement: total 0.00 [ms], avg. 0.00 [ms], run count: 113
        └── doesPathCrossAnyFence: total 0.00 [ms], avg. 0.00 [ms], run count: 32
```

*after*

```
⏰ Worst Case Execution Time ⏰
objectsCallback: total 5.76 [ms], avg. 5.76 [ms], run count: 1
    ├── trafficSignalsCallback: total 0.01 [ms], avg. 0.01 [ms], run count: 1
    ├── removeStaleTrafficLightInfo: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── updateObjectData: total 0.00 [ms], avg. 0.00 [ms], run count: 21
    ├── getCurrentLanelets: total 1.24 [ms], avg. 0.06 [ms], run count: 21
    │   ├── checkCloseLaneletCondition: total 0.44 [ms], avg. 0.00 [ms], run count: 210
    │   ├── isDuplicated: total 0.00 [ms], avg. 0.00 [ms], run count: 19
    │   └── calculateLocalLikelihood: total 0.04 [ms], avg. 0.00 [ms], run count: 14
    ├── updateRoadUsersHistory: total 0.07 [ms], avg. 0.00 [ms], run count: 21
    ├── getPredictedReferencePath: total 0.37 [ms], avg. 0.05 [ms], run count: 7
    │   ├── predictObjectManeuver: total 0.05 [ms], avg. 0.01 [ms], run count: 5
    │   │   └── predictObjectManeuverByLatDiffDistance: total 0.04 [ms], avg. 0.01 [ms], run count: 5
    │   │       └── calcRightLateralOffset: total 0.00 [ms], avg. 0.00 [ms], run count: 12
    │   ├── calculateManeuverProbability: total 0.00 [ms], avg. 0.00 [ms], run count: 5
    │   └── addReferencePaths: total 0.15 [ms], avg. 0.01 [ms], run count: 15
    │       ├── updateFuturePossibleLanelets: total 0.00 [ms], avg. 0.00 [ms], run count: 10
    │       └── convertPathType: total 0.09 [ms], avg. 0.01 [ms], run count: 10
    ├── updateCrosswalkUserHistory: total 0.00 [ms], avg. 0.00 [ms], run count: 41
    └── getPredictedObjectAsCrosswalkUser: total 3.19 [ms], avg. 0.08 [ms], run count: 41
        ├── getTrafficSignalId: total 0.00 [ms], avg. 0.00 [ms], run count: 88
        ├── calcIntentionToCrossWithTrafficSignal: total 0.06 [ms], avg. 0.00 [ms], run count: 88
        │   └── getTrafficSignalElement: total 0.00 [ms], avg. 0.00 [ms], run count: 88
        └── doesPathCrossAnyFence: total 0.00 [ms], avg. 0.00 [ms], run count: 15
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/995d3b8a-1cf9-55a8-97f4-db6152dd8896?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
