### PR TITLE
fix(perception_online_evaluator): fix unusedFunction

### DIFF
--- a/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/deviation_metrics.hpp
+++ b/evaluator/perception_online_evaluator/include/perception_online_evaluator/metrics/deviation_metrics.hpp
@@ -45,8 +45,6 @@ double calcLateralDeviation(const std::vector<Pose> & ref_path, const Pose & tar
  */
 double calcYawDeviation(const std::vector<Pose> & ref_path, const Pose & target_pose);
 
-std::vector<double> calcPredictedPathDeviation(
-  const std::vector<Pose> & ref_path, const PredictedPath & pred_path);
 }  // namespace metrics
 }  // namespace perception_diagnostics
 

--- a/evaluator/perception_online_evaluator/src/metrics/deviation_metrics.cpp
+++ b/evaluator/perception_online_evaluator/src/metrics/deviation_metrics.cpp
@@ -47,21 +47,5 @@ double calcYawDeviation(const std::vector<Pose> & ref_path, const Pose & target_
   return std::abs(autoware::universe_utils::calcYawDeviation(ref_path[nearest_index], target_pose));
 }
 
-std::vector<double> calcPredictedPathDeviation(
-  const std::vector<Pose> & ref_path, const PredictedPath & pred_path)
-{
-  std::vector<double> deviations;
-
-  if (ref_path.empty() || pred_path.path.empty()) {
-    return {};
-  }
-  for (const Pose & p : pred_path.path) {
-    const size_t nearest_index = autoware::motion_utils::findNearestIndex(ref_path, p.position);
-    deviations.push_back(
-      autoware::universe_utils::calcDistance2d(ref_path[nearest_index].position, p.position));
-  }
-
-  return deviations;
-}
 }  // namespace metrics
 }  // namespace perception_diagnostics


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.
```
evaluator/perception_online_evaluator/src/metrics/deviation_metrics.cpp:50:0: style: The function 'calcPredictedPathDeviation' is never used. [unusedFunction]
std::vector<double> calcPredictedPathDeviation(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
