### PR TITLE
fix(out_of_lane): fix noConstructor cppcheck warning

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -30,6 +30,7 @@
 #include <lanelet2_core/LaneletMap.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,13 @@ namespace autoware::motion_velocity_planner
 class OutOfLaneModule : public PluginModuleInterface
 {
 public:
+  OutOfLaneModule()
+  : params_(),
+    module_name_("unitialized"),
+    previous_slowdown_pose_(std::nullopt),
+    previous_slowdown_time_(0)
+  {
+  }
   void init(rclcpp::Node & node, const std::string & module_name) override;
   void update_parameters(const std::vector<rclcpp::Parameter> & parameters) override;
   VelocityPlanningResult plan(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -39,13 +39,6 @@ namespace autoware::motion_velocity_planner
 class OutOfLaneModule : public PluginModuleInterface
 {
 public:
-  OutOfLaneModule()
-  : params_(),
-    module_name_("unitialized"),
-    previous_slowdown_pose_(std::nullopt),
-    previous_slowdown_time_(0)
-  {
-  }
   void init(rclcpp::Node & node, const std::string & module_name) override;
   void update_parameters(const std::vector<rclcpp::Parameter> & parameters) override;
   VelocityPlanningResult plan(
@@ -66,17 +59,17 @@ private:
     out_of_lane::EgoData & ego_data, const PlannerData & planner_data,
     std::optional<geometry_msgs::msg::Pose> & previous_slowdown_pose_, const double slow_velocity);
 
-  out_of_lane::PlannerParam params_;
+  out_of_lane::PlannerParam params_{};
 
   inline static const std::string ns_ = "out_of_lane";
-  std::string module_name_;
-  rclcpp::Clock::SharedPtr clock_;
-  std::optional<geometry_msgs::msg::Pose> previous_slowdown_pose_;
-  rclcpp::Time previous_slowdown_time_;
+  std::string module_name_{"unitialized"};
+  rclcpp::Clock::SharedPtr clock_{nullptr};
+  std::optional<geometry_msgs::msg::Pose> previous_slowdown_pose_{std::nullopt};
+  rclcpp::Time previous_slowdown_time_{0};
 
 protected:
   // Debug
-  mutable out_of_lane::DebugData debug_data_;
+  mutable out_of_lane::DebugData debug_data_{};
 };
 }  // namespace autoware::motion_velocity_planner
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -62,7 +62,7 @@ private:
   out_of_lane::PlannerParam params_{};
 
   inline static const std::string ns_ = "out_of_lane";
-  std::string module_name_{"unitialized"};
+  std::string module_name_{"uninitialized"};
   rclcpp::Clock::SharedPtr clock_{nullptr};
   std::optional<geometry_msgs::msg::Pose> previous_slowdown_pose_{std::nullopt};
   rclcpp::Time previous_slowdown_time_{0};


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
