### PR TITLE
fix(autoware_lidar_centerpoint): fix unusedFunction

### DIFF
--- a/perception/autoware_lidar_centerpoint/lib/utils.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/utils.cpp
@@ -19,7 +19,7 @@
 namespace autoware::lidar_centerpoint
 {
 // cspell: ignore divup
-std::size_t divup(const std::size_t a, const std::size_t b)
+std::size_t divup(const std::size_t a, const std::size_t b)  // cppcheck-suppress unusedFunction
 {
   if (a == 0) {
     throw std::runtime_error("A dividend of divup isn't positive.");


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.
It is used in `.cu` files and is suppressed in the comments.

```
perception/autoware_lidar_centerpoint/lib/utils.cpp:22:0: style: The function 'divup' is never used. [unusedFunction]
std::size_t divup(const std::size_t a, const std::size_t b)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
