### PR TITLE
fix(out_of_lane): fix a bug with the rtree reference deleted nodes

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -129,28 +129,27 @@ void calculate_collisions_to_avoid(
   }
 }
 
-OutOfLaneData calculate_outside_points(const EgoData & ego_data)
+std::vector<OutOfLanePoint> calculate_out_of_lane_points(const EgoData & ego_data)
 {
-  OutOfLaneData out_of_lane_data;
-  out_of_lane::OutOfLanePoint p;
+  std::vector<OutOfLanePoint> out_of_lane_points;
+  OutOfLanePoint p;
   for (auto i = 0UL; i < ego_data.trajectory_footprints.size(); ++i) {
     p.trajectory_index = i + ego_data.first_trajectory_idx;
     const auto & footprint = ego_data.trajectory_footprints[i];
-    out_of_lane::Polygons out_of_lane_polygons;
+    Polygons out_of_lane_polygons;
     boost::geometry::difference(footprint, ego_data.drivable_lane_polygons, out_of_lane_polygons);
     for (const auto & area : out_of_lane_polygons) {
       if (!area.outer.empty()) {
         p.outside_ring = area.outer;
-        out_of_lane_data.outside_points.push_back(p);
+        out_of_lane_points.push_back(p);
       }
     }
   }
-  return out_of_lane_data;
+  return out_of_lane_points;
 }
 
-OutOfLaneData calculate_out_of_lane_areas(const EgoData & ego_data)
+void prepare_out_of_lane_areas_rtree(OutOfLaneData & out_of_lane_data)
 {
-  auto out_of_lane_data = calculate_outside_points(ego_data);
   std::vector<OutAreaNode> rtree_nodes;
   for (auto i = 0UL; i < out_of_lane_data.outside_points.size(); ++i) {
     OutAreaNode n;
@@ -160,7 +159,6 @@ OutOfLaneData calculate_out_of_lane_areas(const EgoData & ego_data)
     rtree_nodes.push_back(n);
   }
   out_of_lane_data.outside_areas_rtree = {rtree_nodes.begin(), rtree_nodes.end()};
-  return out_of_lane_data;
 }
 
 }  // namespace autoware::motion_velocity_planner::out_of_lane

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
@@ -47,9 +47,11 @@ void calculate_collisions_to_avoid(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const PlannerParam & params);
 
-/// @brief calculate the areas where ego will drive outside of its lane
-/// @details the OutOfLaneData points and rtree are filled
-OutOfLaneData calculate_out_of_lane_areas(const EgoData & ego_data);
+/// @brief calculate the out of lane points
+std::vector<OutOfLanePoint> calculate_out_of_lane_points(const EgoData & ego_data);
+
+/// @brief prepare the rtree of out of lane points for the given data
+void prepare_out_of_lane_areas_rtree(OutOfLaneData & out_of_lane_data);
 }  // namespace autoware::motion_velocity_planner::out_of_lane
 
 #endif  // OUT_OF_LANE_COLLISIONS_HPP_


### PR DESCRIPTION
## Description

This PR fixes a major bug where the rtree was built with indexes to a vector whose elements were then filtered, causing access to invalid memory in some part of the code.
The fix simply filters the elements before using them to build the rtree.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
