### PR TITLE
fix(autoware_behavior_path_side_shift_module): fix unusedFunction

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/utils.hpp
@@ -29,15 +29,7 @@ using tier4_planning_msgs::msg::PathWithLaneId;
 
 void setOrientation(PathWithLaneId * path);
 
-bool getStartAvoidPose(
-  const PathWithLaneId & path, const double start_distance, const size_t nearest_idx,
-  Pose * start_avoid_pose);
-
 bool isAlmostZero(double v);
-
-Point transformToGrid(
-  const Point & pt, const double longitudinal_offset, const double lateral_offset, const double yaw,
-  const TransformStamped & geom_tf);
 
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp
@@ -53,49 +53,9 @@ void setOrientation(PathWithLaneId * path)
   }
 }
 
-bool getStartAvoidPose(
-  const PathWithLaneId & path, const double start_distance, const size_t nearest_idx,
-  Pose * start_avoid_pose)
-{
-  if (!start_avoid_pose) {
-    return false;
-  }
-  if (nearest_idx >= path.points.size()) {
-    return false;
-  }
-
-  double arclength = 0.0;
-  for (size_t idx = nearest_idx + 1; idx < path.points.size(); ++idx) {
-    const auto pt = path.points.at(idx).point;
-    const auto pt_prev = path.points.at(idx - 1).point;
-    const double dx = pt.pose.position.x - pt_prev.pose.position.x;
-    const double dy = pt.pose.position.y - pt_prev.pose.position.y;
-    arclength += std::hypot(dx, dy);
-
-    if (arclength > start_distance) {
-      *start_avoid_pose = pt.pose;
-      return true;
-    }
-  }
-
-  return false;
-}
-
 bool isAlmostZero(double v)
 {
   return std::fabs(v) < 1.0e-4;
-}
-
-Point transformToGrid(
-  const Point & pt, const double longitudinal_offset, const double lateral_offset, const double yaw,
-  const TransformStamped & geom_tf)
-{
-  Point offset_pt, grid_pt;
-  offset_pt = pt;
-  offset_pt.x += longitudinal_offset * cos(yaw) - lateral_offset * sin(yaw);
-  offset_pt.y += longitudinal_offset * sin(yaw) + lateral_offset * cos(yaw);
-  tf2::doTransform(offset_pt, grid_pt, geom_tf);
-  return grid_pt;
 }
 
 }  // namespace autoware::behavior_path_planner


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp:56:0: style: The function 'getStartAvoidPose' is never used. [unusedFunction]
bool getStartAvoidPose(
^

planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp:89:0: style: The function 'transformToGrid' is never used. [unusedFunction]
Point transformToGrid(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
