### PR TITLE
fix(autoware_behavior_velocity_crosswalk_module): fix unusedFunction

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
@@ -95,8 +95,6 @@ std::set<int64_t> getCrosswalkIdSetOnPath(
   const tier4_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs);
 
-bool checkRegulatoryElementExistence(const lanelet::LaneletMapPtr & lanelet_map_ptr);
-
 std::optional<std::pair<geometry_msgs::msg::Point, geometry_msgs::msg::Point>>
 getPathEndPointsOnCrosswalk(
   const PathWithLaneId & ego_path, const lanelet::BasicPolygon2d & polygon,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/util.cpp
@@ -105,12 +105,6 @@ std::set<lanelet::Id> getCrosswalkIdSetOnPath(
   return crosswalk_id_set;
 }
 
-bool checkRegulatoryElementExistence(const lanelet::LaneletMapPtr & lanelet_map_ptr)
-{
-  const auto all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr);
-  return !lanelet::utils::query::crosswalks(all_lanelets).empty();
-}
-
 /**
  * @brief Calculate path end (= first and last) points on the crosswalk
  *


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/util.cpp:108:0: style: The function 'checkRegulatoryElementExistence' is never used. [unusedFunction]
bool checkRegulatoryElementExistence(const lanelet::LaneletMapPtr & lanelet_map_ptr)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
