### PR TITLE
feat(autoware_map_based_prediction): improve frenet path generation

### DIFF
--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -127,6 +127,7 @@ struct PredictedRefPath
 {
   float probability;
   double speed_limit;
+  double width;
   PosePath path;
   Maneuver maneuver;
 };
@@ -315,9 +316,11 @@ private:
     const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths,
     const double speed_limit = 0.0);
 
-  mutable universe_utils::LRUCache<lanelet::routing::LaneletPaths, std::vector<PosePath>>
+  mutable universe_utils::LRUCache<
+    lanelet::routing::LaneletPaths, std::vector<std::pair<PosePath, double>>>
     lru_cache_of_convert_path_type_{1000};
-  std::vector<PosePath> convertPathType(const lanelet::routing::LaneletPaths & paths) const;
+  std::vector<std::pair<PosePath, double>> convertPathType(
+    const lanelet::routing::LaneletPaths & paths) const;
 
   void updateFuturePossibleLanelets(
     const TrackedObject & object, const lanelet::routing::LaneletPaths & paths);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -292,6 +292,8 @@ private:
     const std::string & object_id);
   std::string tryMatchNewObjectToDisappeared(
     const std::string & object_id, std::unordered_map<std::string, TrackedObject> & current_users);
+  bool searchProperStartingRefPathIndex(
+    const TrackedObject & object, const PosePath & pose_path, size_t & index) const;
   std::vector<PredictedRefPath> getPredictedReferencePath(
     const TrackedObject & object, const LaneletsData & current_lanelets_data,
     const double object_detected_time, const double time_horizon);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -292,8 +292,8 @@ private:
     const std::string & object_id);
   std::string tryMatchNewObjectToDisappeared(
     const std::string & object_id, std::unordered_map<std::string, TrackedObject> & current_users);
-  bool searchProperStartingRefPathIndex(
-    const TrackedObject & object, const PosePath & pose_path, size_t & index) const;
+  std::optional<size_t> searchProperStartingRefPathIndex(
+    const TrackedObject & object, const PosePath & pose_path) const;
   std::vector<PredictedRefPath> getPredictedReferencePath(
     const TrackedObject & object, const LaneletsData & current_lanelets_data,
     const double object_detected_time, const double time_horizon);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -23,7 +23,11 @@
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <tf2/LinearMath/Quaternion.h>
 
 #include <memory>
 #include <utility>
@@ -144,6 +148,9 @@ private:
   std::vector<double> interpolationLerp(
     const std::vector<double> & base_keys, const std::vector<double> & base_values,
     const std::vector<double> & query_keys) const;
+  std::vector<tf2::Quaternion> interpolationLerp(
+    const std::vector<double> & base_keys, const std::vector<tf2::Quaternion> & base_values,
+    const std::vector<double> & query_keys) const;
 
   PosePath interpolateReferencePath(
     const PosePath & base_path, const FrenetPath & frenet_predicted_path) const;
@@ -153,8 +160,8 @@ private:
     const PosePath & ref_path) const;
 
   FrenetPoint getFrenetPoint(
-    const TrackedObject & object, const PosePath & ref_path, const double duration,
-    PosePath & target_path, const double speed_limit = 0.0) const;
+    const TrackedObject & object, const geometry_msgs::msg::Pose & ref_pose, const double duration,
+    const double speed_limit = 0.0) const;
 };
 }  // namespace autoware::map_based_prediction
 

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -141,6 +141,10 @@ private:
   Eigen::Vector2d calcLonCoefficients(
     const FrenetPoint & current_point, const FrenetPoint & target_point, const double T) const;
 
+  std::vector<double> interpolationLerp(
+    const std::vector<double> & base_keys, const std::vector<double> & base_values,
+    const std::vector<double> & query_keys) const;
+
   PosePath interpolateReferencePath(
     const PosePath & base_path, const FrenetPath & frenet_predicted_path) const;
 

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -150,7 +150,7 @@ private:
 
   FrenetPoint getFrenetPoint(
     const TrackedObject & object, const PosePath & ref_path, const double duration,
-    const double speed_limit = 0.0) const;
+    PosePath & target_path, const double speed_limit = 0.0) const;
 };
 }  // namespace autoware::map_based_prediction
 

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -95,8 +95,9 @@ public:
     const TrackedObject & object, const double duration) const;
 
   PredictedPath generatePathForOnLaneVehicle(
-    const TrackedObject & object, const PosePath & ref_paths, const double duration,
-    const double lateral_duration, const double speed_limit = 0.0) const;
+    const TrackedObject & object, const PosePath & ref_path, const double duration,
+    const double lateral_duration, const double path_width = 0.0,
+    const double speed_limit = 0.0) const;
 
   PredictedPath generatePathForCrosswalkUser(
     const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk,
@@ -129,7 +130,8 @@ private:
 
   PredictedPath generatePolynomialPath(
     const TrackedObject & object, const PosePath & ref_path, const double duration,
-    const double lateral_duration, const double speed_limit = 0.0) const;
+    const double lateral_duration, const double backlash_width,
+    const double speed_limit = 0.0) const;
 
   FrenetPath generateFrenetPath(
     const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length,

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -134,7 +134,7 @@ private:
 
   PredictedPath generatePolynomialPath(
     const TrackedObject & object, const PosePath & ref_path, const double duration,
-    const double lateral_duration, const double backlash_width,
+    const double lateral_duration, const double path_width, const double backlash_width,
     const double speed_limit = 0.0) const;
 
   FrenetPath generateFrenetPath(

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2006,9 +2006,10 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
 
   // Step 3. Search starting point for each reference path
   for (auto it = all_ref_paths.begin(); it != all_ref_paths.end();) {
-    std::unique_ptr<ScopedTimeTrack> st_ptr;
+    std::unique_ptr<ScopedTimeTrack> st1_ptr;
     if (time_keeper_)
-      st_ptr = std::make_unique<ScopedTimeTrack>("searching_refpath_starting_point", *time_keeper_);
+      st1_ptr =
+        std::make_unique<ScopedTimeTrack>("searching_refpath_starting_point", *time_keeper_);
 
     auto & pose_path = it->path;
     if (pose_path.empty()) {
@@ -2021,9 +2022,9 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
       // starting segment index is a segment close enough to the object
       const auto obj_point = object.kinematics.pose_with_covariance.pose.position;
       {
-        std::unique_ptr<ScopedTimeTrack> st_ptr;
+        std::unique_ptr<ScopedTimeTrack> st2_ptr;
         if (time_keeper_)
-          st_ptr = std::make_unique<ScopedTimeTrack>("find_close_segment_index", *time_keeper_);
+          st2_ptr = std::make_unique<ScopedTimeTrack>("find_close_segment_index", *time_keeper_);
 
         starting_segment_idx = 0;
         double min_dist_sq = std::numeric_limits<double>::max();
@@ -2046,9 +2047,9 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
       // starting segment index that have the best score
       size_t idx = 0;
       {  // find target segmentation index
-        std::unique_ptr<ScopedTimeTrack> st_ptr;
+        std::unique_ptr<ScopedTimeTrack> st3_ptr;
         if (time_keeper_)
-          st_ptr = std::make_unique<ScopedTimeTrack>("find_target_seg_index", *time_keeper_);
+          st3_ptr = std::make_unique<ScopedTimeTrack>("find_target_seg_index", *time_keeper_);
 
         const double obj_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
         constexpr double search_distance = 22.0;  // [m]

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2449,6 +2449,7 @@ std::vector<std::pair<PosePath, double>> MapBasedPredictionNode::convertPathType
             continue;
           }
 
+          // only considers yaw of the lanelet
           const double lane_yaw = std::atan2(
             current_p.position.y - prev_p.position.y, current_p.position.x - prev_p.position.x);
           const double sin_yaw_half = std::sin(lane_yaw / 2.0);

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -243,7 +243,6 @@ PredictedPath PathGenerator::generatePolynomialPath(
   FrenetPoint terminal_point;
   terminal_point.s_vel = std::hypot(current_point.s_vel, current_point.d_vel);
   terminal_point.s_acc = 0.0;
-  terminal_point.d = 0.0;
   terminal_point.d_vel = 0.0;
   terminal_point.d_acc = 0.0;
 
@@ -278,7 +277,7 @@ PredictedPath PathGenerator::generatePolynomialPath(
     return generateStraightPath(object, duration);
   }
 
-  // Step4. Convert predicted trajectory from Frenet to Cartesian coordinate
+  // Step 4. Convert predicted trajectory from Frenet to Cartesian coordinate
   return convertToPredictedPath(object, frenet_predicted_path, interpolated_ref_path);
 }
 
@@ -316,14 +315,10 @@ FrenetPath PathGenerator::generateFrenetPath(
       break;
     }
 
-    // We assume the object is traveling at a constant speed along s direction
+    // Fill the FrenetPoint, velocity and acceleration are not used in the path generator
     FrenetPoint point;
     point.s = s_next;
-    point.s_vel = current_point.s_vel;
-    point.s_acc = current_point.s_acc;
     point.d = d_next;
-    point.d_vel = current_point.d_vel;
-    point.d_acc = current_point.d_acc;
     path.push_back(point);
   }
 
@@ -414,8 +409,8 @@ std::vector<double> PathGenerator::interpolationLerp(
     }
     last_query_key = query_key;
 
-    const double src_val = base_values.at(key_index);
-    const double dst_val = base_values.at(key_index + 1);
+    const double & src_val = base_values.at(key_index);
+    const double & dst_val = base_values.at(key_index + 1);
     const double ratio = (query_key - base_keys.at(key_index)) /
                          (base_keys.at(key_index + 1) - base_keys.at(key_index));
 
@@ -460,8 +455,8 @@ std::vector<tf2::Quaternion> PathGenerator::interpolationLerp(
     }
     last_query_key = query_key;
 
-    const tf2::Quaternion src_val = base_values.at(key_index);
-    const tf2::Quaternion dst_val = base_values.at(key_index + 1);
+    const tf2::Quaternion & src_val = base_values.at(key_index);
+    const tf2::Quaternion & dst_val = base_values.at(key_index + 1);
     const double ratio = (query_key - base_keys.at(key_index)) /
                          (base_keys.at(key_index + 1) - base_keys.at(key_index));
 
@@ -494,6 +489,7 @@ PosePath PathGenerator::interpolateReferencePath(
     return interpolated_path;
   }
 
+  // Prepare base path vectors
   std::vector<double> base_path_x(base_path.size());
   std::vector<double> base_path_y(base_path.size());
   std::vector<double> base_path_z(base_path.size());
@@ -512,6 +508,7 @@ PosePath PathGenerator::interpolateReferencePath(
     }
   }
 
+  // Prepare resampled s vector
   std::vector<double> resampled_s(frenet_predicted_path.size());
   for (size_t i = 0; i < frenet_predicted_path.size(); ++i) {
     resampled_s.at(i) = frenet_predicted_path.at(i).s;
@@ -524,9 +521,9 @@ PosePath PathGenerator::interpolateReferencePath(
   std::vector<tf2::Quaternion> lerp_ref_path_orientation =
     interpolationLerp(base_path_s, base_path_orientation, resampled_s);
 
+  // Set the interpolated PosePath
   interpolated_path.resize(interpolate_num);
   for (size_t i = 0; i < interpolate_num; ++i) {
-    // Set the interpolated pose
     geometry_msgs::msg::Pose interpolated_pose;
     interpolated_pose.position = autoware::universe_utils::createPoint(
       lerp_ref_path_x.at(i), lerp_ref_path_y.at(i), lerp_ref_path_z.at(i));

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -205,7 +205,7 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   backlash_width = std::max(backlash_width, 0.0);  // minimum is 0.0
 
   return generatePolynomialPath(
-    object, ref_path, duration, lateral_duration, backlash_width, speed_limit);
+    object, ref_path, duration, lateral_duration, path_width, backlash_width, speed_limit);
 }
 
 PredictedPath PathGenerator::generateStraightPath(
@@ -230,7 +230,8 @@ PredictedPath PathGenerator::generateStraightPath(
 
 PredictedPath PathGenerator::generatePolynomialPath(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
-  const double lateral_duration, const double backlash_width, const double speed_limit) const
+  const double lateral_duration, const double path_width, const double backlash_width,
+  const double speed_limit) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
@@ -255,7 +256,7 @@ PredictedPath PathGenerator::generatePolynomialPath(
       // calculation cost
       terminal_point.d = 0.0;
     } else {
-      constexpr double return_width = 1.5;  // [m]
+      const double return_width = path_width / 2.0;  // [m]
       const double current_momentum_d =
         current_point.d + 0.5 * current_point.d_vel * lateral_duration;
       const double momentum_d_abs = std::abs(current_momentum_d);

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -192,10 +192,10 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
 
   // get object width
   double object_width = 5.0;  // a large number
-  if (
-    object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX ||
-    object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     object_width = object.shape.dimensions.y;
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    object_width = object.shape.dimensions.x;
   }
   // calculate backlash_width, which may the object can be biased from the reference path
   constexpr double margin = 0.5;  // margin of 0.5m

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -197,8 +197,10 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     object_width = object.shape.dimensions.x;
   }
-  // calculate backlash_width, which may the object can be biased from the reference path
-  constexpr double margin = 0.5;  // margin of 0.5m
+  // Calculate the backlash width, which represents the maximum distance the object can be biased
+  // from the reference path
+  constexpr double margin =
+    0.5;  // Set a safety margin of 0.5m for the object to stay away from the edge of the lane
   double backlash_width = (path_width - object_width) / 2.0 - margin;
   backlash_width = std::max(backlash_width, 0.0);  // minimum is 0.0
 

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -256,20 +256,20 @@ PredictedPath PathGenerator::generatePolynomialPath(
       terminal_point.d = 0.0;
     } else {
       constexpr double return_width = 1.5;  // [m]
-      const double return_coeff =
-        return_width / backlash_width;  // if the object is biased too much, back to the center path
       const double current_momentum_d =
         current_point.d + 0.5 * current_point.d_vel * lateral_duration;
-      const double offset_ratio = std::abs(current_momentum_d / backlash_width);
+      const double momentum_d_abs = std::abs(current_momentum_d);
 
-      if (offset_ratio < 1) {
+      if (momentum_d_abs < backlash_width) {
         // If the object momentum is within the backlash width, we set the target d position to the
         // current momentum
         terminal_point.d = current_momentum_d;
-      } else if (offset_ratio >= 1 && offset_ratio < return_coeff + 1) {
+      } else if (
+        momentum_d_abs >= backlash_width && momentum_d_abs < backlash_width + return_width) {
         // If the object momentum is within the return zone, we set the target d position close to
         // the zero gradually
-        terminal_point.d = ((1 - offset_ratio) * backlash_width + return_width) / return_coeff;
+        terminal_point.d =
+          (backlash_width + return_width - momentum_d_abs) * backlash_width / return_width;
         terminal_point.d *= (current_momentum_d > 0) ? 1 : -1;
       } else {
         // If the object momentum is outside the backlash width + return zone, we set the target d

--- a/perception/autoware_map_based_prediction/src/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/src/path_generator.cpp
@@ -251,6 +251,8 @@ PredictedPath PathGenerator::generatePolynomialPath(
   // calculate terminal d position, based on backlash width
   {
     if (backlash_width < 0.01 /*m*/) {
+      // If the backlash width is less than 0.01m, do not consider the backlash width and reduce
+      // calculation cost
       terminal_point.d = 0.0;
     } else {
       constexpr double return_width = 1.5;  // [m]


### PR DESCRIPTION
## Description

1. Add backlash within lanelet when predict paths. (Background: Small bikes are tend to drive side within the lane. However, the predictor yields the paths always to the center of the lane.)

* Before : The target path is to center line position of the target lanelet.
* After : The target path allows offset if the momentum (lateral position + 0.5 * lateral velocity * lateral_duration) is within the backlash width. The backlash width is determined by the path width - the object width. The bias is modeled by a continuous function.

Before

https://github.com/user-attachments/assets/ecfebfdf-47da-4fc3-bb44-e57bc71a9cca

https://github.com/user-attachments/assets/84b1d6b9-be35-4f28-8c25-df0b9eb479f9


After

https://github.com/user-attachments/assets/c4ca2ebd-44a5-429d-8877-2644bc9a8457

https://github.com/user-attachments/assets/573753aa-907c-47bf-bb60-d3abdd757661



2.  Considering proper starting reference path for Frenet path generation

Since the reference path and the starting point of the Frenet path is important, related logic has been changed.

* Before: Search the closest path position and calculate the Frenet path boundary condition. If the angle of the closest path is steep, the generated path could be extremely curved.
* After: The starting path in the reference path will be found considering the object motion. If the path is not suitable to generate proper path, the path prediction will be replaced by a straight path. 


Before

https://github.com/user-attachments/assets/d752db4f-911e-4543-ab4c-a3f20de7beb5

https://github.com/user-attachments/assets/5b6a5600-2262-4456-bb6c-c88ea078bddb

After

https://github.com/user-attachments/assets/3f5d20ed-ecbc-4617-a3a4-ae3c6db936a0

https://github.com/user-attachments/assets/c9fc76ea-1076-4a75-9ed5-036886ee19d0


3. Interpolation and extrapolation of the path generation is customized to support 2

4, Bug fix related to the initial position of the Frenet path generation




## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

[TIER IV Cloud](https://evaluation.tier4.jp/evaluation/reports/7a00c6c1-d977-5d10-8990-ead641680a61?project_id=prd_jt)
4127/4130

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
