### PR TITLE
refactor(ekf_localizer): add namespace "autoware::ekf_localizer::"

### DIFF
--- a/localization/ekf_localizer/CMakeLists.txt
+++ b/localization/ekf_localizer/CMakeLists.txt
@@ -25,7 +25,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "EKFLocalizer"
+  PLUGIN "autoware::ekf_localizer::EKFLocalizer"
   EXECUTABLE ${PROJECT_NAME}_node
   EXECUTOR SingleThreadedExecutor
 )

--- a/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
@@ -18,6 +18,9 @@
 #include <cstddef>
 #include <queue>
 
+namespace autoware::ekf_localizer
+{
+
 template <typename Object>
 class AgedObjectQueue
 {
@@ -62,5 +65,7 @@ private:
   std::queue<Object> objects_;
   std::queue<size_t> ages_;
 };
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__AGED_OBJECT_QUEUE_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/covariance.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/covariance.hpp
@@ -17,7 +17,12 @@
 
 #include "ekf_localizer/matrix_types.hpp"
 
+namespace autoware::ekf_localizer
+{
+
 std::array<double, 36> ekf_covariance_to_pose_message_covariance(const Matrix6d & P);
 std::array<double, 36> ekf_covariance_to_twist_message_covariance(const Matrix6d & P);
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__COVARIANCE_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/diagnostics.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/diagnostics.hpp
@@ -20,6 +20,9 @@
 #include <string>
 #include <vector>
 
+namespace autoware::ekf_localizer
+{
+
 diagnostic_msgs::msg::DiagnosticStatus check_process_activated(const bool is_activated);
 
 diagnostic_msgs::msg::DiagnosticStatus check_measurement_updated(
@@ -39,5 +42,7 @@ diagnostic_msgs::msg::DiagnosticStatus check_covariance_ellipse(
 
 diagnostic_msgs::msg::DiagnosticStatus merge_diagnostic_status(
   const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & stat_array);
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__DIAGNOSTICS_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -50,6 +50,9 @@
 #include <string>
 #include <vector>
 
+namespace autoware::ekf_localizer
+{
+
 class Simple1DFilter
 {
 public:
@@ -242,4 +245,7 @@ private:
 
   friend class EKFLocalizerTestSuite;  // for test code
 };
+
+}  // namespace autoware::ekf_localizer
+
 #endif  // EKF_LOCALIZER__EKF_LOCALIZER_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_module.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_module.hpp
@@ -34,6 +34,8 @@
 #include <memory>
 #include <vector>
 
+namespace autoware::ekf_localizer
+{
 using autoware::kalman_filter::TimeDelayKalmanFilter;
 
 struct EKFDiagnosticInfo
@@ -92,5 +94,7 @@ private:
   std::vector<double> accumulated_delay_times_;
   const HyperParameters params_;
 };
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__EKF_MODULE_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/hyper_parameters.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/hyper_parameters.hpp
@@ -20,6 +20,9 @@
 #include <algorithm>
 #include <string>
 
+namespace autoware::ekf_localizer
+{
+
 class HyperParameters
 {
 public:
@@ -101,5 +104,7 @@ public:
 
   const double threshold_observable_velocity_mps;
 };
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__HYPER_PARAMETERS_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/mahalanobis.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/mahalanobis.hpp
@@ -18,9 +18,14 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
+namespace autoware::ekf_localizer
+{
+
 double squared_mahalanobis(
   const Eigen::VectorXd & x, const Eigen::VectorXd & y, const Eigen::MatrixXd & C);
 
 double mahalanobis(const Eigen::VectorXd & x, const Eigen::VectorXd & y, const Eigen::MatrixXd & C);
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__MAHALANOBIS_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/matrix_types.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/matrix_types.hpp
@@ -17,7 +17,12 @@
 
 #include <Eigen/Core>
 
+namespace autoware::ekf_localizer
+{
+
 using Vector6d = Eigen::Matrix<double, 6, 1>;
 using Matrix6d = Eigen::Matrix<double, 6, 6>;
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__MATRIX_TYPES_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/measurement.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/measurement.hpp
@@ -17,11 +17,16 @@
 
 #include <Eigen/Core>
 
+namespace autoware::ekf_localizer
+{
+
 Eigen::Matrix<double, 3, 6> pose_measurement_matrix();
 Eigen::Matrix<double, 2, 6> twist_measurement_matrix();
 Eigen::Matrix3d pose_measurement_covariance(
   const std::array<double, 36ul> & covariance, const size_t smoothing_step);
 Eigen::Matrix2d twist_measurement_covariance(
   const std::array<double, 36ul> & covariance, const size_t smoothing_step);
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__MEASUREMENT_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/numeric.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/numeric.hpp
@@ -19,6 +19,9 @@
 
 #include <cmath>
 
+namespace autoware::ekf_localizer
+{
+
 inline bool has_inf(const Eigen::MatrixXd & v)
 {
   return v.array().isInf().any();
@@ -28,5 +31,7 @@ inline bool has_nan(const Eigen::MatrixXd & v)
 {
   return v.array().isNaN().any();
 }
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__NUMERIC_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/state_index.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/state_index.hpp
@@ -15,6 +15,9 @@
 #ifndef EKF_LOCALIZER__STATE_INDEX_HPP_
 #define EKF_LOCALIZER__STATE_INDEX_HPP_
 
+namespace autoware::ekf_localizer
+{
+
 enum IDX {
   X = 0,
   Y = 1,
@@ -23,5 +26,7 @@ enum IDX {
   VX = 4,
   WZ = 5,
 };
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__STATE_INDEX_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/state_transition.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/state_transition.hpp
@@ -17,10 +17,15 @@
 
 #include "ekf_localizer/matrix_types.hpp"
 
+namespace autoware::ekf_localizer
+{
+
 double normalize_yaw(const double & yaw);
 Vector6d predict_next_state(const Vector6d & X_curr, const double dt);
 Matrix6d create_state_transition_matrix(const Vector6d & X_curr, const double dt);
 Matrix6d process_noise_covariance(
   const double proc_cov_yaw_d, const double proc_cov_vx_d, const double proc_cov_wz_d);
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__STATE_TRANSITION_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/string.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/string.hpp
@@ -17,6 +17,9 @@
 
 #include <string>
 
+namespace autoware::ekf_localizer
+{
+
 inline std::string erase_leading_slash(const std::string & s)
 {
   std::string a = s;
@@ -25,5 +28,7 @@ inline std::string erase_leading_slash(const std::string & s)
   }
   return a;
 }
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__STRING_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/warning.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/warning.hpp
@@ -19,6 +19,9 @@
 
 #include <string>
 
+namespace autoware::ekf_localizer
+{
+
 class Warning
 {
 public:
@@ -39,5 +42,7 @@ public:
 private:
   rclcpp::Node * node_;
 };
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__WARNING_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/warning_message.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/warning_message.hpp
@@ -17,6 +17,9 @@
 
 #include <string>
 
+namespace autoware::ekf_localizer
+{
+
 std::string pose_delay_step_warning_message(
   const double delay_time, const double delay_time_threshold);
 std::string twist_delay_step_warning_message(
@@ -24,5 +27,7 @@ std::string twist_delay_step_warning_message(
 std::string pose_delay_time_warning_message(const double delay_time);
 std::string twist_delay_time_warning_message(const double delay_time);
 std::string mahalanobis_warning_message(const double distance, const double max_distance);
+
+}  // namespace autoware::ekf_localizer
 
 #endif  // EKF_LOCALIZER__WARNING_MESSAGE_HPP_

--- a/localization/ekf_localizer/src/covariance.cpp
+++ b/localization/ekf_localizer/src/covariance.cpp
@@ -17,6 +17,9 @@
 #include "autoware/universe_utils/ros/msg_covariance.hpp"
 #include "ekf_localizer/state_index.hpp"
 
+namespace autoware::ekf_localizer
+{
+
 using COV_IDX = autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 
 std::array<double, 36> ekf_covariance_to_pose_message_covariance(const Matrix6d & P)
@@ -49,3 +52,5 @@ std::array<double, 36> ekf_covariance_to_twist_message_covariance(const Matrix6d
 
   return covariance;
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/src/diagnostics.cpp
+++ b/localization/ekf_localizer/src/diagnostics.cpp
@@ -19,6 +19,9 @@
 #include <string>
 #include <vector>
 
+namespace autoware::ekf_localizer
+{
+
 diagnostic_msgs::msg::DiagnosticStatus check_process_activated(const bool is_activated)
 {
   diagnostic_msgs::msg::DiagnosticStatus stat;
@@ -200,3 +203,5 @@ diagnostic_msgs::msg::DiagnosticStatus merge_diagnostic_status(
 
   return merged_stat;
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -34,6 +34,9 @@
 #include <string>
 #include <utility>
 
+namespace autoware::ekf_localizer
+{
+
 // clang-format off
 #define PRINT_MAT(X) std::cout << #X << ":\n" << X << std::endl << std::endl // NOLINT
 #define DEBUG_INFO(...) {if (params_.show_debug_info) {RCLCPP_INFO(__VA_ARGS__);}} // NOLINT
@@ -495,5 +498,7 @@ void EKFLocalizer::service_trigger_node(
   res->success = true;
 }
 
+}  // namespace autoware::ekf_localizer
+
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(EKFLocalizer)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::ekf_localizer::EKFLocalizer)

--- a/localization/ekf_localizer/src/ekf_module.cpp
+++ b/localization/ekf_localizer/src/ekf_module.cpp
@@ -29,6 +29,9 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
 
+namespace autoware::ekf_localizer
+{
+
 // clang-format off
 #define DEBUG_PRINT_MAT(X) {if (params_.show_debug_info) {std::cout << #X << ": " << X << std::endl;}} // NOLINT
 // clang-format on
@@ -392,3 +395,5 @@ bool EKFModule::measurement_update_twist(
 
   return true;
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/src/mahalanobis.cpp
+++ b/localization/ekf_localizer/src/mahalanobis.cpp
@@ -14,6 +14,9 @@
 
 #include "ekf_localizer/mahalanobis.hpp"
 
+namespace autoware::ekf_localizer
+{
+
 double squared_mahalanobis(
   const Eigen::VectorXd & x, const Eigen::VectorXd & y, const Eigen::MatrixXd & C)
 {
@@ -25,3 +28,5 @@ double mahalanobis(const Eigen::VectorXd & x, const Eigen::VectorXd & y, const E
 {
   return std::sqrt(squared_mahalanobis(x, y, C));
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/src/measurement.cpp
+++ b/localization/ekf_localizer/src/measurement.cpp
@@ -17,6 +17,9 @@
 #include "autoware/universe_utils/ros/msg_covariance.hpp"
 #include "ekf_localizer/state_index.hpp"
 
+namespace autoware::ekf_localizer
+{
+
 Eigen::Matrix<double, 3, 6> pose_measurement_matrix()
 {
   Eigen::Matrix<double, 3, 6> c = Eigen::Matrix<double, 3, 6>::Zero();
@@ -54,3 +57,5 @@ Eigen::Matrix2d twist_measurement_covariance(
     covariance.at(COV_IDX::YAW_YAW);
   return r * static_cast<double>(smoothing_step);
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/src/state_transition.cpp
+++ b/localization/ekf_localizer/src/state_transition.cpp
@@ -17,6 +17,9 @@
 
 #include <cmath>
 
+namespace autoware::ekf_localizer
+{
+
 double normalize_yaw(const double & yaw)
 {
   // FIXME(IshitaTakeshi) I think the computation here can be simplified
@@ -93,3 +96,5 @@ Matrix6d process_noise_covariance(
   q(IDX::WZ, IDX::WZ) = proc_cov_wz_d;  // for wz
   return q;
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/src/warning_message.cpp
+++ b/localization/ekf_localizer/src/warning_message.cpp
@@ -18,6 +18,9 @@
 
 #include <string>
 
+namespace autoware::ekf_localizer
+{
+
 std::string pose_delay_step_warning_message(
   const double delay_time, const double delay_time_threshold)
 {
@@ -53,3 +56,5 @@ std::string mahalanobis_warning_message(const double distance, const double max_
   const std::string s = "The Mahalanobis distance {:.4f} is over the limit {:.4f}.";
   return fmt::format(s, distance, max_distance);
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_aged_object_queue.cpp
+++ b/localization/ekf_localizer/test/test_aged_object_queue.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(AgedObjectQueue, DiscardsObjectWhenAgeReachesMaximum)
 {
   AgedObjectQueue<std::string> queue(3);
@@ -99,3 +102,5 @@ TEST(AgedObjectQueue, Back)
 
   EXPECT_EQ(queue.back(), std::string{"b"});
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_covariance.cpp
+++ b/localization/ekf_localizer/test/test_covariance.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(EKFCovarianceToPoseMessageCovariance, SmokeTest)
 {
   {
@@ -77,3 +80,5 @@ TEST(EKFCovarianceToTwistMessageCovariance, SmokeTest)
     }
   }
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/ekf_localizer/test/test_diagnostics.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(TestEkfDiagnostics, check_process_activated)
 {
   diagnostic_msgs::msg::DiagnosticStatus stat;
@@ -190,3 +193,5 @@ TEST(TestLocalizationErrorMonitorDiagnostics, merge_diagnostic_status)
   EXPECT_EQ(merged_stat.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
   EXPECT_EQ(merged_stat.message, "ERROR0; ERROR1");
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_mahalanobis.cpp
+++ b/localization/ekf_localizer/test/test_mahalanobis.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 constexpr double tolerance = 1e-8;
 
 TEST(squared_mahalanobis, SmokeTest)
@@ -59,3 +62,5 @@ TEST(mahalanobis, SmokeTest)
     EXPECT_NEAR(mahalanobis(x, y, c), std::sqrt(5.0), tolerance);
   }
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_measurement.cpp
+++ b/localization/ekf_localizer/test/test_measurement.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(Measurement, pose_measurement_matrix)
 {
   const Eigen::Matrix<double, 3, 6> m = pose_measurement_matrix();
@@ -79,3 +82,5 @@ TEST(Measurement, twist_measurement_covariance)
     EXPECT_EQ(m.norm(), 0);
   }
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_numeric.cpp
+++ b/localization/ekf_localizer/test/test_numeric.cpp
@@ -18,6 +18,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(Numeric, has_nan)
 {
   const Eigen::VectorXd empty(0);
@@ -45,3 +48,5 @@ TEST(Numeric, has_inf)
 
   EXPECT_TRUE(has_inf(Eigen::Vector3d(0., 1., inf)));
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_state_transition.cpp
+++ b/localization/ekf_localizer/test/test_state_transition.cpp
@@ -20,6 +20,9 @@
 
 #include <cmath>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(StateTransition, normalize_yaw)
 {
   const double tolerance = 1e-6;
@@ -94,3 +97,5 @@ TEST(process_noise_covariance, process_noise_covariance)
   // Make sure other elements are zero
   EXPECT_EQ(process_noise_covariance(0, 0, 0).norm(), 0.);
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_string.cpp
+++ b/localization/ekf_localizer/test/test_string.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(erase_leading_slash, SmokeTest)
 {
   EXPECT_EQ(erase_leading_slash("/topic"), "topic");
@@ -24,3 +27,5 @@ TEST(erase_leading_slash, SmokeTest)
   EXPECT_EQ(erase_leading_slash(""), "");
   EXPECT_EQ(erase_leading_slash("/"), "");
 }
+
+}  // namespace autoware::ekf_localizer

--- a/localization/ekf_localizer/test/test_warning_message.cpp
+++ b/localization/ekf_localizer/test/test_warning_message.cpp
@@ -18,6 +18,9 @@
 
 #include <gtest/gtest.h>
 
+namespace autoware::ekf_localizer
+{
+
 TEST(pose_delay_step_warning_message, SmokeTest)
 {
   EXPECT_STREQ(
@@ -60,3 +63,5 @@ TEST(mahalanobis_warning_message, SmokeTest)
     mahalanobis_warning_message(1.0, 0.5).c_str(),
     "The Mahalanobis distance 1.0000 is over the limit 0.5000.");
 }
+
+}  // namespace autoware::ekf_localizer


### PR DESCRIPTION
## Description

Add namespace `autoware::ekf_localizer::` to `ekf_localizer` package.

## How was this PR tested?

I have confirmed autoware with [autoware_tools](https://github.com/autowarefoundation/autoware_tools) and [localization_evaluation_tools (TIER IV INTERNAL)](https://github.com/tier4/localization_evaluator_tools) can be built.

Also, the mean error in logging_simulator about AWSIM data is almost the same as before. (7.0cm -> 7.3cm)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
