### PR TITLE
feat(autoware_universe_utils): add thread_id check to time_keeper

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace autoware::universe_utils
@@ -169,6 +170,7 @@ private:
   std::shared_ptr<ProcessingTimeNode>
     current_time_node_;                            //!< Shared pointer to the current time node
   std::shared_ptr<ProcessingTimeNode> root_node_;  //!< Shared pointer to the root time node
+  std::thread::id root_node_thread_id_;            //!< ID of the thread that started the tracking
   autoware::universe_utils::StopWatch<
     std::chrono::milliseconds, std::chrono::microseconds, std::chrono::steady_clock>
     stop_watch_;  //!< StopWatch object for tracking the processing time

--- a/common/autoware_universe_utils/src/system/time_keeper.cpp
+++ b/common/autoware_universe_utils/src/system/time_keeper.cpp
@@ -14,6 +14,9 @@
 
 #include "autoware/universe_utils/system/time_keeper.hpp"
 
+#include <rclcpp/logging.hpp>
+#include <rclcpp/rclcpp.hpp>
+
 #include <fmt/format.h>
 
 #include <stdexcept>
@@ -129,7 +132,14 @@ void TimeKeeper::start_track(const std::string & func_name)
   if (current_time_node_ == nullptr) {
     current_time_node_ = std::make_shared<ProcessingTimeNode>(func_name);
     root_node_ = current_time_node_;
+    root_node_thread_id_ = std::this_thread::get_id();
   } else {
+    if (root_node_thread_id_ != std::this_thread::get_id()) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("TimeKeeper"),
+        "TimeKeeper::start_track() is called from a different thread. Ignoring the call.");
+      return;
+    }
     current_time_node_ = current_time_node_->add_child(func_name);
   }
   stop_watch_.tic(func_name);
@@ -145,6 +155,9 @@ void TimeKeeper::comment(const std::string & comment)
 
 void TimeKeeper::end_track(const std::string & func_name)
 {
+  if (root_node_thread_id_ != std::this_thread::get_id()) {
+    return;
+  }
   if (current_time_node_->get_name() != func_name) {
     throw std::runtime_error(fmt::format(
       "You must call end_track({}) first, but end_track({}) is called",
@@ -178,7 +191,7 @@ ScopedTimeTrack::ScopedTimeTrack(const std::string & func_name, TimeKeeper & tim
   time_keeper_.start_track(func_name_);
 }
 
-ScopedTimeTrack::~ScopedTimeTrack()
+ScopedTimeTrack::~ScopedTimeTrack()  // NOLINT
 {
   time_keeper_.end_track(func_name_);
 }

--- a/common/autoware_universe_utils/test/src/system/test_time_keeper.cpp
+++ b/common/autoware_universe_utils/test/src/system/test_time_keeper.cpp
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #include "autoware/universe_utils/system/time_keeper.hpp"
 
 #include <rclcpp/node.hpp>
@@ -20,34 +19,74 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <iostream>
+#include <sstream>
 #include <thread>
 
-TEST(system, TimeKeeper)
+class TimeKeeperTest : public ::testing::Test
+{
+protected:
+  std::ostringstream oss;
+  rclcpp::Node::SharedPtr node;
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr publisher;
+  std::unique_ptr<autoware::universe_utils::TimeKeeper> time_keeper;
+
+  void SetUp() override
+  {
+    node = std::make_shared<rclcpp::Node>("test_node");
+    publisher = node->create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+      "~/debug/processing_time_tree", 1);
+    time_keeper = std::make_unique<autoware::universe_utils::TimeKeeper>(&oss, publisher);
+  }
+};
+
+TEST_F(TimeKeeperTest, BasicFunctionality)
 {
   using autoware::universe_utils::ScopedTimeTrack;
-  using autoware::universe_utils::TimeKeeper;
 
-  rclcpp::Node node{"sample_node"};
+  {
+    ScopedTimeTrack st{"main_func", *time_keeper};
 
-  auto publisher = node.create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
-    "~/debug/processing_time_tree", 1);
+    {  // funcA
+      ScopedTimeTrack st{"funcA", *time_keeper};
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
 
-  TimeKeeper time_keeper(&std::cerr, publisher);
-
-  ScopedTimeTrack st{"main_func", time_keeper};
-
-  {  // funcA
-    ScopedTimeTrack st{"funcA", time_keeper};
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-  }
-
-  {  // funcB
-    ScopedTimeTrack st{"funcB", time_keeper};
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    {  // funcC
-      ScopedTimeTrack st{"funcC", time_keeper};
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+    {  // funcB
+      ScopedTimeTrack st{"funcB", *time_keeper};
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      {  // funcC
+        ScopedTimeTrack st{"funcC", *time_keeper};
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
     }
   }
+
+  // Check if the output contains all function names
+  std::string output = oss.str();
+  EXPECT_TRUE(output.find("main_func") != std::string::npos);
+  EXPECT_TRUE(output.find("funcA") != std::string::npos);
+  EXPECT_TRUE(output.find("funcB") != std::string::npos);
+  EXPECT_TRUE(output.find("funcC") != std::string::npos);
+}
+
+TEST_F(TimeKeeperTest, MultiThreadWarning)
+{
+  testing::internal::CaptureStderr();
+
+  std::thread t([this]() {
+    time_keeper->start_track("ThreadFunction");
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    time_keeper->end_track("ThreadFunction");
+  });
+
+  time_keeper->start_track("MainFunction");
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  time_keeper->end_track("MainFunction");
+
+  t.join();
+
+  std::string err = testing::internal::GetCapturedStderr();
+  EXPECT_TRUE(
+    err.find("TimeKeeper::start_track() is called from a different thread. Ignoring the call.") !=
+    std::string::npos);
 }


### PR DESCRIPTION
## Description

In the current implementation, if we use time_keeper in different threads, it may cause an error and lead to termination.

In this PR, we check the thread_id before creating the ProcessingTimeNode, and if the thread_id does not match the root node, we discard creating downstream of the node.

## Related links

- [TIER IV Internal Slack](https://star4.slack.com/archives/C04ATE0264Q/p1724647801437319)

## How was this PR tested?

By unit testing.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
