### PR TITLE
fix(autoware_detected_object_validation): fix functionStatic

### DIFF
--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/debugger.hpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/debugger.hpp
@@ -66,6 +66,7 @@ public:
     pointcloud_within_polygon_->clear();
   }
 
+  // cppcheck-suppress functionStatic
   void addNeighborPointcloud(const pcl::PointCloud<pcl::PointXY>::Ptr & input)
   {
     pcl::PointCloud<pcl::PointXYZ>::Ptr input_xyz = toXYZ(input);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck functionStatic warnings

Since this function internally calls another function and updates member variables within it, it was decided that it would be better to call it using an instance. Therefore, I have suppressed the warning with a comment.

```
perception/autoware_detected_object_validation/src/obstacle_pointcloud/debugger.hpp:69:8: performance: inconclusive: Technically the member function 'autoware::detected_object_validation::obstacle_pointcloud::Debugger::addNeighborPointcloud' can be static (but you may consider moving to unnamed namespace). [functionStatic]
  void addNeighborPointcloud(const pcl::PointCloud<pcl::PointXY>::Ptr & input)
       ^
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
