### PR TITLE
fix(lane_change): update rtc status for some failure condition

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -258,11 +258,17 @@ bool LaneChangeInterface::canTransitFailureState()
 
   if (!module_type_->isValidPath()) {
     log_debug_throttled("Transit to failure state due not to find valid path");
+    updateRTCStatus(
+      std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), true,
+      State::FAILED);
     return true;
   }
 
   if (module_type_->isAbortState() && module_type_->hasFinishedAbort()) {
     log_debug_throttled("Abort process has completed.");
+    updateRTCStatus(
+      std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), true,
+      State::FAILED);
     return true;
   }
 


### PR DESCRIPTION
## Description
 In this previous PR https://github.com/autowarefoundation/autoware.universe/pull/7436, some conditions were added so that the state will transit from `RUNNING` to `FAILURE`. The module itself would transit to the appropriate state however, the RTC cooperateStatus would not be updated. In this PR I have resolved this problem by calling the `updateRTCStatus` function by providing the `FAILURE` status.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/7436

## How was this PR tested?
https://evaluation.tier4.jp/evaluation/reports/1f0f0af5-d1b1-579a-890b-be2aa856e208?project_id=prd_jt

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
