### PR TITLE
refactor(lane_change): rename prepare_segment_ignore_object_velocity_thresh

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -106,7 +106,7 @@
         general_lanes: false
         intersection: true
         turns: true
-      prepare_segment_ignore_object_velocity_thresh: 0.1 # [m/s]
+      stopped_object_velocity_threshold: 1.0 # [m/s]
       check_objects_on_current_lanes: true
       check_objects_on_other_lanes: true
       use_all_predicted_path: true

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -131,7 +131,7 @@ struct Parameters
   bool enable_collision_check_for_prepare_phase_in_general_lanes{false};
   bool enable_collision_check_for_prepare_phase_in_intersection{true};
   bool enable_collision_check_for_prepare_phase_in_turns{true};
-  double prepare_segment_ignore_object_velocity_thresh{0.1};
+  double stopped_object_velocity_threshold{0.1};
   bool check_objects_on_current_lanes{true};
   bool check_objects_on_other_lanes{true};
   bool use_all_predicted_path{false};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -74,8 +74,8 @@ void LaneChangeModuleManager::initParams(rclcpp::Node * node)
     *node, parameter("enable_collision_check_for_prepare_phase.intersection"));
   p.enable_collision_check_for_prepare_phase_in_turns =
     getOrDeclareParameter<bool>(*node, parameter("enable_collision_check_for_prepare_phase.turns"));
-  p.prepare_segment_ignore_object_velocity_thresh = getOrDeclareParameter<double>(
-    *node, parameter("prepare_segment_ignore_object_velocity_thresh"));
+  p.stopped_object_velocity_threshold =
+    getOrDeclareParameter<double>(*node, parameter("stopped_object_velocity_threshold"));
   p.check_objects_on_current_lanes =
     getOrDeclareParameter<bool>(*node, parameter("check_objects_on_current_lanes"));
   p.check_objects_on_other_lanes =

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1092,8 +1092,7 @@ ExtendedPredictedObject transform(
 
   const auto & time_resolution = lane_change_parameters.prediction_time_resolution;
   const auto & prepare_duration = lane_change_parameters.lane_change_prepare_duration;
-  const auto & velocity_threshold =
-    lane_change_parameters.prepare_segment_ignore_object_velocity_thresh;
+  const auto & velocity_threshold = lane_change_parameters.stopped_object_velocity_threshold;
   const auto start_time = check_at_prepare_phase ? 0.0 : prepare_duration;
   const double obj_vel_norm = std::hypot(
     extended_object.initial_twist.twist.linear.x, extended_object.initial_twist.twist.linear.y);


### PR DESCRIPTION
## Description

Rename parameter to a more expressive name

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/1125

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

🔴⬆️ -->

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `prepare_segment_ignore_object_velocity_thresh` | `double` | `0.1`         | Param description |
| New     | `stopped_object_velocity_threshold` | `double` | `1.0`         | Param description |



## Effects on system behavior

None.
