### PR TITLE
fix(ekf_localizer): change roll, pitch proc dev

### DIFF
--- a/localization/ekf_localizer/config/ekf_localizer.param.yaml
+++ b/localization/ekf_localizer/config/ekf_localizer.param.yaml
@@ -30,8 +30,8 @@
     simple_1d_filter_parameters:
       #Simple1DFilter parameters
       z_filter_proc_dev: 1.0
-      roll_filter_proc_dev: 0.01
-      pitch_filter_proc_dev: 0.01
+      roll_filter_proc_dev: 0.1
+      pitch_filter_proc_dev: 0.1
 
     diagnostics:
       # for diagnostics

--- a/localization/ekf_localizer/schema/sub/simple_1d_filter_parameters.sub_schema.json
+++ b/localization/ekf_localizer/schema/sub/simple_1d_filter_parameters.sub_schema.json
@@ -13,12 +13,12 @@
         "roll_filter_proc_dev": {
           "type": "number",
           "description": "Simple1DFilter - Roll filter process deviation",
-          "default": 0.01
+          "default": 0.1
         },
         "pitch_filter_proc_dev": {
           "type": "number",
           "description": "Simple1DFilter - Pitch filter process deviation",
-          "default": 0.01
+          "default": 0.1
         }
       },
       "required": ["z_filter_proc_dev", "roll_filter_proc_dev", "pitch_filter_proc_dev"],


### PR DESCRIPTION
## Description


In [this PR](https://github.com/autowarefoundation/autoware.universe/pull/8576
), since the squared value is now set, like
```
roll_filter_.set_proc_var(params_.roll_filter_proc_dev * params_.roll_filter_proc_dev);
```
So the parameter value has been adjusted by taking the square root.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

test with https://github.com/autowarefoundation/autoware_launch/pull/1140

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
