### PR TITLE
fix(static_obstacle_avoidance): target object sorting

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1732,8 +1732,8 @@ void compensateLostTargetObjects(
   const std::shared_ptr<AvoidanceParameters> & parameters)
 {
   const auto include = [](const auto & objects, const auto & search_id) {
-    return std::all_of(objects.begin(), objects.end(), [&search_id](const auto & o) {
-      return o.object.object_id != search_id;
+    return std::any_of(objects.begin(), objects.end(), [&search_id](const auto & o) {
+      return o.object.object_id == search_id;
     });
   };
 
@@ -1783,6 +1783,10 @@ void compensateLostTargetObjects(
 
   // STEP1-2: UPDATE STORED OBJECTS IF THERE ARE NEW OBJECTS.
   for (const auto & current_object : data.target_objects) {
+    if (stored_objects.empty()) {
+      stored_objects.push_back(current_object);
+    }
+
     if (!include(stored_objects, current_object.object.object_id)) {
       stored_objects.push_back(current_object);
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1783,10 +1783,6 @@ void compensateLostTargetObjects(
 
   // STEP1-2: UPDATE STORED OBJECTS IF THERE ARE NEW OBJECTS.
   for (const auto & current_object : data.target_objects) {
-    if (stored_objects.empty()) {
-      stored_objects.push_back(current_object);
-    }
-
     if (!include(stored_objects, current_object.object.object_id)) {
       stored_objects.push_back(current_object);
     }


### PR DESCRIPTION
## Description
The targets object was not added to the member variable `registered_objects_`, so the envelope polygon for the target object was updated with a single shot polygon. This PR will fix the above problem by adding the target objects into  `registered_objects_` appropriately.

## Related links
None

## How was this PR tested?
[TIER IV internal test](https://evaluation.tier4.jp/evaluation/reports/3959d9b3-f390-5e97-acf8-35841e62d97d?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
