### PR TITLE
feat(simple_planning_simulator): print actual and expected value in test

### DIFF
--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -221,6 +221,7 @@ void isOnForward(const Odometry & state, const Odometry & init)
 {
   double forward_thr = 1.0;
   double dx = state.pose.pose.position.x - init.pose.pose.position.x;
+  std::cout << "isOnForward: dx: " << dx << ", forward_thr: " << forward_thr << std::endl;
   EXPECT_GT(dx, forward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
 
@@ -228,6 +229,7 @@ void isOnBackward(const Odometry & state, const Odometry & init)
 {
   double backward_thr = -1.0;
   double dx = state.pose.pose.position.x - init.pose.pose.position.x;
+  std::cout << "isOnBackward: dx: " << dx << ", backward_thr: " << backward_thr << std::endl;
   EXPECT_LT(dx, backward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
 
@@ -237,6 +239,8 @@ void isOnForwardLeft(const Odometry & state, const Odometry & init)
   double left_thr = 0.1f;
   double dx = state.pose.pose.position.x - init.pose.pose.position.x;
   double dy = state.pose.pose.position.y - init.pose.pose.position.y;
+  std::cout << "isOnForwardLeft: dx: " << dx << ", forward_thr: " << forward_thr << ", dy: " << dy
+            << ", left_thr: " << left_thr << std::endl;
   EXPECT_GT(dx, forward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
   EXPECT_GT(dy, left_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
@@ -247,6 +251,8 @@ void isOnBackwardRight(const Odometry & state, const Odometry & init)
   double right_thr = -0.1;
   double dx = state.pose.pose.position.x - init.pose.pose.position.x;
   double dy = state.pose.pose.position.y - init.pose.pose.position.y;
+  std::cout << "isOnBackwardRight: dx: " << dx << ", backward_thr: " << backward_thr
+            << ", dy: " << dy << ", right_thr: " << right_thr << std::endl;
   EXPECT_LT(dx, backward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
   EXPECT_LT(dy, right_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
@@ -302,7 +308,6 @@ TEST_P(TestSimplePlanningSimulator, TestIdealSteerVel)
   const auto common_params = get_common_params(params);
   const auto command_type = common_params.first;
   const auto vehicle_model_type = common_params.second;
-  std::cout << "\n\n vehicle model = " << vehicle_model_type << std::endl << std::endl;
   // optional parameters
   std::optional<std::string> conversion_type{};  // for ActuationCmdParamType
 
@@ -338,7 +343,12 @@ TEST_P(TestSimplePlanningSimulator, TestIdealSteerVel)
   node_options.append_parameter_override("vgr_coef_b", 0.053);
   node_options.append_parameter_override("vgr_coef_c", 0.042);
   if (conversion_type.has_value()) {
+    std::cout << "\n\n vehicle model = " << vehicle_model_type
+              << ", conversion_type = " << conversion_type.value() << std::endl
+              << std::endl;
     node_options.append_parameter_override("convert_steer_cmd_method", conversion_type.value());
+  } else {
+    std::cout << "\n\n vehicle model = " << vehicle_model_type << std::endl << std::endl;
   }
 
   declareVehicleInfoParams(node_options);


### PR DESCRIPTION
## Description

just add print values in test.

```
1:  vehicle model = ACTUATION_CMD, conversion_type = steer_map
1:
1: isOnForward: dx: 3.68665, forward_thr: 1
1: isOnBackward: dx: -5.6944, backward_thr: -1
1: isOnForwardLeft: dx: 1.50116, forward_thr: 1, dy: 3.5285, left_thr: 0.1
1: isOnBackwardRight: dx: -3.79643, backward_thr: -1, dy: -2.40294, right_thr: -0.1
1: [       OK ] TestForEachVehicleModelTrue/TestSimplePlanningSimulator.TestIdealSteerVel/1 (7615 ms)
1: [ RUN      ] TestForEachVehicleModelTrue/TestSimplePlanningSimulator.TestIdealSteerVel/2
1:
```

currently, actual and expected values are printed only when tests fail.
It is hard to debug by comparing the success and failure cases.

ex) In follwing test only `-cuda` option failed, but we could not compare the one without `-cuda`
https://github.com/autowarefoundation/autoware.universe/pull/8088
https://github.com/autowarefoundation/autoware.universe/actions/runs/10487288486/job/29047329337?pr=8088




## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
