### PR TITLE
fix(intersection): fix for detection lane division

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -934,6 +934,14 @@ std::vector<lanelet::ConstLineString3d> IntersectionModule::generateDetectionLan
     detection_lanelets.push_back(detection_lanelet);
   }
 
+  std::vector<lanelet::ConstLineString3d> detection_divisions;
+  if (detection_lanelets.empty()) {
+    // NOTE(soblin): due to the above filtering detection_lanelets may be empty or do not contain
+    // conflicting_detection_lanelets
+    // OK to return empty detction_divsions
+    return detection_divisions;
+  }
+
   // (1) tsort detection_lanelets
   const auto [merged_detection_lanelets, originals] = util::mergeLaneletsByTopologicalSort(
     detection_lanelets, conflicting_detection_lanelets, routing_graph_ptr);
@@ -952,7 +960,6 @@ std::vector<lanelet::ConstLineString3d> IntersectionModule::generateDetectionLan
   }
 
   // (3) discretize each merged lanelet
-  std::vector<lanelet::ConstLineString3d> detection_divisions;
   for (const auto & [merged_lanelet, area] : merged_lanelet_with_area) {
     const double length = bg::length(merged_lanelet.centerline());
     const double width = area / length;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -269,7 +269,9 @@ mergeLaneletsByTopologicalSort(
   }
   std::set<size_t> terminal_inds;
   for (const auto & terminal_lanelet : terminal_lanelets) {
-    terminal_inds.insert(Id2ind[terminal_lanelet.id()]);
+    if (Id2ind.count(terminal_lanelet.id()) > 0) {
+      terminal_inds.insert(Id2ind[terminal_lanelet.id()]);
+    }
   }
 
   // create adjacency matrix


### PR DESCRIPTION
## Description

Additional fix for https://github.com/autowarefoundation/autoware.universe/pull/8520

for occlusion detection, detection_lanelets are filtered and it could be empty

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/893c0289-c9f7-598e-9f69-28f0317cb78d?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
