### PR TITLE
fix(ground-segmentation): missing ament_index_cpp dependency

### DIFF
--- a/perception/autoware_ground_segmentation/package.xml
+++ b/perception/autoware_ground_segmentation/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>libopencv-dev</depend>


### PR DESCRIPTION
Required for `Jazzy` compilation