### PR TITLE
fix(autoware_smart_mpc_trajectory_follower): fix unusedFunction

### DIFF
--- a/control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/src/proxima_calc.cpp
+++ b/control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/src/proxima_calc.cpp
@@ -26,10 +26,6 @@ Eigen::VectorXd tanh(const Eigen::VectorXd & v)
 {
   return v.array().tanh();
 }
-Eigen::VectorXd d_tanh(const Eigen::VectorXd & v)
-{
-  return 1 / (v.array().cosh() * v.array().cosh());
-}
 Eigen::VectorXd sigmoid(const Eigen::VectorXd & v)
 {
   return 0.5 * (0.5 * v).array().tanh() + 0.5;
@@ -43,16 +39,6 @@ Eigen::VectorXd relu(const Eigen::VectorXd & x)
     }
   }
   return x_;
-}
-Eigen::VectorXd d_relu(const Eigen::VectorXd & x)
-{
-  Eigen::VectorXd result = Eigen::VectorXd::Ones(x.size());
-  for (int i = 0; i < x.size(); i++) {
-    if (x[i] < 0) {
-      result[i] = 0;
-    }
-  }
-  return result;
 }
 Eigen::MatrixXd d_relu_product(const Eigen::MatrixXd & m, const Eigen::VectorXd & x)
 {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/src/proxima_calc.cpp:29:0: style: The function 'd_tanh' is never used. [unusedFunction]
Eigen::VectorXd d_tanh(const Eigen::VectorXd & v)
^

control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/src/proxima_calc.cpp:47:0: style: The function 'd_relu' is never used. [unusedFunction]
Eigen::VectorXd d_relu(const Eigen::VectorXd & x)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
