### PR TITLE
fix(autoware_mission_planner): fix unusedFunction

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/arrival_checker.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/arrival_checker.cpp
@@ -43,17 +43,6 @@ void ArrivalChecker::set_goal(const PoseWithUuidStamped & goal)
   goal_with_uuid_ = goal;
 }
 
-void ArrivalChecker::modify_goal(const PoseWithUuidStamped & modified_goal)
-{
-  if (!goal_with_uuid_) {
-    return;
-  }
-  if (goal_with_uuid_.value().uuid.uuid != modified_goal.uuid.uuid) {
-    return;
-  }
-  set_goal(modified_goal);
-}
-
 bool ArrivalChecker::is_arrived(const PoseStamped & pose) const
 {
   if (!goal_with_uuid_) {

--- a/planning/autoware_mission_planner/src/mission_planner/arrival_checker.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/arrival_checker.hpp
@@ -33,7 +33,6 @@ public:
   explicit ArrivalChecker(rclcpp::Node * node);
   void set_goal();
   void set_goal(const PoseWithUuidStamped & goal);
-  void modify_goal(const PoseWithUuidStamped & modified_goal);
   bool is_arrived(const PoseStamped & pose) const;
 
 private:


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/autoware_mission_planner/src/mission_planner/arrival_checker.cpp:46:0: style: The function 'modify_goal' is never used. [unusedFunction]
void ArrivalChecker::modify_goal(const PoseWithUuidStamped & modified_goal)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
