### PR TITLE
fix(autoware_costmap_generator): fix unusedFunction

### DIFF
--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/object_map_utils.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/object_map_utils.hpp
@@ -53,29 +53,6 @@
 namespace object_map
 {
 /*!
- * Publishes in_gridmap using the specified in_publisher
- * @param[in] in_gridmap GridMap object to publish
- * @param[in] in_publisher Valid Publisher object to use
- */
-void PublishGridMap(
-  const grid_map::GridMap & in_gridmap,
-  const rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr in_publisher);
-
-/*!
- * Convert and publishes a GridMap layer to a standard Ros OccupancyGrid
- * @param[in] in_gridmap GridMap object to extract the layer
- * @param[in] in_publisher ROS Publisher to use to publish the occupancy grid
- * @param[in] in_layer Name of the layer to convert
- * @param[in] in_min_value Minimum value in the layer
- * @param[in] in_max_value Maximum value in the layer
- */
-
-void PublishOccupancyGrid(
-  const grid_map::GridMap & in_gridmap,
-  const rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr in_publisher,
-  const std::string & in_layer, double in_min_value, double in_max_value, double in_height);
-
-/*!
  * Projects the in_area_points forming the road, stores the result in out_grid_map.
  * @param[out] out_grid_map GridMap object to add the road grid
  * @param[in] in_points Array of points containing the selected primitives

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/object_map_utils.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/object_map_utils.cpp
@@ -37,25 +37,6 @@
 
 namespace object_map
 {
-void PublishGridMap(
-  const grid_map::GridMap & in_gridmap,
-  const rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr in_publisher)
-{
-  auto message = grid_map::GridMapRosConverter::toMessage(in_gridmap);
-  in_publisher->publish(*message);
-}
-
-void PublishOccupancyGrid(
-  const grid_map::GridMap & in_gridmap,
-  const rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr in_publisher,
-  const std::string & in_layer, double in_min_value, double in_max_value, double in_height)
-{
-  nav_msgs::msg::OccupancyGrid message;
-  grid_map::GridMapRosConverter::toOccupancyGrid(
-    in_gridmap, in_layer, in_min_value, in_max_value, message);
-  message.info.origin.position.z = in_height;
-  in_publisher->publish(message);
-}
 
 void FillPolygonAreas(
   grid_map::GridMap & out_grid_map,


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/autoware_costmap_generator/nodes/autoware_costmap_generator/object_map_utils.cpp:40:0: style: The function 'PublishGridMap' is never used. [unusedFunction]
void PublishGridMap(
^

planning/autoware_costmap_generator/nodes/autoware_costmap_generator/object_map_utils.cpp:48:0: style: The function 'PublishOccupancyGrid' is never used. [unusedFunction]
void PublishOccupancyGrid(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
