### PR TITLE
fix(autoware_planning_validator): fix unusedFunction

### DIFF
--- a/planning/autoware_planning_validator/include/autoware/planning_validator/utils.hpp
+++ b/planning/autoware_planning_validator/include/autoware/planning_validator/utils.hpp
@@ -28,10 +28,6 @@ namespace autoware::planning_validator
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 
-std::pair<double, size_t> getMaxValAndIdx(const std::vector<double> & v);
-
-std::pair<double, size_t> getMinValAndIdx(const std::vector<double> & v);
-
 std::pair<double, size_t> getAbsMaxValAndIdx(const std::vector<double> & v);
 
 Trajectory resampleTrajectory(const Trajectory & trajectory, const double min_interval);

--- a/planning/autoware_planning_validator/src/utils.cpp
+++ b/planning/autoware_planning_validator/src/utils.cpp
@@ -46,20 +46,6 @@ void takeSmaller(double & v_min, size_t & i_min, double v, size_t i)
 }
 }  // namespace
 
-std::pair<double, size_t> getMaxValAndIdx(const std::vector<double> & v)
-{
-  const auto iter = std::max_element(v.begin(), v.end());
-  const auto idx = std::distance(v.begin(), iter);
-  return {*iter, idx};
-}
-
-std::pair<double, size_t> getMinValAndIdx(const std::vector<double> & v)
-{
-  const auto iter = std::min_element(v.begin(), v.end());
-  const auto idx = std::distance(v.begin(), iter);
-  return {*iter, idx};
-}
-
 std::pair<double, size_t> getAbsMaxValAndIdx(const std::vector<double> & v)
 {
   const auto iter = std::max_element(


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/autoware_planning_validator/src/utils.cpp:49:0: style: The function 'getMaxValAndIdx' is never used. [unusedFunction]
std::pair<double, size_t> getMaxValAndIdx(const std::vector<double> & v)
^

planning/autoware_planning_validator/src/utils.cpp:56:0: style: The function 'getMinValAndIdx' is never used. [unusedFunction]
std::pair<double, size_t> getMinValAndIdx(const std::vector<double> & v)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
