### PR TITLE
chore: remove unused include

### DIFF
--- a/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp
+++ b/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp
@@ -19,7 +19,6 @@
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <random>
 
@@ -258,8 +257,7 @@ Polygon2d inward_denting(LinearRing2d & ring)
   LinearRing2d convex_ring;
   std::vector<Point2d> q;
   q.reserve(ring.size());
-  boost::geometry::strategy::convex_hull::graham_andrew<LinearRing2d, Point2d> strategy;
-  boost::geometry::convex_hull(ring, convex_ring, strategy);
+  boost::geometry::convex_hull(ring, convex_ring);
   PolygonWithEdges polygon_with_edges;
   polygon_with_edges.polygon.outer() = convex_ring;
   polygon_with_edges.edges.resize(polygon_with_edges.polygon.outer().size());

--- a/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp
+++ b/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp
@@ -19,6 +19,7 @@
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
+#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <random>
 
@@ -257,7 +258,8 @@ Polygon2d inward_denting(LinearRing2d & ring)
   LinearRing2d convex_ring;
   std::vector<Point2d> q;
   q.reserve(ring.size());
-  boost::geometry::convex_hull(ring, convex_ring);
+  boost::geometry::strategy::convex_hull::graham_andrew<LinearRing2d, Point2d> strategy;
+  boost::geometry::convex_hull(ring, convex_ring, strategy);
   PolygonWithEdges polygon_with_edges;
   polygon_with_edges.polygon.outer() = convex_ring;
   polygon_with_edges.edges.resize(polygon_with_edges.polygon.outer().size());

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -20,7 +20,6 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/touches.hpp>
 #include <boost/geometry/io/wkt/write.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <gtest/gtest.h>
 

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -20,6 +20,7 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/touches.hpp>
 #include <boost/geometry/io/wkt/write.hpp>
+#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <gtest/gtest.h>
 

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -29,7 +29,6 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/within.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <pcl/PCLPointCloud2.h>
 #include <pcl/filters/crop_hull.h>

--- a/control/predicted_path_checker/src/predicted_path_checker_node/utils.cpp
+++ b/control/predicted_path_checker/src/predicted_path_checker_node/utils.cpp
@@ -16,7 +16,6 @@
 
 #include <boost/format.hpp>
 #include <boost/geometry/algorithms/convex_hull.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 namespace utils
 {

--- a/planning/autoware_obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/planner_utils.cpp
@@ -25,7 +25,6 @@
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/within.hpp>
-#include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
 


### PR DESCRIPTION
## Description

I ran into this trying to compile in jazzy, it could not be found. But didn't seem neccesary.

## Related links

**Parent Issue:**

None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Compilation verified, CI should succeed

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
