### PR TITLE
feat(control): use output=both in launch instead of output=screen

### DIFF
--- a/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
+++ b/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
@@ -6,7 +6,7 @@
   <arg name="input_predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
   <arg name="input_objects" default="/perception/object_recognition/objects"/>
 
-  <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
+  <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="both">
     <!-- load config files -->
     <param from="$(var param_path)"/>
     <!-- remap topic name -->

--- a/control/autoware_control_validator/launch/control_validator.launch.xml
+++ b/control/autoware_control_validator/launch/control_validator.launch.xml
@@ -3,7 +3,7 @@
   <arg name="input_reference_trajectory" default="/planning/scenario_planning/trajectory"/>
   <arg name="input_predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
 
-  <node name="control_validator" exec="autoware_control_validator_node" pkg="autoware_control_validator" output="screen">
+  <node name="control_validator" exec="autoware_control_validator_node" pkg="autoware_control_validator" output="both">
     <!-- load config a file -->
     <param from="$(var control_validator_param_path)"/>
 

--- a/control/autoware_external_cmd_selector/launch/external_cmd_selector.launch.xml
+++ b/control/autoware_external_cmd_selector/launch/external_cmd_selector.launch.xml
@@ -26,7 +26,7 @@
   <arg name="output/current_selector_mode" default="~/current_selector_mode"/>
 
   <!-- node -->
-  <node pkg="autoware_external_cmd_selector" exec="autoware_external_cmd_selector" name="external_cmd_selector" output="screen">
+  <node pkg="autoware_external_cmd_selector" exec="autoware_external_cmd_selector" name="external_cmd_selector" output="both">
     <remap from="~/service/select_external_command" to="$(var service/select_external_command)"/>
     <remap from="~/input/local/control_cmd" to="$(var input/local/control_cmd)"/>
     <remap from="~/input/local/shift_cmd" to="$(var input/local/shift_cmd)"/>

--- a/control/autoware_joy_controller/launch/joy_controller.launch.xml
+++ b/control/autoware_joy_controller/launch/joy_controller.launch.xml
@@ -14,7 +14,7 @@
 
   <arg name="config_file" default="$(find-pkg-share autoware_joy_controller)/config/joy_controller_ds4.param.yaml"/>
 
-  <node pkg="autoware_joy_controller" exec="autoware_joy_controller" name="joy_controller" output="screen">
+  <node pkg="autoware_joy_controller" exec="autoware_joy_controller" name="joy_controller" output="both">
     <remap from="input/joy" to="$(var input_joy)"/>
     <remap from="input/odometry" to="$(var input_odometry)"/>
 
@@ -32,7 +32,7 @@
     <param from="$(var config_file)" allow_substs="true"/>
   </node>
 
-  <node pkg="joy" exec="joy_node" name="joy_node" output="screen">
+  <node pkg="joy" exec="joy_node" name="joy_node" output="both">
     <param name="autorepeat_rate" value="1.0"/>
     <param name="deadzone" value="0.0"/>
   </node>

--- a/control/autoware_lane_departure_checker/launch/lane_departure_checker.launch.xml
+++ b/control/autoware_lane_departure_checker/launch/lane_departure_checker.launch.xml
@@ -9,7 +9,7 @@
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
-  <node pkg="autoware_lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" output="screen">
+  <node pkg="autoware_lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" output="both">
     <remap from="~/input/odometry" to="$(var input/odometry)"/>
     <remap from="~/input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
     <remap from="~/input/route" to="$(var input/route)"/>

--- a/control/autoware_operation_mode_transition_manager/launch/operation_mode_transition_manager.launch.xml
+++ b/control/autoware_operation_mode_transition_manager/launch/operation_mode_transition_manager.launch.xml
@@ -3,7 +3,7 @@
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
   <!-- autoware_operation_mode_transition_manager -->
-  <node pkg="autoware_operation_mode_transition_manager" exec="autoware_operation_mode_transition_manager_exe" name="autoware_operation_mode_transition_manager" output="screen">
+  <node pkg="autoware_operation_mode_transition_manager" exec="autoware_operation_mode_transition_manager_exe" name="autoware_operation_mode_transition_manager" output="both">
     <!-- args -->
     <param from="$(var vehicle_info_param_file)"/>
     <param from="$(var operation_mode_transition_manager_param)"/>

--- a/control/autoware_pure_pursuit/launch/pure_pursuit.launch.xml
+++ b/control/autoware_pure_pursuit/launch/pure_pursuit.launch.xml
@@ -5,7 +5,7 @@
   <arg name="input/current_odometry" default="/localization/kinematic_state"/>
   <arg name="output/control_raw" default="lateral/control_cmd"/>
 
-  <node pkg="pure_pursuit" exec="pure_pursuit" name="pure_pursuit" output="screen">
+  <node pkg="pure_pursuit" exec="pure_pursuit" name="pure_pursuit" output="both">
     <remap from="input/reference_trajectory" to="$(var input/reference_trajectory)"/>
     <remap from="input/current_odometry" to="$(var input/current_odometry)"/>
     <remap from="output/control_raw" to="$(var output/control_raw)"/>

--- a/control/autoware_shift_decider/launch/shift_decider.launch.xml
+++ b/control/autoware_shift_decider/launch/shift_decider.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="config_file" default="$(find-pkg-share autoware_shift_decider)/config/shift_decider.param.yaml"/>
 
-  <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
+  <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="both">
     <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
     <remap from="input/state" to="/autoware/state"/>
     <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>

--- a/control/autoware_trajectory_follower_node/launch/simple_trajectory_follower.launch.xml
+++ b/control/autoware_trajectory_follower_node/launch/simple_trajectory_follower.launch.xml
@@ -4,7 +4,7 @@
   <arg name="lateral_deviation" default="0.0"/>
 
   <!-- engage_transition_manager -->
-  <node pkg="autoware_trajectory_follower_node" exec="simple_trajectory_follower_exe" name="simple_trajectory_follower" output="screen">
+  <node pkg="autoware_trajectory_follower_node" exec="simple_trajectory_follower_exe" name="simple_trajectory_follower" output="both">
     <param from="$(find-pkg-share autoware_trajectory_follower_node)/config/simple_trajectory_follower.param.yaml" allow_substs="true"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>

--- a/control/autoware_vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/autoware_vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -5,7 +5,7 @@
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
-  <node pkg="autoware_vehicle_cmd_gate" exec="vehicle_cmd_gate_exe" name="vehicle_cmd_gate" output="screen">
+  <node pkg="autoware_vehicle_cmd_gate" exec="vehicle_cmd_gate_exe" name="vehicle_cmd_gate" output="both">
     <remap from="input/steering" to="/vehicle/status/steering_status"/>
 
     <remap from="input/auto/control_cmd" to="trajectory_follower/control_cmd"/>

--- a/control/control_performance_analysis/launch/control_performance_analysis.launch.xml
+++ b/control/control_performance_analysis/launch/control_performance_analysis.launch.xml
@@ -10,7 +10,7 @@
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
-  <node pkg="control_performance_analysis" exec="control_performance_analysis_exe" name="control_performance_analysis_exe" output="screen">
+  <node pkg="control_performance_analysis" exec="control_performance_analysis_exe" name="control_performance_analysis_exe" output="both">
     <param from="$(var control_performance_analysis_param_path)"/>
     <param from="$(var vehicle_info_param_file)"/>
 

--- a/control/obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
+++ b/control/obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
@@ -8,7 +8,7 @@
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
-  <node pkg="obstacle_collision_checker" exec="obstacle_collision_checker_node" name="obstacle_collision_checker_node" output="screen">
+  <node pkg="obstacle_collision_checker" exec="obstacle_collision_checker_node" name="obstacle_collision_checker_node" output="both">
     <param from="$(var config_file)"/>
     <param from="$(var vehicle_info_param_file)"/>
     <remap from="input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>

--- a/control/predicted_path_checker/launch/predicted_path_checker.launch.xml
+++ b/control/predicted_path_checker/launch/predicted_path_checker.launch.xml
@@ -9,7 +9,7 @@
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
-  <node pkg="predicted_path_checker" exec="predicted_path_checker_node" name="predicted_path_checker_node" output="screen">
+  <node pkg="predicted_path_checker" exec="predicted_path_checker_node" name="predicted_path_checker_node" output="both">
     <param from="$(var config_file)"/>
     <param from="$(var vehicle_info_param_file)"/>
     <remap from="~/input/objects" to="$(var input/objects)"/>


### PR DESCRIPTION
## Description

use `output="both"` in launch instead of `output="screen"` to track the log not only in the terminal but also in the log file.

The command to modify the files:
```bash
sed -i 's/output="screen"/output="both"/g' "$file"
```

## Related links


TIER IV's internal link: https://star4.slack.com/archives/C4P0NSMB5/p1723112515306229

## How was this PR tested?

simple planning simulator worked.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
