### PR TITLE
fix(autoware_traffic_light_fine_detector): fix unusedFunction

### DIFF
--- a/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
+++ b/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
@@ -49,11 +49,6 @@ float calWeightedIou(
 
 namespace autoware::traffic_light
 {
-inline std::vector<float> toFloatVector(const std::vector<double> & double_vector)
-{
-  return std::vector<float>(double_vector.begin(), double_vector.end());
-}
-
 TrafficLightFineDetectorNode::TrafficLightFineDetectorNode(const rclcpp::NodeOptions & options)
 : Node("traffic_light_fine_detector_node", options)
 {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp:52:0: style: The function 'toFloatVector' is never used. [unusedFunction]
inline std::vector<float> toFloatVector(const std::vector<double> & double_vector)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
