### PR TITLE
fix(control_performance_analysis): fix unusedFunction

### DIFF
--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
@@ -79,10 +79,6 @@ inline geometry_msgs::msg::Quaternion createOrientationMsgFromYaw(double yaw_ang
 // p-points a, b contains [x, y] coordinates.
 double determinant(std::array<double, 2> const & a, std::array<double, 2> const & b);
 
-double triangleArea(
-  std::array<double, 2> const & a, std::array<double, 2> const & b,
-  std::array<double, 2> const & c);
-
 double curvatureFromThreePoints(
   std::array<double, 2> const & a, std::array<double, 2> const & b,
   std::array<double, 2> const & c);

--- a/control/control_performance_analysis/src/control_performance_analysis_utils.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_utils.cpp
@@ -25,15 +25,5 @@ double determinant(std::array<double, 2> const & a, std::array<double, 2> const 
   return a[0] * b[1] - b[0] * a[1];
 }
 
-double triangleArea(
-  std::array<double, 2> const & a, std::array<double, 2> const & b, std::array<double, 2> const & c)
-{
-  double m1 = determinant(a, b);
-  double m2 = determinant(b, c);
-  double m3 = determinant(c, a);
-
-  return 0.5 * (m1 + m2 + m3);
-}
-
 }  // namespace utils
 }  // namespace control_performance_analysis


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
control/control_performance_analysis/src/control_performance_analysis_utils.cpp:28:0: style: The function 'triangleArea' is never used. [unusedFunction]
double triangleArea(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
