### PR TITLE
feat(lane_change): fix delay logic that caused timing to be late

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/behavior_path_lane_change_module/utils/utils.hpp"
 
+#include "autoware/behavior_path_lane_change_module/utils/calculation.hpp"
 #include "autoware/behavior_path_lane_change_module/utils/data_structs.hpp"
 #include "autoware/behavior_path_lane_change_module/utils/path.hpp"
 #include "autoware/behavior_path_planner_common/marker_utils/utils.hpp"
@@ -988,30 +989,41 @@ bool passed_parked_objects(
   }
 
   const auto & current_path_end = current_lane_path.points.back().point.pose.position;
-  double min_dist_to_end_of_current_lane = std::numeric_limits<double>::max();
-  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
-  const auto is_goal_in_route = route_handler.isInGoalRouteSection(target_lanes.back());
-  for (const auto & point : leading_obj_poly.outer()) {
-    const auto obj_p = autoware::universe_utils::createPoint(point.x(), point.y(), 0.0);
-    const double dist = autoware::motion_utils::calcSignedArcLength(
-      current_lane_path.points, obj_p, current_path_end);
-    min_dist_to_end_of_current_lane = std::min(dist, min_dist_to_end_of_current_lane);
-    if (is_goal_in_route) {
+  const auto dist_to_path_end = [&](const auto & src_point) {
+    if (common_data_ptr->lanes_ptr->current_lane_in_goal_section) {
       const auto goal_pose = route_handler.getGoalPose();
-      const double dist_to_goal = autoware::motion_utils::calcSignedArcLength(
-        current_lane_path.points, obj_p, goal_pose.position);
-      min_dist_to_end_of_current_lane = std::min(min_dist_to_end_of_current_lane, dist_to_goal);
+      return motion_utils::calcSignedArcLength(
+        current_lane_path.points, src_point, goal_pose.position);
     }
-  }
+    return motion_utils::calcSignedArcLength(current_lane_path.points, src_point, current_path_end);
+  };
+
+  const auto min_dist_to_end_of_current_lane = std::invoke([&]() {
+    auto min_dist_to_end_of_current_lane = std::numeric_limits<double>::max();
+    for (const auto & point : leading_obj_poly.outer()) {
+      const auto obj_p = autoware::universe_utils::createPoint(point.x(), point.y(), 0.0);
+      const auto dist = dist_to_path_end(obj_p);
+      min_dist_to_end_of_current_lane = std::min(dist, min_dist_to_end_of_current_lane);
+    }
+    return min_dist_to_end_of_current_lane;
+  });
 
   // If there are still enough length after the target object, we delay the lane change
-  if (min_dist_to_end_of_current_lane > minimum_lane_change_length) {
-    debug.second.unsafe_reason = "delay lane change";
-    utils::path_safety_checker::updateCollisionCheckDebugMap(object_debug, debug, false);
-    return false;
+  if (min_dist_to_end_of_current_lane <= minimum_lane_change_length) {
+    return true;
   }
 
-  return true;
+  const auto current_pose = common_data_ptr->get_ego_pose();
+  const auto dist_ego_to_obj = motion_utils::calcSignedArcLength(
+    current_lane_path.points, current_pose.position, leading_obj.initial_pose.pose.position);
+
+  if (dist_ego_to_obj < lane_change_path.info.length.lane_changing) {
+    return true;
+  }
+
+  debug.second.unsafe_reason = "delay lane change";
+  utils::path_safety_checker::updateCollisionCheckDebugMap(object_debug, debug, false);
+  return false;
 }
 
 std::optional<size_t> getLeadingStaticObjectIdx(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1001,7 +1001,7 @@ bool passed_parked_objects(
   const auto min_dist_to_end_of_current_lane = std::invoke([&]() {
     auto min_dist_to_end_of_current_lane = std::numeric_limits<double>::max();
     for (const auto & point : leading_obj_poly.outer()) {
-      const auto obj_p = autoware::universe_utils::createPoint(point.x(), point.y(), 0.0);
+      const auto obj_p = universe_utils::createPoint(point.x(), point.y(), 0.0);
       const auto dist = dist_to_path_end(obj_p);
       min_dist_to_end_of_current_lane = std::min(dist, min_dist_to_end_of_current_lane);
     }


### PR DESCRIPTION
## Description

With delay lane change, ego will start changing lane only when it is beside the last parked object.

![image](https://github.com/user-attachments/assets/208f3eae-e3c2-4e2e-8169-fb5b68c6ad5d)


We would like to start changing lanes earlier, so we want to find this point while delaying lane change.

![image](https://github.com/user-attachments/assets/18d7c3b9-3a45-4e75-a779-4beaae0aff0c)


#### Before PR

Delay lane change is activated instead of safety check

https://github.com/user-attachments/assets/568f2fa3-864c-45cf-b155-f1fcf08c21e9


#### After PR

Safety check is activated instead of delay lane change.

https://github.com/user-attachments/assets/bb7f7ae4-6cb9-4de9-b032-ba2b631033ad

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. PSIM
2. [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/d4326584-6e6d-5a51-bc39-f4c3f29d0c8a?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
