### PR TITLE
fix(tier4_planning_rviz_plugin): fix unusedFunction

### DIFF
--- a/common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.cpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.cpp
@@ -62,11 +62,6 @@ ScopedPixelBuffer::~ScopedPixelBuffer()
   pixel_buffer_->unlock();
 }
 
-Ogre::HardwarePixelBufferSharedPtr ScopedPixelBuffer::getPixelBuffer()
-{
-  return pixel_buffer_;
-}
-
 QImage ScopedPixelBuffer::getQImage(unsigned int width, unsigned int height)
 {
   const Ogre::PixelBox & pixelBox = pixel_buffer_->getCurrentLock();

--- a/common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.hpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.hpp
@@ -89,7 +89,6 @@ class ScopedPixelBuffer
 public:
   explicit ScopedPixelBuffer(Ogre::HardwarePixelBufferSharedPtr pixel_buffer);
   virtual ~ScopedPixelBuffer();
-  virtual Ogre::HardwarePixelBufferSharedPtr getPixelBuffer();
   virtual QImage getQImage(unsigned int width, unsigned int height);
   virtual QImage getQImage(OverlayObject & overlay);
   virtual QImage getQImage(unsigned int width, unsigned int height, QColor & bg_color);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.cpp:65:0: style: The function 'getPixelBuffer' is never used. [unusedFunction]
Ogre::HardwarePixelBufferSharedPtr ScopedPixelBuffer::getPixelBuffer()
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
