### PR TITLE
feat(vehicle): use output=both in launch instead of output=screen

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml
+++ b/vehicle/autoware_accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml
@@ -11,7 +11,7 @@
   <arg name="calibration_method" default="each_cell"/>
 
   <!-- calibration interface -->
-  <node pkg="autoware_accel_brake_map_calibrator" exec="accel_brake_map_calibrator" name="accel_brake_map_calibrator" output="screen">
+  <node pkg="autoware_accel_brake_map_calibrator" exec="accel_brake_map_calibrator" name="accel_brake_map_calibrator" output="both">
     <param from="$(var accel_brake_map_calib_param)"/>
     <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
     <remap from="~/input/steer" to="/vehicle/status/steering_status"/>
@@ -27,9 +27,9 @@
   </node>
 
   <!-- calibration plot and map server node -->
-  <node pkg="autoware_accel_brake_map_calibrator" exec="new_accel_brake_map_server.py" name="new_accel_brake_map_server" output="screen">
+  <node pkg="autoware_accel_brake_map_calibrator" exec="new_accel_brake_map_server.py" name="new_accel_brake_map_server" output="both">
     <param name="calibration_method" value="$(var calibration_method)"/>
   </node>
   <!-- Rviz -->
-  <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share autoware_accel_brake_map_calibrator)/rviz/occupancy.rviz" if="$(var rviz)"/>
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="both" args="-d $(find-pkg-share autoware_accel_brake_map_calibrator)/rviz/occupancy.rviz" if="$(var rviz)"/>
 </launch>

--- a/vehicle/autoware_external_cmd_converter/launch/external_cmd_converter.launch.xml
+++ b/vehicle/autoware_external_cmd_converter/launch/external_cmd_converter.launch.xml
@@ -24,7 +24,7 @@
   <arg name="out/latest_external_control_cmd" default="/api/external/get/command/selected/control"/>
 
   <!-- node -->
-  <node pkg="autoware_external_cmd_converter" exec="external_cmd_converter_node" name="external_cmd_converter" output="screen">
+  <node pkg="autoware_external_cmd_converter" exec="external_cmd_converter_node" name="external_cmd_converter" output="both">
     <param from="$(var external_cmd_converter_param)" allow_substs="true"/>
     <remap from="in/external_control_cmd" to="$(var in/external_control_cmd)"/>
     <remap from="in/shift_cmd" to="$(var in/shift_cmd)"/>

--- a/vehicle/autoware_raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
@@ -9,7 +9,7 @@
   <!-- Parameter -->
   <arg name="config_file" default="$(find-pkg-share autoware_raw_vehicle_cmd_converter)/config/raw_vehicle_cmd_converter.param.yaml"/>
 
-  <node pkg="autoware_raw_vehicle_cmd_converter" exec="autoware_raw_vehicle_cmd_converter_node" name="raw_vehicle_cmd_converter" output="screen">
+  <node pkg="autoware_raw_vehicle_cmd_converter" exec="autoware_raw_vehicle_cmd_converter_node" name="raw_vehicle_cmd_converter" output="both">
     <param from="$(var config_file)" allow_substs="true"/>
     <remap from="~/input/control_cmd" to="$(var input_control_cmd)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>

--- a/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
+++ b/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
@@ -12,7 +12,7 @@
   </include>
 
   <!-- steer offset estimator -->
-  <node pkg="autoware_steer_offset_estimator" exec="steer_offset_estimator" name="steer_offset_estimator" output="screen">
+  <node pkg="autoware_steer_offset_estimator" exec="steer_offset_estimator" name="steer_offset_estimator" output="both">
     <param from="$(var config_file)"/>
     <remap from="~/input/twist" to="$(var output_twist_topic)"/>
     <remap from="~/input/steer" to="/vehicle/status/steering_status"/>


### PR DESCRIPTION
## Description

use `output="both"` in launch instead of `output="screen"` to track the log not only in the terminal but also in the log file.

The command to modify the files:
```bash
sed -i 's/output="screen"/output="both"/g' "$file"
```

## Related links


TIER IV's internal link: https://star4.slack.com/archives/C4P0NSMB5/p1723112515306229

## How was this PR tested?

simple planning simulator worked.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
