### PR TITLE
feat(simulator): use output=both in launch instead of output=screen

### DIFF
--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -14,7 +14,7 @@
     <arg name="max_real_delta_seconds" default="0.05"/>
 
     <!-- CARLA Interface -->
-    <node pkg="autoware_carla_interface" exec="autoware_carla_interface" name="autoware_carla_interface" output="screen">
+    <node pkg="autoware_carla_interface" exec="autoware_carla_interface" name="autoware_carla_interface" output="both">
       <param name="host" value="$(var host)"/>
       <param name="port" value="$(var port)"/>
       <param name="timeout" value="$(var timeout)"/>
@@ -35,7 +35,7 @@
     <arg name="output_actuation_cmd" default="/control/command/actuation_cmd"/>
     <arg name="config_file" default="$(find-pkg-share autoware_carla_interface)/raw_vehicle_cmd_converter.param.yaml"/>
 
-    <node pkg="autoware_raw_vehicle_cmd_converter" exec="autoware_raw_vehicle_cmd_converter_node" name="autoware_raw_vehicle_cmd_converter" output="screen">
+    <node pkg="autoware_raw_vehicle_cmd_converter" exec="autoware_raw_vehicle_cmd_converter_node" name="autoware_raw_vehicle_cmd_converter" output="both">
       <param from="$(var config_file)" allow_substs="true"/>
       <remap from="~/input/control_cmd" to="$(var input_control_cmd)"/>
       <remap from="~/input/odometry" to="$(var input_odometry)"/>

--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -9,7 +9,7 @@
   <group>
     <push-ros-namespace namespace="simulation"/>
     <group if="$(var real)">
-      <node pkg="dummy_perception_publisher" exec="dummy_perception_publisher_node" name="dummy_perception_publisher" output="screen">
+      <node pkg="dummy_perception_publisher" exec="dummy_perception_publisher_node" name="dummy_perception_publisher" output="both">
         <remap from="output/dynamic_object" to="/perception/object_recognition/detection/labeled_clusters"/>
         <remap from="output/objects_pose" to="debug/object_pose"/>
         <remap from="output/points_raw" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -30,7 +30,7 @@
       </include>
     </group>
     <group unless="$(var real)">
-      <node pkg="dummy_perception_publisher" exec="dummy_perception_publisher_node" name="dummy_perception_publisher" output="screen">
+      <node pkg="dummy_perception_publisher" exec="dummy_perception_publisher_node" name="dummy_perception_publisher" output="both">
         <remap from="output/dynamic_object" to="/perception/object_recognition/detection/objects_with_feature"/>
         <remap from="output/objects_pose" to="debug/object_pose"/>
         <remap from="output/points_raw" to="/perception/obstacle_segmentation/pointcloud"/>

--- a/simulator/fault_injection/launch/fault_injection.launch.xml
+++ b/simulator/fault_injection/launch/fault_injection.launch.xml
@@ -3,7 +3,7 @@
   <arg name="config_file" default="$(find-pkg-share fault_injection)/config/fault_injection.param.yaml"/>
   <arg name="log-level" default="info"/>
 
-  <node pkg="fault_injection" exec="fault_injection_node" name="fault_injection" output="screen" args="--ros-args --log-level fault_injection:=$(var log-level)">
+  <node pkg="fault_injection" exec="fault_injection_node" name="fault_injection" output="both" args="--ros-args --log-level fault_injection:=$(var log-level)">
     <remap from="~/input/simulation_events" to="$(var input/simulation_events)"/>
     <param from="$(var config_file)"/>
   </node>

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -91,7 +91,7 @@ def launch_setup(context, *args, **kwargs):
         executable="simple_planning_simulator_exe",
         name="simple_planning_simulator",
         namespace="simulation",
-        output="screen",
+        output="both",
         parameters=[
             vehicle_info_param,
             vehicle_characteristics_param,


### PR DESCRIPTION
## Description

use `output="both"` in launch instead of `output="screen"` to track the log not only in the terminal but also in the log file.

The command to modify the files:
```bash
sed -i 's/output="screen"/output="both"/g' "$file"
```

## Related links


TIER IV's internal link: https://star4.slack.com/archives/C4P0NSMB5/p1723112515306229

## How was this PR tested?

simple planning simulator worked.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
