### PR TITLE
chore(stop_filter): extract stop_filter.param.yaml to autoware_launch

### DIFF
--- a/launch/tier4_localization_launch/launch/localization.launch.xml
+++ b/launch/tier4_localization_launch/launch/localization.launch.xml
@@ -14,6 +14,7 @@
   <!-- Parameter files -->
   <arg name="localization_error_monitor_param_path"/>
   <arg name="ekf_localizer_param_path"/>
+  <arg name="stop_filter_param_path"/>
   <arg name="pose_initializer_param_path"/>
   <arg name="eagleye_param_path"/>
   <arg name="ar_tag_based_localizer_param_path"/>

--- a/launch/tier4_localization_launch/launch/pose_twist_fusion_filter/pose_twist_fusion_filter.launch.xml
+++ b/launch/tier4_localization_launch/launch/pose_twist_fusion_filter/pose_twist_fusion_filter.launch.xml
@@ -22,6 +22,7 @@
       <arg name="input_odom_name" value="/localization/pose_twist_fusion_filter/kinematic_state"/>
       <arg name="input_twist_with_covariance_name" value="/localization/pose_twist_fusion_filter/twist_with_covariance"/>
       <arg name="output_odom_name" value="/localization/kinematic_state"/>
+      <arg name="param_path" value="$(var stop_filter_param_path)"/>
     </include>
   </group>
 


### PR DESCRIPTION
## Description

Enable to set the `param_path` of `stop filter.param.yaml`.
Especially expected to get from autoware_launch.

## Related links

**This PR has to work and be merged with https://github.com/autowarefoundation/autoware_launch/pull/1145 together.**

## How was this PR tested?

1. Checked that [rosbag replay tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) works.
2. Checked that `ros2 param dump /localization/pose_twist_fusion_filter/stop_filter` return the following. When I changed `vx_threshold` to 1.1.
```
/localization/pose_twist_fusion_filter/stop_filter:
  ros__parameters:
    qos_overrides:
      /clock:
        subscription:
          depth: 1
          durability: volatile
          history: keep_last
          reliability: best_effort
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
    use_sim_time: true
    vx_threshold: 1.1
    wz_threshold: 0.02
```
3.  Confirmed that minimum `twist.x` of `/localization/kinematic_state` changes when I change the parameter in autoware_launch.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

`stop_filter` will get parameters from `stop_filter.param.yaml` in autoware_launch
