### PR TITLE
fix(tier4_localization_rviz_plugin): fix unusedFunction

### DIFF
--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
@@ -50,11 +50,13 @@ void PoseHistory::onInitialize()
   lines_ = std::make_unique<rviz_rendering::BillboardLine>(scene_manager_, scene_node_);
 }
 
+// cppcheck-suppress unusedFunction
 void PoseHistory::onEnable()
 {
   subscribe();
 }
 
+// cppcheck-suppress unusedFunction
 void PoseHistory::onDisable()
 {
   unsubscribe();


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp:53:0: style: The function 'onEnable' is never used. [unusedFunction]
void PoseHistory::onEnable()
^

common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp:58:0: style: The function 'onDisable' is never used. [unusedFunction]
void PoseHistory::onDisable()
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
