### PR TITLE
test(autoware_pid_longitudinal_controller): add unit test for all the necessary functions in autoware_pid_longitudinal_controller

### DIFF
--- a/control/autoware_pid_longitudinal_controller/CMakeLists.txt
+++ b/control/autoware_pid_longitudinal_controller/CMakeLists.txt
@@ -14,6 +14,7 @@ if(BUILD_TESTING)
     test/test_pid.cpp
     test/test_smooth_stop.cpp
     test/test_longitudinal_controller_utils.cpp
+    test/test_pid_longitudinal_controller.cpp
   )
   set(TEST_LONGITUDINAL_CONTROLLER_EXE test_longitudinal_controller)
   ament_add_ros_isolated_gtest(${TEST_LONGITUDINAL_CONTROLLER_EXE} ${TEST_LON_SOURCES})

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -109,21 +109,23 @@ TEST_F(TestPidLongitudinalController, run)
     EXPECT_EQ(output.control_cmd.velocity, 0.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, GetControlData)
+TEST_F(TestPidLongitudinalController, getControlData) // more tests can be added
 {
     geometry_msgs::msg::Pose pose;
     pose.position.x = 1.0;
     pose.position.y = 1.0;
+    controller_->m_current_kinematic_state.twist.twist.linear.x = 1.0;
 
     auto control_data = controller_->getControlData(pose);
-    EXPECT_GE(control_data.current_motion.vel, 0.0);
+    EXPECT_EQ(control_data.current_motion.vel, 1.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, CalcEmergencyCtrlCmd)
+TEST_F(TestPidLongitudinalController, calcEmergencyCtrlCmd)
 {
     double dt = 0.1;
+    controller_->m_prev_raw_ctrl_cmd.vel = 0.0;
     auto cmd = controller_->calcEmergencyCtrlCmd(dt);
-    EXPECT_LE(cmd.acc, 0.0);
+    EXPECT_EQ(cmd.vel, 0.0);
 }
 
 TEST_F(PidLongitudinalControllerTest, UpdateControlState)

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -1,0 +1,253 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include "pid_longitudinal_controller.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "diagnostic_updater/diagnostic_updater.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
+
+using namespace autoware::motion::control::pid_longitudinal_controller;
+
+class PidLongitudinalControllerTest : public ::testing::Test
+{
+protected:
+    std::shared_ptr<rclcpp::Node> node_;
+    std::shared_ptr<PidLongitudinalController> controller_;
+    std::shared_ptr<diagnostic_updater::Updater> diag_updater_;
+
+    void SetUp() override
+    {
+        rclcpp::init(0, nullptr);
+        node_ = std::make_shared<rclcpp::Node>("test_node");
+        diag_updater_ = std::make_shared<diagnostic_updater::Updater>(node_);
+        controller_ = std::make_shared<PidLongitudinalController>(*node_, diag_updater_);
+    }
+
+    void TearDown() override
+    {
+        rclcpp::shutdown();
+    }
+};
+
+TEST_F(TestPidLongitudinalController, setupDiagnosticUpdater)
+{
+    controller_->setupDiagnosticUpdater();
+    EXPECT_EQ(diag_updater_->getHardwareID(), "autoware_pid_longitudinal_controller");
+
+    bool control_state_added = false;
+    for (const auto & task : diag_updater_->getDiagnosticTasks())
+    {
+        if (task.name == "control_state")
+        {
+            control_state_added = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(control_state_added);
+}
+
+TEST_F(PidLongitudinalControllerTest, SetKinematicState)
+{
+    nav_msgs::msg::Odometry odom;
+    odom.twist.twist.linear.x = 10.0;
+    controller_->setKinematicState(odom);
+    EXPECT_EQ(controller_->m_current_kinematic_state.twist.twist.linear.x, 10.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, SetCurrentAcceleration)
+{
+    geometry_msgs::msg::AccelWithCovarianceStamped accel;
+    accel.accel.accel.linear.x = 2.0;
+    controller_->setCurrentAcceleration(accel);
+    EXPECT_EQ(controller_->m_current_accel.accel.accel.linear.x, 2.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, SetCurrentOperationMode)
+{
+    autoware_adapi_v1_msgs::msg::OperationModeState mode;
+    mode.mode = autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS;
+    controller_->setCurrentOperationMode(mode);
+    EXPECT_EQ(controller_->m_current_operation_mode.mode, autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS);
+}
+
+TEST_F(PidLongitudinalControllerTest, SetTrajectory)
+{
+    autoware_planning_msgs::msg::Trajectory traj;
+    traj.points.resize(3);
+    controller_->setTrajectory(traj);
+    EXPECT_EQ(controller_->m_trajectory.points.size(), 3);
+}
+
+TEST_F(PidLongitudinalControllerTest, IsReady)
+{
+    trajectory_follower::InputData input_data;
+    EXPECT_TRUE(controller_->isReady(input_data));
+}
+
+TEST_F(PidLongitudinalControllerTest, Run)
+{
+    trajectory_follower::InputData input_data;
+    autoware_planning_msgs::msg::Trajectory traj;
+    traj.points.resize(2);
+    input_data.current_trajectory = traj;
+
+    nav_msgs::msg::Odometry odom;
+    odom.twist.twist.linear.x = 1.0;
+    input_data.current_odometry = odom;
+
+    geometry_msgs::msg::AccelWithCovarianceStamped accel;
+    accel.accel.accel.linear.x = 0.5;
+    input_data.current_accel = accel;
+
+    autoware_adapi_v1_msgs::msg::OperationModeState mode;
+    mode.mode = autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS;
+    input_data.current_operation_mode = mode;
+
+    auto output = controller_->run(input_data);
+    EXPECT_GE(output.control_cmd.velocity, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, GetControlData)
+{
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = 1.0;
+    pose.position.y = 1.0;
+
+    auto control_data = controller_->getControlData(pose);
+    EXPECT_GE(control_data.current_motion.vel, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, CalcEmergencyCtrlCmd)
+{
+    double dt = 0.1;
+    auto cmd = controller_->calcEmergencyCtrlCmd(dt);
+    EXPECT_LE(cmd.acc, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, UpdateControlState)
+{
+    PidLongitudinalController::ControlData control_data;
+    control_data.current_motion.vel = 5.0;
+    control_data.stop_dist = 0.1;
+
+    controller_->updateControlState(control_data);
+    EXPECT_EQ(controller_->m_control_state, PidLongitudinalController::ControlState::STOPPING);
+}
+
+TEST_F(PidLongitudinalControllerTest, CalcCtrlCmd)
+{
+    PidLongitudinalController::ControlData control_data;
+    control_data.current_motion.vel = 5.0;
+
+    auto cmd = controller_->calcCtrlCmd(control_data);
+    EXPECT_GE(cmd.acc, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, CreateCtrlCmdMsg)
+{
+    PidLongitudinalController::Motion cmd;
+    cmd.vel = 10.0;
+    cmd.acc = 1.0;
+
+    auto ctrl_cmd_msg = controller_->createCtrlCmdMsg(cmd, 5.0);
+    EXPECT_EQ(ctrl_cmd_msg.velocity, 10.0);
+    EXPECT_EQ(ctrl_cmd_msg.acceleration, 1.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, PublishDebugData)
+{
+    PidLongitudinalController::Motion cmd;
+    PidLongitudinalController::ControlData control_data;
+    control_data.slope_angle = 0.1;
+
+    controller_->publishDebugData(cmd, control_data);
+}
+
+TEST_F(PidLongitudinalControllerTest, GetDt)
+{
+    auto dt = controller_->getDt();
+    EXPECT_GT(dt, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, GetCurrentShift)
+{
+    PidLongitudinalController::ControlData control_data;
+    control_data.interpolated_traj.points.resize(2);
+    control_data.interpolated_traj.points[1].longitudinal_velocity_mps = 1.0;
+
+    auto shift = controller_->getCurrentShift(control_data);
+    EXPECT_EQ(shift, PidLongitudinalController::Shift::Forward);
+}
+
+TEST_F(PidLongitudinalControllerTest, StoreAccelCmd)
+{
+    controller_->storeAccelCmd(1.0);
+    EXPECT_FALSE(controller_->m_ctrl_cmd_vec.empty());
+}
+
+TEST_F(PidLongitudinalControllerTest, ApplySlopeCompensation)
+{
+    auto acc = controller_->applySlopeCompensation(1.0, 0.1, PidLongitudinalController::Shift::Forward);
+    EXPECT_GT(acc, 1.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, KeepBrakeBeforeStop)
+{
+    PidLongitudinalController::ControlData control_data;
+    PidLongitudinalController::Motion target_motion;
+
+    auto motion = controller_->keepBrakeBeforeStop(control_data, target_motion, 0);
+    EXPECT_LE(motion.acc, target_motion.acc);
+}
+
+TEST_F(PidLongitudinalControllerTest, CalcInterpolatedTrajPointAndSegment)
+{
+    autoware_planning_msgs::msg::Trajectory traj;
+    traj.points.resize(3);
+
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = 1.0;
+    pose.position.y = 1.0;
+
+    auto result = controller_->calcInterpolatedTrajPointAndSegment(traj, pose);
+    EXPECT_EQ(result.second, 0);
+}
+
+TEST_F(PidLongitudinalControllerTest, PredictedStateAfterDelay)
+{
+    PidLongitudinalController::Motion current_motion;
+    current_motion.vel = 10.0;
+    current_motion.acc = 1.0;
+
+    auto state = controller_->predictedStateAfterDelay(current_motion, 0.5);
+    EXPECT_GT(state.vel, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, ApplyVelocityFeedback)
+{
+    PidLongitudinalController::ControlData control_data;
+    control_data.current_motion.vel = 10.0;
+
+    auto acc = controller_->applyVelocityFeedback(control_data);
+    EXPECT_GT(acc, 0.0);
+}
+
+TEST_F(PidLongitudinalControllerTest, UpdatePitchDebugValues)
+{
+    controller_->updatePitchDebugValues(0.1, 0.2, 0.3);
+}
+
+TEST_F(PidLongitudinalControllerTest, UpdateDebugVelAcc)
+{
+    PidLongitudinalController::ControlData control_data;
+    control_data.current_motion.vel = 10.0;
+    controller_->updateDebugVelAcc(control_data);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -213,15 +213,6 @@ TEST_F(TestPidLongitudinalController, predictedStateAfterDelay)
     EXPECT_GT(state.vel, 10.0 + 1.0 * 0.5);
 }
 
-TEST_F(PidLongitudinalControllerTest, ApplyVelocityFeedback)
-{
-    PidLongitudinalController::ControlData control_data;
-    control_data.current_motion.vel = 10.0;
-
-    auto acc = controller_->applyVelocityFeedback(control_data);
-    EXPECT_GT(acc, 0.0);
-}
-
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -165,32 +165,33 @@ TEST_F(TestPidLongitudinalController, createCtrlCmdMsg)
     EXPECT_EQ(ctrl_cmd_msg.acceleration, 1.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, GetDt)
+TEST_F(TestPidLongitudinalController, getDt)
 {
     auto dt = controller_->getDt();
-    EXPECT_GT(dt, 0.0);
+    EXPECT_GT(dt, 0.03);
 }
 
-TEST_F(PidLongitudinalControllerTest, GetCurrentShift)
+TEST_F(TestPidLongitudinalController, getCurrentShift)
 {
     PidLongitudinalController::ControlData control_data;
-    control_data.interpolated_traj.points.resize(2);
-    control_data.interpolated_traj.points[1].longitudinal_velocity_mps = 1.0;
+    control_data.target_idx = 0;
+    control_data.interpolated_traj.points[control_data.target_idx].longitudinal_velocity_mps = 1.0;
 
     auto shift = controller_->getCurrentShift(control_data);
     EXPECT_EQ(shift, PidLongitudinalController::Shift::Forward);
 }
 
-TEST_F(PidLongitudinalControllerTest, StoreAccelCmd)
+TEST_F(TestPidLongitudinalController, storeAccelCmd)
 {
+    m_ctrl_cmd_vec.clear();
     controller_->storeAccelCmd(1.0);
     EXPECT_FALSE(controller_->m_ctrl_cmd_vec.empty());
 }
 
-TEST_F(PidLongitudinalControllerTest, ApplySlopeCompensation)
+TEST_F(TestPidLongitudinalController, applySlopeCompensation)
 {
-    auto acc = controller_->applySlopeCompensation(1.0, 0.1, PidLongitudinalController::Shift::Forward);
-    EXPECT_GT(acc, 1.0);
+    auto acc = controller_->applySlopeCompensation(1.0, 0.05, PidLongitudinalController::Shift::Forward);
+    EXPECT_EQ(acc, 1.0 + 9.81 * std::sin(0.05));
 }
 
 TEST_F(PidLongitudinalControllerTest, KeepBrakeBeforeStop)

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
-#include "pid_longitudinal_controller.hpp"
+#include "autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "nav_msgs/msg/odometry.hpp"

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -212,9 +212,3 @@ TEST_F(TestPidLongitudinalController, predictedStateAfterDelay)
     auto state = controller_->predictedStateAfterDelay(current_motion, 0.5);
     EXPECT_GT(state.vel, 10.0 + 1.0 * 0.5);
 }
-
-int main(int argc, char **argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -128,23 +128,30 @@ TEST_F(TestPidLongitudinalController, calcEmergencyCtrlCmd)
     EXPECT_EQ(cmd.vel, 0.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, UpdateControlState)
+TEST_F(TestPidLongitudinalController, updateControlState)
 {
     PidLongitudinalController::ControlData control_data;
+    controller_->m_control_state = ControlState::DRIVE;
     control_data.current_motion.vel = 5.0;
-    control_data.stop_dist = 0.1;
+    control_data.stop_dist = -5.0;
+    control_data.nearest_idx = 0;
+    control_data.interpolated_traj.points.at(control_data.nearest_idx).longitudinal_velocity_mps = 0.0;
 
     controller_->updateControlState(control_data);
-    EXPECT_EQ(controller_->m_control_state, PidLongitudinalController::ControlState::STOPPING);
+    EXPECT_EQ(controller_->m_control_state, PidLongitudinalController::ControlState::EMERGENCY);
 }
 
-TEST_F(PidLongitudinalControllerTest, CalcCtrlCmd)
+TEST_F(TestPidLongitudinalController, calcCtrlCmd)
 {
     PidLongitudinalController::ControlData control_data;
-    control_data.current_motion.vel = 5.0;
+    controller_->m_control_state == ControlState::STOPPED;
+    controller_->m_prev_ctrl_cmd.acc = 0.0;
+    control_data.target_idx = 0;
+    control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps = 0.0;
+    control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2 = 0.0;
 
     auto cmd = controller_->calcCtrlCmd(control_data);
-    EXPECT_GE(cmd.acc, 0.0);
+    EXPECT_EQ(cmd.acc, -3.4);
 }
 
 TEST_F(PidLongitudinalControllerTest, CreateCtrlCmdMsg)

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 #include <memory>
 #include "pid_longitudinal_controller.hpp"

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -183,7 +183,7 @@ TEST_F(TestPidLongitudinalController, getCurrentShift)
 
 TEST_F(TestPidLongitudinalController, storeAccelCmd)
 {
-    m_ctrl_cmd_vec.clear();
+    controller_->m_ctrl_cmd_vec.clear();
     controller_->storeAccelCmd(1.0);
     EXPECT_FALSE(controller_->m_ctrl_cmd_vec.empty());
 }
@@ -208,7 +208,7 @@ TEST_F(TestPidLongitudinalController, predictedStateAfterDelay)
     PidLongitudinalController::Motion current_motion;
     current_motion.vel = 10.0;
     current_motion.acc = 1.0;
-    m_ctrl_cmd_vec.clear();
+    controller_->m_ctrl_cmd_vec.clear();
     auto state = controller_->predictedStateAfterDelay(current_motion, 0.5);
     EXPECT_GT(state.vel, 10.0 + 1.0 * 0.5);
 }

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -154,7 +154,7 @@ TEST_F(TestPidLongitudinalController, calcCtrlCmd)
     EXPECT_EQ(cmd.acc, -3.4);
 }
 
-TEST_F(PidLongitudinalControllerTest, CreateCtrlCmdMsg)
+TEST_F(TestPidLongitudinalController, createCtrlCmdMsg)
 {
     PidLongitudinalController::Motion cmd;
     cmd.vel = 10.0;
@@ -163,15 +163,6 @@ TEST_F(PidLongitudinalControllerTest, CreateCtrlCmdMsg)
     auto ctrl_cmd_msg = controller_->createCtrlCmdMsg(cmd, 5.0);
     EXPECT_EQ(ctrl_cmd_msg.velocity, 10.0);
     EXPECT_EQ(ctrl_cmd_msg.acceleration, 1.0);
-}
-
-TEST_F(PidLongitudinalControllerTest, PublishDebugData)
-{
-    PidLongitudinalController::Motion cmd;
-    PidLongitudinalController::ControlData control_data;
-    control_data.slope_angle = 0.1;
-
-    controller_->publishDebugData(cmd, control_data);
 }
 
 TEST_F(PidLongitudinalControllerTest, GetDt)

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -194,36 +194,23 @@ TEST_F(TestPidLongitudinalController, applySlopeCompensation)
     EXPECT_EQ(acc, 1.0 + 9.81 * std::sin(0.05));
 }
 
-TEST_F(PidLongitudinalControllerTest, KeepBrakeBeforeStop)
+TEST_F(TestPidLongitudinalController, keepBrakeBeforeStop)
 {
     PidLongitudinalController::ControlData control_data;
     PidLongitudinalController::Motion target_motion;
-
+    target_motion.acc = 1.0;
     auto motion = controller_->keepBrakeBeforeStop(control_data, target_motion, 0);
-    EXPECT_LE(motion.acc, target_motion.acc);
+    EXPECT_EQ(motion.acc, 1.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, CalcInterpolatedTrajPointAndSegment)
-{
-    autoware_planning_msgs::msg::Trajectory traj;
-    traj.points.resize(3);
-
-    geometry_msgs::msg::Pose pose;
-    pose.position.x = 1.0;
-    pose.position.y = 1.0;
-
-    auto result = controller_->calcInterpolatedTrajPointAndSegment(traj, pose);
-    EXPECT_EQ(result.second, 0);
-}
-
-TEST_F(PidLongitudinalControllerTest, PredictedStateAfterDelay)
+TEST_F(TestPidLongitudinalController, predictedStateAfterDelay)
 {
     PidLongitudinalController::Motion current_motion;
     current_motion.vel = 10.0;
     current_motion.acc = 1.0;
-
+    m_ctrl_cmd_vec.clear();
     auto state = controller_->predictedStateAfterDelay(current_motion, 0.5);
-    EXPECT_GT(state.vel, 0.0);
+    EXPECT_GT(state.vel, 10.0 + 1.0 * 0.5);
 }
 
 TEST_F(PidLongitudinalControllerTest, ApplyVelocityFeedback)

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -222,18 +222,6 @@ TEST_F(PidLongitudinalControllerTest, ApplyVelocityFeedback)
     EXPECT_GT(acc, 0.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, UpdatePitchDebugValues)
-{
-    controller_->updatePitchDebugValues(0.1, 0.2, 0.3);
-}
-
-TEST_F(PidLongitudinalControllerTest, UpdateDebugVelAcc)
-{
-    PidLongitudinalController::ControlData control_data;
-    control_data.current_motion.vel = 10.0;
-    controller_->updateDebugVelAcc(control_data);
-}
-
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -10,7 +10,7 @@
 
 using namespace autoware::motion::control::pid_longitudinal_controller;
 
-class PidLongitudinalControllerTest : public ::testing::Test
+class TestPidLongitudinalController : public ::testing::Test
 {
 protected:
     std::shared_ptr<rclcpp::Node> node_;
@@ -48,7 +48,7 @@ TEST_F(TestPidLongitudinalController, setupDiagnosticUpdater)
     EXPECT_TRUE(control_state_added);
 }
 
-TEST_F(PidLongitudinalControllerTest, SetKinematicState)
+TEST_F(TestPidLongitudinalController, setKinematicState)
 {
     nav_msgs::msg::Odometry odom;
     odom.twist.twist.linear.x = 10.0;
@@ -56,7 +56,7 @@ TEST_F(PidLongitudinalControllerTest, SetKinematicState)
     EXPECT_EQ(controller_->m_current_kinematic_state.twist.twist.linear.x, 10.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, SetCurrentAcceleration)
+TEST_F(TestPidLongitudinalController, setCurrentAcceleration)
 {
     geometry_msgs::msg::AccelWithCovarianceStamped accel;
     accel.accel.accel.linear.x = 2.0;
@@ -64,7 +64,7 @@ TEST_F(PidLongitudinalControllerTest, SetCurrentAcceleration)
     EXPECT_EQ(controller_->m_current_accel.accel.accel.linear.x, 2.0);
 }
 
-TEST_F(PidLongitudinalControllerTest, SetCurrentOperationMode)
+TEST_F(TestPidLongitudinalController, setCurrentOperationMode)
 {
     autoware_adapi_v1_msgs::msg::OperationModeState mode;
     mode.mode = autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS;
@@ -72,7 +72,7 @@ TEST_F(PidLongitudinalControllerTest, SetCurrentOperationMode)
     EXPECT_EQ(controller_->m_current_operation_mode.mode, autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS);
 }
 
-TEST_F(PidLongitudinalControllerTest, SetTrajectory)
+TEST_F(TestPidLongitudinalController, setTrajectory)
 {
     autoware_planning_msgs::msg::Trajectory traj;
     traj.points.resize(3);
@@ -80,13 +80,13 @@ TEST_F(PidLongitudinalControllerTest, SetTrajectory)
     EXPECT_EQ(controller_->m_trajectory.points.size(), 3);
 }
 
-TEST_F(PidLongitudinalControllerTest, IsReady)
+TEST_F(TestPidLongitudinalController, isReady)
 {
     trajectory_follower::InputData input_data;
     EXPECT_TRUE(controller_->isReady(input_data));
 }
 
-TEST_F(PidLongitudinalControllerTest, Run)
+TEST_F(TestPidLongitudinalController, run)
 {
     trajectory_follower::InputData input_data;
     autoware_planning_msgs::msg::Trajectory traj;
@@ -104,9 +104,9 @@ TEST_F(PidLongitudinalControllerTest, Run)
     autoware_adapi_v1_msgs::msg::OperationModeState mode;
     mode.mode = autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS;
     input_data.current_operation_mode = mode;
-
+    controller_->m_control_state = PidLongitudinalController::ControlState::DRIVE;
     auto output = controller_->run(input_data);
-    EXPECT_GE(output.control_cmd.velocity, 0.0);
+    EXPECT_EQ(output.control_cmd.velocity, 0.0);
 }
 
 TEST_F(PidLongitudinalControllerTest, GetControlData)


### PR DESCRIPTION
## Description
Add the unit test for the pid_longitudinal_controller.cpp

There lacks the test file for the pid_longitudinal_controller.cpp; its test coverage is 0%.
This PR adds the test for most functions in pid_longitudinal_controller.cpp.

## How was this PR tested?

run unit tests and generate code coverage report.

before:
![image](https://github.com/user-attachments/assets/f511b5f0-3ff7-4443-81b2-62e1bc0e28a4)


after:


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
