### PR TITLE
fix(autoware_behavior_path_planner_common): fix unusedFunction

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -67,11 +67,6 @@ void clipPathLength(
 void clipPathLength(
   PathWithLaneId & path, const size_t target_idx, const BehaviorPathPlannerParameters & params);
 
-std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
-  const lanelet::ConstLanelets & current_lanes, const ShiftedPath & path,
-  const ShiftLine & shift_line, const Pose & pose, const double & velocity,
-  const BehaviorPathPlannerParameters & common_parameter);
-
 PathWithLaneId convertWayPointsToPathWithLaneId(
   const autoware::freespace_planning_algorithms::PlannerWaypoints & waypoints,
   const double velocity, const lanelet::ConstLanelets & lanelets);
@@ -82,8 +77,6 @@ std::vector<PathWithLaneId> dividePath(
   const PathWithLaneId & path, const std::vector<size_t> & indices);
 
 void correctDividedPathVelocity(std::vector<PathWithLaneId> & divided_paths);
-
-bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double distance_threshold);
 
 // only two points is supported
 std::vector<double> splineTwoPoints(
@@ -102,8 +95,6 @@ PathWithLaneId calcCenterLinePath(
   const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
 
 PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
-
-std::optional<Pose> getFirstStopPoseFromPath(const PathWithLaneId & path);
 
 BehaviorModuleOutput getReferencePath(
   const lanelet::ConstLanelet & current_lane,

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/utils.hpp
@@ -104,8 +104,6 @@ FrenetPoint convertToFrenetPoint(
   return frenet_point;
 }
 
-std::vector<lanelet::Id> getIds(const lanelet::ConstLanelets & lanelets);
-
 // distance (arclength) calculation
 
 double l2Norm(const Vector3 vector);
@@ -125,14 +123,6 @@ double getSignedDistance(
 double getArcLengthToTargetLanelet(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelet & target_lane,
   const Pose & pose);
-
-double getDistanceBetweenPredictedPaths(
-  const PredictedPath & path1, const PredictedPath & path2, const double start_time,
-  const double end_time, const double resolution);
-
-double getDistanceBetweenPredictedPathAndObject(
-  const PredictedObject & object, const PredictedPath & path, const double start_time,
-  const double end_time, const double resolution);
 
 /**
  * @brief Check collision between ego path footprints with extra longitudinal stopping margin and
@@ -223,8 +213,6 @@ PathWithLaneId refinePathForGoal(
   const double search_radius_range, const double search_rad_range, const PathWithLaneId & input,
   const Pose & goal, const int64_t goal_lane_id);
 
-bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal_id);
-
 bool isAllowedGoalModification(const std::shared_ptr<RouteHandler> & route_handler);
 bool checkOriginalGoalIsInShoulder(const std::shared_ptr<RouteHandler> & route_handler);
 
@@ -269,10 +257,6 @@ Polygon2d toPolygon2d(const lanelet::ConstLanelet & lanelet);
 
 Polygon2d toPolygon2d(const lanelet::BasicPolygon2d & polygon);
 
-std::vector<Polygon2d> getTargetLaneletPolygons(
-  const lanelet::ConstLanelets & lanelets, const Pose & pose, const double check_length,
-  const std::string & target_type);
-
 PathWithLaneId getCenterLinePathFromLanelet(
   const lanelet::ConstLanelet & current_route_lanelet,
   const std::shared_ptr<const PlannerData> & planner_data);
@@ -282,11 +266,6 @@ PathWithLaneId getCenterLinePath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
   const Pose & pose, const double backward_path_length, const double forward_path_length,
   const BehaviorPathPlannerParameters & parameter);
-
-PathWithLaneId setDecelerationVelocity(
-  const RouteHandler & route_handler, const PathWithLaneId & input,
-  const lanelet::ConstLanelets & lanelet_sequence, const double lane_change_prepare_duration,
-  const double lane_change_buffer);
 
 // object label
 std::uint8_t getHighestProbLabel(const std::vector<ObjectClassification> & classification);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
@@ -341,6 +341,7 @@ MarkerArray createObjectsMarkerArray(
   return msg;
 }
 
+// cppcheck-suppress unusedFunction
 MarkerArray createDrivableLanesMarkerArray(
   const std::vector<DrivableLanes> & drivable_lanes, std::string && ns)
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -622,20 +622,6 @@ std::vector<Point> updateBoundary(
   return updated_bound;
 }
 
-[[maybe_unused]] geometry_msgs::msg::Point calcCenterOfGeometry(const Polygon2d & obj_poly)
-{
-  geometry_msgs::msg::Point center_pos;
-  for (const auto & point : obj_poly.outer()) {
-    center_pos.x += point.x();
-    center_pos.y += point.y();
-  }
-
-  center_pos.x = center_pos.x / obj_poly.outer().size();
-  center_pos.y = center_pos.y / obj_poly.outer().size();
-  center_pos.z = center_pos.z / obj_poly.outer().size();
-
-  return center_pos;
-}
 }  // namespace autoware::behavior_path_planner::utils::drivable_area_processing
 
 namespace autoware::behavior_path_planner::utils

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
@@ -104,16 +104,6 @@ void initializeCollisionCheckDebugMap(CollisionCheckDebugMap & collision_check_d
   collision_check_debug_map.clear();
 }
 
-void updateSafetyCheckTargetObjectsData(
-  StartGoalPlannerData & data, const PredictedObjects & filtered_objects,
-  const TargetObjectsOnLane & target_objects_on_lane,
-  const std::vector<PoseWithVelocityStamped> & ego_predicted_path)
-{
-  data.filtered_objects = filtered_objects;
-  data.target_objects_on_lane = target_objects_on_lane;
-  data.ego_predicted_path = ego_predicted_path;
-}
-
 std::pair<double, double> getPairsTerminalVelocityAndAccel(
   const std::vector<std::pair<double, double>> & pairs_terminal_velocity_and_accel,
   const size_t current_path_idx)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -99,53 +99,7 @@ double l2Norm(const Vector3 vector)
   return std::sqrt(std::pow(vector.x, 2) + std::pow(vector.y, 2) + std::pow(vector.z, 2));
 }
 
-double getDistanceBetweenPredictedPaths(
-  const PredictedPath & object_path, const PredictedPath & ego_path, const double start_time,
-  const double end_time, const double resolution)
-{
-  double min_distance = std::numeric_limits<double>::max();
-  for (double t = start_time; t < end_time; t += resolution) {
-    const auto object_pose = object_recognition_utils::calcInterpolatedPose(object_path, t);
-    if (!object_pose) {
-      continue;
-    }
-    const auto ego_pose = object_recognition_utils::calcInterpolatedPose(ego_path, t);
-    if (!ego_pose) {
-      continue;
-    }
-    double distance = autoware::universe_utils::calcDistance3d(*object_pose, *ego_pose);
-    if (distance < min_distance) {
-      min_distance = distance;
-    }
-  }
-  return min_distance;
-}
-
-double getDistanceBetweenPredictedPathAndObject(
-  const PredictedObject & object, const PredictedPath & ego_path, const double start_time,
-  const double end_time, const double resolution)
-{
-  auto clock{rclcpp::Clock{RCL_ROS_TIME}};
-  auto t_delta{rclcpp::Duration::from_seconds(resolution)};
-  double min_distance = std::numeric_limits<double>::max();
-  rclcpp::Time ros_start_time = clock.now() + rclcpp::Duration::from_seconds(start_time);
-  rclcpp::Time ros_end_time = clock.now() + rclcpp::Duration::from_seconds(end_time);
-  const auto obj_polygon = autoware::universe_utils::toPolygon2d(object);
-  for (double t = start_time; t < end_time; t += resolution) {
-    const auto ego_pose = object_recognition_utils::calcInterpolatedPose(ego_path, t);
-    if (!ego_pose) {
-      continue;
-    }
-    Point2d ego_point{ego_pose->position.x, ego_pose->position.y};
-
-    double distance = boost::geometry::distance(obj_polygon, ego_point);
-    if (distance < min_distance) {
-      min_distance = distance;
-    }
-  }
-  return min_distance;
-}
-
+// cppcheck-suppress unusedFunction
 bool checkCollisionBetweenPathFootprintsAndObjects(
   const autoware::universe_utils::LinearRing2d & local_vehicle_footprint,
   const PathWithLaneId & ego_path, const PredictedObjects & dynamic_objects, const double margin)
@@ -247,24 +201,6 @@ double calcLongitudinalDistanceFromEgoToObjects(
       calcLongitudinalDistanceFromEgoToObject(ego_pose, base_link2front, base_link2rear, object));
   }
   return min_distance;
-}
-
-std::vector<double> calcObjectsDistanceToPath(
-  const PredictedObjects & objects, const PathWithLaneId & ego_path)
-{
-  std::vector<double> distance_array;
-  for (const auto & obj : objects.objects) {
-    const auto obj_polygon = autoware::universe_utils::toPolygon2d(obj);
-    LineString2d ego_path_line;
-    ego_path_line.reserve(ego_path.points.size());
-    for (const auto & p : ego_path.points) {
-      boost::geometry::append(
-        ego_path_line, Point2d(p.point.pose.position.x, p.point.pose.position.y));
-    }
-    const double distance = boost::geometry::distance(obj_polygon, ego_path_line);
-    distance_array.push_back(distance);
-  }
-  return distance_array;
 }
 
 template <typename T>
@@ -455,16 +391,6 @@ PathWithLaneId refinePathForGoal(
   } else {
     return filtered_path;
   }
-}
-
-bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal_id)
-{
-  for (const auto & lane : lanes) {
-    if (lane.id() == goal_id) {
-      return true;
-    }
-  }
-  return false;
 }
 
 bool isInLanelets(const Pose & pose, const lanelet::ConstLanelets & lanes)
@@ -771,16 +697,6 @@ double getSignedDistance(
   return arc_goal.length - arc_current.length;
 }
 
-std::vector<lanelet::Id> getIds(const lanelet::ConstLanelets & lanelets)
-{
-  std::vector<lanelet::Id> ids;
-  ids.reserve(lanelets.size());
-  for (const auto & llt : lanelets) {
-    ids.push_back(llt.id());
-  }
-  return ids;
-}
-
 PathPointWithLaneId insertStopPoint(const double length, PathWithLaneId & path)
 {
   const size_t original_size = path.points.size();
@@ -1034,50 +950,6 @@ Polygon2d toPolygon2d(const lanelet::BasicPolygon2d & polygon)
            : autoware::universe_utils::inverseClockwise(ret);
 }
 
-std::vector<Polygon2d> getTargetLaneletPolygons(
-  const lanelet::PolygonLayer & map_polygons, lanelet::ConstLanelets & lanelets, const Pose & pose,
-  const double check_length, const std::string & target_type)
-{
-  std::vector<Polygon2d> polygons;
-
-  // create lanelet polygon
-  const auto arclength = lanelet::utils::getArcCoordinates(lanelets, pose);
-  const auto llt_polygon = lanelet::utils::getPolygonFromArcLength(
-    lanelets, arclength.length, arclength.length + check_length);
-  const auto llt_polygon_2d = lanelet::utils::to2D(llt_polygon).basicPolygon();
-
-  // If the number of vertices is not enough to create polygon, return empty polygon container
-  if (llt_polygon_2d.size() < 3) {
-    return polygons;
-  }
-
-  Polygon2d llt_polygon_bg;
-  llt_polygon_bg.outer().reserve(llt_polygon_2d.size() + 1);
-  for (const auto & llt_pt : llt_polygon_2d) {
-    llt_polygon_bg.outer().emplace_back(llt_pt.x(), llt_pt.y());
-  }
-  llt_polygon_bg.outer().push_back(llt_polygon_bg.outer().front());
-
-  for (const auto & map_polygon : map_polygons) {
-    const std::string type = map_polygon.attributeOr(lanelet::AttributeName::Type, "");
-    // If the target_type is different
-    // or the number of vertices is not enough to create polygon, skip the loop
-    if (type == target_type && map_polygon.size() > 2) {
-      // create map polygon
-      Polygon2d map_polygon_bg;
-      map_polygon_bg.outer().reserve(map_polygon.size() + 1);
-      for (const auto & pt : map_polygon) {
-        map_polygon_bg.outer().emplace_back(pt.x(), pt.y());
-      }
-      map_polygon_bg.outer().push_back(map_polygon_bg.outer().front());
-      if (boost::geometry::intersects(llt_polygon_bg, map_polygon_bg)) {
-        polygons.push_back(map_polygon_bg);
-      }
-    }
-  }
-  return polygons;
-}
-
 // TODO(Horibe) There is a similar function in route_handler.
 std::shared_ptr<PathWithLaneId> generateCenterLinePath(
   const std::shared_ptr<const PlannerData> & planner_data)
@@ -1172,31 +1044,9 @@ PathWithLaneId getCenterLinePath(
   return resampled_path_with_lane_id;
 }
 
-// for lane following
-PathWithLaneId setDecelerationVelocity(
-  const RouteHandler & route_handler, const PathWithLaneId & input,
-  const lanelet::ConstLanelets & lanelet_sequence, const double lane_change_prepare_duration,
-  const double lane_change_buffer)
-{
-  auto reference_path = input;
-  if (
-    route_handler.isDeadEndLanelet(lanelet_sequence.back()) &&
-    lane_change_prepare_duration > std::numeric_limits<double>::epsilon()) {
-    for (auto & point : reference_path.points) {
-      const double lane_length = lanelet::utils::getLaneletLength2d(lanelet_sequence);
-      const auto arclength = lanelet::utils::getArcCoordinates(lanelet_sequence, point.point.pose);
-      const double distance_to_end =
-        std::max(0.0, lane_length - std::abs(lane_change_buffer) - arclength.length);
-      point.point.longitudinal_velocity_mps = std::min(
-        point.point.longitudinal_velocity_mps,
-        static_cast<float>(distance_to_end / lane_change_prepare_duration));
-    }
-  }
-  return reference_path;
-}
-
 // TODO(murooka) remove calcSignedArcLength using findNearestSegmentIndex inside the
 // function
+// cppcheck-suppress unusedFunction
 PathWithLaneId setDecelerationVelocity(
   const PathWithLaneId & input, const double target_velocity, const Pose target_pose,
   const double buffer, const double deceleration_interval)
@@ -1643,6 +1493,7 @@ lanelet::ConstLanelets getLaneletsFromPath(
   return lanelets;
 }
 
+// cppcheck-suppress unusedFunction
 std::string convertToSnakeCase(const std::string & input_str)
 {
   std::string output_str = std::string{static_cast<char>(std::tolower(input_str.at(0)))};


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp:344:0: style: The function 'createDrivableLanesMarkerArray' is never used. [unusedFunction]
MarkerArray createDrivableLanesMarkerArray(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:625:0: style: The function 'calcCenterOfGeometry' is never used. [unusedFunction]
[[maybe_unused]] geometry_msgs::msg::Point calcCenterOfGeometry(const Polygon2d & obj_poly)
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp:107:0: style: The function 'updateSafetyCheckTargetObjectsData' is never used. [unusedFunction]
void updateSafetyCheckTargetObjectsData(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:212:0: style: The function 'getPathTurnSignal' is never used. [unusedFunction]
std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:434:0: style: The function 'isCloseToPath' is never used. [unusedFunction]
bool isCloseToPath(const PathWithLaneId & path, const Pose & pose, const double distance_threshold)
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp:582:0: style: The function 'getFirstStopPoseFromPath' is never used. [unusedFunction]
std::optional<Pose> getFirstStopPoseFromPath(const PathWithLaneId & path)
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:102:0: style: The function 'getDistanceBetweenPredictedPaths' is never used. [unusedFunction]
double getDistanceBetweenPredictedPaths(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:124:0: style: The function 'getDistanceBetweenPredictedPathAndObject' is never used. [unusedFunction]
double getDistanceBetweenPredictedPathAndObject(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:149:0: style: The function 'checkCollisionBetweenPathFootprintsAndObjects' is never used. [unusedFunction]
bool checkCollisionBetweenPathFootprintsAndObjects(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:252:0: style: The function 'calcObjectsDistanceToPath' is never used. [unusedFunction]
std::vector<double> calcObjectsDistanceToPath(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:460:0: style: The function 'containsGoal' is never used. [unusedFunction]
bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal_id)
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:769:0: style: The function 'getIds' is never used. [unusedFunction]
std::vector<lanelet::Id> getIds(const lanelet::ConstLanelets & lanelets)
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:1028:0: style: The function 'getTargetLaneletPolygons' is never used. [unusedFunction]
std::vector<Polygon2d> getTargetLaneletPolygons(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:1167:0: style: The function 'setDecelerationVelocity' is never used. [unusedFunction]
PathWithLaneId setDecelerationVelocity(
^

planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp:1638:0: style: The function 'convertToSnakeCase' is never used. [unusedFunction]
std::string convertToSnakeCase(const std::string & input_str)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
