### PR TITLE
feat(autoware_perception_rviz_plugin): rviz predicted path mark as triangle

### DIFF
--- a/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -701,7 +701,7 @@ void calc_2d_bounding_box_bottom_direction_line_list(
   geometry_msgs::msg::Point point;
 
   // triangle-shaped direction indicator
-  const double point_list[6][3] = {
+  const double point_list[3][3] = {
     {length_half, 0, -height_half},
     {length_half - triangle_size_half, width_half, -height_half},
     {length_half - triangle_size_half, -width_half, -height_half},
@@ -914,7 +914,7 @@ void calc_path_line_list(
   const autoware_perception_msgs::msg::PredictedPath & paths,
   std::vector<geometry_msgs::msg::Point> & points, const bool is_simple)
 {
-  const int circle_line_num = is_simple ? 5 : 10;
+  // const int circle_line_num = is_simple ? 5 : 10;
 
   for (int i = 0; i < static_cast<int>(paths.path.size()) - 1; ++i) {
     geometry_msgs::msg::Point point;
@@ -926,8 +926,28 @@ void calc_path_line_list(
     point.y = paths.path.at(i + 1).position.y;
     point.z = paths.path.at(i + 1).position.z;
     points.push_back(point);
+
     if (!is_simple || i % 2 == 0) {
-      calc_circle_line_list(point, 0.25, points, circle_line_num);
+      // get yaw from the line
+      const double yaw = std::atan2(
+        paths.path.at(i + 1).position.y - paths.path.at(i).position.y,
+        paths.path.at(i + 1).position.x - paths.path.at(i).position.x);
+      constexpr double length = 0.5;
+      const double arrow_angle = M_PI * 5.0 / 6.0;
+      // draw triangle
+      const double point_list[3][3] = {
+        {point.x, point.y, point.z},
+        {point.x + length * std::cos(yaw + arrow_angle),
+         point.y + length * std::sin(yaw + arrow_angle), point.z},
+        {point.x + length * std::cos(yaw - arrow_angle),
+         point.y + length * std::sin(yaw - arrow_angle), point.z},
+      };
+      const int point_pairs[3][2] = {
+        {0, 1},
+        {1, 2},
+        {2, 0},
+      };
+      calc_line_list_from_points(point_list, point_pairs, 3, points);
     }
   }
 }

--- a/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -914,9 +914,8 @@ void calc_path_line_list(
   const autoware_perception_msgs::msg::PredictedPath & paths,
   std::vector<geometry_msgs::msg::Point> & points, const bool is_simple)
 {
-  // const int circle_line_num = is_simple ? 5 : 10;
-
   for (int i = 0; i < static_cast<int>(paths.path.size()) - 1; ++i) {
+    // draw line
     geometry_msgs::msg::Point point;
     point.x = paths.path.at(i).position.x;
     point.y = paths.path.at(i).position.y;
@@ -929,12 +928,11 @@ void calc_path_line_list(
 
     if (!is_simple || i % 2 == 0) {
       // get yaw from the line
-      const double yaw = std::atan2(
-        paths.path.at(i + 1).position.y - paths.path.at(i).position.y,
-        paths.path.at(i + 1).position.x - paths.path.at(i).position.x);
+      const double yaw =
+        std::atan2(point.y - paths.path.at(i).position.y, point.x - paths.path.at(i).position.x);
+      // draw triangle
       constexpr double length = 0.5;
       const double arrow_angle = M_PI * 5.0 / 6.0;
-      // draw triangle
       const double point_list[3][3] = {
         {point.x, point.y, point.z},
         {point.x + length * std::cos(yaw + arrow_angle),


### PR DESCRIPTION
## Description

Replace path marker from circle to triangle. 
It may reduce rendering load and adds information of its direction.

Before

![Screenshot from 2024-08-20 18-12-03](https://github.com/user-attachments/assets/cad5d946-f0b6-45cc-8c5a-1484336edeec)

After

![Screenshot from 2024-08-20 20-00-00](https://github.com/user-attachments/assets/933d7cd2-eb6f-4d28-831a-82be8e962d44)



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
