### PR TITLE
fix(simple_planning_simulator): fix acc output for the model sim_model_delay_steer_acc_geared_wo_fall_guard

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp
@@ -64,6 +64,7 @@ private:
     VX,
     STEER,
     PEDAL_ACCX,
+    ACCX,
   };
   enum IDX_U { PEDAL_ACCX_DES = 0, GEAR, SLOPE_ACCX, STEER_DES };
 

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
@@ -64,7 +64,7 @@ double SimModelDelaySteerAccGearedWoFallGuard::getVy()
 }
 double SimModelDelaySteerAccGearedWoFallGuard::getAx()
 {
-  return state_(IDX::PEDAL_ACCX);
+  return state_(IDX::ACCX);
 }
 double SimModelDelaySteerAccGearedWoFallGuard::getWz()
 {
@@ -103,6 +103,8 @@ void SimModelDelaySteerAccGearedWoFallGuard::update(const double & dt)
     // stop condition is satisfied
     state_(IDX::VX) = 0.0;
   }
+
+  state_(IDX::ACCX) = (state_(IDX::VX) - prev_state(IDX::VX)) / dt;
 }
 
 void SimModelDelaySteerAccGearedWoFallGuard::initializeInputQueue(const double & dt)


### PR DESCRIPTION
## Description
A recently added vehicle model sim_model_delay_steer_acc_geared_wo_fall_guard has a bug that publish the input acc_cmd as the current acceleration. https://github.com/autowarefoundation/autoware.universe/pull/7651

This PR fix this issue.


## Related links

## How was this PR tested?
psim

## Notes for reviewers
I know the zero division line is newly added by this PR.

## Interface changes

None.

## Effects on system behavior

None.
