### PR TITLE
feat(motion_velocity_planner,planning_evaluator): add  stop, slow_down diags

### DIFF
--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -184,7 +184,8 @@ private:
   // queue for diagnostics and time stamp
   std::deque<std::pair<DiagnosticStatus, rclcpp::Time>> diag_queue_;
   const std::vector<std::string> target_functions_ = {
-    "obstacle_cruise_planner_stop", "obstacle_cruise_planner_slow_down",
+    "obstacle_cruise_planner_stop",
+    "obstacle_cruise_planner_slow_down",
     "obstacle_cruise_planner_cruise",
     "autoware::motion_velocity_planner::OutOfLaneModule.stop",
     "autoware::motion_velocity_planner::OutOfLaneModule.slow_down",
@@ -192,7 +193,7 @@ private:
     "autoware::motion_velocity_planner::ObstacleVelocityLimiterModule.slow_down",
     "autoware::motion_velocity_planner::DynamicObstacleStopModule.stop",
     "autoware::motion_velocity_planner::DynamicObstacleStopModule.slow_down",
-    };
+  };
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
 };
 }  // namespace planning_diagnostics

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -185,7 +185,14 @@ private:
   std::deque<std::pair<DiagnosticStatus, rclcpp::Time>> diag_queue_;
   const std::vector<std::string> target_functions_ = {
     "obstacle_cruise_planner_stop", "obstacle_cruise_planner_slow_down",
-    "obstacle_cruise_planner_cruise"};
+    "obstacle_cruise_planner_cruise",
+    "autoware::motion_velocity_planner::OutOfLaneModule.stop",
+    "autoware::motion_velocity_planner::OutOfLaneModule.slow_down",
+    "autoware::motion_velocity_planner::ObstacleVelocityLimiterModule.stop",
+    "autoware::motion_velocity_planner::ObstacleVelocityLimiterModule.slow_down",
+    "autoware::motion_velocity_planner::DynamicObstacleStopModule.stop",
+    "autoware::motion_velocity_planner::DynamicObstacleStopModule.slow_down",
+    };
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
 };
 }  // namespace planning_diagnostics

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/launch/motion_velocity_planner.launch.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/launch/motion_velocity_planner.launch.xml
@@ -15,7 +15,7 @@
   <!-- <arg name="motion_velocity_planner_template_module_param_path"/> -->
   <arg name="motion_velocity_planner_param_file" default="$(find-pkg-share autoware_motion_velocity_planner_node)/config/motion_velocity_planner.param.yaml"/>
 
-  <node pkg="autoware_motion_velocity_planner_node" exec="autoware_motion_velocity_planner_node_exe" name="motion_velocity_planner" output="screen">
+  <node pkg="autoware_motion_velocity_planner_node" exec="motion_velocity_planner_node_exe" name="motion_velocity_planner" output="screen">
     <!-- topic remap -->
     <remap from="~/input/trajectory" to="trajectory"/>
     <remap from="~/input/vector_map" to="/map/vector_map"/>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/launch/motion_velocity_planner.launch.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/launch/motion_velocity_planner.launch.xml
@@ -15,7 +15,7 @@
   <!-- <arg name="motion_velocity_planner_template_module_param_path"/> -->
   <arg name="motion_velocity_planner_param_file" default="$(find-pkg-share autoware_motion_velocity_planner_node)/config/motion_velocity_planner.param.yaml"/>
 
-  <node pkg="autoware_motion_velocity_planner_node" exec="motion_velocity_planner_node_exe" name="motion_velocity_planner" output="screen">
+  <node pkg="autoware_motion_velocity_planner_node" exec="autoware_motion_velocity_planner_node_exe" name="motion_velocity_planner" output="screen">
     <!-- topic remap -->
     <remap from="~/input/trajectory" to="trajectory"/>
     <remap from="~/input/vector_map" to="/map/vector_map"/>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -295,7 +295,11 @@ void MotionVelocityPlannerNode::on_trajectory(
   processing_time_msg.data = processing_times["Total"];
   processing_time_publisher_->publish(processing_time_msg);
 
-  planner_manager_.publish_diagnostics(diagnostics_pub_, get_clock()->now(), true);
+  std::shared_ptr<DiagnosticArray> diagnostics =
+    planner_manager_.get_diagnostics(get_clock()->now(), true);
+  if (diagnostics) {
+    diagnostics_pub_->publish(*diagnostics);
+  }
   planner_manager_.clear_diagnostics();
 }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -296,7 +296,7 @@ void MotionVelocityPlannerNode::on_trajectory(
   processing_time_publisher_->publish(processing_time_msg);
 
   std::shared_ptr<DiagnosticArray> diagnostics =
-    planner_manager_.get_diagnostics(get_clock()->now(), true);
+    planner_manager_.get_diagnostics(get_clock()->now());
   if (!diagnostics->status.empty()) {
     diagnostics_pub_->publish(*diagnostics);
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -297,7 +297,7 @@ void MotionVelocityPlannerNode::on_trajectory(
 
   std::shared_ptr<DiagnosticArray> diagnostics =
     planner_manager_.get_diagnostics(get_clock()->now(), true);
-  if (diagnostics) {
+  if (!diagnostics->status.empty()) {
     diagnostics_pub_->publish(*diagnostics);
   }
   planner_manager_.clear_diagnostics();

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -85,6 +85,7 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
       "~/output/velocity_factors", 1);
   processing_time_publisher_ =
     this->create_publisher<tier4_debug_msgs::msg::Float64Stamped>("~/debug/processing_time_ms", 1);
+  diagnostics_pub_ = this->create_publisher<DiagnosticArray>("/diagnostics", 10);
 
   // Parameters
   smooth_velocity_before_planning_ = declare_parameter<bool>("smooth_velocity_before_planning");
@@ -293,6 +294,9 @@ void MotionVelocityPlannerNode::on_trajectory(
   processing_time_msg.stamp = get_clock()->now();
   processing_time_msg.data = processing_times["Total"];
   processing_time_publisher_->publish(processing_time_msg);
+
+  planner_manager_.publishDiagnostics(diagnostics_pub_, get_clock()->now(), true);
+  planner_manager_.clearDiagnostics();
 }
 
 void MotionVelocityPlannerNode::insert_stop(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -295,8 +295,8 @@ void MotionVelocityPlannerNode::on_trajectory(
   processing_time_msg.data = processing_times["Total"];
   processing_time_publisher_->publish(processing_time_msg);
 
-  planner_manager_.publishDiagnostics(diagnostics_pub_, get_clock()->now(), true);
-  planner_manager_.clearDiagnostics();
+  planner_manager_.publish_diagnostics(diagnostics_pub_, get_clock()->now(), true);
+  planner_manager_.clear_diagnostics();
 }
 
 void MotionVelocityPlannerNode::insert_stop(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
@@ -43,6 +43,8 @@
 #include <string>
 #include <vector>
 
+using DiagnosticArray = diagnostic_msgs::msg::DiagnosticArray;
+
 namespace autoware::motion_velocity_planner
 {
 using autoware_map_msgs::msg::LaneletMapBin;
@@ -101,6 +103,7 @@ private:
     this, "~/debug/processing_time_ms_diag"};
   rclcpp::Publisher<tier4_debug_msgs::msg::Float64Stamped>::SharedPtr processing_time_publisher_;
   autoware::universe_utils::PublishedTimePublisher published_time_publisher_{this};
+  rclcpp::Publisher<DiagnosticArray>::SharedPtr diagnostics_pub_;
 
   //  parameters
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_callback_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -104,10 +104,6 @@ std::shared_ptr<DiagnosticArray> MotionVelocityPlannerManager::get_diagnostics(
       diagnostics->status.push_back(*ds_ptr);
     }
   }
-  if (decided_diagnostics_only && diagnostics->status.empty()) {
-    return nullptr;
-  }
-
   diagnostics->header.stamp = current_time;
   diagnostics->header.frame_id = "map";
   return diagnostics;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<DiagnosticArray> MotionVelocityPlannerManager::get_diagnostics(
 
   for (const auto & ds_ptr : diagnostics_) {
     if (
-      ds_ptr && !ds_ptr->values.empty() && ds_ptr->values[0].key == "decision" &&
+      !ds_ptr->values.empty() && ds_ptr->values[0].key == "decision" &&
       ds_ptr->values[0].value != "none") {
       diagnostics->status.push_back(*ds_ptr);
     }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -72,11 +72,11 @@ void MotionVelocityPlannerManager::update_module_parameters(
 }
 
 std::shared_ptr<DiagnosticStatus> MotionVelocityPlannerManager::make_diagnostic(
-  const std::string & reason, const bool is_decided)
+  const std::string & module_name, const std::string & reason, const bool is_decided)
 {
   auto status = std::make_shared<DiagnosticStatus>();
   status->level = status->OK;
-  status->name = reason;
+  status->name = module_name + '.' + reason;
   diagnostic_msgs::msg::KeyValue key_value;
   {
     // Decision
@@ -92,15 +92,14 @@ std::shared_ptr<DiagnosticStatus> MotionVelocityPlannerManager::make_diagnostic(
 }
 
 std::shared_ptr<DiagnosticArray> MotionVelocityPlannerManager::get_diagnostics(
-  const rclcpp::Time & current_time, const bool decided_diagnostics_only) const
+  const rclcpp::Time & current_time) const
 {
   auto diagnostics = std::make_shared<DiagnosticArray>();
 
   for (const auto & ds_ptr : diagnostics_) {
     if (
-      (!decided_diagnostics_only) ||
-      (ds_ptr && !ds_ptr->values.empty() && ds_ptr->values[0].key == "decision" &&
-       ds_ptr->values[0].value != "none")) {
+      ds_ptr && !ds_ptr->values.empty() && ds_ptr->values[0].key == "decision" &&
+      ds_ptr->values[0].value != "none") {
       diagnostics->status.push_back(*ds_ptr);
     }
   }
@@ -119,11 +118,11 @@ std::vector<VelocityPlanningResult> MotionVelocityPlannerManager::plan_velocitie
     results.push_back(res);
 
     auto stop_reason_diag =
-      make_diagnostic(plugin->get_module_name() + ".stop", res.stop_points.size() > 0);
+      make_diagnostic(plugin->get_module_name(), "stop", res.stop_points.size() > 0);
     diagnostics_.push_back(stop_reason_diag);
 
     auto slow_down_reason_diag =
-      make_diagnostic(plugin->get_module_name() + ".slow_down", res.slowdown_intervals.size() > 0);
+      make_diagnostic(plugin->get_module_name(), "slow_down", res.slowdown_intervals.size() > 0);
     diagnostics_.push_back(slow_down_reason_diag);
   }
   return results;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -92,10 +92,6 @@ std::shared_ptr<DiagnosticStatus> MotionVelocityPlannerManager::makeDiagnostic(
   return status;
 }
 
-void MotionVelocityPlannerManager::clearDiagnostics()
-{
-  diagnostics_.clear();
-}
 
 void MotionVelocityPlannerManager::publishDiagnostics(
   const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -117,7 +117,7 @@ std::vector<VelocityPlanningResult> MotionVelocityPlannerManager::plan_velocitie
     VelocityPlanningResult res = plugin->plan(ego_trajectory_points, planner_data);
     results.push_back(res);
 
-    auto stop_reason_diag =
+    const auto stop_reason_diag =
       make_diagnostic(plugin->get_module_name(), "stop", res.stop_points.size() > 0);
     diagnostics_.push_back(stop_reason_diag);
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -121,7 +121,7 @@ std::vector<VelocityPlanningResult> MotionVelocityPlannerManager::plan_velocitie
       make_diagnostic(plugin->get_module_name(), "stop", res.stop_points.size() > 0);
     diagnostics_.push_back(stop_reason_diag);
 
-    auto slow_down_reason_diag =
+    const auto slow_down_reason_diag =
       make_diagnostic(plugin->get_module_name(), "slow_down", res.slowdown_intervals.size() > 0);
     diagnostics_.push_back(slow_down_reason_diag);
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -71,7 +71,7 @@ void MotionVelocityPlannerManager::update_module_parameters(
   for (auto & plugin : loaded_plugins_) plugin->update_parameters(parameters);
 }
 
-std::shared_ptr<DiagnosticStatus> MotionVelocityPlannerManager::makeDiagnostic(
+std::shared_ptr<DiagnosticStatus> MotionVelocityPlannerManager::make_diagnostic(
   const std::string & reason,
   const bool is_decided)
 {
@@ -93,7 +93,7 @@ std::shared_ptr<DiagnosticStatus> MotionVelocityPlannerManager::makeDiagnostic(
 }
 
 
-void MotionVelocityPlannerManager::publishDiagnostics(
+void MotionVelocityPlannerManager::publish_diagnostics(
   const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr,
   const rclcpp::Time & current_time,
   const bool publish_decided_diagnostics_only
@@ -132,10 +132,10 @@ std::vector<VelocityPlanningResult> MotionVelocityPlannerManager::plan_velocitie
     VelocityPlanningResult res = plugin->plan(ego_trajectory_points, planner_data);
     results.push_back(res);
 
-    auto stop_reason_diag = makeDiagnostic(plugin->get_module_name()+".stop", res.stop_points.size() > 0);
+    auto stop_reason_diag = make_diagnostic(plugin->get_module_name()+".stop", res.stop_points.size() > 0);
     diagnostics_.push_back(stop_reason_diag);
 
-    auto slow_down_reason_diag = makeDiagnostic(plugin->get_module_name()+".slow_down", res.slowdown_intervals.size() > 0);
+    auto slow_down_reason_diag = make_diagnostic(plugin->get_module_name()+".slow_down", res.slowdown_intervals.size() > 0);
     diagnostics_.push_back(slow_down_reason_diag);
   }
   return results;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -55,9 +55,8 @@ public:
   // Diagnostic
   std::shared_ptr<DiagnosticStatus> make_diagnostic(
     const std::string & reason, const bool is_decided = true);
-  void publish_diagnostics(
-    const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr, const rclcpp::Time & current_time,
-    const bool publish_decided_diagnostics_only = true) const;
+  std::shared_ptr<DiagnosticArray> get_diagnostics(
+    const rclcpp::Time & current_time, const bool decided_diagnostics_only = true) const;
   void clear_diagnostics() { diagnostics_.clear(); }
 
 private:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -54,14 +54,11 @@ public:
 
   // Diagnostic
   std::shared_ptr<DiagnosticStatus> make_diagnostic(
-    const std::string & reason, 
-    const bool is_decided = true);
+    const std::string & reason, const bool is_decided = true);
   void publish_diagnostics(
-    const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr,
-    const rclcpp::Time & current_time,
+    const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr, const rclcpp::Time & current_time,
     const bool publish_decided_diagnostics_only = true) const;
-  void clear_diagnostics(){diagnostics_.clear();}
-
+  void clear_diagnostics() { diagnostics_.clear(); }
 
 private:
   std::vector<std::shared_ptr<DiagnosticStatus>> diagnostics_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -54,9 +54,8 @@ public:
 
   // Diagnostic
   std::shared_ptr<DiagnosticStatus> make_diagnostic(
-    const std::string & reason, const bool is_decided = true);
-  std::shared_ptr<DiagnosticArray> get_diagnostics(
-    const rclcpp::Time & current_time, const bool decided_diagnostics_only = true) const;
+    const std::string & module_name, const std::string & reason, const bool is_decided = true);
+  std::shared_ptr<DiagnosticArray> get_diagnostics(const rclcpp::Time & current_time) const;
   void clear_diagnostics() { diagnostics_.clear(); }
 
 private:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -35,6 +35,9 @@
 #include <string>
 #include <vector>
 
+using DiagnosticStatus = diagnostic_msgs::msg::DiagnosticStatus;
+using DiagnosticArray = diagnostic_msgs::msg::DiagnosticArray;
+
 namespace autoware::motion_velocity_planner
 {
 class MotionVelocityPlannerManager
@@ -48,7 +51,19 @@ public:
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & ego_trajectory_points,
     const std::shared_ptr<const PlannerData> planner_data);
 
+  // Diagnostic
+  std::shared_ptr<DiagnosticStatus> makeEmptyDiagnostic(const std::string & reason);
+  std::shared_ptr<DiagnosticStatus> makeDiagnostic(
+    const std::string & reason, 
+    const DiagnosticStatus::Level level=DiagnosticStatus::OK,
+    const bool is_decided = true, 
+    [[maybe_unused]] const std::shared_ptr<const PlannerData> planner_data);
+  DiagnosticArray getDiagnostics(const rclcpp::Time & current_time) const;
+  void clearDiagnostics();
+
+
 private:
+  std::vector<std::shared_ptr<DiagnosticStatus>> diagnostics_;
   pluginlib::ClassLoader<PluginModuleInterface> plugin_loader_;
   std::vector<std::shared_ptr<PluginModuleInterface>> loaded_plugins_;
 };

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -60,7 +60,7 @@ public:
     const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr,
     const rclcpp::Time & current_time,
     const bool publish_decided_diagnostics_only = true) const;
-  void clearDiagnostics();
+  void clearDiagnostics(){diagnostics_.clear();}
 
 
 private:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -23,6 +23,7 @@
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
@@ -52,13 +53,13 @@ public:
     const std::shared_ptr<const PlannerData> planner_data);
 
   // Diagnostic
-  std::shared_ptr<DiagnosticStatus> makeEmptyDiagnostic(const std::string & reason);
   std::shared_ptr<DiagnosticStatus> makeDiagnostic(
     const std::string & reason, 
-    const DiagnosticStatus::Level level=DiagnosticStatus::OK,
-    const bool is_decided = true, 
-    [[maybe_unused]] const std::shared_ptr<const PlannerData> planner_data);
-  DiagnosticArray getDiagnostics(const rclcpp::Time & current_time) const;
+    const bool is_decided = true);
+  void publishDiagnostics(
+    const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr,
+    const rclcpp::Time & current_time,
+    const bool publish_decided_diagnostics_only = true) const;
   void clearDiagnostics();
 
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.hpp
@@ -53,14 +53,14 @@ public:
     const std::shared_ptr<const PlannerData> planner_data);
 
   // Diagnostic
-  std::shared_ptr<DiagnosticStatus> makeDiagnostic(
+  std::shared_ptr<DiagnosticStatus> make_diagnostic(
     const std::string & reason, 
     const bool is_decided = true);
-  void publishDiagnostics(
+  void publish_diagnostics(
     const rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_ptr,
     const rclcpp::Time & current_time,
     const bool publish_decided_diagnostics_only = true) const;
-  void clearDiagnostics(){diagnostics_.clear();}
+  void clear_diagnostics(){diagnostics_.clear();}
 
 
 private:


### PR DESCRIPTION
## Description

This PR adds a publisher in `motion_velocity_planner` to publish diagnostics as what [this PR](https://github.com/autowarefoundation/autoware.universe/pull/7960) did for `cruise_planner`.

The published diagnostics contain information that shows which module (DynamicObstacleStopModule; OutOfLaneModule; ObstacleVelocityLimiterModule) made what decision (stop; slow_down). An example is as follows:

```bash
$ ros2 topic echo /diagnostics
---
header:
  stamp:
    sec: 1723713886
    nanosec: 559327470
  frame_id: map
status:
- level: "\0"
  name: autoware::motion_velocity_planner::OutOfLaneModule.stop
  message: ''
  hardware_id: ''
  values:
  - key: decision
    value: none
- level: "\0"
  name: autoware::motion_velocity_planner::OutOfLaneModule.slow_down
  message: ''
  hardware_id: ''
  values:
  - key: decision
    value: autoware::motion_velocity_planner::OutOfLaneModule.slow_down
- level: "\0"
  name: autoware::motion_velocity_planner::ObstacleVelocityLimiterModule.stop
  message: ''
  hardware_id: ''
  values:
  - key: decision
    value: none
- level: "\0"
  name: autoware::motion_velocity_planner::ObstacleVelocityLimiterModule.slow_down
  message: ''
  hardware_id: ''
  values:
  - key: decision
    value: none
- level: "\0"
  name: autoware::motion_velocity_planner::DynamicObstacleStopModule.stop
  message: ''
  hardware_id: ''
  values:
  - key: decision
    value: none
- level: "\0"
  name: autoware::motion_velocity_planner::DynamicObstacleStopModule.slow_down
  message: ''
  hardware_id: ''
  values:
  - key: decision
    value: none
---
```
the decision info in diags will be used by [planning evaluator](https://github.com/autowarefoundation/autoware.universe/pull/7849).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
[Screencast from 2024年08月15日 18時24分11秒.webm](https://github.com/user-attachments/assets/dc0faf68-d040-4199-bd8a-aca99a56802e)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
