### PR TITLE
docs(autoware_multi_object_tracker): update input_channels schema with default values

### DIFF
--- a/perception/autoware_multi_object_tracker/schema/input_channels.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/input_channels.schema.json
@@ -8,22 +8,26 @@
       "properties": {
         "topic": {
           "type": "string",
-          "description": "The ROS topic name for the input channel."
+          "description": "The ROS topic name for the input channel.",
+          "default": "/perception/object_recognition/detection/objects"
         },
         "can_spawn_new_tracker": {
           "type": "boolean",
-          "description": "Indicates if the input channel can spawn new trackers."
+          "description": "Indicates if the input channel can spawn new trackers.",
+          "default": true
         },
         "optional": {
           "type": "object",
           "properties": {
             "name": {
               "type": "string",
-              "description": "The name of the input channel."
+              "description": "The name of the input channel.",
+              "default": "detected_objects"
             },
             "short_name": {
               "type": "string",
-              "description": "The short name of the input channel."
+              "description": "The short name of the input channel.",
+              "default": "all"
             }
           }
         }


### PR DESCRIPTION
## Description

add missing default values to fix https://autowarefoundation.github.io/autoware.universe/main/perception/autoware_multi_object_tracker/

## Related links

- Link
https://github.com/autowarefoundation/autoware.universe/pull/8179

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
