### PR TITLE
feat(dummy_perception_publisher): modify orientation availability of dummy objects 

### DIFF
--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -119,6 +119,8 @@ TrackedObject ObjectInfo::toTrackedObject(
   tracked_object.shape.dimensions.y = width;
   tracked_object.shape.dimensions.z = height;
   tracked_object.object_id = object.id;
+  tracked_object.kinematics.orientation_availability =
+    autoware_perception_msgs::msg::TrackedObjectKinematics::SIGN_UNKNOWN;
   return tracked_object;
 }
 
@@ -282,7 +284,7 @@ void DummyPerceptionPublisherNode::timerCallback()
       feature_object.object.kinematics.twist_with_covariance =
         object.initial_state.twist_covariance;
       feature_object.object.kinematics.orientation_availability =
-        autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
+        autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
       feature_object.object.kinematics.has_twist = false;
       tf2::toMsg(
         tf_base_link2noised_moved_object,


### PR DESCRIPTION
## Description

Predicting object path utilizes object orientation availability. 
Simulating objects with the orientation availability of `SIGN_UNKNOWN` is more useful.


Before
![Screenshot from 2024-08-20 18-14-08](https://github.com/user-attachments/assets/c96fcb4f-951e-4ff8-a7b3-577720493b22)


After
![Screenshot from 2024-08-20 18-12-03](https://github.com/user-attachments/assets/35ba5c3d-a587-49c5-a34f-254fb852322c)




## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
