### PR TITLE
fix(tier4_state_rviz_plugin): fix unmatchedSuppression

### DIFF
--- a/common/tier4_state_rviz_plugin/src/custom_container.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_container.cpp
@@ -40,7 +40,6 @@ QSize CustomContainer::sizeHint() const
   return QSize(width, height);
 }
 
-// cppcheck-suppress unusedFunction
 QSize CustomContainer::minimumSizeHint() const
 {
   return sizeHint();

--- a/common/tier4_state_rviz_plugin/src/custom_icon_label.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_icon_label.cpp
@@ -50,13 +50,11 @@ QSize CustomIconLabel::sizeHint() const
   return QSize(size, size);
 }
 
-// cppcheck-suppress unusedFunction
 QSize CustomIconLabel::minimumSizeHint() const
 {
   return sizeHint();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomIconLabel::paintEvent(QPaintEvent *)
 {
   QPainter painter(this);

--- a/common/tier4_state_rviz_plugin/src/custom_label.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_label.cpp
@@ -46,13 +46,11 @@ QSize CustomLabel::sizeHint() const
   return QSize(width, height);
 }
 
-// cppcheck-suppress unusedFunction
 QSize CustomLabel::minimumSizeHint() const
 {
   return sizeHint();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomLabel::paintEvent(QPaintEvent *)
 {
   QPainter painter(this);

--- a/common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp
@@ -55,13 +55,11 @@ QSize CustomSegmentedButton::sizeHint() const
   //   layout->itemAt(0)->widget()->height() + 10);
 }
 
-// cppcheck-suppress unusedFunction
 QSize CustomSegmentedButton::minimumSizeHint() const
 {
   return sizeHint();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomSegmentedButton::paintEvent(QPaintEvent *)
 {
   QPainter painter(this);

--- a/common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp
@@ -76,7 +76,6 @@ void CustomSegmentedButtonItem::setActivated(bool activated)
   update();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomSegmentedButtonItem::paintEvent(QPaintEvent *)
 {
   QPainter painter(this);

--- a/common/tier4_state_rviz_plugin/src/custom_slider.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_slider.cpp
@@ -19,7 +19,6 @@ CustomSlider::CustomSlider(Qt::Orientation orientation, QWidget * parent)
   setMinimumHeight(40);  // Ensure there's enough space for the custom track
 }
 
-// cppcheck-suppress unusedFunction
 void CustomSlider::paintEvent(QPaintEvent *)
 {
   QPainter painter(this);

--- a/common/tier4_state_rviz_plugin/src/custom_toggle_switch.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_toggle_switch.cpp
@@ -30,7 +30,6 @@ QSize CustomToggleSwitch::sizeHint() const
   return QSize(50, 30);  // Preferred size of the toggle switch
 }
 
-// cppcheck-suppress unusedFunction
 void CustomToggleSwitch::paintEvent(QPaintEvent *)
 {
   QPainter p(this);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unmatchedSuppression warnings.

Added a warning suppression comment in a previous PR, but corrected it because it had added an extra one as well.
```
common/tier4_state_rviz_plugin/src/custom_container.cpp:44:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
QSize CustomContainer::minimumSizeHint() const
^
common/tier4_state_rviz_plugin/src/custom_icon_label.cpp:54:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
QSize CustomIconLabel::minimumSizeHint() const
^
common/tier4_state_rviz_plugin/src/custom_icon_label.cpp:60:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomIconLabel::paintEvent(QPaintEvent *)
^
common/tier4_state_rviz_plugin/src/custom_label.cpp:50:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
QSize CustomLabel::minimumSizeHint() const
^
common/tier4_state_rviz_plugin/src/custom_label.cpp:56:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomLabel::paintEvent(QPaintEvent *)
^
common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp:59:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
QSize CustomSegmentedButton::minimumSizeHint() const
^
common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp:65:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSegmentedButton::paintEvent(QPaintEvent *)
^
common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp:80:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSegmentedButtonItem::paintEvent(QPaintEvent *)
^
common/tier4_state_rviz_plugin/src/custom_slider.cpp:23:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSlider::paintEvent(QPaintEvent *)
^
common/tier4_state_rviz_plugin/src/custom_toggle_switch.cpp:34:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomToggleSwitch::paintEvent(QPaintEvent *)
```
## Related links

**Parent Issue:**

- Link ：[#8608](https://github.com/autowarefoundation/autoware.universe/pull/8608) 

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
