### PR TITLE
refactor(start_planner): remove redundant calculation in shift pull out 

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -311,7 +311,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
 
     // before means distance on road lane
     // Note: the pull_out_distance is the required distance on the shifted path. Now we need to
-    // calculate the distance on the center line used for the shift pathpath_shifter generation.
+    // calculate the distance on the center line used for the shift path_shifter generation.
     // However, since the calcBeforeShiftedArcLength is an approximate conversion from center line
     // to center line (not shift path to centerline), the conversion result may too long or short.
     // To prevent too short length, take maximum with the original distance.

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -61,6 +61,8 @@ std::optional<PullOutPath> ShiftPullOut::plan(
     return std::nullopt;
   }
 
+  const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
+
   // get safe path
   for (auto & pull_out_path : pull_out_paths) {
     universe_utils::ScopedTimeTrack st("get safe path", *time_keeper_);
@@ -78,8 +80,6 @@ std::optional<PullOutPath> ShiftPullOut::plan(
         path_shift_start_to_end.points.begin(), shift_path.points.begin() + pull_out_start_idx,
         shift_path.points.begin() + pull_out_end_idx + 1);
     }
-
-    const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
 
     // if lane departure check override is true, and if the initial pose is not fully within a lane,
     // cancel lane departure check
@@ -269,26 +269,38 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   });
 
   bool has_non_shifted_path = false;
+
+  // if shift length is too short, add non sifted path
+  constexpr double MINIMUM_SHIFT_LENGTH = 0.01;
+  const double shift_length = arc_position_start.distance;
+  const bool is_smaller_than_minimum = std::abs(shift_length) < MINIMUM_SHIFT_LENGTH;
+
+  if (is_smaller_than_minimum) {
+    candidate_paths.push_back(non_shifted_path);
+    has_non_shifted_path = true;
+  }
+
+  // calculate pull out distance, longitudinal acc, terminal velocity
+  const size_t shift_start_idx =
+    findNearestIndex(road_lane_reference_path.points, start_pose.position);
+  const double road_velocity =
+    road_lane_reference_path.points.at(shift_start_idx).point.longitudinal_velocity_mps;
+
+  // clip from ego pose
+  PathWithLaneId road_lane_reference_path_from_ego = road_lane_reference_path;
+  road_lane_reference_path_from_ego.points.erase(
+    road_lane_reference_path_from_ego.points.begin(),
+    road_lane_reference_path_from_ego.points.begin() + shift_start_idx);
+
+  const auto curvatures_and_segment_lengths =
+    autoware::motion_utils::calcCurvatureAndSegmentLength(road_lane_reference_path_from_ego.points);
+
   for (double lateral_acc = minimum_lateral_acc; lateral_acc <= maximum_lateral_acc;
        lateral_acc += acc_resolution) {
     PathShifter path_shifter{};
 
     path_shifter.setPath(road_lane_reference_path);
 
-    // if shift length is too short, add non sifted path
-    constexpr double MINIMUM_SHIFT_LENGTH = 0.01;
-    const double shift_length = getArcCoordinates(road_lanes, start_pose).distance;
-    if (std::abs(shift_length) < MINIMUM_SHIFT_LENGTH && !has_non_shifted_path) {
-      candidate_paths.push_back(non_shifted_path);
-      has_non_shifted_path = true;
-      continue;
-    }
-
-    // calculate pull out distance, longitudinal acc, terminal velocity
-    const size_t shift_start_idx =
-      findNearestIndex(road_lane_reference_path.points, start_pose.position);
-    const double road_velocity =
-      road_lane_reference_path.points.at(shift_start_idx).point.longitudinal_velocity_mps;
     const double shift_time =
       PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, lateral_acc);
     const double longitudinal_acc = std::clamp(road_velocity / shift_time, 0.0, /* max acc */ 1.0);
@@ -297,17 +309,12 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
       minimum_shift_pull_out_distance);
     const double terminal_velocity = longitudinal_acc * shift_time;
 
-    // clip from ego pose
-    PathWithLaneId road_lane_reference_path_from_ego = road_lane_reference_path;
-    road_lane_reference_path_from_ego.points.erase(
-      road_lane_reference_path_from_ego.points.begin(),
-      road_lane_reference_path_from_ego.points.begin() + shift_start_idx);
     // before means distance on road lane
     // Note: the pull_out_distance is the required distance on the shifted path. Now we need to
-    // calculate the distance on the center line used for the shift path generation. However, since
-    // the calcBeforeShiftedArcLength is an approximate conversion from center line to center line
-    // (not shift path to centerline), the conversion result may too long or short. To prevent too
-    // short length, take maximum with the original distance.
+    // calculate the distance on the center line used for the shift pathpath_shifter generation.
+    // However, since the calcBeforeShiftedArcLength is an approximate conversion from center line
+    // to center line (not shift path to centerline), the conversion result may too long or short.
+    // To prevent too short length, take maximum with the original distance.
     // TODO(kosuke55): update the conversion function and get rid of the comparison with original
     // distance.
     const double pull_out_distance_converted = std::max(
@@ -325,10 +332,6 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
       // variable to store that distance.
       double pull_out_distance = pull_out_distance_converted;
       double min_curvature_after_distance_converted = std::numeric_limits<double>::max();
-
-      const auto curvatures_and_segment_lengths =
-        autoware::motion_utils::calcCurvatureAndSegmentLength(
-          road_lane_reference_path_from_ego.points);
 
       const auto update_arc_length = [&](size_t i, const auto & segment_length) {
         arc_length += (i == curvatures_and_segment_lengths.size() - 1)
@@ -374,9 +377,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
 
     // get shift end pose
     const auto shift_end_pose_ptr = std::invoke([&]() {
-      const auto arc_position_shift_start =
-        lanelet::utils::getArcCoordinates(road_lanes, start_pose);
-      const double s_start = arc_position_shift_start.length + before_shifted_pull_out_distance;
+      const double s_start = arc_position_start.length + before_shifted_pull_out_distance;
       const double s_end = s_start + std::numeric_limits<double>::epsilon();
       const auto path = route_handler.getCenterLinePath(road_lanes, s_start, s_end, true);
       return path.points.empty()


### PR DESCRIPTION
## Description
There was some redundant calculation in the `ShiftPullOut::calcPullOutPaths`. This PR removes the redundant calculation outside the for loop and decreases the calculation time.　Below is an example of the processing time.

Before:
```
100.00% planWaitingApproval: total 110.06 [ms], avg. 7.34 [ms], run count: 15
    ├── 95.95% updatePullOutStatus: total 105.60 [ms], avg. 7.04 [ms], run count: 15
    │   ├── 0.12% calcBackwardPathFromStartPose: total 0.13 [ms], avg. 0.13 [ms], run count: 1
    │   ├── 0.10% searchPullOutStartPoseCandidates: total 0.11 [ms], avg. 0.11 [ms], run count: 1
    │   │   ├── 0.04% filterStopObjectsInPullOutLanes: total 0.04 [ms], avg. 0.02 [ms], run count: 2
    │   │   └── 0.06% rest: 0.06 [ms]
    │   ├── 95.66% planWithPriority: total 105.28 [ms], avg. 105.28 [ms], run count: 1
    │   │   ├── 0.00% determinePriorityOrder: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   ├── 95.64% findPullOutPaths: total 105.26 [ms], avg. 105.26 [ms], run count: 1
    │   │   │   ├── 40.63% calcPullOutPaths: total 44.72 [ms], avg. 1.60 [ms], run count: 28
    │   │   │   ├── 37.59% get safe path: total 41.37 [ms], avg. 0.37 [ms], run count: 112
    │   │   │   │   ├── 27.04% checkPathWillLeaveLane: total 29.76 [ms], avg. 0.27 [ms], run count: 112
    │   │   │   │   │   ├── 23.64% getFusedLaneletPolygonForPath: total 26.01 [ms], avg. 0.23 [ms], run count: 112
    │   │   │   │   │   │   ├── 7.37% getLaneletsFromPath: total 8.11 [ms], avg. 0.07 [ms], run count: 112
    │   │   │   │   │   │   └── 16.27% rest: 17.90 [ms]
    │   │   │   │   │   └── 3.40% rest: 3.74 [ms]
    │   │   │   │   ├── 9.57% cropPointsOutsideOfLanes: total 10.54 [ms], avg. 0.66 [ms], run count: 16
    │   │   │   │   │   ├── 8.34% getFusedLaneletPolygonForPath: total 9.18 [ms], avg. 0.57 [ms], run count: 16
    │   │   │   │   │   │   ├── 2.28% getLaneletsFromPath: total 2.51 [ms], avg. 0.16 [ms], run count: 16
    │   │   │   │   │   │   └── 6.06% rest: 6.67 [ms]
    │   │   │   │   │   ├── 0.72% check if footprint is within fused_lanlets_polygon: total 0.79 [ms], avg. 0.05 [ms], run count: 16
    │   │   │   │   │   └── 0.52% rest: 0.57 [ms]
    │   │   │   │   └── 0.97% rest: 1.07 [ms]
    │   │   │   └── 17.42% rest: 19.18 [ms]
    │   │   └── 0.02% rest: 0.02 [ms]
    │   └── 0.08% rest: 0.09 [ms]
    ├── 0.05% isPreventingRearVehicleFromPassingThrough: total 0.06 [ms], avg. 0.06 [ms], run count: 1
    │   ├── 0.15% isPreventingRearVehicleFromPassingThrough: total 0.16 [ms], avg. 0.08 [ms], run count: 2
    │   └── -0.10% rest: -0.10 [ms]
    ├── 0.03% isSafePath: total 0.04 [ms], avg. 0.04 [ms], run count: 1
    └── 3.96% rest: 4.36 [ms]
```

After:
```
100.00% planWaitingApproval: total 105.15 [ms], avg. 4.04 [ms], run count: 26
    ├── 92.88% updatePullOutStatus: total 97.67 [ms], avg. 3.76 [ms], run count: 26
    │   ├── 0.18% calcBackwardPathFromStartPose: total 0.19 [ms], avg. 0.19 [ms], run count: 1
    │   ├── 0.17% searchPullOutStartPoseCandidates: total 0.17 [ms], avg. 0.17 [ms], run count: 1
    │   │   ├── 0.07% filterStopObjectsInPullOutLanes: total 0.07 [ms], avg. 0.04 [ms], run count: 2
    │   │   └── 0.10% rest: 0.10 [ms]
    │   ├── 92.39% planWithPriority: total 97.16 [ms], avg. 97.16 [ms], run count: 1
    │   │   ├── 0.00% determinePriorityOrder: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   ├── 92.36% findPullOutPaths: total 97.12 [ms], avg. 97.12 [ms], run count: 1
    │   │   │   ├── 33.84% calcPullOutPaths: total 35.58 [ms], avg. 1.27 [ms], run count: 28
    │   │   │   ├── 38.55% get safe path: total 40.54 [ms], avg. 0.36 [ms], run count: 112
    │   │   │   │   ├── 27.80% checkPathWillLeaveLane: total 29.23 [ms], avg. 0.26 [ms], run count: 112
    │   │   │   │   │   ├── 24.41% getFusedLaneletPolygonForPath: total 25.67 [ms], avg. 0.23 [ms], run count: 112
    │   │   │   │   │   │   ├── 6.89% getLaneletsFromPath: total 7.24 [ms], avg. 0.06 [ms], run count: 112
    │   │   │   │   │   │   └── 17.53% rest: 18.43 [ms]
    │   │   │   │   │   └── 3.39% rest: 3.56 [ms]
    │   │   │   │   ├── 9.79% cropPointsOutsideOfLanes: total 10.29 [ms], avg. 0.64 [ms], run count: 16
    │   │   │   │   │   ├── 8.65% getFusedLaneletPolygonForPath: total 9.09 [ms], avg. 0.57 [ms], run count: 16
    │   │   │   │   │   │   ├── 2.43% getLaneletsFromPath: total 2.56 [ms], avg. 0.16 [ms], run count: 16
    │   │   │   │   │   │   └── 6.21% rest: 6.53 [ms]
    │   │   │   │   │   ├── 0.66% check if footprint is within fused_lanlets_polygon: total 0.69 [ms], avg. 0.04 [ms], run count: 16
    │   │   │   │   │   └── 0.49% rest: 0.51 [ms]
    │   │   │   │   └── 0.97% rest: 1.02 [ms]
    │   │   │   └── 19.97% rest: 20.99 [ms]
    │   │   └── 0.04% rest: 0.04 [ms]
    │   └── 0.15% rest: 0.15 [ms]
    ├── 0.09% isPreventingRearVehicleFromPassingThrough: total 0.09 [ms], avg. 0.09 [ms], run count: 1
    │   ├── 0.20% isPreventingRearVehicleFromPassingThrough: total 0.21 [ms], avg. 0.10 [ms], run count: 2
    │   └── -0.11% rest: -0.11 [ms]
    ├── 0.05% isSafePath: total 0.06 [ms], avg. 0.06 [ms], run count: 1
    └── 6.97% rest: 7.33 [ms]
```

## Related links
None

## How was this PR tested?
[TIER IV internal simulator](https://evaluation.tier4.jp/evaluation/reports/feacbd16-7b96-5ff3-94d8-3514f2e381d5?page_size=50&project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
