### PR TITLE
fix(autonomous_emergency_braking): fix debug marker visual bug

### DIFF
--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -156,10 +156,7 @@ public:
    * @brief Get the closest object data
    * @return Object data of the closest object
    */
-  [[nodiscard]] ObjectData get() const
-  {
-    return (closest_object_.has_value()) ? closest_object_.value() : ObjectData();
-  }
+  [[nodiscard]] std::optional<ObjectData> get() const { return closest_object_; }
 
   /**
    * @brief Get the previous closest object data


### PR DESCRIPTION
## Description
In current OSS Autoware there is a visual bug that makes it so the rss distance is always 0. This is caused because the RSS distance is calculated AFTER the debug marker is published, this PR fixes the problem by calculating the distance first (which is saved on the collision_data_keeper_ member class) and then, using that data to publish the debug info.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
![cap- 2024-08-26-14-06-38](https://github.com/user-attachments/assets/101793e6-87f4-40ae-b95a-b86cf3bff2d4)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
