### PR TITLE
fix(autoware_behavior_velocity_intersection_module): fix unusedFunction

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
@@ -159,25 +159,6 @@ visualization_msgs::msg::MarkerArray createLineMarkerArray(
   return msg;
 }
 
-[[maybe_unused]] visualization_msgs::msg::Marker createPointMarkerArray(
-  const geometry_msgs::msg::Point & point, const std::string & ns, const int64_t id, const double r,
-  const double g, const double b)
-{
-  visualization_msgs::msg::Marker marker_point{};
-  marker_point.header.frame_id = "map";
-  marker_point.ns = ns + "_point";
-  marker_point.id = id;
-  marker_point.lifetime = rclcpp::Duration::from_seconds(0.3);
-  marker_point.type = visualization_msgs::msg::Marker::SPHERE;
-  marker_point.action = visualization_msgs::msg::Marker::ADD;
-  marker_point.scale = createMarkerScale(2.0, 2.0, 2.0);
-  marker_point.color = createMarkerColor(r, g, b, 0.999);
-
-  marker_point.pose.position = point;
-
-  return marker_point;
-}
-
 constexpr std::tuple<float, float, float> white()
 {
   constexpr uint64_t code = 0xfdfdfd;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -327,13 +327,20 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
 
+  // cppcheck-suppress unusedFunction
   const std::set<lanelet::Id> & getAssociativeIds() const { return associative_ids_; }
 
+  // cppcheck-suppress unusedFunction
   UUID getOcclusionUUID() const { return occlusion_uuid_; }
+  // cppcheck-suppress unusedFunction
   bool getOcclusionSafety() const { return occlusion_safety_; }
+  // cppcheck-suppress unusedFunction
   double getOcclusionDistance() const { return occlusion_stop_distance_; }
+  // cppcheck-suppress unusedFunction
   void setOcclusionActivation(const bool activation) { occlusion_activated_ = activation; }
+  // cppcheck-suppress unusedFunction
   bool isOcclusionFirstStopRequired() const { return occlusion_first_stop_required_; }
+  // cppcheck-suppress unusedFunction
   InternalDebugData & getInternalDebugData() const { return internal_debug_data_; }
 
 private:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -327,20 +327,13 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
 
-  // cppcheck-suppress unusedFunction
   const std::set<lanelet::Id> & getAssociativeIds() const { return associative_ids_; }
 
-  // cppcheck-suppress unusedFunction
   UUID getOcclusionUUID() const { return occlusion_uuid_; }
-  // cppcheck-suppress unusedFunction
   bool getOcclusionSafety() const { return occlusion_safety_; }
-  // cppcheck-suppress unusedFunction
   double getOcclusionDistance() const { return occlusion_stop_distance_; }
-  // cppcheck-suppress unusedFunction
   void setOcclusionActivation(const bool activation) { occlusion_activated_ = activation; }
-  // cppcheck-suppress unusedFunction
   bool isOcclusionFirstStopRequired() const { return occlusion_first_stop_required_; }
-  // cppcheck-suppress unusedFunction
   InternalDebugData & getInternalDebugData() const { return internal_debug_data_; }
 
 private:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -336,17 +336,6 @@ bool isOverTargetIndex(
   return static_cast<bool>(closest_idx > target_idx);
 }
 
-bool isBeforeTargetIndex(
-  const tier4_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx,
-  const geometry_msgs::msg::Pose & current_pose, const size_t target_idx)
-{
-  if (closest_idx == target_idx) {
-    const geometry_msgs::msg::Pose target_pose = path.points.at(target_idx).point.pose;
-    return planning_utils::isAheadOf(target_pose, current_pose);
-  }
-  return static_cast<bool>(target_idx > closest_idx);
-}
-
 std::optional<autoware::universe_utils::Polygon2d> getIntersectionArea(
   lanelet::ConstLanelet assigned_lane, lanelet::LaneletMapConstPtr lanelet_map_ptr)
 {
@@ -358,16 +347,6 @@ std::optional<autoware::universe_utils::Polygon2d> getIntersectionArea(
   Polygon2d poly{};
   for (const auto & p : poly_3d) poly.outer().emplace_back(p.x(), p.y());
   return std::make_optional(poly);
-}
-
-bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane)
-{
-  std::optional<int> tl_id = std::nullopt;
-  for (auto && tl_reg_elem : lane.regulatoryElementsAs<lanelet::TrafficLight>()) {
-    tl_id = tl_reg_elem->id();
-    break;
-  }
-  return tl_id.has_value();
 }
 
 std::optional<InterpolatedPathInfo> generateInterpolatedPath(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.hpp
@@ -76,24 +76,8 @@ bool isOverTargetIndex(
   const tier4_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx,
   const geometry_msgs::msg::Pose & current_pose, const size_t target_idx);
 
-/**
- * @brief check if ego is before the target_idx. If the index is same, compare the exact pose
- * @param[in] path path
- * @param[in] closest_idx ego's closest index on the path
- * @param[in] current_pose ego's exact pose
- * @return true if ego is over the target_idx
- */
-bool isBeforeTargetIndex(
-  const tier4_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx,
-  const geometry_msgs::msg::Pose & current_pose, const size_t target_idx);
-
 std::optional<autoware::universe_utils::Polygon2d> getIntersectionArea(
   lanelet::ConstLanelet assigned_lane, lanelet::LaneletMapConstPtr lanelet_map_ptr);
-
-/**
- * @brief check if the given lane has related traffic light
- */
-bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane);
 
 /**
  * @brief interpolate PathWithLaneId


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp:162:0: style: The function 'createPointMarkerArray' is never used. [unusedFunction]
[[maybe_unused]] visualization_msgs::msg::Marker createPointMarkerArray(
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:330:0: style: The function 'getAssociativeIds' is never used. [unusedFunction]
  const std::set<lanelet::Id> & getAssociativeIds() const { return associative_ids_; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:332:0: style: The function 'getOcclusionUUID' is never used. [unusedFunction]
  UUID getOcclusionUUID() const { return occlusion_uuid_; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:333:0: style: The function 'getOcclusionSafety' is never used. [unusedFunction]
  bool getOcclusionSafety() const { return occlusion_safety_; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:334:0: style: The function 'getOcclusionDistance' is never used. [unusedFunction]
  double getOcclusionDistance() const { return occlusion_stop_distance_; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:335:0: style: The function 'setOcclusionActivation' is never used. [unusedFunction]
  void setOcclusionActivation(const bool activation) { occlusion_activated_ = activation; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:336:0: style: The function 'isOcclusionFirstStopRequired' is never used. [unusedFunction]
  bool isOcclusionFirstStopRequired() const { return occlusion_first_stop_required_; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp:337:0: style: The function 'getInternalDebugData' is never used. [unusedFunction]
  InternalDebugData & getInternalDebugData() const { return internal_debug_data_; }
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp:324:0: style: The function 'isBeforeTargetIndex' is never used. [unusedFunction]
bool isBeforeTargetIndex(
^

planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp:348:0: style: The function 'hasAssociatedTrafficLight' is never used. [unusedFunction]
bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
