### PR TITLE
fix(ground_segmentation): missing default parameters ERROR

### DIFF
--- a/perception/autoware_ground_segmentation/config/ground_segmentation.param.yaml
+++ b/perception/autoware_ground_segmentation/config/ground_segmentation.param.yaml
@@ -1,20 +1,5 @@
 /**:
   ros__parameters:
-    additional_lidars: []
-    ransac_input_topics: []
-    use_single_frame_filter: False
-    use_time_series_filter: True
-
-    common_crop_box_filter:
-      parameters:
-        min_x: -50.0
-        max_x: 100.0
-        min_y: -50.0
-        max_y: 50.0
-        max_z: 2.5  # recommended 2.5 for non elevation_grid_mode
-        min_z: -2.5 # recommended 0.0 for non elevation_grid_mode
-        negative: False
-
     common_ground_filter:
       plugin: "autoware::ground_segmentation::ScanGroundFilterComponent"
       parameters:

--- a/perception/autoware_ground_segmentation/launch/scan_ground_filter.launch.py
+++ b/perception/autoware_ground_segmentation/launch/scan_ground_filter.launch.py
@@ -33,6 +33,15 @@ def launch_setup(context, *args, **kwargs):
     with open(vehicle_info_param_path, "r") as f:
         vehicle_info_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
+    ground_segmentation_param_path = os.path.join(
+        get_package_share_directory("autoware_ground_segmentation"),
+        "config",
+        "ground_segmentation.param.yaml",
+    )
+
+    with open(ground_segmentation_param_path, "r") as f:
+        ground_segmentation_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+
     nodes = [
         ComposableNode(
             package="autoware_ground_segmentation",
@@ -43,12 +52,9 @@ def launch_setup(context, *args, **kwargs):
                 ("output", LaunchConfiguration("output/pointcloud")),
             ],
             parameters=[
-                {
-                    "global_slope_max_angle_deg": 10.0,
-                    "local_slope_max_angle_deg": 30.0,
-                    "split_points_distance_tolerance": 0.2,
-                    "split_height_distance": 0.2,
-                },
+                ground_segmentation_param["common_ground_filter"]["parameters"],
+                {"input_frame": "base_link"},
+                {"output_frame": "base_link"},
                 vehicle_info_param,
             ],
         ),


### PR DESCRIPTION
## Description
- To fix missing parameters error: 
```
ubuntu22:~/autoware$ ros2 launch autoware_ground_segmentation scan_ground_filter.launch.py 
[INFO] [launch]: All log files can be found below /home/autoware/.ros/log/2024-08-20-20-50-28-074447-npc2201009-ubuntu22-95182
[INFO] [launch]: Default logging verbosity is set to INFO
...
rclcpp_components::NodeFactoryTemplate<autoware::ground_segmentation::ScanGroundFilterComponent>
[component_container-1] [ERROR] [1724154628.708955855] [scan_ground_filter_container]: Component constructor threw an exception: Statically typed parameter 'low_priority_region_x' must be initialized.
[ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'scan_ground_filter' of type 'autoware::ground_segmentation::ScanGroundFilterComponent' in container '/scan_ground_filter_container': Component constructor threw an exception: Statically typed parameter 'low_priority_region_x' must be initialized.

```
- To remove unused parameters
- Releated to https://github.com/tier4/autoware.universe/issues/1228
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Confirmed  `ros2 launch autoware_ground_segmentation scan_ground_filter.launch.py` worked
```
ubuntu22:~/autoware$ ros2 launch autoware_ground_segmentation scan_ground_filter.launch.py 
[INFO] [launch]: All log files can be found below /home/autoware/.ros/log/2024-08-20-20-56-06-469739-npc2201009-ubuntu22-96487
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [component_container-1]: process started with pid [96498]
[component_container-1] [INFO] [1724154966.828702283] [scan_ground_filter_container]: Load Library: /home/autoware/autoware/install/autoware_ground_segmentation/lib/libautoware_ground_segmentation.so
[component_container-1] [INFO] [1724154966.880554280] [scan_ground_filter_container]: Found class: rclcpp_components::NodeFactoryTemplate<autoware::ground_segmentation::RANSACGroundFilterComponent>
[component_container-1] [INFO] [1724154966.880624768] [scan_ground_filter_container]: Found class: rclcpp_components::NodeFactoryTemplate<autoware::ground_segmentation::RayGroundFilterComponent>
[component_container-1] [INFO] [1724154966.880629587] [scan_ground_filter_container]: Found class: rclcpp_components::NodeFactoryTemplate<autoware::ground_segmentation::ScanGroundFilterComponent>
[component_container-1] [INFO] [1724154966.880633680] [scan_ground_filter_container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<autoware::ground_segmentation::ScanGroundFilterComponent>
[INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/scan_ground_filter' in container '/scan_ground_filter_container'

```
 


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
