### PR TITLE
fix: fix not to show error message during manual driving

### DIFF
--- a/planning/autoware_planning_validator/include/autoware/planning_validator/planning_validator.hpp
+++ b/planning/autoware_planning_validator/include/autoware/planning_validator/planning_validator.hpp
@@ -26,7 +26,9 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_debug_msgs/msg/float64_stamped.hpp>
@@ -105,6 +107,10 @@ private:
 
   autoware::universe_utils::InterProcessPollingSubscriber<Odometry> sub_kinematics_{
     this, "~/input/kinematics"};
+  autoware::universe_utils::InterProcessPollingSubscriber<autoware_adapi_v1_msgs::msg::OperationModeState> sub_operation_mode_{
+    this, "/api/operation_mode/state"};
+  autoware::universe_utils::InterProcessPollingSubscriber<autoware_vehicle_msgs::msg::ControlModeReport> sub_control_mode_{
+    this, "/vehicle/status/control_mode"};
   rclcpp::Subscription<Trajectory>::SharedPtr sub_traj_;
   rclcpp::Publisher<Trajectory>::SharedPtr pub_traj_;
   rclcpp::Publisher<PlanningValidatorStatus>::SharedPtr pub_status_;
@@ -134,6 +140,9 @@ private:
   Trajectory::ConstSharedPtr previous_published_trajectory_;
 
   Odometry::ConstSharedPtr current_kinematics_;
+
+  autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr operation_mode_;
+  autoware_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
 
   std::shared_ptr<PlanningValidatorDebugMarkerPublisher> debug_pose_publisher_;
 

--- a/planning/autoware_planning_validator/package.xml
+++ b/planning/autoware_planning_validator/package.xml
@@ -15,11 +15,13 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/planning/autoware_planning_validator/src/planning_validator.cpp
+++ b/planning/autoware_planning_validator/src/planning_validator.cpp
@@ -101,7 +101,15 @@ void PlanningValidator::setupParameters()
 void PlanningValidator::setStatus(
   DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg)
 {
+  using ControlModeStatus = autoware_vehicle_msgs::msg::ControlModeReport;
+  using OperationModeStatus = autoware_adapi_v1_msgs::msg::OperationModeState;
+  
+  operation_mode_ = sub_operation_mode_.takeData();
+  control_mode_ = sub_control_mode_.takeData();
+  
   if (is_ok) {
+    stat.summary(DiagnosticStatus::OK, "validated.");
+  } else if (operation_mode_->mode != OperationModeStatus::AUTONOMOUS || control_mode_->mode != ControlModeStatus::AUTONOMOUS) {
     stat.summary(DiagnosticStatus::OK, "validated.");
   } else if (validation_status_.invalid_count < diag_error_count_threshold_) {
     const auto warn_msg = msg + " (invalid count is less than error threshold: " +
@@ -114,7 +122,7 @@ void PlanningValidator::setStatus(
 }
 
 void PlanningValidator::setupDiag()
-{
+{ 
   diag_updater_ = std::make_shared<Updater>(this);
   auto & d = diag_updater_;
   d->setHardwareID("planning_validator");


### PR DESCRIPTION
## Description
Update not to show error message (eg. relative angle is too large) during manual driving.
This message is necessary only during autonomous driving.

## Related links
None.

## How was this PR tested?
Here is a way to conduct the test. You can check error messages on rqt_runtime_monitor.

1. Launch the planning simulator.
2. Add a manual controller(https://github.com/autowarefoundation/autoware_tools/tree/main/common/tier4_control_rviz_plugin).
3. Use the manual controller to intentionally shift the route.
4. Confirm that no error message appears in this state.
5. Switch to autonomous driving after deviating from the route.
6. Confirm that a message appears when the route is deviated during autonomous driving.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
