### PR TITLE
fix(autoware_behavior_velocity_run_out_module): fix unusedFunction

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp
@@ -134,20 +134,6 @@ bool isSamePoint(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg:
   return false;
 }
 
-// if path points have the same point as target_point, return the index
-std::optional<size_t> haveSamePoint(
-  const PathPointsWithLaneId & path_points, const geometry_msgs::msg::Point & target_point)
-{
-  for (size_t i = 0; i < path_points.size(); i++) {
-    const auto & path_point = path_points.at(i).point.pose.position;
-    if (isSamePoint(path_point, target_point)) {
-      return i;
-    }
-  }
-
-  return {};
-}
-
 // insert path velocity which doesn't exceed original velocity
 void insertPathVelocityFromIndexLimited(
   const size_t & start_idx, const float velocity_mps, PathPointsWithLaneId & path_points)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.hpp
@@ -224,10 +224,6 @@ std::vector<geometry_msgs::msg::Point> findLateralSameSidePoints(
 
 bool isSamePoint(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2);
 
-// if path points have the same point as target_point, return the index
-std::optional<size_t> haveSamePoint(
-  const PathPointsWithLaneId & path_points, const geometry_msgs::msg::Point & target_point);
-
 // insert path velocity which doesn't exceed original velocity
 void insertPathVelocityFromIndexLimited(
   const size_t & start_idx, const float velocity_mps, PathPointsWithLaneId & path_points);


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp:138:0: style: The function 'haveSamePoint' is never used. [unusedFunction]
std::optional<size_t> haveSamePoint(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
