### PR TITLE
fix(perception_utils): install library after build

### DIFF
--- a/common/perception_utils/CMakeLists.txt
+++ b/common/perception_utils/CMakeLists.txt
@@ -4,8 +4,6 @@ project(perception_utils)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-ament_auto_package()
-
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/run_length_encoder.cpp
 )
@@ -14,3 +12,5 @@ find_package(OpenCV REQUIRED)
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBS}
 )
+
+ament_auto_package()


### PR DESCRIPTION
## Description
This PR aims to fix `symbol lookup error` on a node (`autoware_tensorrt_yolox`), which uses the dynamic link library generated from `perception_util` package

## Related links
This issue seems happen after merging https://github.com/autowarefoundation/autoware.universe/pull/8435

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
```bash
ros2 launch autoware_tensorrt_yolox yolox.launch.xml
```
And subscribe the result of the yolox by:
```bash
ros2 run rqt_image_view rqt_image_view
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
