### PR TITLE
fix(tier4_perception_rviz_plugin): fix unusedFunction

### DIFF
--- a/common/tier4_perception_rviz_plugin/src/tools/util.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/util.cpp
@@ -21,6 +21,7 @@
 #include <OgreRay.h>
 #include <OgreViewport.h>
 
+// cppcheck-suppress unusedFunction
 std::optional<Ogre::Vector3> get_point_from_mouse(rviz_common::ViewportMouseEvent & event)
 {
   using rviz_rendering::RenderWindowOgreAdapter;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
common/tier4_perception_rviz_plugin/src/tools/util.cpp:24:0: style: The function 'get_point_from_mouse' is never used. [unusedFunction]
std::optional<Ogre::Vector3> get_point_from_mouse(rviz_common::ViewportMouseEvent & event)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
