### PR TITLE
fix(autoware_image_projection_based_fusion): fix unusedFunction

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
@@ -74,9 +74,6 @@ std::optional<geometry_msgs::msg::TransformStamped> getTransformStamped(
 
 Eigen::Affine3d transformToEigen(const geometry_msgs::msg::Transform & t);
 
-void convertCluster2FeatureObject(
-  const std_msgs::msg::Header & header, const PointCloud & cluster,
-  DetectedObjectWithFeature & feature_obj);
 void closest_cluster(
   const PointCloud2 & cluster, const double cluster_2d_tolerance, const int min_cluster_size,
   const pcl::PointXYZ & center, PointCloud2 & out_cluster);
@@ -89,11 +86,6 @@ void updateOutputFusedObjects(
   std::vector<DetectedObjectWithFeature> & output_fused_objects);
 
 geometry_msgs::msg::Point getCentroid(const sensor_msgs::msg::PointCloud2 & pointcloud);
-
-pcl::PointXYZ getClosestPoint(const pcl::PointCloud<pcl::PointXYZ> & cluster);
-void addShapeAndKinematic(
-  const pcl::PointCloud<pcl::PointXYZ> & cluster,
-  tier4_perception_msgs::msg::DetectedObjectWithFeature & feature_obj);
 
 }  // namespace autoware::image_projection_based_fusion
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.
```
perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:51:0: style: The function 'convertCluster2FeatureObject' is never used. [unusedFunction]
void convertCluster2FeatureObject(
^

perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:177:0: style: The function 'addShapeAndKinematic' is never used. [unusedFunction]
void addShapeAndKinematic(
^

perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:264:0: style: The function 'getClosestPoint' is never used. [unusedFunction]
pcl::PointXYZ getClosestPoint(const pcl::PointCloud<pcl::PointXYZ> & cluster)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
