### PR TITLE
feat(autoware_universe_utils): reduce dependence on Boost.Geometry

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -121,7 +121,23 @@ autoware::universe_utils::Point2d to_boost(const Point2d & point);
 autoware::universe_utils::Polygon2d to_boost(const ConvexPolygon2d & polygon);
 }  // namespace alt
 
+enum BufferStrategy {
+  JOIN_ROUND = 0b0,
+  JOIN_MITER = 0b1,
+  END_ROUND = 0b00,
+  END_FLAT = 0b10,
+  POINT_CIRCLE = 0b000,
+  POINT_SQUARE = 0b100,
+};
+
 double area(const alt::ConvexPolygon2d & poly);
+
+// Usage example:
+// buffer(points, 1.0, 0.5,
+//        BufferStrategy::JOIN_ROUND | BufferStrategy::END_FLAT | BufferStrategy::POINT_CIRCLE);
+/* alt::Polygon2d buffer(
+  const alt::Points2d & points, const double left_dist, const double right_dist,
+  const int strategy); */
 
 alt::ConvexPolygon2d convex_hull(const alt::Points2d & points);
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -169,7 +169,7 @@ double area(const alt::ConvexPolygon2d & poly);
 
 std::optional<alt::ConvexPolygon2d> convex_hull(const alt::Points2d & points);
 
-void correct(alt::ConvexPolygon2d & poly);
+void correct(alt::Polygon2d & poly);
 
 bool covered_by(const alt::Point2d & point, const alt::ConvexPolygon2d & poly);
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -140,6 +140,9 @@ bool equals(const alt::Point2d & point1, const alt::Point2d & point2);
 
 bool equals(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d & poly2);
 
+alt::Points2d::const_iterator find_farthest(
+  const alt::Points2d & points, const alt::Point2d & seg_start, const alt::Point2d & seg_end);
+
 bool intersects(
   const alt::Point2d & seg1_start, const alt::Point2d & seg1_end, const alt::Point2d & seg2_start,
   const alt::Point2d & seg2_end);

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -149,23 +149,7 @@ private:
 };
 }  // namespace alt
 
-enum BufferStrategy {
-  JOIN_ROUND = 0b0,
-  JOIN_MITER = 0b1,
-  END_ROUND = 0b00,
-  END_FLAT = 0b10,
-  POINT_CIRCLE = 0b000,
-  POINT_SQUARE = 0b100,
-};
-
 double area(const alt::ConvexPolygon2d & poly);
-
-// Usage example:
-// buffer(points, 1.0, 0.5,
-//        BufferStrategy::JOIN_ROUND | BufferStrategy::END_FLAT | BufferStrategy::POINT_CIRCLE);
-/* alt::Polygon2d buffer(
-  const alt::Points2d & points, const double left_dist, const double right_dist,
-  const int strategy); */
 
 std::optional<alt::ConvexPolygon2d> convex_hull(const alt::Points2d & points);
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -136,6 +136,8 @@ double distance(
 
 double distance(const alt::Point2d & point, const alt::ConvexPolygon2d & poly);
 
+alt::ConvexPolygon2d envelope(const alt::ConvexPolygon2d & poly);
+
 bool equals(const alt::Point2d & point1, const alt::Point2d & point2);
 
 bool equals(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d & poly2);

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -180,7 +180,7 @@ double distance(
 
 double distance(const alt::Point2d & point, const alt::ConvexPolygon2d & poly);
 
-std::optional<alt::ConvexPolygon2d> envelope(const alt::ConvexPolygon2d & poly);
+std::optional<alt::ConvexPolygon2d> envelope(const alt::Polygon2d & poly);
 
 bool equals(const alt::Point2d & point1, const alt::Point2d & point2);
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -154,6 +154,8 @@ bool is_above(
 
 bool is_clockwise(const alt::ConvexPolygon2d & poly);
 
+alt::Points2d simplify(const alt::Points2d & points, const double max_distance);
+
 bool touches(
   const alt::Point2d & point, const alt::Point2d & seg_start, const alt::Point2d & seg_end);
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -198,6 +198,8 @@ bool intersects(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d &
 bool is_above(
   const alt::Point2d & point, const alt::Point2d & seg_start, const alt::Point2d & seg_end);
 
+bool is_clockwise(const alt::PointList2d & vertices);
+
 bool is_convex(const alt::Polygon2d & poly);
 
 alt::PointList2d simplify(const alt::PointList2d & line, const double max_distance);

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -17,6 +17,8 @@
 
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 
+#include <list>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -32,6 +34,10 @@ public:
   Vector2d() : x_(0.0), y_(0.0) {}
 
   Vector2d(const double x, const double y) : x_(x), y_(y) {}
+
+  explicit Vector2d(const autoware::universe_utils::Point2d & point) : x_(point.x()), y_(point.y())
+  {
+  }
 
   double cross(const Vector2d & other) const { return x_ * other.y() - y_ * other.x(); }
 
@@ -60,38 +66,6 @@ private:
   double y_;
 };
 
-// We use Vector2d to represent points, but we do not name the class Point2d directly
-// as it has some vector operation functions.
-using Point2d = Vector2d;
-using Points2d = std::vector<Point2d>;
-
-class ConvexPolygon2d
-{
-public:
-  explicit ConvexPolygon2d(const Points2d & vertices)
-  {
-    if (vertices.size() < 3) {
-      throw std::invalid_argument("At least 3 points are required for vertices.");
-    }
-    vertices_ = vertices;
-  }
-
-  explicit ConvexPolygon2d(Points2d && vertices)
-  {
-    if (vertices.size() < 3) {
-      throw std::invalid_argument("At least 3 points are required for vertices.");
-    }
-    vertices_ = std::move(vertices);
-  }
-
-  const Points2d & vertices() const { return vertices_; }
-
-  Points2d & vertices() { return vertices_; }
-
-private:
-  Points2d vertices_;
-};
-
 inline Vector2d operator+(const Vector2d & v1, const Vector2d & v2)
 {
   return {v1.x() + v2.x(), v1.y() + v2.y()};
@@ -112,13 +86,67 @@ inline Vector2d operator*(const double & s, const Vector2d & v)
   return {s * v.x(), s * v.y()};
 }
 
-Point2d from_boost(const autoware::universe_utils::Point2d & point);
+// We use Vector2d to represent points, but we do not name the class Point2d directly
+// as it has some vector operation functions.
+using Point2d = Vector2d;
+using Points2d = std::vector<Point2d>;
+using PointList2d = std::list<Point2d>;
 
-ConvexPolygon2d from_boost(const autoware::universe_utils::Polygon2d & polygon);
+class Polygon2d
+{
+public:
+  static std::optional<Polygon2d> create(
+    const PointList2d & outer, const std::vector<PointList2d> & inners) noexcept;
 
-autoware::universe_utils::Point2d to_boost(const Point2d & point);
+  static std::optional<Polygon2d> create(
+    PointList2d && outer, std::vector<PointList2d> && inners) noexcept;
 
-autoware::universe_utils::Polygon2d to_boost(const ConvexPolygon2d & polygon);
+  static std::optional<Polygon2d> create(
+    const autoware::universe_utils::Polygon2d & polygon) noexcept;
+
+  const PointList2d & outer() const noexcept { return outer_; }
+
+  PointList2d & outer() noexcept { return outer_; }
+
+  const std::vector<PointList2d> & inners() const noexcept { return inners_; }
+
+  std::vector<PointList2d> & inners() noexcept { return inners_; }
+
+protected:
+  Polygon2d(const PointList2d & outer, const std::vector<PointList2d> & inners)
+  : outer_(outer), inners_(inners)
+  {
+  }
+
+  Polygon2d(PointList2d && outer, std::vector<PointList2d> && inners)
+  : outer_(std::move(outer)), inners_(std::move(inners))
+  {
+  }
+
+  PointList2d outer_;
+
+  std::vector<PointList2d> inners_;
+};
+
+class ConvexPolygon2d : public Polygon2d
+{
+public:
+  static std::optional<ConvexPolygon2d> create(const PointList2d & vertices) noexcept;
+
+  static std::optional<ConvexPolygon2d> create(PointList2d && vertices) noexcept;
+
+  static std::optional<ConvexPolygon2d> create(
+    const autoware::universe_utils::Polygon2d & polygon) noexcept;
+
+  const PointList2d & vertices() const noexcept { return outer(); }
+
+  PointList2d & vertices() noexcept { return outer(); }
+
+private:
+  explicit ConvexPolygon2d(const PointList2d & vertices) : Polygon2d(vertices, {}) {}
+
+  explicit ConvexPolygon2d(PointList2d && vertices) : Polygon2d(std::move(vertices), {}) {}
+};
 }  // namespace alt
 
 enum BufferStrategy {
@@ -139,7 +167,7 @@ double area(const alt::ConvexPolygon2d & poly);
   const alt::Points2d & points, const double left_dist, const double right_dist,
   const int strategy); */
 
-alt::ConvexPolygon2d convex_hull(const alt::Points2d & points);
+std::optional<alt::ConvexPolygon2d> convex_hull(const alt::Points2d & points);
 
 void correct(alt::ConvexPolygon2d & poly);
 
@@ -152,11 +180,11 @@ double distance(
 
 double distance(const alt::Point2d & point, const alt::ConvexPolygon2d & poly);
 
-alt::ConvexPolygon2d envelope(const alt::ConvexPolygon2d & poly);
+std::optional<alt::ConvexPolygon2d> envelope(const alt::ConvexPolygon2d & poly);
 
 bool equals(const alt::Point2d & point1, const alt::Point2d & point2);
 
-bool equals(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d & poly2);
+bool equals(const alt::Polygon2d & poly1, const alt::Polygon2d & poly2);
 
 alt::Points2d::const_iterator find_farthest(
   const alt::Points2d & points, const alt::Point2d & seg_start, const alt::Point2d & seg_end);
@@ -170,9 +198,9 @@ bool intersects(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d &
 bool is_above(
   const alt::Point2d & point, const alt::Point2d & seg_start, const alt::Point2d & seg_end);
 
-bool is_clockwise(const alt::ConvexPolygon2d & poly);
+bool is_convex(const alt::Polygon2d & poly);
 
-alt::Points2d simplify(const alt::Points2d & points, const double max_distance);
+alt::PointList2d simplify(const alt::PointList2d & line, const double max_distance);
 
 bool touches(
   const alt::Point2d & point, const alt::Point2d & seg_start, const alt::Point2d & seg_end);

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -86,9 +86,9 @@ std::optional<ConvexPolygon2d> ConvexPolygon2d::create(const PointList2d & verti
     return std::nullopt;
   }
 
-  if (!is_convex(poly)) {
-    return std::nullopt;
-  }
+  // if (!is_convex(poly)) {
+  //   return std::nullopt;
+  // }
 
   return poly;
 }
@@ -102,9 +102,9 @@ std::optional<ConvexPolygon2d> ConvexPolygon2d::create(PointList2d && vertices) 
     return std::nullopt;
   }
 
-  if (!is_convex(poly)) {
-    return std::nullopt;
-  }
+  // if (!is_convex(poly)) {
+  //   return std::nullopt;
+  // }
 
   return poly;
 }

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -239,6 +239,23 @@ double distance(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
   return min_distance;
 }
 
+alt::ConvexPolygon2d envelope(const alt::ConvexPolygon2d & poly)
+{
+  const auto [x_min_vertex, x_max_vertex] = std::minmax_element(
+    poly.vertices().begin(), poly.vertices().end(),
+    [](const auto & a, const auto & b) { return a.x() < b.x(); });
+
+  const auto [y_min_vertex, y_max_vertex] = std::minmax_element(
+    poly.vertices().begin(), poly.vertices().end(),
+    [](const auto & a, const auto & b) { return a.y() < b.y(); });
+
+  return alt::ConvexPolygon2d{
+    {{x_min_vertex->x(), y_min_vertex->y()},
+     {x_min_vertex->x(), y_max_vertex->y()},
+     {x_max_vertex->x(), y_max_vertex->y()},
+     {x_max_vertex->x(), y_min_vertex->y()}}};
+}
+
 bool equals(const alt::Point2d & point1, const alt::Point2d & point2)
 {
   constexpr double epsilon = 1e-3;

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -132,66 +132,7 @@ double area(const alt::ConvexPolygon2d & poly)
 
   return area;
 }
-/*
-alt::Polygon2d buffer(
-  const alt::Points2d & points, const double left_dist, const double right_dist, const int strategy)
-{
-  constexpr std::size_t points_per_circle = 90;
-  const bool join_round = strategy & BufferStrategy::JOIN_ROUND;
-  const bool end_round = strategy & BufferStrategy::END_ROUND;
-  const bool point_circle = strategy & BufferStrategy::POINT_CIRCLE;
-  alt::Polygon2d buffered_poly;
-  if (points.size() == 1) {
-    const double dist = std::max(left_dist, right_dist);
-    if (point_circle) {
-      for (std::size_t i = 0; i < points_per_circle; ++i) {
-        const double theta = 2 * M_PI * i / points_per_circle;
-        buffered_poly.push_back(
-          points.front() + dist * alt::Point2d{std::cos(theta), std::sin(theta)});
-      }
-    } else {
-      const std::vector<alt::Point2d> vertices = {
-        {-dist, -dist}, {dist, -dist}, {dist, dist}, {-dist, dist}};
-      for (const auto & vertex : vertices) {
-        buffered_poly.push_back(points.front() + vertex);
-      }
-    }
-  } else {
-    for (std::size_t i = 0; i < points.size(); ++i) {
-      const auto & p1 = points[i];
-      const auto & p2 = points[(i + 1) % points.size()];
-      const auto v = (p2 - p1).normalized();
-      const auto n = v.vector_triple(alt::Vector2d{0, 0}, 1);
-      alt::Points2d buffer_points;
-      const std::vector<alt::Point2d> square_vertices = {
-        p1 - left_dist * n, p2 - left_dist * n, p2 + right_dist * n, p1 + right_dist * n};
-      for (const auto & vertex : square_vertices) {
-        buffer_points.push_back(vertex);
-      }
-      auto draw_arc = [](const auto & arc_center, const auto start_angle) {
-        const auto radius = (right_dist + left_dist) / 2;
-        for (std::size_t j = 0; j < points_per_circle; ++j) {
-          const double theta = start_angle + M_PI * j / points_per_circle;
-          buffer_points.push_back(
-            arc_center + radius * alt::Point2d{std::cos(theta), std::sin(theta)});
-        }
-      };
-      if ((i > 0 && join_round) || end_round) {
-        const auto arc_center = p1 + (right_dist - left_dist) * n;
-        const auto start_angle = std::atan2(-n.y(), -n.x());
-        draw_arc(arc_center, start_angle);
-      }
-      if ((i < points.size() - 1 && join_round) || end_round) {
-        const auto arc_center = p2 + (right_dist - left_dist) * n;
-        const auto start_angle = std::atan2(n.y(), n.x());
-        draw_arc(arc_center, start_angle);
-      }
-      buffered_poly = union_(buffered_poly, alt::ConvexPolygon2d{buffer_points});
-    }
-  }
-  return buffered_poly;
-}
-*/
+
 std::optional<alt::ConvexPolygon2d> convex_hull(const alt::Points2d & points)
 {
   if (points.size() < 3) {

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -62,7 +62,66 @@ double area(const alt::ConvexPolygon2d & poly)
 
   return area;
 }
-
+/*
+alt::Polygon2d buffer(
+  const alt::Points2d & points, const double left_dist, const double right_dist, const int strategy)
+{
+  constexpr std::size_t points_per_circle = 90;
+  const bool join_round = strategy & BufferStrategy::JOIN_ROUND;
+  const bool end_round = strategy & BufferStrategy::END_ROUND;
+  const bool point_circle = strategy & BufferStrategy::POINT_CIRCLE;
+  alt::Polygon2d buffered_poly;
+  if (points.size() == 1) {
+    const double dist = std::max(left_dist, right_dist);
+    if (point_circle) {
+      for (std::size_t i = 0; i < points_per_circle; ++i) {
+        const double theta = 2 * M_PI * i / points_per_circle;
+        buffered_poly.push_back(
+          points.front() + dist * alt::Point2d{std::cos(theta), std::sin(theta)});
+      }
+    } else {
+      const std::vector<alt::Point2d> vertices = {
+        {-dist, -dist}, {dist, -dist}, {dist, dist}, {-dist, dist}};
+      for (const auto & vertex : vertices) {
+        buffered_poly.push_back(points.front() + vertex);
+      }
+    }
+  } else {
+    for (std::size_t i = 0; i < points.size(); ++i) {
+      const auto & p1 = points[i];
+      const auto & p2 = points[(i + 1) % points.size()];
+      const auto v = (p2 - p1).normalized();
+      const auto n = v.vector_triple(alt::Vector2d{0, 0}, 1);
+      alt::Points2d buffer_points;
+      const std::vector<alt::Point2d> square_vertices = {
+        p1 - left_dist * n, p2 - left_dist * n, p2 + right_dist * n, p1 + right_dist * n};
+      for (const auto & vertex : square_vertices) {
+        buffer_points.push_back(vertex);
+      }
+      auto draw_arc = [](const auto & arc_center, const auto start_angle) {
+        const auto radius = (right_dist + left_dist) / 2;
+        for (std::size_t j = 0; j < points_per_circle; ++j) {
+          const double theta = start_angle + M_PI * j / points_per_circle;
+          buffer_points.push_back(
+            arc_center + radius * alt::Point2d{std::cos(theta), std::sin(theta)});
+        }
+      };
+      if ((i > 0 && join_round) || end_round) {
+        const auto arc_center = p1 + (right_dist - left_dist) * n;
+        const auto start_angle = std::atan2(-n.y(), -n.x());
+        draw_arc(arc_center, start_angle);
+      }
+      if ((i < points.size() - 1 && join_round) || end_round) {
+        const auto arc_center = p2 + (right_dist - left_dist) * n;
+        const auto start_angle = std::atan2(n.y(), n.x());
+        draw_arc(arc_center, start_angle);
+      }
+      buffered_poly = union_(buffered_poly, alt::ConvexPolygon2d{buffer_points});
+    }
+  }
+  return buffered_poly;
+}
+*/
 alt::ConvexPolygon2d convex_hull(const alt::Points2d & points)
 {
   if (points.size() < 3) {

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -522,6 +522,16 @@ bool is_above(
   return (seg_end - seg_start).cross(point - seg_start) > 0;
 }
 
+bool is_clockwise(const alt::PointList2d & vertices)
+{
+  double sum = 0.;
+  for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
+    sum += (std::next(it)->x() - it->x()) * (std::next(it)->y() + it->y());
+  }
+
+  return sum > 0;
+}
+
 bool is_convex(const alt::Polygon2d & poly)
 {
   constexpr double epsilon = 1e-6;

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -387,14 +387,14 @@ double distance(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
   return min_distance;
 }
 
-std::optional<alt::ConvexPolygon2d> envelope(const alt::ConvexPolygon2d & poly)
+std::optional<alt::ConvexPolygon2d> envelope(const alt::Polygon2d & poly)
 {
   const auto [x_min_vertex, x_max_vertex] = std::minmax_element(
-    poly.vertices().begin(), std::prev(poly.vertices().end()),
+    poly.outer().begin(), std::prev(poly.outer().end()),
     [](const auto & a, const auto & b) { return a.x() < b.x(); });
 
   const auto [y_min_vertex, y_max_vertex] = std::minmax_element(
-    poly.vertices().begin(), std::prev(poly.vertices().end()),
+    poly.outer().begin(), std::prev(poly.outer().end()),
     [](const auto & a, const auto & b) { return a.y() < b.y(); });
 
   return alt::ConvexPolygon2d::create(alt::PointList2d{

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -89,11 +89,7 @@ alt::ConvexPolygon2d convex_hull(const alt::Points2d & points)
         return;
       }
 
-      const auto farthest =
-        *std::max_element(points.begin(), points.end(), [&](const auto & a, const auto & b) {
-          const auto seg_vec = p2 - p1;
-          return seg_vec.cross(a - p1) < seg_vec.cross(b - p1);
-        });
+      const auto & farthest = *find_farthest(points, p1, p2);
 
       alt::Points2d subset1, subset2;
       for (const auto & point : points) {
@@ -255,6 +251,15 @@ bool equals(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d & pol
     return std::any_of(poly2.vertices().begin(), poly2.vertices().end(), [&](const auto & b) {
       return equals(a, b);
     });
+  });
+}
+
+alt::Points2d::const_iterator find_farthest(
+  const alt::Points2d & points, const alt::Point2d & seg_start, const alt::Point2d & seg_end)
+{
+  const auto seg_vec = seg_end - seg_start;
+  return std::max_element(points.begin(), points.end(), [&](const auto & a, const auto & b) {
+    return std::abs(seg_vec.cross(a - seg_start)) < std::abs(seg_vec.cross(b - seg_start));
   });
 }
 

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -19,35 +19,105 @@ namespace autoware::universe_utils
 // Alternatives for Boost.Geometry ----------------------------------------------------------------
 namespace alt
 {
-Point2d from_boost(const autoware::universe_utils::Point2d & point)
+std::optional<Polygon2d> Polygon2d::create(
+  const PointList2d & outer, const std::vector<PointList2d> & inners) noexcept
 {
-  return {point.x(), point.y()};
+  Polygon2d poly(outer, inners);
+  // correct(poly);
+
+  if (poly.outer().size() < 4) {
+    return std::nullopt;
+  }
+
+  for (const auto & inner : poly.inners()) {
+    if (inner.size() < 4) {
+      return std::nullopt;
+    }
+  }
+
+  return poly;
 }
 
-ConvexPolygon2d from_boost(const autoware::universe_utils::Polygon2d & polygon)
+std::optional<Polygon2d> Polygon2d::create(
+  PointList2d && outer, std::vector<PointList2d> && inners) noexcept
 {
-  Points2d points;
+  Polygon2d poly(std::move(outer), std::move(inners));
+  // correct(poly);
+
+  if (poly.outer().size() < 4) {
+    return std::nullopt;
+  }
+
+  for (const auto & inner : poly.inners()) {
+    if (inner.size() < 4) {
+      return std::nullopt;
+    }
+  }
+
+  return poly;
+}
+
+std::optional<Polygon2d> Polygon2d::create(
+  const autoware::universe_utils::Polygon2d & polygon) noexcept
+{
+  PointList2d outer;
   for (const auto & point : polygon.outer()) {
-    points.push_back(from_boost(point));
+    outer.push_back(Point2d(point));
   }
 
-  ConvexPolygon2d _polygon(points);
-  correct(_polygon);
-  return _polygon;
-}
-
-autoware::universe_utils::Point2d to_boost(const Point2d & point)
-{
-  return {point.x(), point.y()};
-}
-
-autoware::universe_utils::Polygon2d to_boost(const ConvexPolygon2d & polygon)
-{
-  autoware::universe_utils::Polygon2d _polygon;
-  for (const auto & vertex : polygon.vertices()) {
-    _polygon.outer().push_back(to_boost(vertex));
+  std::vector<PointList2d> inners;
+  for (const auto & inner : polygon.inners()) {
+    PointList2d _inner;
+    for (const auto & point : inner) {
+      _inner.push_back(Point2d(point));
+    }
+    inners.push_back(_inner);
   }
-  return _polygon;
+
+  return Polygon2d::create(outer, inners);
+}
+
+std::optional<ConvexPolygon2d> ConvexPolygon2d::create(const PointList2d & vertices) noexcept
+{
+  ConvexPolygon2d poly(vertices);
+  correct(poly);
+
+  if (poly.vertices().size() < 4) {
+    return std::nullopt;
+  }
+
+  if (!is_convex(poly)) {
+    return std::nullopt;
+  }
+
+  return poly;
+}
+
+std::optional<ConvexPolygon2d> ConvexPolygon2d::create(PointList2d && vertices) noexcept
+{
+  ConvexPolygon2d poly(std::move(vertices));
+  correct(poly);
+
+  if (poly.vertices().size() < 4) {
+    return std::nullopt;
+  }
+
+  if (!is_convex(poly)) {
+    return std::nullopt;
+  }
+
+  return poly;
+}
+
+std::optional<ConvexPolygon2d> ConvexPolygon2d::create(
+  const autoware::universe_utils::Polygon2d & polygon) noexcept
+{
+  PointList2d vertices;
+  for (const auto & point : polygon.outer()) {
+    vertices.push_back(Point2d(point));
+  }
+
+  return ConvexPolygon2d::create(vertices);
 }
 }  // namespace alt
 
@@ -56,8 +126,8 @@ double area(const alt::ConvexPolygon2d & poly)
   const auto & vertices = poly.vertices();
 
   double area = 0.;
-  for (size_t i = 1; i < vertices.size() - 1; ++i) {
-    area += (vertices[i + 1] - vertices.front()).cross(vertices[i] - vertices.front()) / 2;
+  for (auto it = std::next(vertices.cbegin()); it != std::prev(vertices.cend(), 2); ++it) {
+    area += (*std::next(it) - vertices.front()).cross(*it - vertices.front()) / 2;
   }
 
   return area;
@@ -122,10 +192,10 @@ alt::Polygon2d buffer(
   return buffered_poly;
 }
 */
-alt::ConvexPolygon2d convex_hull(const alt::Points2d & points)
+std::optional<alt::ConvexPolygon2d> convex_hull(const alt::Points2d & points)
 {
   if (points.size() < 3) {
-    throw std::invalid_argument("At least 3 points are required for calculating convex hull.");
+    return std::nullopt;
   }
 
   // QuickHull algorithm
@@ -135,7 +205,7 @@ alt::ConvexPolygon2d convex_hull(const alt::Points2d & points)
   const auto & p_min = *p_minmax_itr.first;
   const auto & p_max = *p_minmax_itr.second;
 
-  alt::Points2d vertices;
+  alt::PointList2d vertices;
 
   if (points.size() == 3) {
     std::rotate_copy(
@@ -179,24 +249,44 @@ alt::ConvexPolygon2d convex_hull(const alt::Points2d & points)
     make_hull(make_hull, p_max, p_min, below_points);
   }
 
-  alt::ConvexPolygon2d hull(vertices);
-  correct(hull);
+  auto hull = alt::ConvexPolygon2d::create(vertices);
+  if (!hull) {
+    return std::nullopt;
+  }
 
   return hull;
 }
 
 void correct(alt::ConvexPolygon2d & poly)
 {
-  auto & vertices = poly.vertices();
+  auto correct_vertices = [](alt::PointList2d & vertices) {
+    // remove adjacent duplicate points
+    const auto it = std::unique(
+      vertices.begin(), vertices.end(),
+      [](const auto & a, const auto & b) { return equals(a, b); });
+    vertices.erase(it, vertices.end());
 
-  // sort points in clockwise order with respect to the first point
-  std::sort(vertices.begin() + 1, vertices.end(), [&](const auto & a, const auto & b) {
-    return (a - vertices.front()).cross(b - vertices.front()) < 0;
-  });
+    const auto first_point = vertices.front();
+    vertices.pop_front();
 
-  if (equals(vertices.front(), vertices.back())) {
-    vertices.pop_back();
-  }
+    if (equals(vertices.back(), first_point)) {
+      vertices.pop_back();
+    }
+
+    // TODO(mitukou1109): support non-convex polygons
+    // sort points in clockwise order with respect to the first point
+    vertices.sort(
+      [&](const auto & a, const auto & b) { return (a - first_point).cross(b - first_point) < 0; });
+
+    vertices.push_front(first_point);
+    vertices.push_back(first_point);
+  };
+
+  correct_vertices(poly.vertices());
+  // correct_vertices(poly.outer());
+  // for (auto & inner : poly.inners()) {
+  //   correct_vertices(inner);
+  // }
 }
 
 bool covered_by(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
@@ -204,19 +294,19 @@ bool covered_by(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
   constexpr double epsilon = 1e-6;
 
   const auto & vertices = poly.vertices();
-  const auto num_of_vertices = vertices.size();
-  int64_t winding_number = 0;
+  std::size_t winding_number = 0;
 
   const auto [y_min_vertex, y_max_vertex] = std::minmax_element(
-    vertices.begin(), vertices.end(), [](const auto & a, const auto & b) { return a.y() < b.y(); });
+    vertices.begin(), std::prev(vertices.end()),
+    [](const auto & a, const auto & b) { return a.y() < b.y(); });
   if (point.y() < y_min_vertex->y() || point.y() > y_max_vertex->y()) {
     return false;
   }
 
   double cross;
-  for (size_t i = 0; i < num_of_vertices; ++i) {
-    const auto & p1 = vertices[i];
-    const auto & p2 = vertices[(i + 1) % num_of_vertices];
+  for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
+    const auto & p1 = *it;
+    const auto & p2 = *std::next(it);
 
     if (p1.y() <= point.y() && p2.y() >= point.y()) {  // upward edge
       cross = (p2 - p1).cross(point - p1);
@@ -290,29 +380,28 @@ double distance(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
   // TODO(mitukou1109): Use plane sweep method to improve performance?
   const auto & vertices = poly.vertices();
   double min_distance = std::numeric_limits<double>::max();
-  for (size_t i = 0; i < vertices.size(); ++i) {
-    min_distance =
-      std::min(min_distance, distance(point, vertices[i], vertices[(i + 1) % vertices.size()]));
+  for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
+    min_distance = std::min(min_distance, distance(point, *it, *std::next(it)));
   }
 
   return min_distance;
 }
 
-alt::ConvexPolygon2d envelope(const alt::ConvexPolygon2d & poly)
+std::optional<alt::ConvexPolygon2d> envelope(const alt::ConvexPolygon2d & poly)
 {
   const auto [x_min_vertex, x_max_vertex] = std::minmax_element(
-    poly.vertices().begin(), poly.vertices().end(),
+    poly.vertices().begin(), std::prev(poly.vertices().end()),
     [](const auto & a, const auto & b) { return a.x() < b.x(); });
 
   const auto [y_min_vertex, y_max_vertex] = std::minmax_element(
-    poly.vertices().begin(), poly.vertices().end(),
+    poly.vertices().begin(), std::prev(poly.vertices().end()),
     [](const auto & a, const auto & b) { return a.y() < b.y(); });
 
-  return alt::ConvexPolygon2d{
-    {{x_min_vertex->x(), y_min_vertex->y()},
-     {x_min_vertex->x(), y_max_vertex->y()},
-     {x_max_vertex->x(), y_max_vertex->y()},
-     {x_max_vertex->x(), y_min_vertex->y()}}};
+  return alt::ConvexPolygon2d::create(alt::PointList2d{
+    {x_min_vertex->x(), y_min_vertex->y()},
+    {x_min_vertex->x(), y_max_vertex->y()},
+    {x_max_vertex->x(), y_max_vertex->y()},
+    {x_max_vertex->x(), y_min_vertex->y()}});
 }
 
 bool equals(const alt::Point2d & point1, const alt::Point2d & point2)
@@ -321,13 +410,23 @@ bool equals(const alt::Point2d & point1, const alt::Point2d & point2)
   return std::abs(point1.x() - point2.x()) < epsilon && std::abs(point1.y() - point2.y()) < epsilon;
 }
 
-bool equals(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d & poly2)
+bool equals(const alt::Polygon2d & poly1, const alt::Polygon2d & poly2)
 {
-  return std::all_of(poly1.vertices().begin(), poly1.vertices().end(), [&](const auto & a) {
-    return std::any_of(poly2.vertices().begin(), poly2.vertices().end(), [&](const auto & b) {
-      return equals(a, b);
-    });
-  });
+  const auto outer_equals = std::equal(
+    poly1.outer().begin(), std::prev(poly1.outer().end()), poly2.outer().begin(),
+    std::prev(poly2.outer().end()), [](const auto & a, const auto & b) { return equals(a, b); });
+
+  auto inners_equal = true;
+  for (const auto & inner1 : poly1.inners()) {
+    inners_equal &=
+      std::any_of(poly2.inners().begin(), poly2.inners().end(), [&](const auto & inner2) {
+        return std::equal(
+          inner1.begin(), std::prev(inner1.end()), inner2.begin(), std::prev(inner2.end()),
+          [](const auto & a, const auto & b) { return equals(a, b); });
+      });
+  }
+
+  return outer_equals && inners_equal;
 }
 
 alt::Points2d::const_iterator find_farthest(
@@ -378,7 +477,7 @@ bool intersects(const alt::ConvexPolygon2d & poly1, const alt::ConvexPolygon2d &
     auto find_farthest_vertex =
       [](const alt::ConvexPolygon2d & poly, const alt::Vector2d & direction) {
         return std::max_element(
-          poly.vertices().begin(), poly.vertices().end(),
+          poly.vertices().begin(), std::prev(poly.vertices().end()),
           [&](const auto & a, const auto & b) { return direction.dot(a) <= direction.dot(b); });
       };
     return *find_farthest_vertex(poly1, direction) - *find_farthest_vertex(poly2, -direction);
@@ -423,19 +522,37 @@ bool is_above(
   return (seg_end - seg_start).cross(point - seg_start) > 0;
 }
 
-bool is_clockwise(const alt::ConvexPolygon2d & poly)
+bool is_convex(const alt::Polygon2d & poly)
 {
-  return area(poly) > 0;
-}
+  constexpr double epsilon = 1e-6;
 
-alt::Points2d simplify(const alt::Points2d & points, const double max_distance)
-{
-  if (points.size() < 3) {
-    return points;
+  if (!poly.inners().empty()) {
+    return false;
   }
 
-  alt::Points2d pending(std::next(points.begin()), std::prev(points.end()));
-  alt::Points2d simplified;
+  const auto & outer = poly.outer();
+
+  for (auto it = ++outer.cbegin(); it != --outer.cend(); ++it) {
+    const auto & p1 = *--it;
+    const auto & p2 = *it;
+    const auto & p3 = *++it;
+
+    if ((p2 - p1).cross(p3 - p2) > epsilon) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+alt::PointList2d simplify(const alt::PointList2d & line, const double max_distance)
+{
+  if (line.size() < 3) {
+    return line;
+  }
+
+  alt::Points2d pending(std::next(line.begin()), std::prev(line.end()));
+  alt::PointList2d simplified;
 
   // Douglas-Peucker algorithm
 
@@ -459,9 +576,9 @@ alt::Points2d simplify(const alt::Points2d & points, const double max_distance)
     self(self, farthest, seg_end);
   };
 
-  simplified.push_back(points.front());
-  douglas_peucker(douglas_peucker, points.front(), points.back());
-  simplified.push_back(points.back());
+  simplified.push_back(line.front());
+  douglas_peucker(douglas_peucker, line.front(), line.back());
+  simplified.push_back(line.back());
 
   return simplified;
 }
@@ -481,17 +598,17 @@ bool touches(
 bool touches(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
 {
   const auto & vertices = poly.vertices();
-  const auto num_of_vertices = vertices.size();
 
   const auto [y_min_vertex, y_max_vertex] = std::minmax_element(
-    vertices.begin(), vertices.end(), [](const auto & a, const auto & b) { return a.y() < b.y(); });
+    vertices.begin(), std::prev(vertices.end()),
+    [](const auto & a, const auto & b) { return a.y() < b.y(); });
   if (point.y() < y_min_vertex->y() || point.y() > y_max_vertex->y()) {
     return false;
   }
 
-  for (size_t i = 0; i < num_of_vertices; ++i) {
+  for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
     // check if the point is on each edge of the polygon
-    if (touches(point, vertices[i], vertices[(i + 1) % num_of_vertices])) {
+    if (touches(point, *it, *std::next(it))) {
       return true;
     }
   }
@@ -504,19 +621,19 @@ bool within(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
   constexpr double epsilon = 1e-6;
 
   const auto & vertices = poly.vertices();
-  const auto num_of_vertices = vertices.size();
   int64_t winding_number = 0;
 
   const auto [y_min_vertex, y_max_vertex] = std::minmax_element(
-    vertices.begin(), vertices.end(), [](const auto & a, const auto & b) { return a.y() < b.y(); });
+    vertices.begin(), std::prev(vertices.end()),
+    [](const auto & a, const auto & b) { return a.y() < b.y(); });
   if (point.y() <= y_min_vertex->y() || point.y() >= y_max_vertex->y()) {
     return false;
   }
 
   double cross;
-  for (size_t i = 0; i < num_of_vertices; ++i) {
-    const auto & p1 = vertices[i];
-    const auto & p2 = vertices[(i + 1) % num_of_vertices];
+  for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
+    const auto & p1 = *it;
+    const auto & p2 = *std::next(it);
 
     if (p1.y() < point.y() && p2.y() > point.y()) {  // upward edge
       cross = (p2 - p1).cross(point - p1);

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -302,22 +302,25 @@ TEST(alt_geometry, distance)
 TEST(geometry, envelope)
 {
   using autoware::universe_utils::envelope;
-  using autoware::universe_utils::alt::ConvexPolygon2d;
   using autoware::universe_utils::alt::PointList2d;
+  using autoware::universe_utils::alt::Polygon2d;
 
   {
-    const auto poly = ConvexPolygon2d::create(PointList2d{
-                                                {2.0, 1.3},
-                                                {2.4, 1.7},
-                                                {2.8, 1.8},
-                                                {3.4, 1.2},
-                                                {3.7, 1.6},
-                                                {3.4, 2.0},
-                                                {4.1, 3.0},
-                                                {5.3, 2.6},
-                                                {5.4, 1.2},
-                                                {4.9, 0.8},
-                                                {2.9, 0.7}})
+    const auto poly = Polygon2d::create(
+                        PointList2d{
+                          {2.0, 1.3},
+                          {2.4, 1.7},
+                          {2.8, 1.8},
+                          {3.4, 1.2},
+                          {3.7, 1.6},
+                          {3.4, 2.0},
+                          {4.1, 3.0},
+                          {5.3, 2.6},
+                          {5.4, 1.2},
+                          {4.9, 0.8},
+                          {2.9, 0.7},
+                          {2.0, 1.3}},
+                        {PointList2d{{4.0, 2.0}, {4.2, 1.4}, {4.8, 1.9}, {4.4, 2.2}, {4.0, 2.0}}})
                         .value();
     const auto result = envelope(poly);
 

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -108,8 +108,8 @@ TEST(alt_geometry, correct)
     PointList2d vertices;
     vertices.push_back({1.0, 1.0});
     vertices.push_back({-1.0, 1.0});
-    vertices.push_back({1.0, -1.0});
     vertices.push_back({-1.0, -1.0});
+    vertices.push_back({1.0, -1.0});
     auto poly = ConvexPolygon2d::create(vertices).value();  // correct()-ed in create()
 
     PointList2d ground_truth = {{1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}};

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -517,6 +517,28 @@ TEST(alt_geometry, isClockwise)
   }
 }
 
+TEST(geometry, simplify)
+{
+  using autoware::universe_utils::simplify;
+  using autoware::universe_utils::alt::Points2d;
+
+  {
+    const Points2d points = {{1.1, 1.1}, {2.5, 2.1}, {3.1, 3.1}, {4.9, 1.1}, {3.1, 1.9}};
+    const double max_distance = 0.5;
+    const auto result = simplify(points, max_distance);
+
+    EXPECT_EQ(result.size(), 4);
+    EXPECT_NEAR(result.at(0).x(), 1.1, epsilon);
+    EXPECT_NEAR(result.at(0).y(), 1.1, epsilon);
+    EXPECT_NEAR(result.at(1).x(), 3.1, epsilon);
+    EXPECT_NEAR(result.at(1).y(), 3.1, epsilon);
+    EXPECT_NEAR(result.at(2).x(), 4.9, epsilon);
+    EXPECT_NEAR(result.at(2).y(), 1.1, epsilon);
+    EXPECT_NEAR(result.at(3).x(), 3.1, epsilon);
+    EXPECT_NEAR(result.at(3).y(), 1.9, epsilon);
+  }
+}
+
 TEST(alt_geometry, touches)
 {
   using autoware::universe_utils::touches;

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -35,30 +35,21 @@ TEST(alt_geometry, area)
   using autoware::universe_utils::alt::ConvexPolygon2d;
   using autoware::universe_utils::alt::Point2d;
 
-  {  // Clockwise
+  {
     const Point2d p1 = {0.0, 0.0};
     const Point2d p2 = {0.0, 7.0};
     const Point2d p3 = {4.0, 2.0};
     const Point2d p4 = {2.0, 0.0};
-    const auto result = area(ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = area(ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_NEAR(result, 16.0, epsilon);
-  }
-
-  {  // Counter-clockwise
-    const Point2d p1 = {0.0, 0.0};
-    const Point2d p2 = {2.0, 0.0};
-    const Point2d p3 = {4.0, 2.0};
-    const Point2d p4 = {0.0, 7.0};
-    const auto result = area(ConvexPolygon2d({p1, p2, p3, p4}));
-
-    EXPECT_NEAR(result, -16.0, epsilon);
   }
 }
 
 TEST(alt_geometry, convexHull)
 {
   using autoware::universe_utils::convex_hull;
+  using autoware::universe_utils::alt::PointList2d;
   using autoware::universe_utils::alt::Points2d;
 
   {
@@ -76,21 +67,16 @@ TEST(alt_geometry, convexHull)
     points.push_back({2.9, 0.7});
     const auto result = convex_hull(points);
 
-    ASSERT_EQ(result.vertices().size(), 7);
-    EXPECT_NEAR(result.vertices().at(0).x(), 2.0, epsilon);
-    EXPECT_NEAR(result.vertices().at(0).y(), 1.3, epsilon);
-    EXPECT_NEAR(result.vertices().at(1).x(), 2.4, epsilon);
-    EXPECT_NEAR(result.vertices().at(1).y(), 1.7, epsilon);
-    EXPECT_NEAR(result.vertices().at(2).x(), 4.1, epsilon);
-    EXPECT_NEAR(result.vertices().at(2).y(), 3.0, epsilon);
-    EXPECT_NEAR(result.vertices().at(3).x(), 5.3, epsilon);
-    EXPECT_NEAR(result.vertices().at(3).y(), 2.6, epsilon);
-    EXPECT_NEAR(result.vertices().at(4).x(), 5.4, epsilon);
-    EXPECT_NEAR(result.vertices().at(4).y(), 1.2, epsilon);
-    EXPECT_NEAR(result.vertices().at(5).x(), 4.9, epsilon);
-    EXPECT_NEAR(result.vertices().at(5).y(), 0.8, epsilon);
-    EXPECT_NEAR(result.vertices().at(6).x(), 2.9, epsilon);
-    EXPECT_NEAR(result.vertices().at(6).y(), 0.7, epsilon);
+    ASSERT_TRUE(result);
+    PointList2d ground_truth = {{2.0, 1.3}, {2.4, 1.7}, {4.1, 3.0}, {5.3, 2.6},
+                                {5.4, 1.2}, {4.9, 0.8}, {2.9, 0.7}, {2.0, 1.3}};
+    ASSERT_EQ(result->vertices().size(), ground_truth.size());
+    auto alt_it = result->vertices().begin();
+    auto ground_truth_it = ground_truth.begin();
+    for (; alt_it != result->vertices().end(); ++alt_it, ++ground_truth_it) {
+      EXPECT_NEAR(alt_it->x(), ground_truth_it->x(), epsilon);
+      EXPECT_NEAR(alt_it->y(), ground_truth_it->y(), epsilon);
+    }
   }
 }
 
@@ -98,46 +84,42 @@ TEST(alt_geometry, correct)
 {
   using autoware::universe_utils::correct;
   using autoware::universe_utils::alt::ConvexPolygon2d;
-  using autoware::universe_utils::alt::Points2d;
+  using autoware::universe_utils::alt::PointList2d;
 
   {  // Correctly oriented
-    Points2d vertices;
+    PointList2d vertices;
     vertices.push_back({1.0, 1.0});
     vertices.push_back({1.0, -1.0});
     vertices.push_back({-1.0, -1.0});
     vertices.push_back({-1.0, 1.0});
-    ConvexPolygon2d poly(vertices);
-    correct(poly);
+    auto poly = ConvexPolygon2d::create(vertices).value();  // correct()-ed in create()
 
-    ASSERT_EQ(poly.vertices().size(), 4);
-    EXPECT_NEAR(poly.vertices().at(0).x(), 1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(0).y(), 1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(1).x(), 1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(1).y(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(2).x(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(2).y(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(3).x(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(3).y(), 1.0, epsilon);
+    PointList2d ground_truth = {{1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}};
+    ASSERT_EQ(poly.vertices().size(), ground_truth.size());
+    auto alt_it = poly.vertices().begin();
+    auto ground_truth_it = ground_truth.begin();
+    for (; alt_it != poly.vertices().end(); ++alt_it, ++ground_truth_it) {
+      EXPECT_NEAR(alt_it->x(), ground_truth_it->x(), epsilon);
+      EXPECT_NEAR(alt_it->y(), ground_truth_it->y(), epsilon);
+    }
   }
 
   {  // Wrongly oriented
-    Points2d vertices;
+    PointList2d vertices;
     vertices.push_back({1.0, 1.0});
     vertices.push_back({-1.0, 1.0});
     vertices.push_back({1.0, -1.0});
     vertices.push_back({-1.0, -1.0});
-    ConvexPolygon2d poly(vertices);
-    correct(poly);
+    auto poly = ConvexPolygon2d::create(vertices).value();  // correct()-ed in create()
 
-    ASSERT_EQ(poly.vertices().size(), 4);
-    EXPECT_NEAR(poly.vertices().at(0).x(), 1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(0).y(), 1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(1).x(), 1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(1).y(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(2).x(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(2).y(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(3).x(), -1.0, epsilon);
-    EXPECT_NEAR(poly.vertices().at(3).y(), 1.0, epsilon);
+    PointList2d ground_truth = {{1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}};
+    ASSERT_EQ(poly.vertices().size(), ground_truth.size());
+    auto alt_it = poly.vertices().begin();
+    auto ground_truth_it = ground_truth.begin();
+    for (; alt_it != poly.vertices().end(); ++alt_it, ++ground_truth_it) {
+      EXPECT_NEAR(alt_it->x(), ground_truth_it->x(), epsilon);
+      EXPECT_NEAR(alt_it->y(), ground_truth_it->y(), epsilon);
+    }
   }
 }
 
@@ -153,7 +135,7 @@ TEST(alt_geometry, coveredBy)
     const Point2d p2 = {1.0, -1.0};
     const Point2d p3 = {-1.0, -1.0};
     const Point2d p4 = {-1.0, 1.0};
-    const auto result = covered_by(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = covered_by(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_TRUE(result);
   }
@@ -164,7 +146,7 @@ TEST(alt_geometry, coveredBy)
     const Point2d p2 = {2.0, 1.0};
     const Point2d p3 = {1.0, 1.0};
     const Point2d p4 = {1.0, 2.0};
-    const auto result = covered_by(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = covered_by(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_FALSE(result);
   }
@@ -175,7 +157,7 @@ TEST(alt_geometry, coveredBy)
     const Point2d p2 = {2.0, -1.0};
     const Point2d p3 = {0.0, -1.0};
     const Point2d p4 = {0.0, 1.0};
-    const auto result = covered_by(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = covered_by(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_TRUE(result);
   }
@@ -196,8 +178,9 @@ TEST(alt_geometry, disjoint)
     const Point2d p6 = {4.0, 4.0};
     const Point2d p7 = {6.0, 2.0};
     const Point2d p8 = {4.0, 0.0};
-    const auto result =
-      disjoint(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = disjoint(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_TRUE(result);
   }
@@ -211,8 +194,9 @@ TEST(alt_geometry, disjoint)
     const Point2d p6 = {2.0, 4.0};
     const Point2d p7 = {4.0, 2.0};
     const Point2d p8 = {2.0, 0.0};
-    const auto result =
-      disjoint(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = disjoint(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_FALSE(result);
   }
@@ -298,7 +282,7 @@ TEST(alt_geometry, distance)
     const Point2d p2 = {3.0, -1.0};
     const Point2d p3 = {1.0, -1.0};
     const Point2d p4 = {1.0, 1.0};
-    const auto result = distance(p, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = distance(p, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_NEAR(result, 1.0, epsilon);
   }
@@ -309,7 +293,7 @@ TEST(alt_geometry, distance)
     const Point2d p2 = {2.0, -1.0};
     const Point2d p3 = {-1.0, -1.0};
     const Point2d p4 = {-1.0, 1.0};
-    const auto result = distance(p, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = distance(p, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_NEAR(result, 0.0, epsilon);
   }
@@ -319,31 +303,34 @@ TEST(geometry, envelope)
 {
   using autoware::universe_utils::envelope;
   using autoware::universe_utils::alt::ConvexPolygon2d;
+  using autoware::universe_utils::alt::PointList2d;
 
   {
-    const ConvexPolygon2d poly{
-      {{2.0, 1.3},
-       {2.4, 1.7},
-       {2.8, 1.8},
-       {3.4, 1.2},
-       {3.7, 1.6},
-       {3.4, 2.0},
-       {4.1, 3.0},
-       {5.3, 2.6},
-       {5.4, 1.2},
-       {4.9, 0.8},
-       {2.9, 0.7}}};
+    const auto poly = ConvexPolygon2d::create(PointList2d{
+                                                {2.0, 1.3},
+                                                {2.4, 1.7},
+                                                {2.8, 1.8},
+                                                {3.4, 1.2},
+                                                {3.7, 1.6},
+                                                {3.4, 2.0},
+                                                {4.1, 3.0},
+                                                {5.3, 2.6},
+                                                {5.4, 1.2},
+                                                {4.9, 0.8},
+                                                {2.9, 0.7}})
+                        .value();
     const auto result = envelope(poly);
 
-    ASSERT_EQ(result.vertices().size(), 4);
-    EXPECT_NEAR(result.vertices().at(0).x(), 2.0, epsilon);
-    EXPECT_NEAR(result.vertices().at(0).y(), 0.7, epsilon);
-    EXPECT_NEAR(result.vertices().at(1).x(), 2.0, epsilon);
-    EXPECT_NEAR(result.vertices().at(1).y(), 3.0, epsilon);
-    EXPECT_NEAR(result.vertices().at(2).x(), 5.4, epsilon);
-    EXPECT_NEAR(result.vertices().at(2).y(), 3.0, epsilon);
-    EXPECT_NEAR(result.vertices().at(3).x(), 5.4, epsilon);
-    EXPECT_NEAR(result.vertices().at(3).y(), 0.7, epsilon);
+    ASSERT_TRUE(result);
+
+    PointList2d ground_truth = {{2.0, 0.7}, {2.0, 3.0}, {5.4, 3.0}, {5.4, 0.7}, {2.0, 0.7}};
+    ASSERT_EQ(result->vertices().size(), ground_truth.size());
+    auto alt_it = result->vertices().begin();
+    auto ground_truth_it = ground_truth.begin();
+    for (; alt_it != result->vertices().end(); ++alt_it, ++ground_truth_it) {
+      EXPECT_NEAR(alt_it->x(), ground_truth_it->x(), epsilon);
+      EXPECT_NEAR(alt_it->y(), ground_truth_it->y(), epsilon);
+    }
   }
 }
 
@@ -452,8 +439,9 @@ TEST(alt_geometry, intersects)
     const Point2d p6 = {2.0, 0.0};
     const Point2d p7 = {0.0, 0.0};
     const Point2d p8 = {0.0, 2.0};
-    const auto result =
-      intersects(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = intersects(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_TRUE(result);
   }
@@ -467,8 +455,9 @@ TEST(alt_geometry, intersects)
     const Point2d p6 = {3.0, 2.0};
     const Point2d p7 = {2.0, 2.0};
     const Point2d p8 = {2.0, 3.0};
-    const auto result =
-      intersects(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = intersects(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_FALSE(result);
   }
@@ -482,8 +471,9 @@ TEST(alt_geometry, intersects)
     const Point2d p6 = {2.0, 1.0};
     const Point2d p7 = {1.0, 1.0};
     const Point2d p8 = {1.0, 2.0};
-    const auto result =
-      intersects(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = intersects(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_FALSE(result);
   }
@@ -522,52 +512,24 @@ TEST(alt_geometry, isAbove)
   }
 }
 
-TEST(alt_geometry, isClockwise)
-{
-  using autoware::universe_utils::is_clockwise;
-  using autoware::universe_utils::alt::ConvexPolygon2d;
-  using autoware::universe_utils::alt::Point2d;
-
-  {  // Clockwise
-    const Point2d p1 = {0.0, 0.0};
-    const Point2d p2 = {0.0, 7.0};
-    const Point2d p3 = {4.0, 2.0};
-    const Point2d p4 = {2.0, 0.0};
-    const auto result = is_clockwise(ConvexPolygon2d({p1, p2, p3, p4}));
-
-    EXPECT_TRUE(result);
-  }
-
-  {  // Counter-clockwise
-    const Point2d p1 = {0.0, 0.0};
-    const Point2d p2 = {2.0, 0.0};
-    const Point2d p3 = {4.0, 2.0};
-    const Point2d p4 = {0.0, 7.0};
-    const auto result = is_clockwise(ConvexPolygon2d({p1, p2, p3, p4}));
-
-    EXPECT_FALSE(result);
-  }
-}
-
 TEST(geometry, simplify)
 {
   using autoware::universe_utils::simplify;
-  using autoware::universe_utils::alt::Points2d;
+  using autoware::universe_utils::alt::PointList2d;
 
   {
-    const Points2d points = {{1.1, 1.1}, {2.5, 2.1}, {3.1, 3.1}, {4.9, 1.1}, {3.1, 1.9}};
+    const PointList2d points = {{1.1, 1.1}, {2.5, 2.1}, {3.1, 3.1}, {4.9, 1.1}, {3.1, 1.9}};
     const double max_distance = 0.5;
     const auto result = simplify(points, max_distance);
 
-    ASSERT_EQ(result.size(), 4);
-    EXPECT_NEAR(result.at(0).x(), 1.1, epsilon);
-    EXPECT_NEAR(result.at(0).y(), 1.1, epsilon);
-    EXPECT_NEAR(result.at(1).x(), 3.1, epsilon);
-    EXPECT_NEAR(result.at(1).y(), 3.1, epsilon);
-    EXPECT_NEAR(result.at(2).x(), 4.9, epsilon);
-    EXPECT_NEAR(result.at(2).y(), 1.1, epsilon);
-    EXPECT_NEAR(result.at(3).x(), 3.1, epsilon);
-    EXPECT_NEAR(result.at(3).y(), 1.9, epsilon);
+    PointList2d ground_truth = {{1.1, 1.1}, {3.1, 3.1}, {4.9, 1.1}, {3.1, 1.9}};
+    ASSERT_EQ(result.size(), ground_truth.size());
+    auto alt_it = result.begin();
+    auto ground_truth_it = ground_truth.begin();
+    for (; alt_it != result.end(); ++alt_it, ++ground_truth_it) {
+      EXPECT_NEAR(alt_it->x(), ground_truth_it->x(), epsilon);
+      EXPECT_NEAR(alt_it->y(), ground_truth_it->y(), epsilon);
+    }
   }
 }
 
@@ -622,7 +584,7 @@ TEST(alt_geometry, touches)
     const Point2d p2 = {2.0, -1.0};
     const Point2d p3 = {0.0, -1.0};
     const Point2d p4 = {0.0, 1.0};
-    const auto result = touches(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = touches(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_TRUE(result);
   }
@@ -633,7 +595,7 @@ TEST(alt_geometry, touches)
     const Point2d p2 = {2.0, 1.0};
     const Point2d p3 = {1.0, 1.0};
     const Point2d p4 = {1.0, 2.0};
-    const auto result = touches(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = touches(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_FALSE(result);
   }
@@ -651,7 +613,7 @@ TEST(alt_geometry, within)
     const Point2d p2 = {1.0, -1.0};
     const Point2d p3 = {-1.0, -1.0};
     const Point2d p4 = {-1.0, 1.0};
-    const auto result = within(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = within(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_TRUE(result);
   }
@@ -662,7 +624,7 @@ TEST(alt_geometry, within)
     const Point2d p2 = {2.0, 1.0};
     const Point2d p3 = {1.0, 1.0};
     const Point2d p4 = {1.0, 2.0};
-    const auto result = within(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = within(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_FALSE(result);
   }
@@ -673,7 +635,7 @@ TEST(alt_geometry, within)
     const Point2d p2 = {2.0, -1.0};
     const Point2d p3 = {0.0, -1.0};
     const Point2d p4 = {0.0, 1.0};
-    const auto result = within(point, ConvexPolygon2d({p1, p2, p3, p4}));
+    const auto result = within(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_FALSE(result);
   }
@@ -687,8 +649,9 @@ TEST(alt_geometry, within)
     const Point2d p6 = {2.0, -2.0};
     const Point2d p7 = {-2.0, -2.0};
     const Point2d p8 = {-2.0, 2.0};
-    const auto result =
-      within(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = within(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_TRUE(result);
   }
@@ -702,8 +665,9 @@ TEST(alt_geometry, within)
     const Point2d p6 = {3.0, 2.0};
     const Point2d p7 = {2.0, 2.0};
     const Point2d p8 = {2.0, 3.0};
-    const auto result =
-      within(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = within(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_FALSE(result);
   }
@@ -717,8 +681,9 @@ TEST(alt_geometry, within)
     const Point2d p6 = {1.0, -1.0};
     const Point2d p7 = {-1.0, -1.0};
     const Point2d p8 = {-1.0, 1.0};
-    const auto result =
-      within(ConvexPolygon2d({p1, p2, p3, p4}), ConvexPolygon2d({p5, p6, p7, p8}));
+    const auto result = within(
+      ConvexPolygon2d::create({p1, p2, p3, p4}).value(),
+      ConvexPolygon2d::create({p5, p6, p7, p8}).value());
 
     EXPECT_TRUE(result);
   }
@@ -745,7 +710,8 @@ TEST(alt_geometry, areaRand)
       const auto ground_truth = boost::geometry::area(polygons[i]);
       ground_truth_area_ns += sw.toc();
 
-      const auto alt_poly = autoware::universe_utils::alt::from_boost(polygons[i]);
+      const auto alt_poly =
+        autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[i]).value();
       sw.tic();
       const auto alt = autoware::universe_utils::area(alt_poly);
       alt_area_ns += sw.toc();
@@ -789,21 +755,19 @@ TEST(alt_geometry, convexHullRand)
       boost::geometry::convex_hull(outer, ground_truth);
       ground_truth_hull_ns += sw.toc();
 
-      const auto vertices = autoware::universe_utils::alt::from_boost(polygons[i]).vertices();
+      const auto vertices =
+        autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[i]).value().vertices();
       sw.tic();
-      const auto alt = autoware::universe_utils::convex_hull(vertices);
+      const auto alt = autoware::universe_utils::convex_hull({vertices.begin(), vertices.end()});
       alt_hull_ns += sw.toc();
 
-      if (ground_truth.outer().size() - 1 != alt.vertices().size()) {
-        std::cout << "Alt failed for the polygon: ";
-        std::cout << boost::geometry::wkt(polygons[i]) << std::endl;
-      }
-      ASSERT_EQ(
-        ground_truth.outer().size() - 1,
-        alt.vertices().size());  // alt::ConvexPolygon2d does not have closing point
-      for (size_t i = 0; i < alt.vertices().size(); ++i) {
-        EXPECT_NEAR(ground_truth.outer().at(i).x(), alt.vertices().at(i).x(), epsilon);
-        EXPECT_NEAR(ground_truth.outer().at(i).y(), alt.vertices().at(i).y(), epsilon);
+      ASSERT_TRUE(alt);
+      ASSERT_EQ(ground_truth.outer().size(), alt->vertices().size());
+      auto ground_truth_it = ground_truth.outer().begin();
+      auto alt_it = alt->vertices().begin();
+      for (; ground_truth_it != ground_truth.outer().end(); ++ground_truth_it, ++alt_it) {
+        EXPECT_NEAR(ground_truth_it->x(), alt_it->x(), epsilon);
+        EXPECT_NEAR(ground_truth_it->y(), alt_it->y(), epsilon);
       }
     }
     std::printf("polygons_nb = %d, vertices = %ld\n", polygons_nb, vertices);
@@ -844,8 +808,9 @@ TEST(alt_geometry, coveredByRand)
             ground_truth_not_covered_ns += sw.toc();
           }
 
-          const auto alt_point = autoware::universe_utils::alt::from_boost(point);
-          const auto alt_poly = autoware::universe_utils::alt::from_boost(polygons[j]);
+          const auto alt_point = autoware::universe_utils::alt::Point2d(point);
+          const auto alt_poly =
+            autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[j]).value();
           sw.tic();
           const auto alt = autoware::universe_utils::covered_by(alt_point, alt_poly);
           if (alt) {
@@ -909,8 +874,10 @@ TEST(alt_geometry, disjointRand)
           ground_truth_not_disjoint_ns += sw.toc();
         }
 
-        const auto alt_poly1 = autoware::universe_utils::alt::from_boost(polygons[i]);
-        const auto alt_poly2 = autoware::universe_utils::alt::from_boost(polygons[j]);
+        const auto alt_poly1 =
+          autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[i]).value();
+        const auto alt_poly2 =
+          autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[j]).value();
         sw.tic();
         const auto alt = autoware::universe_utils::disjoint(alt_poly1, alt_poly2);
         if (alt) {
@@ -973,8 +940,10 @@ TEST(alt_geometry, intersectsRand)
           ground_truth_no_intersect_ns += sw.toc();
         }
 
-        const auto alt_poly1 = autoware::universe_utils::alt::from_boost(polygons[i]);
-        const auto alt_poly2 = autoware::universe_utils::alt::from_boost(polygons[j]);
+        const auto alt_poly1 =
+          autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[i]).value();
+        const auto alt_poly2 =
+          autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[j]).value();
         sw.tic();
         const auto alt = autoware::universe_utils::intersects(alt_poly1, alt_poly2);
         if (alt) {
@@ -1038,8 +1007,9 @@ TEST(alt_geometry, touchesRand)
             ground_truth_not_touching_ns += sw.toc();
           }
 
-          const auto alt_point = autoware::universe_utils::alt::from_boost(point);
-          const auto alt_poly = autoware::universe_utils::alt::from_boost(polygons[j]);
+          const auto alt_point = autoware::universe_utils::alt::Point2d(point);
+          const auto alt_poly =
+            autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[j]).value();
           sw.tic();
           const auto alt = autoware::universe_utils::touches(alt_point, alt_poly);
           if (alt) {
@@ -1103,8 +1073,10 @@ TEST(alt_geometry, withinPolygonRand)
           ground_truth_not_within_ns += sw.toc();
         }
 
-        const auto alt_poly1 = autoware::universe_utils::alt::from_boost(polygons[i]);
-        const auto alt_poly2 = autoware::universe_utils::alt::from_boost(polygons[j]);
+        const auto alt_poly1 =
+          autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[i]).value();
+        const auto alt_poly2 =
+          autoware::universe_utils::alt::ConvexPolygon2d::create(polygons[j]).value();
         sw.tic();
         const auto alt = autoware::universe_utils::within(alt_poly1, alt_poly2);
         if (alt) {

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -315,6 +315,38 @@ TEST(alt_geometry, distance)
   }
 }
 
+TEST(geometry, envelope)
+{
+  using autoware::universe_utils::envelope;
+  using autoware::universe_utils::alt::ConvexPolygon2d;
+
+  {
+    const ConvexPolygon2d poly{
+      {{2.0, 1.3},
+       {2.4, 1.7},
+       {2.8, 1.8},
+       {3.4, 1.2},
+       {3.7, 1.6},
+       {3.4, 2.0},
+       {4.1, 3.0},
+       {5.3, 2.6},
+       {5.4, 1.2},
+       {4.9, 0.8},
+       {2.9, 0.7}}};
+    const auto result = envelope(poly);
+
+    ASSERT_EQ(result.vertices().size(), 4);
+    EXPECT_NEAR(result.vertices().at(0).x(), 2.0, epsilon);
+    EXPECT_NEAR(result.vertices().at(0).y(), 0.7, epsilon);
+    EXPECT_NEAR(result.vertices().at(1).x(), 2.0, epsilon);
+    EXPECT_NEAR(result.vertices().at(1).y(), 3.0, epsilon);
+    EXPECT_NEAR(result.vertices().at(2).x(), 5.4, epsilon);
+    EXPECT_NEAR(result.vertices().at(2).y(), 3.0, epsilon);
+    EXPECT_NEAR(result.vertices().at(3).x(), 5.4, epsilon);
+    EXPECT_NEAR(result.vertices().at(3).y(), 0.7, epsilon);
+  }
+}
+
 TEST(alt_geometry, intersects)
 {
   using autoware::universe_utils::intersects;
@@ -527,7 +559,7 @@ TEST(geometry, simplify)
     const double max_distance = 0.5;
     const auto result = simplify(points, max_distance);
 
-    EXPECT_EQ(result.size(), 4);
+    ASSERT_EQ(result.size(), 4);
     EXPECT_NEAR(result.at(0).x(), 1.1, epsilon);
     EXPECT_NEAR(result.at(0).y(), 1.1, epsilon);
     EXPECT_NEAR(result.at(1).x(), 3.1, epsilon);

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -515,6 +515,34 @@ TEST(alt_geometry, isAbove)
   }
 }
 
+TEST(alt_geometry, isClockwise)
+{
+  using autoware::universe_utils::is_clockwise;
+  using autoware::universe_utils::alt::PointList2d;
+
+  {  // Clockwise
+    PointList2d vertices;
+    vertices.push_back({0.0, 0.0});
+    vertices.push_back({0.0, 7.0});
+    vertices.push_back({4.0, 2.0});
+    vertices.push_back({2.0, 0.0});
+    const auto result = is_clockwise(vertices);
+
+    EXPECT_TRUE(result);
+  }
+
+  {  // Counter-clockwise
+    PointList2d vertices;
+    vertices.push_back({0.0, 0.0});
+    vertices.push_back({2.0, 0.0});
+    vertices.push_back({4.0, 2.0});
+    vertices.push_back({0.0, 7.0});
+    const auto result = is_clockwise(vertices);
+
+    EXPECT_FALSE(result);
+  }
+}
+
 TEST(geometry, simplify)
 {
   using autoware::universe_utils::simplify;


### PR DESCRIPTION
## Description

This PR enables to support non-convex polygons and adds the following and some utility functions to reduce dependence on Boost.Geometry.

|Boost.Geometry <br> (`boost::geometry`)|alternative <br> (`autoware::universe_utils`)|supported types|
|----|----|----|
|`envelope()`|`envelope()`|polygon|
|`simplify()`|`simplify()`|line (point list)|

Notes:
- Polygons **do have** closing points (i.e. the last vertex in the list should match the first, as any polygon given is considered to be closed).

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/8128

## How was this PR tested?

```
colcon test --packages-select autoware_universe_utils
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
