### PR TITLE
refactor(safety_checker): remove redundant polygon creation

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -59,9 +59,10 @@ Polygon2d createExtendedPolygon(
   const Pose & base_link_pose, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const double lon_length, const double lat_margin, const bool is_stopped_obj,
   CollisionCheckDebug & debug);
+
 Polygon2d createExtendedPolygon(
-  const Pose & obj_pose, const Shape & shape, const double lon_length, const double lat_margin,
-  const bool is_stopped_obj, CollisionCheckDebug & debug);
+  const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const double lon_length,
+  const double lat_margin, const bool is_stopped_obj, CollisionCheckDebug & debug);
 
 PredictedPath convertToPredictedPath(
   const std::vector<PoseWithVelocityStamped> & path, const double time_resolution);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
@@ -161,8 +161,14 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedObjPolygon)
     const bool is_stopped_object = false;
 
     CollisionCheckDebug debug;
+
+    using autoware::behavior_path_planner::utils::path_safety_checker::
+      PoseWithVelocityAndPolygonStamped;
+
+    PoseWithVelocityAndPolygonStamped obj_pose_with_poly(
+      0.0, obj_pose, 0.0, autoware::universe_utils::toPolygon2d(obj_pose, shape));
     const auto polygon =
-      createExtendedPolygon(obj_pose, shape, lon_length, lat_margin, is_stopped_object, debug);
+      createExtendedPolygon(obj_pose_with_poly, lon_length, lat_margin, is_stopped_object, debug);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 


### PR DESCRIPTION
## Description

Replace redundant polygon creation with the already created polygon as input.

## Related links

**Parent Issue:**

- Link

[TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/3a660fc7-c751-5dec-80d1-19f5b6085d49?page=1&project_id=prd_jt)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
