### PR TITLE
feat(plannig): use output=both in launch instead of output=screen

### DIFF
--- a/planning/autoware_costmap_generator/launch/costmap_generator.launch.xml
+++ b/planning/autoware_costmap_generator/launch/costmap_generator.launch.xml
@@ -8,7 +8,7 @@
 
   <arg name="costmap_generator_param_file" default="$(find-pkg-share autoware_costmap_generator)/config/costmap_generator.param.yaml"/>
 
-  <node pkg="autoware_costmap_generator" exec="costmap_generator" name="costmap_generator" output="screen">
+  <node pkg="autoware_costmap_generator" exec="costmap_generator" name="costmap_generator" output="both">
     <remap from="~/input/objects" to="$(var input_objects)"/>
     <remap from="~/input/points_no_ground" to="$(var input_points_no_ground)"/>
     <remap from="~/input/vector_map" to="$(var input_lanelet_map)"/>

--- a/planning/autoware_external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.xml
+++ b/planning/autoware_external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.xml
@@ -10,7 +10,7 @@
   <arg name="output_velocity_limit_from_selector" default="/planning/scenario_planning/max_velocity"/>
   <arg name="output_debug_string" default="/planning/scenario_planning/external_velocity_limit_selector/debug"/>
 
-  <node pkg="autoware_external_velocity_limit_selector" exec="external_velocity_limit_selector" name="external_velocity_limit_selector" output="screen">
+  <node pkg="autoware_external_velocity_limit_selector" exec="external_velocity_limit_selector" name="external_velocity_limit_selector" output="both">
     <param from="$(var common_param_path)"/>
     <param from="$(var param_path)"/>
     <remap from="input/velocity_limit_from_api" to="$(var input_velocity_limit_from_api)"/>

--- a/planning/autoware_freespace_planner/launch/freespace_planner.launch.xml
+++ b/planning/autoware_freespace_planner/launch/freespace_planner.launch.xml
@@ -11,7 +11,7 @@
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
-  <node pkg="autoware_freespace_planner" exec="freespace_planner" name="freespace_planner" output="screen">
+  <node pkg="autoware_freespace_planner" exec="freespace_planner" name="freespace_planner" output="both">
     <remap from="~/input/route" to="$(var input_route)"/>
     <remap from="~/input/occupancy_grid" to="$(var input_occupancy_grid)"/>
     <remap from="~/input/scenario" to="$(var input_scenario)"/>

--- a/planning/autoware_mission_planner/launch/goal_pose_visualizer.launch.xml
+++ b/planning/autoware_mission_planner/launch/goal_pose_visualizer.launch.xml
@@ -2,7 +2,7 @@
   <arg name="route_topic_name" default="/planning/mission_planning/route"/>
   <arg name="echo_back_goal_pose_topic_name" default="/planning/mission_planning/echo_back_goal_pose"/>
 
-  <node pkg="autoware_mission_planner" exec="goal_pose_visualizer" name="goal_pose_visualizer" output="screen">
+  <node pkg="autoware_mission_planner" exec="goal_pose_visualizer" name="goal_pose_visualizer" output="both">
     <remap from="input/route" to="$(var route_topic_name)"/>
     <remap from="output/goal_pose" to="$(var echo_back_goal_pose_topic_name)"/>
   </node>

--- a/planning/autoware_obstacle_cruise_planner/launch/obstacle_cruise_planner.launch.xml
+++ b/planning/autoware_obstacle_cruise_planner/launch/obstacle_cruise_planner.launch.xml
@@ -17,7 +17,7 @@
   <arg name="output_velocity_limit" default="/planning/scenario_planning/max_velocity_candidates"/>
   <arg name="output_clear_velocity_limit" default="/planning/scenario_planning/clear_velocity_limit"/>
 
-  <node pkg="autoware_obstacle_cruise_planner" exec="autoware_obstacle_cruise_planner" name="obstacle_cruise_planner" output="screen">
+  <node pkg="autoware_obstacle_cruise_planner" exec="autoware_obstacle_cruise_planner" name="obstacle_cruise_planner" output="both">
     <!-- param -->
     <param from="$(var obstacle_cruise_planner_param_path)"/>
     <param from="$(var vehicle_info_param_path)"/>

--- a/planning/autoware_obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/autoware_obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -14,7 +14,7 @@
   <arg name="output_velocity_limit" default="/planning/scenario_planning/max_velocity_candidates"/>
   <arg name="output_velocity_limit_clear_command" default="/planning/scenario_planning/clear_velocity_limit"/>
 
-  <node pkg="obstacle_stop_planner" exec="obstacle_stop_planner_node" name="obstacle_stop_planner" output="screen">
+  <node pkg="obstacle_stop_planner" exec="obstacle_stop_planner_node" name="obstacle_stop_planner" output="both">
     <!-- load config files -->
     <param from="$(var common_param_path)"/>
     <param from="$(var adaptive_cruise_control_param_path)"/>

--- a/planning/autoware_path_optimizer/launch/launch_visualization.launch.xml
+++ b/planning/autoware_path_optimizer/launch/launch_visualization.launch.xml
@@ -13,6 +13,6 @@
 
   <!-- Rviz -->
   <group>
-    <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share autoware_path_optimizer)/rviz/autoware_path_optimizer.rviz"/>
+    <node pkg="rviz2" exec="rviz2" name="rviz2" output="both" args="-d $(find-pkg-share autoware_path_optimizer)/rviz/autoware_path_optimizer.rviz"/>
   </group>
 </launch>

--- a/planning/autoware_path_optimizer/launch/path_optimizer.launch.xml
+++ b/planning/autoware_path_optimizer/launch/path_optimizer.launch.xml
@@ -3,7 +3,7 @@
   <arg name="output_path_topic" default="output/path"/>
   <arg name="enable_debug_info" default="false"/>
   <arg name="param_path" default="$(find-pkg-share autoware_path_optimizer)/config/path_optimizer.param.yaml"/>
-  <node pkg="autoware_path_optimizer" exec="path_optimizer_node" name="path_optimizer_node" output="screen">
+  <node pkg="autoware_path_optimizer" exec="path_optimizer_node" name="path_optimizer_node" output="both">
     <remap from="~/input/path" to="$(var input_path_topic)"/>
     <remap from="~/input/odometry" to="/localization/kinematic_state"/>
     <remap from="~/output/path" to="$(var output_path_topic)"/>

--- a/planning/autoware_path_smoother/launch/elastic_band_smoother.launch.xml
+++ b/planning/autoware_path_smoother/launch/elastic_band_smoother.launch.xml
@@ -5,7 +5,7 @@
   <arg name="enable_debug_info" default="false"/>
   <arg name="param_path" default="$(find-pkg-share autoware_path_smoother)/config/elastic_band_smoother.param.yaml"/>
 
-  <node pkg="autoware_path_smoother" exec="elastic_band_smoother" name="elastic_band_smoother" output="screen">
+  <node pkg="autoware_path_smoother" exec="elastic_band_smoother" name="elastic_band_smoother" output="both">
     <remap from="~/input/path" to="$(var input_path_topic)"/>
     <remap from="~/input/odometry" to="/localization/kinematic_state"/>
     <remap from="~/output/traj" to="$(var output_trajectory_topic)"/>

--- a/planning/autoware_planning_validator/launch/invalid_trajectory_publisher.launch.xml
+++ b/planning/autoware_planning_validator/launch/invalid_trajectory_publisher.launch.xml
@@ -2,7 +2,7 @@
   <arg name="input/trajectory" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
   <arg name="output/trajectory" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
 
-  <node name="invalid_trajectory_publisher" exec="invalid_trajectory_publisher" pkg="autoware_planning_validator" output="screen">
+  <node name="invalid_trajectory_publisher" exec="invalid_trajectory_publisher" pkg="autoware_planning_validator" output="both">
     <remap from="~/input/trajectory" to="$(var input/trajectory)"/>
     <remap from="~/output/trajectory" to="$(var output/trajectory)"/>
   </node>

--- a/planning/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -3,7 +3,7 @@
   <arg name="input_trajectory" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
   <arg name="output_trajectory" default="/planning/scenario_planning/trajectory"/>
 
-  <node name="planning_validator" exec="planning_validator_node" pkg="autoware_planning_validator" output="screen">
+  <node name="planning_validator" exec="planning_validator_node" pkg="autoware_planning_validator" output="both">
     <!-- load config a file -->
     <param from="$(var planning_validator_param_path)"/>
 

--- a/planning/autoware_remaining_distance_time_calculator/launch/remaining_distance_time_calculator.launch.xml
+++ b/planning/autoware_remaining_distance_time_calculator/launch/remaining_distance_time_calculator.launch.xml
@@ -5,7 +5,7 @@
   <arg name="input_map" default="/map/vector_map"/>
   <arg name="input_route" default="/planning/mission_planning/route"/>
 
-  <node pkg="autoware_remaining_distance_time_calculator" exec="autoware_remaining_distance_time_calculator_node" name="remaining_distance_time_calculator" output="screen">
+  <node pkg="autoware_remaining_distance_time_calculator" exec="autoware_remaining_distance_time_calculator_node" name="remaining_distance_time_calculator" output="both">
     <!-- param -->
     <param from="$(var remaining_distance_time_calculator_param_path)"/>
 

--- a/planning/autoware_scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
+++ b/planning/autoware_scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
@@ -12,5 +12,5 @@
   <node pkg="topic_tools" exec="relay" name="scenario_trajectory_relay" output="log" args="$(var input_lane_driving_trajectory) $(var output_trajectory)"/>
 
   <arg name="cmd" default="ros2 topic pub $(var output_scenario) tier4_planning_msgs/msg/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'"/>
-  <executable cmd="$(var cmd)" name="scenario_pub" output="screen" shell="true"/>
+  <executable cmd="$(var cmd)" name="scenario_pub" output="both" shell="true"/>
 </launch>

--- a/planning/autoware_scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
+++ b/planning/autoware_scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
@@ -12,5 +12,5 @@
   <node pkg="topic_tools" exec="relay" name="scenario_trajectory_relay" output="log" args="$(var input_parking_trajectory) $(var output_trajectory)"/>
 
   <arg name="cmd" default="ros2 topic pub $(var output_scenario) tier4_planning_msgs/msg/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'"/>
-  <executable cmd="$(var cmd)" name="scenario_pub" output="screen" shell="true"/>
+  <executable cmd="$(var cmd)" name="scenario_pub" output="both" shell="true"/>
 </launch>

--- a/planning/autoware_scenario_selector/launch/scenario_selector.launch.xml
+++ b/planning/autoware_scenario_selector/launch/scenario_selector.launch.xml
@@ -12,7 +12,7 @@
   <!-- Parameter -->
   <arg name="config_file" default="$(find-pkg-share autoware_scenario_selector)/config/scenario_selector.param.yaml"/>
 
-  <node pkg="autoware_scenario_selector" exec="autoware_scenario_selector_node" name="scenario_selector" output="screen">
+  <node pkg="autoware_scenario_selector" exec="autoware_scenario_selector_node" name="scenario_selector" output="both">
     <remap from="input/lane_driving/trajectory" to="$(var input_lane_driving_trajectory)"/>
     <remap from="input/parking/trajectory" to="$(var input_parking_trajectory)"/>
     <remap from="input/lanelet_map" to="$(var input_lanelet_map)"/>

--- a/planning/autoware_static_centerline_generator/launch/run_planning_server.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/run_planning_server.launch.xml
@@ -8,5 +8,5 @@
   </include>
 
   <!-- local server to connect path optimizer and cloud software -->
-  <node pkg="autoware_static_centerline_generator" exec="app.py" name="static_centerline_generator_http_server" output="screen"/>
+  <node pkg="autoware_static_centerline_generator" exec="app.py" name="static_centerline_generator_http_server" output="both"/>
 </launch>

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -87,5 +87,5 @@
   </group>
 
   <!-- rviz -->
-  <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share autoware_static_centerline_generator)/rviz/static_centerline_generator.rviz" if="$(var rviz)"/>
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="both" args="-d $(find-pkg-share autoware_static_centerline_generator)/rviz/static_centerline_generator.rviz" if="$(var rviz)"/>
 </launch>

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -35,7 +35,7 @@ def generate_test_description():
     static_centerline_generator_node = Node(
         package="autoware_static_centerline_generator",
         executable="main",
-        output="screen",
+        output="both",
         parameters=[
             {"lanelet2_map_path": lanelet2_map_path},
             {"mode": "AUTO"},

--- a/planning/autoware_surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
+++ b/planning/autoware_surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
@@ -7,7 +7,7 @@
   <arg name="output_velocity_limit" default="/planning/scenario_planning/max_velocity_candidates"/>
   <arg name="output_velocity_limit_clear_command" default="/planning/scenario_planning/clear_velocity_limit"/>
 
-  <node pkg="autoware_surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="screen">
+  <node pkg="autoware_surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="both">
     <param from="$(var param_path)"/>
     <remap from="~/output/no_start_reason" to="/planning/scenario_planning/status/no_start_reason"/>
     <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>

--- a/planning/autoware_velocity_smoother/launch/velocity_smoother.launch.xml
+++ b/planning/autoware_velocity_smoother/launch/velocity_smoother.launch.xml
@@ -15,7 +15,7 @@
   <arg name="param_path" default="$(find-pkg-share autoware_velocity_smoother)/config/default_velocity_smoother.param.yaml"/>
   <arg name="velocity_smoother_param_path" default="$(find-pkg-share autoware_velocity_smoother)/config/$(var velocity_smoother_type).param.yaml"/>
 
-  <node pkg="autoware_velocity_smoother" exec="velocity_smoother_node" name="velocity_smoother_node" output="screen">
+  <node pkg="autoware_velocity_smoother" exec="velocity_smoother_node" name="velocity_smoother_node" output="both">
     <param from="$(var common_param_path)"/>
     <param from="$(var nearest_search_param_path)"/>
     <param from="$(var param_path)"/>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/launch/behavior_path_planner.launch.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/launch/behavior_path_planner.launch.xml
@@ -22,7 +22,7 @@
   <arg name="behavior_path_planner_sampling_planner_module_param_path"/>
   <arg name="behavior_path_planner_drivable_area_expansion_param_path"/>
 
-  <node pkg="behavior_path_planner" exec="behavior_path_planner" name="behavior_path_planner" output="screen">
+  <node pkg="behavior_path_planner" exec="behavior_path_planner" name="behavior_path_planner" output="both">
     <!-- topic remap -->
     <remap from="~/input/route" to="/planning/scenario_planning/scenario"/>
     <remap from="~/input/vector_map" to="/map/vector_map"/>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -28,7 +28,7 @@
   <!-- <arg name="behavior_velocity_planner_template_module_param_path"/> -->
   <arg name="behavior_velocity_planner_param_file" default="$(find-pkg-share behavior_velocity_planner)/config/behavior_velocity_planner.param.yaml"/>
 
-  <node pkg="autoware_behavior_velocity_planner" exec="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
+  <node pkg="autoware_behavior_velocity_planner" exec="behavior_velocity_planner_node" name="behavior_velocity_planner" output="both">
     <!-- topic remap -->
     <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>
     <remap from="~/input/vector_map" to="/map/vector_map"/>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/launch/motion_velocity_planner.launch.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/launch/motion_velocity_planner.launch.xml
@@ -15,7 +15,7 @@
   <!-- <arg name="motion_velocity_planner_template_module_param_path"/> -->
   <arg name="motion_velocity_planner_param_file" default="$(find-pkg-share autoware_motion_velocity_planner_node)/config/motion_velocity_planner.param.yaml"/>
 
-  <node pkg="autoware_motion_velocity_planner_node" exec="motion_velocity_planner_node_exe" name="motion_velocity_planner" output="screen">
+  <node pkg="autoware_motion_velocity_planner_node" exec="motion_velocity_planner_node_exe" name="motion_velocity_planner" output="both">
     <!-- topic remap -->
     <remap from="~/input/trajectory" to="trajectory"/>
     <remap from="~/input/vector_map" to="/map/vector_map"/>

--- a/planning/sampling_based_planner/autoware_frenet_planner/launch/frenet_planner.launch
+++ b/planning/sampling_based_planner/autoware_frenet_planner/launch/frenet_planner.launch
@@ -3,7 +3,7 @@
   <arg name="input_scenario" />
   <arg name="output_trajectory" />
 
-  <node pkg="autoware_frenet_planner" type="autoware_frenet_planner" name="autoware_frenet_planner" output="screen">
+  <node pkg="autoware_frenet_planner" type="autoware_frenet_planner" name="autoware_frenet_planner" output="both">
     <remap from="~input/path" to="$(arg input_path)" />
     <remap from="~input/scenario" to="$(arg input_scenario)" />
     <remap from="~output/trajectory" to="$(arg output_trajectory)" />


### PR DESCRIPTION
## Description

use `output="both"` in launch instead of `output="screen"` to track the log not only in the terminal but also in the log file.

The command to modify the files:
```bash
sed -i 's/output="screen"/output="both"/g' "$file"
```

## Related links


TIER IV's internal link: https://star4.slack.com/archives/C4P0NSMB5/p1723112515306229

## How was this PR tested?

simple planning simulator worked.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
