### PR TITLE
feat(raw_vehicle_cmd_converter): set convert_actuation_to_steering_status false by default

### DIFF
--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/node.cpp
@@ -87,7 +87,7 @@ RawVehicleCommandConverterNode::RawVehicleCommandConverterNode(
 
   // NOTE: The steering status can be published from the vehicle side or converted in this node.
   convert_actuation_to_steering_status_ =
-    declare_parameter<bool>("convert_actuation_to_steering_status");
+    declare_parameter<bool>("convert_actuation_to_steering_status", false);
   if (convert_actuation_to_steering_status_) {
     pub_steering_status_ = create_publisher<Steering>("~/output/steering_status", 1);
   } else {


### PR DESCRIPTION
## Description

In https://github.com/autowarefoundation/autoware.universe/pull/8588, we introduced new parameter, but it is hard to modify all the prameter file for many vehicles. so set false by default to keep the previous behavior with out parameter file modification.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
