### PR TITLE
fix(autoware_multi_object_tracker): enable trigger publish when delay_compensation is false

### DIFF
--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -209,6 +209,12 @@ void MultiObjectTracker::onTrigger()
   const bool is_objects_ready = input_manager_->getObjects(current_time, objects_list);
   if (!is_objects_ready) return;
   onMessage(objects_list);
+
+  // Publish without delay compensation
+  if (!publish_timer_) {
+    const auto latest_object_time = rclcpp::Time(objects_list.back().second.header.stamp);
+    checkAndPublish(latest_object_time);
+  }
 }
 
 void MultiObjectTracker::onTimer()
@@ -222,7 +228,7 @@ void MultiObjectTracker::onTimer()
     onMessage(objects_list);
   }
 
-  // Publish
+  // Publish with delay compensation
   checkAndPublish(current_time);
 }
 


### PR DESCRIPTION
## Description

Fix a bug that the object is not published when the option `enable_delay_compensation` is false.

## Related links
Caused by PR https://github.com/tier4/autoware.universe/pull/1436

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
