### PR TITLE
feat(ground_segmentation): add time_keeper

### DIFF
--- a/perception/autoware_ground_segmentation/config/ground_segmentation.param.yaml
+++ b/perception/autoware_ground_segmentation/config/ground_segmentation.param.yaml
@@ -19,3 +19,6 @@
         radial_divider_angle_deg: 1.0
         use_recheck_ground_cluster: true
         use_lowest_point: true
+
+        # debug parameters
+        publish_processing_time_detail: false

--- a/perception/autoware_ground_segmentation/config/ransac_ground_filter.param.yaml
+++ b/perception/autoware_ground_segmentation/config/ransac_ground_filter.param.yaml
@@ -12,3 +12,6 @@
     voxel_size_z: 0.04
     height_threshold: 0.01
     debug: false
+
+    # debug parameters
+    publish_processing_time_detail: false

--- a/perception/autoware_ground_segmentation/config/ray_ground_filter.param.yaml
+++ b/perception/autoware_ground_segmentation/config/ray_ground_filter.param.yaml
@@ -12,3 +12,6 @@
       min_height_threshold: 0.15
       concentric_divider_distance: 0.0
       reclass_distance_threshold: 0.1
+
+      # debug parameters
+      publish_processing_time_detail: false

--- a/perception/autoware_ground_segmentation/config/scan_ground_filter.param.yaml
+++ b/perception/autoware_ground_segmentation/config/scan_ground_filter.param.yaml
@@ -16,3 +16,6 @@
     radial_divider_angle_deg: 1.0
     use_recheck_ground_cluster: true
     use_lowest_point: true
+
+    # debug parameters
+    publish_processing_time_detail: false

--- a/perception/autoware_ground_segmentation/package.xml
+++ b/perception/autoware_ground_segmentation/package.xml
@@ -21,6 +21,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
+  <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>libopencv-dev</depend>
   <depend>pcl_conversions</depend>

--- a/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.cpp
@@ -81,6 +81,7 @@ PlaneBasis getPlaneBasis(const Eigen::Vector3d & plane_normal)
 }
 
 using autoware::pointcloud_preprocessor::get_param;
+using autoware::universe_utils::ScopedTimeTrack;
 
 RANSACGroundFilterComponent::RANSACGroundFilterComponent(const rclcpp::NodeOptions & options)
 : Filter("RANSACGroundFilter", options)
@@ -118,6 +119,15 @@ RANSACGroundFilterComponent::RANSACGroundFilterComponent(const rclcpp::NodeOptio
 
   managed_tf_buffer_ =
     std::make_unique<autoware::universe_utils::ManagedTransformBuffer>(this, has_static_tf_only_);
+
+  bool use_time_keeper = declare_parameter<bool>("publish_processing_time_detail");
+  if (use_time_keeper) {
+    detailed_processing_time_publisher_ =
+      this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+        "~/debug/ground_segm_processing_time_detail_ms", 1);
+    auto time_keeper = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
+    time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper);
+  }
 }
 
 void RANSACGroundFilterComponent::setDebugPublisher()
@@ -204,6 +214,9 @@ void RANSACGroundFilterComponent::applyRANSAC(
   const pcl::PointCloud<PointType>::Ptr & input, pcl::PointIndices::Ptr & output_inliers,
   pcl::ModelCoefficients::Ptr & output_coefficients)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   pcl::SACSegmentation<PointType> seg;
   seg.setOptimizeCoefficients(true);
   seg.setRadiusLimits(0.3, std::numeric_limits<double>::max());
@@ -219,6 +232,9 @@ void RANSACGroundFilterComponent::filter(
   const PointCloud2::ConstSharedPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   std::scoped_lock lock(mutex_);
   sensor_msgs::msg::PointCloud2::SharedPtr input_transformed_ptr(new sensor_msgs::msg::PointCloud2);
   if (!transformPointCloud(base_frame_, input, input_transformed_ptr)) {

--- a/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.cpp
@@ -124,7 +124,7 @@ RANSACGroundFilterComponent::RANSACGroundFilterComponent(const rclcpp::NodeOptio
   if (use_time_keeper) {
     detailed_processing_time_publisher_ =
       this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
-        "~/debug/ground_segm_processing_time_detail_ms", 1);
+        "~/debug/processing_time_detail_ms", 1);
     auto time_keeper = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
     time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper);
   }

--- a/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.hpp
@@ -16,6 +16,7 @@
 #define RANSAC_GROUND_FILTER__NODE_HPP_
 
 #include "autoware/pointcloud_preprocessor/filter.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 
 #include <autoware/universe_utils/ros/managed_transform_buffer.hpp>
 
@@ -84,6 +85,11 @@ private:
   bool is_initialized_debug_message_ = false;
   Eigen::Vector3d unit_vec_ = Eigen::Vector3d::UnitZ();
   std::unique_ptr<autoware::universe_utils::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
+
+  // time keeper related
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    detailed_processing_time_publisher_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   /*!
    * Output transformed PointCloud from in_cloud_ptr->header.frame_id to in_target_frame

--- a/perception/autoware_ground_segmentation/src/ray_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/ray_ground_filter/node.cpp
@@ -31,12 +31,14 @@
 
 #include "node.hpp"
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace autoware::ground_segmentation
 {
 using autoware::pointcloud_preprocessor::get_param;
+using autoware::universe_utils::ScopedTimeTrack;
 
 RayGroundFilterComponent::RayGroundFilterComponent(const rclcpp::NodeOptions & options)
 : Filter("RayGroundFilter", options)
@@ -69,6 +71,15 @@ RayGroundFilterComponent::RayGroundFilterComponent(const rclcpp::NodeOptions & o
   using std::placeholders::_1;
   set_param_res_ = this->add_on_set_parameters_callback(
     std::bind(&RayGroundFilterComponent::paramCallback, this, _1));
+
+  bool use_time_keeper = declare_parameter<bool>("publish_processing_time_detail");
+  if (use_time_keeper) {
+    detailed_processing_time_publisher_ =
+      this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+        "~/debug/ground_segm_processing_time_detail_ms", 1);
+    auto time_keeper = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
+    time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper);
+  }
 }
 
 void RayGroundFilterComponent::ConvertXYZIToRTZColor(
@@ -76,6 +87,9 @@ void RayGroundFilterComponent::ConvertXYZIToRTZColor(
   std::vector<pcl::PointIndices> & out_radial_divided_indices,
   std::vector<PointCloudXYZRTColor> & out_radial_ordered_clouds)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   out_organized_points.resize(in_cloud->points.size());
   out_radial_divided_indices.clear();
   out_radial_divided_indices.resize(radial_dividers_num_);
@@ -153,6 +167,9 @@ void RayGroundFilterComponent::ClassifyPointCloud(
   std::vector<PointCloudXYZRTColor> & in_radial_ordered_clouds,
   pcl::PointIndices & out_ground_indices, pcl::PointIndices & out_no_ground_indices)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   out_ground_indices.indices.clear();
   out_no_ground_indices.indices.clear();
 #pragma omp for
@@ -275,6 +292,9 @@ void RayGroundFilterComponent::ExtractPointsIndices(
   const PointCloud2::ConstSharedPtr in_cloud_ptr, const pcl::PointIndices & in_indices,
   PointCloud2::SharedPtr ground_cloud_msg_ptr, PointCloud2::SharedPtr no_ground_cloud_msg_ptr)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   initializePointCloud2(in_cloud_ptr, ground_cloud_msg_ptr);
   initializePointCloud2(in_cloud_ptr, no_ground_cloud_msg_ptr);
   int point_step = in_cloud_ptr->point_step;
@@ -312,6 +332,9 @@ void RayGroundFilterComponent::filter(
   const PointCloud2::ConstSharedPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   std::scoped_lock lock(mutex_);
 
   pcl::PointCloud<PointType_>::Ptr current_sensor_cloud_ptr(new pcl::PointCloud<PointType_>);

--- a/perception/autoware_ground_segmentation/src/ray_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/ray_ground_filter/node.cpp
@@ -76,7 +76,7 @@ RayGroundFilterComponent::RayGroundFilterComponent(const rclcpp::NodeOptions & o
   if (use_time_keeper) {
     detailed_processing_time_publisher_ =
       this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
-        "~/debug/ground_segm_processing_time_detail_ms", 1);
+        "~/debug/processing_time_detail_ms", 1);
     auto time_keeper = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
     time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper);
   }

--- a/perception/autoware_ground_segmentation/src/ray_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/ray_ground_filter/node.hpp
@@ -45,6 +45,8 @@
 #ifndef RAY_GROUND_FILTER__NODE_HPP_
 #define RAY_GROUND_FILTER__NODE_HPP_
 
+#include "autoware/universe_utils/system/time_keeper.hpp"
+
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/filters/extract_indices.h>
@@ -72,6 +74,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <chrono>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -139,6 +142,11 @@ private:
   const size_t color_num_ = 10;                          // different number of color to generate
   pcl::PointCloud<PointType_>::Ptr previous_cloud_ptr_;  // holds the previous groundless result of
                                                          // ground classification
+
+  // time keeper related
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    detailed_processing_time_publisher_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   /*!
    * Output transformed PointCloud from in_cloud_ptr->header.frame_id to in_target_frame

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/node.cpp
@@ -87,7 +87,7 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
     stop_watch_ptr_->tic("cyclic_time");
     stop_watch_ptr_->tic("processing_time");
 
-    bool use_time_keeper = true;  // declare_parameter<bool>("publish_processing_time_detail");
+    bool use_time_keeper = declare_parameter<bool>("publish_processing_time_detail");
     if (use_time_keeper) {
       detailed_processing_time_publisher_ =
         this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/node.cpp
@@ -87,7 +87,7 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
     stop_watch_ptr_->tic("cyclic_time");
     stop_watch_ptr_->tic("processing_time");
 
-    bool use_time_keeper = declare_parameter<bool>("publish_processing_time_detail");
+    bool use_time_keeper = true;  // declare_parameter<bool>("publish_processing_time_detail");
     if (use_time_keeper) {
       detailed_processing_time_publisher_ =
         this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
@@ -141,40 +141,50 @@ void ScanGroundFilterComponent::convertPointcloudGridScan(
   const size_t in_cloud_data_size = in_cloud->data.size();
   const size_t in_cloud_point_step = in_cloud->point_step;
 
-  size_t point_index = 0;
-  pcl::PointXYZ input_point;
-  for (size_t global_offset = 0; global_offset + in_cloud_point_step <= in_cloud_data_size;
-       global_offset += in_cloud_point_step) {
-    get_point_from_global_offset(in_cloud, input_point, global_offset);
+  {  // add scope for time keeper
+    std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
+    if (time_keeper_) inner_st_ptr = std::make_unique<ScopedTimeTrack>("scan", *time_keeper_);
 
-    auto x{input_point.x - x_shift};  // base on front wheel center
-    auto radius{static_cast<float>(std::hypot(x, input_point.y))};
-    auto theta{normalizeRadian(std::atan2(x, input_point.y), 0.0)};
+    size_t point_index = 0;
+    pcl::PointXYZ input_point;
+    for (size_t global_offset = 0; global_offset + in_cloud_point_step <= in_cloud_data_size;
+         global_offset += in_cloud_point_step) {
+      get_point_from_global_offset(in_cloud, input_point, global_offset);
 
-    // divide by vertical angle
-    auto radial_div{static_cast<size_t>(std::floor(theta * inv_radial_divider_angle_rad))};
-    uint16_t grid_id = 0;
-    if (radius <= grid_mode_switch_radius_) {
-      grid_id = static_cast<uint16_t>(radius * inv_grid_size_m);
-    } else {
-      auto gamma{normalizeRadian(std::atan2(radius, virtual_lidar_z_), 0.0f)};
-      grid_id = grid_id_offset + gamma * inv_grid_size_rad;
+      auto x{input_point.x - x_shift};  // base on front wheel center
+      auto radius{static_cast<float>(std::hypot(x, input_point.y))};
+      auto theta{normalizeRadian(std::atan2(x, input_point.y), 0.0)};
+
+      // divide by vertical angle
+      auto radial_div{static_cast<size_t>(std::floor(theta * inv_radial_divider_angle_rad))};
+      uint16_t grid_id = 0;
+      if (radius <= grid_mode_switch_radius_) {
+        grid_id = static_cast<uint16_t>(radius * inv_grid_size_m);
+      } else {
+        auto gamma{normalizeRadian(std::atan2(radius, virtual_lidar_z_), 0.0f)};
+        grid_id = grid_id_offset + gamma * inv_grid_size_rad;
+      }
+      current_point.grid_id = grid_id;
+      current_point.radius = radius;
+      current_point.point_state = PointLabel::INIT;
+      current_point.orig_index = point_index;
+
+      // radial divisions
+      out_radial_ordered_points[radial_div].emplace_back(current_point);
+      ++point_index;
     }
-    current_point.grid_id = grid_id;
-    current_point.radius = radius;
-    current_point.point_state = PointLabel::INIT;
-    current_point.orig_index = point_index;
-
-    // radial divisions
-    out_radial_ordered_points[radial_div].emplace_back(current_point);
-    ++point_index;
   }
 
-  // sort by distance
-  for (size_t i = 0; i < radial_dividers_num_; ++i) {
-    std::sort(
-      out_radial_ordered_points[i].begin(), out_radial_ordered_points[i].end(),
-      [](const PointData & a, const PointData & b) { return a.radius < b.radius; });
+  {  // add scope for time keeper
+    std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
+    if (time_keeper_) inner_st_ptr = std::make_unique<ScopedTimeTrack>("sort", *time_keeper_);
+
+    // sort by distance
+    for (size_t i = 0; i < radial_dividers_num_; ++i) {
+      std::sort(
+        out_radial_ordered_points[i].begin(), out_radial_ordered_points[i].end(),
+        [](const PointData & a, const PointData & b) { return a.radius < b.radius; });
+    }
   }
 }
 
@@ -192,30 +202,41 @@ void ScanGroundFilterComponent::convertPointcloud(
   const size_t in_cloud_data_size = in_cloud->data.size();
   const size_t in_cloud_point_step = in_cloud->point_step;
 
-  size_t point_index = 0;
-  pcl::PointXYZ input_point;
-  for (size_t global_offset = 0; global_offset + in_cloud_point_step <= in_cloud_data_size;
-       global_offset += in_cloud_point_step) {
-    // Point
-    get_point_from_global_offset(in_cloud, input_point, global_offset);
+  {  // add scope for time keeper
+    std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
+    if (time_keeper_) inner_st_ptr = std::make_unique<ScopedTimeTrack>("scan", *time_keeper_);
 
-    auto radius{static_cast<float>(std::hypot(input_point.x, input_point.y))};
-    auto theta{normalizeRadian(std::atan2(input_point.x, input_point.y), 0.0)};
-    auto radial_div{static_cast<size_t>(std::floor(theta * inv_radial_divider_angle_rad))};
+    size_t point_index = 0;
+    pcl::PointXYZ input_point;
+    for (size_t global_offset = 0; global_offset + in_cloud_point_step <= in_cloud_data_size;
+         global_offset += in_cloud_point_step) {
+      // Point
+      get_point_from_global_offset(in_cloud, input_point, global_offset);
 
-    current_point.radius = radius;
-    current_point.point_state = PointLabel::INIT;
-    current_point.orig_index = point_index;
+      auto radius{static_cast<float>(std::hypot(input_point.x, input_point.y))};
+      auto theta{normalizeRadian(std::atan2(input_point.x, input_point.y), 0.0)};
+      auto radial_div{static_cast<size_t>(std::floor(theta * inv_radial_divider_angle_rad))};
 
-    // radial divisions
-    out_radial_ordered_points[radial_div].emplace_back(current_point);
-    ++point_index;
+      current_point.radius = radius;
+      current_point.point_state = PointLabel::INIT;
+      current_point.orig_index = point_index;
+
+      // radial divisions
+      out_radial_ordered_points[radial_div].emplace_back(current_point);
+      ++point_index;
+    }
   }
-  // sort by distance
-  for (size_t i = 0; i < radial_dividers_num_; ++i) {
-    std::sort(
-      out_radial_ordered_points[i].begin(), out_radial_ordered_points[i].end(),
-      [](const PointData & a, const PointData & b) { return a.radius < b.radius; });
+
+  {  // add scope for time keeper
+    std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
+    if (time_keeper_) inner_st_ptr = std::make_unique<ScopedTimeTrack>("sort", *time_keeper_);
+
+    // sort by distance
+    for (size_t i = 0; i < radial_dividers_num_; ++i) {
+      std::sort(
+        out_radial_ordered_points[i].begin(), out_radial_ordered_points[i].end(),
+        [](const PointData & a, const PointData & b) { return a.radius < b.radius; });
+    }
   }
 }
 
@@ -355,120 +376,131 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
-  out_no_ground_indices.indices.clear();
-  for (size_t i = 0; i < in_radial_ordered_clouds.size(); ++i) {
-    PointsCentroid ground_cluster;
-    ground_cluster.initialize();
-    std::vector<GridCenter> gnd_grids;
-    GridCenter curr_gnd_grid;
+  {  // add scope for time keeper (classify_loop)
+    std::unique_ptr<ScopedTimeTrack> classify_loop_st_ptr;
+    if (time_keeper_)
+      classify_loop_st_ptr = std::make_unique<ScopedTimeTrack>("classify_loop", *time_keeper_);
 
-    // check empty ray
-    if (in_radial_ordered_clouds[i].size() == 0) {
-      continue;
-    }
+    out_no_ground_indices.indices.clear();
+    for (size_t i = 0; i < in_radial_ordered_clouds.size(); ++i) {
+      PointsCentroid ground_cluster;
+      ground_cluster.initialize();
+      std::vector<GridCenter> gnd_grids;
+      GridCenter curr_gnd_grid;
 
-    // check the first point in ray
-    auto * p = &in_radial_ordered_clouds[i][0];
-
-    bool initialized_first_gnd_grid = false;
-    bool prev_list_init = false;
-    pcl::PointXYZ p_orig_point, prev_p_orig_point;
-    for (auto & point : in_radial_ordered_clouds[i]) {
-      auto * prev_p = p;  // for checking the distance to prev point
-      prev_p_orig_point = p_orig_point;
-      p = &point;
-      get_point_from_global_offset(in_cloud, p_orig_point, in_cloud->point_step * p->orig_index);
-      float global_slope_ratio_p = p_orig_point.z / p->radius;
-      float non_ground_height_threshold_local = non_ground_height_threshold_;
-      if (p_orig_point.x < low_priority_region_x_) {
-        non_ground_height_threshold_local =
-          non_ground_height_threshold_ * abs(p_orig_point.x / low_priority_region_x_);
-      }
-      // classify first grid's point cloud
-      if (
-        !initialized_first_gnd_grid && global_slope_ratio_p >= global_slope_max_ratio_ &&
-        p_orig_point.z > non_ground_height_threshold_local) {
-        out_no_ground_indices.indices.push_back(p->orig_index);
-        p->point_state = PointLabel::NON_GROUND;
+      // check empty ray
+      if (in_radial_ordered_clouds[i].size() == 0) {
         continue;
       }
 
-      if (
-        !initialized_first_gnd_grid && abs(global_slope_ratio_p) < global_slope_max_ratio_ &&
-        abs(p_orig_point.z) < non_ground_height_threshold_local) {
-        ground_cluster.addPoint(p->radius, p_orig_point.z, p->orig_index);
-        p->point_state = PointLabel::GROUND;
-        initialized_first_gnd_grid = static_cast<bool>(p->grid_id - prev_p->grid_id);
-        continue;
-      }
+      std::unique_ptr<ScopedTimeTrack> radial_loop_st_ptr;
+      if (time_keeper_)
+        radial_loop_st_ptr = std::make_unique<ScopedTimeTrack>("radial_loop", *time_keeper_);
 
-      if (!initialized_first_gnd_grid) {
-        continue;
-      }
+      // check the first point in ray
+      auto * p = &in_radial_ordered_clouds[i][0];
 
-      // initialize lists of previous gnd grids
-      if (!prev_list_init) {
-        float h = ground_cluster.getAverageHeight();
-        float r = ground_cluster.getAverageRadius();
-        initializeFirstGndGrids(h, r, p->grid_id, gnd_grids);
-        prev_list_init = true;
-      }
-
-      // move to new grid
-      if (p->grid_id > prev_p->grid_id && ground_cluster.getAverageRadius() > 0.0) {
-        // check if the prev grid have ground point cloud
-        if (use_recheck_ground_cluster_) {
-          recheckGroundCluster(
-            ground_cluster, non_ground_height_threshold_, use_lowest_point_, out_no_ground_indices);
+      bool initialized_first_gnd_grid = false;
+      bool prev_list_init = false;
+      pcl::PointXYZ p_orig_point, prev_p_orig_point;
+      for (auto & point : in_radial_ordered_clouds[i]) {
+        auto * prev_p = p;  // for checking the distance to prev point
+        prev_p_orig_point = p_orig_point;
+        p = &point;
+        get_point_from_global_offset(in_cloud, p_orig_point, in_cloud->point_step * p->orig_index);
+        float global_slope_ratio_p = p_orig_point.z / p->radius;
+        float non_ground_height_threshold_local = non_ground_height_threshold_;
+        if (p_orig_point.x < low_priority_region_x_) {
+          non_ground_height_threshold_local =
+            non_ground_height_threshold_ * abs(p_orig_point.x / low_priority_region_x_);
         }
-        curr_gnd_grid.radius = ground_cluster.getAverageRadius();
-        curr_gnd_grid.avg_height = ground_cluster.getAverageHeight();
-        curr_gnd_grid.max_height = ground_cluster.getMaxHeight();
-        curr_gnd_grid.grid_id = prev_p->grid_id;
-        gnd_grids.push_back(curr_gnd_grid);
-        ground_cluster.initialize();
-      }
-      // classify
-      if (p_orig_point.z - gnd_grids.back().avg_height > detection_range_z_max_) {
-        p->point_state = PointLabel::OUT_OF_RANGE;
-        continue;
-      }
-      float points_xy_distance_square =
-        (p_orig_point.x - prev_p_orig_point.x) * (p_orig_point.x - prev_p_orig_point.x) +
-        (p_orig_point.y - prev_p_orig_point.y) * (p_orig_point.y - prev_p_orig_point.y);
-      if (
-        prev_p->point_state == PointLabel::NON_GROUND &&
-        points_xy_distance_square < split_points_distance_tolerance_square_ &&
-        p_orig_point.z > prev_p_orig_point.z) {
-        p->point_state = PointLabel::NON_GROUND;
-        out_no_ground_indices.indices.push_back(p->orig_index);
-        continue;
-      }
-      if (global_slope_ratio_p > global_slope_max_ratio_) {
-        out_no_ground_indices.indices.push_back(p->orig_index);
-        continue;
-      }
-      // gnd grid is continuous, the last gnd grid is close
-      uint16_t next_gnd_grid_id_thresh = (gnd_grids.end() - gnd_grid_buffer_size_)->grid_id +
-                                         gnd_grid_buffer_size_ + gnd_grid_continual_thresh_;
-      float curr_grid_size = calcGridSize(*p);
-      if (
-        p->grid_id < next_gnd_grid_id_thresh &&
-        p->radius - gnd_grids.back().radius < gnd_grid_continual_thresh_ * curr_grid_size) {
-        checkContinuousGndGrid(*p, p_orig_point, gnd_grids);
-      } else if (
-        p->radius - gnd_grids.back().radius < gnd_grid_continual_thresh_ * curr_grid_size) {
-        checkDiscontinuousGndGrid(*p, p_orig_point, gnd_grids);
-      } else {
-        checkBreakGndGrid(*p, p_orig_point, gnd_grids);
-      }
-      if (p->point_state == PointLabel::NON_GROUND) {
-        out_no_ground_indices.indices.push_back(p->orig_index);
-      } else if (p->point_state == PointLabel::GROUND) {
-        ground_cluster.addPoint(p->radius, p_orig_point.z, p->orig_index);
+        // classify first grid's point cloud
+        if (
+          !initialized_first_gnd_grid && global_slope_ratio_p >= global_slope_max_ratio_ &&
+          p_orig_point.z > non_ground_height_threshold_local) {
+          out_no_ground_indices.indices.push_back(p->orig_index);
+          p->point_state = PointLabel::NON_GROUND;
+          continue;
+        }
+
+        if (
+          !initialized_first_gnd_grid && abs(global_slope_ratio_p) < global_slope_max_ratio_ &&
+          abs(p_orig_point.z) < non_ground_height_threshold_local) {
+          ground_cluster.addPoint(p->radius, p_orig_point.z, p->orig_index);
+          p->point_state = PointLabel::GROUND;
+          initialized_first_gnd_grid = static_cast<bool>(p->grid_id - prev_p->grid_id);
+          continue;
+        }
+
+        if (!initialized_first_gnd_grid) {
+          continue;
+        }
+
+        // initialize lists of previous gnd grids
+        if (!prev_list_init) {
+          float h = ground_cluster.getAverageHeight();
+          float r = ground_cluster.getAverageRadius();
+          initializeFirstGndGrids(h, r, p->grid_id, gnd_grids);
+          prev_list_init = true;
+        }
+
+        // move to new grid
+        if (p->grid_id > prev_p->grid_id && ground_cluster.getAverageRadius() > 0.0) {
+          // check if the prev grid have ground point cloud
+          if (use_recheck_ground_cluster_) {
+            recheckGroundCluster(
+              ground_cluster, non_ground_height_threshold_, use_lowest_point_,
+              out_no_ground_indices);
+          }
+          curr_gnd_grid.radius = ground_cluster.getAverageRadius();
+          curr_gnd_grid.avg_height = ground_cluster.getAverageHeight();
+          curr_gnd_grid.max_height = ground_cluster.getMaxHeight();
+          curr_gnd_grid.grid_id = prev_p->grid_id;
+          gnd_grids.push_back(curr_gnd_grid);
+          ground_cluster.initialize();
+        }
+        // classify
+        if (p_orig_point.z - gnd_grids.back().avg_height > detection_range_z_max_) {
+          p->point_state = PointLabel::OUT_OF_RANGE;
+          continue;
+        }
+        float points_xy_distance_square =
+          (p_orig_point.x - prev_p_orig_point.x) * (p_orig_point.x - prev_p_orig_point.x) +
+          (p_orig_point.y - prev_p_orig_point.y) * (p_orig_point.y - prev_p_orig_point.y);
+        if (
+          prev_p->point_state == PointLabel::NON_GROUND &&
+          points_xy_distance_square < split_points_distance_tolerance_square_ &&
+          p_orig_point.z > prev_p_orig_point.z) {
+          p->point_state = PointLabel::NON_GROUND;
+          out_no_ground_indices.indices.push_back(p->orig_index);
+          continue;
+        }
+        if (global_slope_ratio_p > global_slope_max_ratio_) {
+          out_no_ground_indices.indices.push_back(p->orig_index);
+          continue;
+        }
+        // gnd grid is continuous, the last gnd grid is close
+        uint16_t next_gnd_grid_id_thresh = (gnd_grids.end() - gnd_grid_buffer_size_)->grid_id +
+                                           gnd_grid_buffer_size_ + gnd_grid_continual_thresh_;
+        float curr_grid_size = calcGridSize(*p);
+        if (
+          p->grid_id < next_gnd_grid_id_thresh &&
+          p->radius - gnd_grids.back().radius < gnd_grid_continual_thresh_ * curr_grid_size) {
+          checkContinuousGndGrid(*p, p_orig_point, gnd_grids);
+        } else if (
+          p->radius - gnd_grids.back().radius < gnd_grid_continual_thresh_ * curr_grid_size) {
+          checkDiscontinuousGndGrid(*p, p_orig_point, gnd_grids);
+        } else {
+          checkBreakGndGrid(*p, p_orig_point, gnd_grids);
+        }
+        if (p->point_state == PointLabel::NON_GROUND) {
+          out_no_ground_indices.indices.push_back(p->orig_index);
+        } else if (p->point_state == PointLabel::GROUND) {
+          ground_cluster.addPoint(p->radius, p_orig_point.z, p->orig_index);
+        }
       }
     }
-  }
+  }  // scope for time keeper ends
 }
 
 void ScanGroundFilterComponent::classifyPointCloud(
@@ -484,107 +516,119 @@ void ScanGroundFilterComponent::classifyPointCloud(
   pcl::PointXYZ virtual_ground_point(0, 0, 0);
   calcVirtualGroundOrigin(virtual_ground_point);
 
-  // point classification algorithm
-  // sweep through each radial division
-  for (size_t i = 0; i < in_radial_ordered_clouds.size(); ++i) {
-    float prev_gnd_radius = 0.0f;
-    float prev_gnd_slope = 0.0f;
-    PointsCentroid ground_cluster, non_ground_cluster;
-    PointLabel prev_point_label = PointLabel::INIT;
-    pcl::PointXYZ prev_gnd_point(0, 0, 0), p_orig_point, prev_p_orig_point;
-    // loop through each point in the radial div
-    for (size_t j = 0; j < in_radial_ordered_clouds[i].size(); ++j) {
-      float points_distance = 0.0f;
-      const float local_slope_max_angle = local_slope_max_angle_rad_;
-      prev_p_orig_point = p_orig_point;
-      auto * p = &in_radial_ordered_clouds[i][j];
-      get_point_from_global_offset(in_cloud, p_orig_point, in_cloud->point_step * p->orig_index);
-      if (j == 0) {
-        bool is_front_side = (p_orig_point.x > virtual_ground_point.x);
-        if (use_virtual_ground_point_ && is_front_side) {
-          prev_gnd_point = virtual_ground_point;
+  {  // add scope for time keeper
+    std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
+    if (time_keeper_)
+      inner_st_ptr = std::make_unique<ScopedTimeTrack>("classify_loop", *time_keeper_);
+
+    // point classification algorithm
+    // sweep through each radial division
+    for (size_t i = 0; i < in_radial_ordered_clouds.size(); ++i) {
+      float prev_gnd_radius = 0.0f;
+      float prev_gnd_slope = 0.0f;
+      PointsCentroid ground_cluster, non_ground_cluster;
+      PointLabel prev_point_label = PointLabel::INIT;
+      pcl::PointXYZ prev_gnd_point(0, 0, 0), p_orig_point, prev_p_orig_point;
+
+      std::unique_ptr<ScopedTimeTrack> radial_loop_st_ptr;
+      if (time_keeper_)
+        radial_loop_st_ptr = std::make_unique<ScopedTimeTrack>("radial_loop", *time_keeper_);
+
+      // loop through each point in the radial div
+      for (size_t j = 0; j < in_radial_ordered_clouds[i].size(); ++j) {
+        float points_distance = 0.0f;
+        const float local_slope_max_angle = local_slope_max_angle_rad_;
+        prev_p_orig_point = p_orig_point;
+        auto * p = &in_radial_ordered_clouds[i][j];
+        get_point_from_global_offset(in_cloud, p_orig_point, in_cloud->point_step * p->orig_index);
+        if (j == 0) {
+          bool is_front_side = (p_orig_point.x > virtual_ground_point.x);
+          if (use_virtual_ground_point_ && is_front_side) {
+            prev_gnd_point = virtual_ground_point;
+          } else {
+            prev_gnd_point = init_ground_point;
+          }
+          prev_gnd_radius = std::hypot(prev_gnd_point.x, prev_gnd_point.y);
+          prev_gnd_slope = 0.0f;
+          ground_cluster.initialize();
+          non_ground_cluster.initialize();
+          points_distance = calcDistance3d(p_orig_point, prev_gnd_point);
         } else {
-          prev_gnd_point = init_ground_point;
+          points_distance = calcDistance3d(p_orig_point, prev_p_orig_point);
         }
-        prev_gnd_radius = std::hypot(prev_gnd_point.x, prev_gnd_point.y);
-        prev_gnd_slope = 0.0f;
-        ground_cluster.initialize();
-        non_ground_cluster.initialize();
-        points_distance = calcDistance3d(p_orig_point, prev_gnd_point);
-      } else {
-        points_distance = calcDistance3d(p_orig_point, prev_p_orig_point);
-      }
 
-      float radius_distance_from_gnd = p->radius - prev_gnd_radius;
-      float height_from_gnd = p_orig_point.z - prev_gnd_point.z;
-      float height_from_obj = p_orig_point.z - non_ground_cluster.getAverageHeight();
-      bool calculate_slope = false;
-      bool is_point_close_to_prev =
-        (points_distance <
-         (p->radius * radial_divider_angle_rad_ + split_points_distance_tolerance_));
+        float radius_distance_from_gnd = p->radius - prev_gnd_radius;
+        float height_from_gnd = p_orig_point.z - prev_gnd_point.z;
+        float height_from_obj = p_orig_point.z - non_ground_cluster.getAverageHeight();
+        bool calculate_slope = false;
+        bool is_point_close_to_prev =
+          (points_distance <
+           (p->radius * radial_divider_angle_rad_ + split_points_distance_tolerance_));
 
-      float global_slope_ratio = p_orig_point.z / p->radius;
-      // check points which is far enough from previous point
-      if (global_slope_ratio > global_slope_max_ratio_) {
-        p->point_state = PointLabel::NON_GROUND;
-        calculate_slope = false;
-      } else if (
-        (prev_point_label == PointLabel::NON_GROUND) &&
-        (std::abs(height_from_obj) >= split_height_distance_)) {
-        calculate_slope = true;
-      } else if (is_point_close_to_prev && std::abs(height_from_gnd) < split_height_distance_) {
-        // close to the previous point, set point follow label
-        p->point_state = PointLabel::POINT_FOLLOW;
-        calculate_slope = false;
-      } else {
-        calculate_slope = true;
-      }
-      if (is_point_close_to_prev) {
-        height_from_gnd = p_orig_point.z - ground_cluster.getAverageHeight();
-        radius_distance_from_gnd = p->radius - ground_cluster.getAverageRadius();
-      }
-      if (calculate_slope) {
-        // far from the previous point
-        auto local_slope = std::atan2(height_from_gnd, radius_distance_from_gnd);
-        if (local_slope - prev_gnd_slope > local_slope_max_angle) {
-          // the point is outside of the local slope threshold
+        float global_slope_ratio = p_orig_point.z / p->radius;
+        // check points which is far enough from previous point
+        if (global_slope_ratio > global_slope_max_ratio_) {
           p->point_state = PointLabel::NON_GROUND;
+          calculate_slope = false;
+        } else if (
+          (prev_point_label == PointLabel::NON_GROUND) &&
+          (std::abs(height_from_obj) >= split_height_distance_)) {
+          calculate_slope = true;
+        } else if (is_point_close_to_prev && std::abs(height_from_gnd) < split_height_distance_) {
+          // close to the previous point, set point follow label
+          p->point_state = PointLabel::POINT_FOLLOW;
+          calculate_slope = false;
         } else {
-          p->point_state = PointLabel::GROUND;
+          calculate_slope = true;
         }
-      }
+        if (is_point_close_to_prev) {
+          height_from_gnd = p_orig_point.z - ground_cluster.getAverageHeight();
+          radius_distance_from_gnd = p->radius - ground_cluster.getAverageRadius();
+        }
+        if (calculate_slope) {
+          // far from the previous point
+          auto local_slope = std::atan2(height_from_gnd, radius_distance_from_gnd);
+          if (local_slope - prev_gnd_slope > local_slope_max_angle) {
+            // the point is outside of the local slope threshold
+            p->point_state = PointLabel::NON_GROUND;
+          } else {
+            p->point_state = PointLabel::GROUND;
+          }
+        }
 
-      if (p->point_state == PointLabel::GROUND) {
-        ground_cluster.initialize();
-        non_ground_cluster.initialize();
-      }
-      if (p->point_state == PointLabel::NON_GROUND) {
-        out_no_ground_indices.indices.push_back(p->orig_index);
-      } else if (  // NOLINT
-        (prev_point_label == PointLabel::NON_GROUND) &&
-        (p->point_state == PointLabel::POINT_FOLLOW)) {
-        p->point_state = PointLabel::NON_GROUND;
-        out_no_ground_indices.indices.push_back(p->orig_index);
-      } else if (  // NOLINT
-        (prev_point_label == PointLabel::GROUND) && (p->point_state == PointLabel::POINT_FOLLOW)) {
-        p->point_state = PointLabel::GROUND;
-      } else {
-      }
+        if (p->point_state == PointLabel::GROUND) {
+          ground_cluster.initialize();
+          non_ground_cluster.initialize();
+        }
+        if (p->point_state == PointLabel::NON_GROUND) {
+          out_no_ground_indices.indices.push_back(p->orig_index);
+        } else if (  // NOLINT
+          (prev_point_label == PointLabel::NON_GROUND) &&
+          (p->point_state == PointLabel::POINT_FOLLOW)) {
+          p->point_state = PointLabel::NON_GROUND;
+          out_no_ground_indices.indices.push_back(p->orig_index);
+        } else if (  // NOLINT
+          (prev_point_label == PointLabel::GROUND) &&
+          (p->point_state == PointLabel::POINT_FOLLOW)) {
+          p->point_state = PointLabel::GROUND;
+        } else {
+        }
 
-      // update the ground state
-      prev_point_label = p->point_state;
-      if (p->point_state == PointLabel::GROUND) {
-        prev_gnd_radius = p->radius;
-        prev_gnd_point = pcl::PointXYZ(p_orig_point.x, p_orig_point.y, p_orig_point.z);
-        ground_cluster.addPoint(p->radius, p_orig_point.z);
-        prev_gnd_slope = ground_cluster.getAverageSlope();
-      }
-      // update the non ground state
-      if (p->point_state == PointLabel::NON_GROUND) {
-        non_ground_cluster.addPoint(p->radius, p_orig_point.z);
+        // update the ground state
+        prev_point_label = p->point_state;
+        if (p->point_state == PointLabel::GROUND) {
+          prev_gnd_radius = p->radius;
+          prev_gnd_point = pcl::PointXYZ(p_orig_point.x, p_orig_point.y, p_orig_point.z);
+          ground_cluster.addPoint(p->radius, p_orig_point.z);
+          prev_gnd_slope = ground_cluster.getAverageSlope();
+        }
+        // update the non ground state
+        if (p->point_state == PointLabel::NON_GROUND) {
+          non_ground_cluster.addPoint(p->radius, p_orig_point.z);
+        }
       }
     }
-  }
+  }  // scope for time keeper ends
 }
 
 void ScanGroundFilterComponent::extractObjectPoints(

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/node.cpp
@@ -91,7 +91,7 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
     if (use_time_keeper) {
       detailed_processing_time_publisher_ =
         this->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
-          "~/debug/ground_segm_processing_time_detail_ms", 1);
+          "~/debug/processing_time_detail_ms", 1);
       auto time_keeper = autoware::universe_utils::TimeKeeper(detailed_processing_time_publisher_);
       time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(time_keeper);
     }

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/pointcloud_preprocessor/filter.hpp"
 #include "autoware/pointcloud_preprocessor/transform_info.hpp"
+#include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info.hpp"
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -200,6 +201,11 @@ private:
                            // otherwise select middle point
   size_t radial_dividers_num_;
   VehicleInfo vehicle_info_;
+
+  // time keeper related
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    detailed_processing_time_publisher_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   /*!
    * Output transformed PointCloud from in_cloud_ptr->header.frame_id to in_target_frame

--- a/perception/autoware_ground_segmentation/test/test_ransac_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/test/test_ransac_ground_filter.cpp
@@ -152,6 +152,7 @@ TEST_F(RansacGroundFilterTestSuite, TestCase1)
   double voxel_size_z = params["voxel_size_z"].as<float>();
   double height_threshold = params["height_threshold"].as<float>();
   bool debug = params["debug"].as<bool>();
+  bool publish_processing_time_detail = params["publish_processing_time_detail"].as<bool>();
 
   const auto pcd_path = share_dir + "/data/test.pcd";
   pcl::PointCloud<pcl::PointXYZI> cloud;
@@ -191,6 +192,7 @@ TEST_F(RansacGroundFilterTestSuite, TestCase1)
   parameters.emplace_back("voxel_size_z", voxel_size_z);
   parameters.emplace_back("height_threshold", height_threshold);
   parameters.emplace_back("debug", debug);
+  parameters.emplace_back("publish_processing_time_detail", publish_processing_time_detail);
 
   rclcpp::NodeOptions node_options;
   node_options.parameter_overrides(parameters);

--- a/perception/autoware_ground_segmentation/test/test_ray_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/test/test_ray_ground_filter.cpp
@@ -121,6 +121,7 @@ TEST_F(RayGroundFilterComponentTestSuite, TestCase1)
   double min_height_threshold_ = params["min_height_threshold"].as<float>();
   double concentric_divider_distance_ = params["concentric_divider_distance"].as<float>();
   double reclass_distance_threshold_ = params["reclass_distance_threshold"].as<float>();
+  bool publish_processing_time_detail_ = params["publish_processing_time_detail"].as<bool>();
 
   const auto pcd_path = share_dir + "/data/test.pcd";
   pcl::PointCloud<pcl::PointXYZI> cloud;
@@ -167,6 +168,8 @@ TEST_F(RayGroundFilterComponentTestSuite, TestCase1)
   parameters.emplace_back(rclcpp::Parameter("min_y", min_y_));
   parameters.emplace_back(rclcpp::Parameter("max_y", max_y_));
   parameters.emplace_back(rclcpp::Parameter("use_vehicle_footprint", use_vehicle_footprint_));
+  parameters.emplace_back(
+    rclcpp::Parameter("publish_processing_time_detail", publish_processing_time_detail_));
 
   node_options.parameter_overrides(parameters);
   auto ray_ground_filter_test = std::make_shared<RayGroundFilterComponentTest>(node_options);

--- a/perception/autoware_ground_segmentation/test/test_scan_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/test/test_scan_ground_filter.cpp
@@ -122,6 +122,8 @@ protected:
     parameters.emplace_back(
       rclcpp::Parameter("use_recheck_ground_cluster", use_recheck_ground_cluster_));
     parameters.emplace_back(rclcpp::Parameter("use_lowest_point", use_lowest_point_));
+    parameters.emplace_back(
+      rclcpp::Parameter("publish_processing_time_detail", publish_processing_time_detail_));
 
     options.parameter_overrides(parameters);
 
@@ -200,6 +202,7 @@ public:
     radial_divider_angle_deg_ = params["radial_divider_angle_deg"].as<float>();
     use_recheck_ground_cluster_ = params["use_recheck_ground_cluster"].as<bool>();
     use_lowest_point_ = params["use_lowest_point"].as<bool>();
+    publish_processing_time_detail_ = params["publish_processing_time_detail"].as<bool>();
   }
 
   float global_slope_max_angle_deg_ = 0.0;
@@ -218,6 +221,7 @@ public:
   float radial_divider_angle_deg_;
   bool use_recheck_ground_cluster_;
   bool use_lowest_point_;
+  bool publish_processing_time_detail_;
 };
 
 TEST_F(ScanGroundFilterTest, TestCase1)


### PR DESCRIPTION
## Description
This PR will add time keeper feature for `ground_segmentation`.

The time tracking is set only for relatively long processing time functions/methods.

You need to modified the parameter file `ground_segmentation.param.yaml` in `autoware_launch` to run in autoware.
- https://github.com/autowarefoundation/autoware_launch/pull/1134

---
Sample output (updated from original comment)
```Text
# total time

- scan_ground_filter
100.00% faster_filter: total 3706.36 [ms], avg. 18.53 [ms], run count: 200
    ├── 67.09% convertPointcloudGridScan: total 2486.72 [ms], avg. 12.43 [ms], run count: 200
    │   ├── 50.49% scan: total 1871.41 [ms], avg. 9.36 [ms], run count: 200
    │   ├── 16.53% sort: total 612.49 [ms], avg. 3.06 [ms], run count: 200
    │   └── 0.08% rest: 2.82 [ms]
    ├── 28.57% classifyPointCloudGridScan: total 1059.02 [ms], avg. 5.30 [ms], run count: 200
    │   ├── 28.56% classify_loop: total 1058.42 [ms], avg. 5.29 [ms], run count: 200
    │   │   ├── 26.91% radial_loop: total 997.52 [ms], avg. 0.01 [ms], run count: 71999
    │   │   └── 1.64% rest: 60.90 [ms]
    │   └── 0.02% rest: 0.60 [ms]
    ├── 3.50% extractObjectPoints: total 129.54 [ms], avg. 0.65 [ms], run count: 200
    └── 0.84% rest: 31.07 [ms]

- ray_ground_filter
  100.00% filter: total 10171.14 [ms], avg. 36.46 [ms], run count: 279
    ├── 70.96% ConvertXYZIToRTZColor: total 7217.59 [ms], avg. 25.87 [ms], run count: 279
    ├── 13.44% ClassifyPointCloud: total 1366.64 [ms], avg. 4.90 [ms], run count: 279
    ├── 6.86% ExtractPointsIndices: total 698.06 [ms], avg. 2.50 [ms], run count: 279
    │   ├── 4.16% initializePointCloud2: total 423.15 [ms], avg. 0.76 [ms], run count: 558
    │   └── 2.70% rest: 274.91 [ms]
    └── 8.74% rest: 888.85 [ms]

- ransac_ground_filter
  100.00% filter: total 130212.22 [ms], avg. 1943.47 [ms], run count: 67
    ├── 0.07% transformPointCloud: total 89.05 [ms], avg. 0.66 [ms], run count: 134
    ├── 99.45% applyRANSAC: total 129490.73 [ms], avg. 1932.70 [ms], run count: 67
    ├── 0.07% extractPointsIndices: total 93.24 [ms], avg. 1.39 [ms], run count: 67
    ├── 0.00% getPlaneAffine: total 0.39 [ms], avg. 0.01 [ms], run count: 67
    └── 0.41% rest: 538.80 [ms]
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
