### PR TITLE
fix(autoware_tracking_object_merger): fix unusedFunction

### DIFF
--- a/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/utils/utils.hpp
+++ b/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/utils/utils.hpp
@@ -80,13 +80,6 @@ autoware_perception_msgs::msg::TrackedObjectKinematics objectKinematicsVXMerger(
 TrackedObject objectClassificationMerger(
   const TrackedObject & main_obj, const TrackedObject & sub_obj, const MergePolicy policy);
 
-// probability merger
-float probabilityMerger(const float main_prob, const float sub_prob, const MergePolicy policy);
-
-// shape merger
-autoware_perception_msgs::msg::Shape shapeMerger(
-  const TrackedObject & main_obj, const TrackedObject & sub_obj, const MergePolicy policy);
-
 // update tracked object
 void updateExceptVelocity(TrackedObject & main_obj, const TrackedObject & sub_obj);
 


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
perception/autoware_tracking_object_merger/src/utils/utils.cpp:301:0: style: The function 'objectsYawIsReverted' is never used. [unusedFunction]
bool objectsYawIsReverted(const TrackedObject & main_obj, const TrackedObject & sub_obj)
^

perception/autoware_tracking_object_merger/src/utils/utils.cpp:413:0: style: The function 'probabilityMerger' is never used. [unusedFunction]
float probabilityMerger(const float main_prob, const float sub_prob, const MergePolicy policy)
^

perception/autoware_tracking_object_merger/src/utils/utils.cpp:428:0: style: The function 'shapeMerger' is never used. [unusedFunction]
autoware_perception_msgs::msg::Shape shapeMerger(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
