### PR TITLE
ci(labeler): tag packages that require cuda

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -39,3 +39,8 @@
   - tools/**/*
 "component:vehicle":
   - vehicle/**/*
+"tag:require-cuda-build-and-test":
+  - perception/**/*
+  - sensing/**/*
+  - common/cuda_utils/**/*
+  - common/tensorrt_common/**/*


### PR DESCRIPTION
## Description

This PR is to prepare functionality that does not execute `build-and-test-differential (humble, -cuda)` for PRs related to packages that are not related to cuda.

The label `tag:require-cuda-build-and-test` is applied only to `perception/**/*`, `sensing/**/*`, `common/cuda_utils/**/*`, and `common/tensorrt_common/**/*`.

## Related links

The functionality to skip cuda build using this PR is implemented in the following:
https://github.com/autowarefoundation/autoware.universe/pull/8547

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
