### PR TITLE
ci(cppcheck): remove unnecessary functionStatic suppression

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -1,7 +1,6 @@
 *:*/test/*
 
 checkersReport
-functionStatic
 missingInclude
 missingIncludeSystem
 noConstructor


### PR DESCRIPTION
## Description

Removed `functionStatic`

## Related links

cppcheck-daily: https://github.com/autowarefoundation/autoware.universe/actions/runs/10412741448/job/28839018963

## How was this PR tested?

## Notes for reviewers

## Interface changes

## Effects on system behavior
