### PR TITLE
fix(freespace_planner): fix free space planner spamming message

### DIFF
--- a/planning/autoware_freespace_planner/src/autoware_freespace_planner/freespace_planner_node.cpp
+++ b/planning/autoware_freespace_planner/src/autoware_freespace_planner/freespace_planner_node.cpp
@@ -416,7 +416,6 @@ void FreespacePlannerNode::onOdometry(const Odometry::ConstSharedPtr msg)
 void FreespacePlannerNode::updateData()
 {
   occupancy_grid_ = occupancy_grid_sub_.takeData();
-  scenario_ = scenario_sub_.takeData();
 
   {
     auto msgs = odom_sub_.takeData();
@@ -440,11 +439,6 @@ bool FreespacePlannerNode::isDataReady()
     is_ready = false;
   }
 
-  if (!scenario_) {
-    RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 5000, "Waiting for scenario.");
-    is_ready = false;
-  }
-
   if (!odom_) {
     RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 5000, "Waiting for odometry.");
     is_ready = false;
@@ -455,14 +449,15 @@ bool FreespacePlannerNode::isDataReady()
 
 void FreespacePlannerNode::onTimer()
 {
-  updateData();
-
-  if (!isDataReady()) {
+  scenario_ = scenario_sub_.takeData();
+  if (!isActive(scenario_)) {
+    reset();
     return;
   }
 
-  if (!isActive(scenario_)) {
-    reset();
+  updateData();
+
+  if (!isDataReady()) {
     return;
   }
 


### PR DESCRIPTION
## Description

Freespace planner node spams the message `Waiting for occupancy grid` when parking scenario is not active.

## Changes

Update input data and check data availability only when parking scenario is active.

## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
