### PR TITLE
feat(autoware_map_based_prediction): add backlash within lanelet

### DIFF
--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -127,6 +127,7 @@ struct PredictedRefPath
 {
   float probability;
   double speed_limit;
+  double width;
   PosePath path;
   Maneuver maneuver;
 };
@@ -315,9 +316,11 @@ private:
     const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths,
     const double speed_limit = 0.0);
 
-  mutable universe_utils::LRUCache<lanelet::routing::LaneletPaths, std::vector<PosePath>>
+  mutable universe_utils::LRUCache<
+    lanelet::routing::LaneletPaths, std::vector<std::pair<PosePath, double>>>
     lru_cache_of_convert_path_type_{1000};
-  std::vector<PosePath> convertPathType(const lanelet::routing::LaneletPaths & paths) const;
+  std::vector<std::pair<PosePath, double>> convertPathType(
+    const lanelet::routing::LaneletPaths & paths) const;
 
   void updateFuturePossibleLanelets(
     const TrackedObject & object, const lanelet::routing::LaneletPaths & paths);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -95,8 +95,9 @@ public:
     const TrackedObject & object, const double duration) const;
 
   PredictedPath generatePathForOnLaneVehicle(
-    const TrackedObject & object, const PosePath & ref_paths, const double duration,
-    const double lateral_duration, const double speed_limit = 0.0) const;
+    const TrackedObject & object, const PosePath & ref_path, const double duration,
+    const double lateral_duration, const double path_width = 0.0,
+    const double speed_limit = 0.0) const;
 
   PredictedPath generatePathForCrosswalkUser(
     const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk,
@@ -129,7 +130,8 @@ private:
 
   PredictedPath generatePolynomialPath(
     const TrackedObject & object, const PosePath & ref_path, const double duration,
-    const double lateral_duration, const double speed_limit = 0.0) const;
+    const double lateral_duration, const double backlash_width,
+    const double speed_limit = 0.0) const;
 
   FrenetPath generateFrenetPath(
     const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length,

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -229,6 +229,25 @@ PredictedPath PathGenerator::generatePolynomialPath(
   terminal_point.d_vel = 0.0;
   terminal_point.d_acc = 0.0;
 
+  // calculate terminal d position, based on playable width
+  const double playable_width = 1.0; // [m]
+  const double return_coeff = 0.5; // returning zone, ratio of the playable width
+
+  const double current_momentum_d = current_point.d + current_point.d_vel * lateral_duration;
+  const double offset_ratio = std::abs(current_momentum_d / playable_width);
+  if (offset_ratio < 1) {
+    // If the object momentum is within the playable width, we set the target d position to the current
+    // momentum
+    terminal_point.d = current_momentum_d;
+  } else if (offset_ratio >= 1 && offset_ratio < 1+return_coeff) {
+    // If the object momentum is within the return zone, we set the target d position close to the
+    // zero gradually
+    terminal_point.d = current_momentum_d * (-offset_ratio+(1+return_coeff))/return_coeff;
+  } else {
+    // If the object momentum is outside the playable width + return zone, we set the target d position to 0
+    terminal_point.d = 0.0;
+  }
+
   // Step2. Generate Predicted Path on a Frenet coordinate
   const auto frenet_predicted_path =
     generateFrenetPath(current_point, terminal_point, ref_path_len, duration, lateral_duration);
@@ -266,7 +285,7 @@ FrenetPath PathGenerator::generateFrenetPath(
                            current_acc * 2.0 * std::pow(t, 2) + lat_coeff(0) * std::pow(t, 3) +
                            lat_coeff(1) * std::pow(t, 4) + lat_coeff(2) * std::pow(t, 5);
     // t > lateral_duration: 0.0, else d_next_
-    const double d_next = t > lateral_duration ? 0.0 : d_next_;
+    const double d_next = t > lateral_duration ? target_point.d : d_next_;
     const double s_next = current_point.s + current_point.s_vel * t +
                           2.0 * current_acc * std::pow(t, 2) + lon_coeff(0) * std::pow(t, 3) +
                           lon_coeff(1) * std::pow(t, 4);


### PR DESCRIPTION
## Description

Add backlash within lanelet when predict paths.

Background: Small bikes are tend to drive side within the lane. However, the predictor yields the paths always to the center of the lane.



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

TIER IV Cloud
1. [planning scenario](https://evaluation.tier4.jp/evaluation/reports/88c99685-3f8a-53d7-b7d8-21133ed1fab5?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
