### PR TITLE
fix(signal_processing): missing include for boost optional_io

### DIFF
--- a/common/signal_processing/test/src/lowpass_filter_1d_test.cpp
+++ b/common/signal_processing/test/src/lowpass_filter_1d_test.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/optional/optional_io.hpp>
+
 constexpr double epsilon = 1e-6;
 
 TEST(lowpass_filter_1d, filter)

--- a/common/signal_processing/test/src/lowpass_filter_test.cpp
+++ b/common/signal_processing/test/src/lowpass_filter_test.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/optional/optional_io.hpp>
+
 constexpr double epsilon = 1e-6;
 
 geometry_msgs::msg::Twist createTwist(


### PR DESCRIPTION
Required for jazzy

fixes:
```
autoware.universe/common/signal_processing/test/src/lowpass_filter_1d_test.cpp:26:3:   required from here
/usr/include/boost/optional/optional.hpp:1656:3: error: static assertion failed: If you want to output boost::optional, include header <boost/optional/optional_io.hpp>
 1656 |   BOOST_STATIC_ASSERT_MSG(sizeof(CharType) == 0, "If you want to output boost::optional, include header <boost/optional/optional_io.hpp>");
```