### PR TITLE
refactor(start_planner, lane_departure_checker): remove redundant calculation in fuseLaneletPolygon

### DIFF
--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
@@ -132,6 +132,11 @@ public:
   std::optional<autoware::universe_utils::Polygon2d> getFusedLaneletPolygonForPath(
     const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
 
+  bool updateFusedLaneletPolygonForPath(
+    const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
+    std::vector<lanelet::Id> & fused_lanelets_id,
+    std::optional<autoware::universe_utils::Polygon2d> & fused_lanelets_polygon) const;
+
   bool checkPathWillLeaveLane(
     const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
 
@@ -181,6 +186,9 @@ private:
   bool willCrossBoundary(
     const std::vector<LinearRing2d> & vehicle_footprints,
     const SegmentRtree & uncrossable_segments) const;
+
+  lanelet::BasicPolygon2d toBasicPolygon2D(const LinearRing2d & footprint_hull) const;
+  autoware::universe_utils::Polygon2d toPolygon2D(const lanelet::BasicPolygon2d & poly) const;
 
   mutable std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
 };

--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
@@ -135,6 +135,11 @@ public:
   bool checkPathWillLeaveLane(
     const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path) const;
 
+  bool checkPathWillLeaveLane(
+    const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
+    std::vector<lanelet::Id> & fused_lanelets_id,
+    std::optional<autoware::universe_utils::Polygon2d> & fused_lanelets_polygon) const;
+
   PathWithLaneId cropPointsOutsideOfLanes(
     const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
     const size_t end_index);

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -414,12 +414,12 @@ bool LaneDepartureChecker::checkPathWillLeaveLane(
   const std::vector<LinearRing2d> vehicle_footprints = createVehicleFootprints(path);
 
   if (fused_lanelets_polygon) {
-    bool is_indside_fused_lanelets = std::all_of(
+    bool is_inside_fused_lanelets = std::all_of(
       vehicle_footprints.begin(), vehicle_footprints.end(), [&](const auto & footprint) {
         return boost::geometry::within(footprint, fused_lanelets_polygon.value());
       });
 
-    if (is_indside_fused_lanelets) {
+    if (is_inside_fused_lanelets) {
       return false;
     }
   }

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -446,7 +446,7 @@ PathWithLaneId LaneDepartureChecker::cropPointsOutsideOfLanes(
 
   {
     universe_utils::ScopedTimeTrack st2(
-      "check if footprint is within fused_lanlets_polygon", *time_keeper_);
+      "check if footprint is within fused_lanelets_polygon", *time_keeper_);
 
     size_t idx = 0;
     std::for_each(

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -339,7 +339,8 @@ LaneDepartureChecker::getFusedLaneletPolygonForPath(
     const auto & p = route_lanelet.polygon2d().basicPolygon();
     autoware::universe_utils::Polygon2d poly = toPolygon2D(p);
     boost::geometry::union_(lanelet_unions, poly, result);
-    lanelet_unions = std::move(result);
+    lanelet_unions = result;
+    result.clear();
   }
 
   if (lanelet_unions.empty()) return std::nullopt;
@@ -372,7 +373,8 @@ bool LaneDepartureChecker::updateFusedLaneletPolygonForPath(
     const auto & p = route_lanelet.polygon2d().basicPolygon();
     autoware::universe_utils::Polygon2d poly = toPolygon2D(p);
     boost::geometry::union_(lanelet_unions, poly, result);
-    lanelet_unions = std::move(result);
+    lanelet_unions = result;
+    result.clear();
     fused_lanelets_id.push_back(route_lanelet.id());
   }
 

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -313,15 +313,8 @@ std::vector<std::pair<double, lanelet::Lanelet>> LaneDepartureChecker::getLanele
   // Get Footprint Hull basic polygon
   std::vector<LinearRing2d> vehicle_footprints = createVehicleFootprints(path);
   LinearRing2d footprint_hull = createHullFromFootprints(vehicle_footprints);
-  auto to_basic_polygon = [](const LinearRing2d & footprint_hull) -> lanelet::BasicPolygon2d {
-    lanelet::BasicPolygon2d basic_polygon;
-    for (const auto & point : footprint_hull) {
-      Eigen::Vector2d p(point.x(), point.y());
-      basic_polygon.push_back(p);
-    }
-    return basic_polygon;
-  };
-  lanelet::BasicPolygon2d footprint_hull_basic_polygon = to_basic_polygon(footprint_hull);
+
+  lanelet::BasicPolygon2d footprint_hull_basic_polygon = toBasicPolygon2D(footprint_hull);
 
   // Find all lanelets that intersect the footprint hull
   return lanelet::geometry::findWithin2d(
@@ -335,39 +328,63 @@ LaneDepartureChecker::getFusedLaneletPolygonForPath(
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto lanelets_distance_pair = getLaneletsFromPath(lanelet_map_ptr, path);
-  auto to_polygon2d =
-    [](const lanelet::BasicPolygon2d & poly) -> autoware::universe_utils::Polygon2d {
-    autoware::universe_utils::Polygon2d polygon;
-    auto & outer = polygon.outer();
-
-    for (const auto & p : poly) {
-      autoware::universe_utils::Point2d p2d(p.x(), p.y());
-      outer.push_back(p2d);
-    }
-    boost::geometry::correct(polygon);
-    return polygon;
-  };
+  if (lanelets_distance_pair.empty()) return std::nullopt;
 
   // Fuse lanelets into a single BasicPolygon2d
-  auto fused_lanelets = [&]() -> std::optional<autoware::universe_utils::Polygon2d> {
-    if (lanelets_distance_pair.empty()) return std::nullopt;
-    autoware::universe_utils::MultiPolygon2d lanelet_unions;
-    autoware::universe_utils::MultiPolygon2d result;
+  autoware::universe_utils::MultiPolygon2d lanelet_unions;
+  autoware::universe_utils::MultiPolygon2d result;
 
-    for (size_t i = 0; i < lanelets_distance_pair.size(); ++i) {
-      const auto & route_lanelet = lanelets_distance_pair.at(i).second;
-      const auto & p = route_lanelet.polygon2d().basicPolygon();
-      autoware::universe_utils::Polygon2d poly = to_polygon2d(p);
-      boost::geometry::union_(lanelet_unions, poly, result);
-      lanelet_unions = result;
-      result.clear();
-    }
+  for (size_t i = 0; i < lanelets_distance_pair.size(); ++i) {
+    const auto & route_lanelet = lanelets_distance_pair.at(i).second;
+    const auto & p = route_lanelet.polygon2d().basicPolygon();
+    autoware::universe_utils::Polygon2d poly = toPolygon2D(p);
+    boost::geometry::union_(lanelet_unions, poly, result);
+    lanelet_unions = result;
+    result.clear();
+  }
 
-    if (lanelet_unions.empty()) return std::nullopt;
-    return lanelet_unions.front();
-  }();
+  if (lanelet_unions.empty()) return std::nullopt;
+  return lanelet_unions.front();
+}
 
-  return fused_lanelets;
+bool LaneDepartureChecker::updateFusedLaneletPolygonForPath(
+  const lanelet::LaneletMapPtr lanelet_map_ptr, const PathWithLaneId & path,
+  std::vector<lanelet::Id> & fused_lanelets_id,
+  std::optional<autoware::universe_utils::Polygon2d> & fused_lanelets_polygon) const
+{
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto lanelets_distance_pair = getLaneletsFromPath(lanelet_map_ptr, path);
+  if (lanelets_distance_pair.empty()) return false;
+
+  autoware::universe_utils::MultiPolygon2d lanelet_unions;
+  autoware::universe_utils::MultiPolygon2d result;
+
+  if (fused_lanelets_polygon) lanelet_unions.push_back(fused_lanelets_polygon.value());
+
+  for (size_t i = 0; i < lanelets_distance_pair.size(); ++i) {
+    const auto & route_lanelet = lanelets_distance_pair.at(i).second;
+    bool id_exist = std::any_of(
+      fused_lanelets_id.begin(), fused_lanelets_id.end(),
+      [&](const auto & id) { return id == route_lanelet.id(); });
+
+    if (id_exist) continue;
+
+    const auto & p = route_lanelet.polygon2d().basicPolygon();
+    autoware::universe_utils::Polygon2d poly = toPolygon2D(p);
+    boost::geometry::union_(lanelet_unions, poly, result);
+    lanelet_unions = result;
+    result.clear();
+    fused_lanelets_id.push_back(route_lanelet.id());
+  }
+
+  if (lanelet_unions.empty()) {
+    fused_lanelets_polygon = std::nullopt;
+    return false;
+  }
+
+  fused_lanelets_polygon = lanelet_unions.front();
+  return true;
 }
 
 bool LaneDepartureChecker::checkPathWillLeaveLane(
@@ -407,63 +424,9 @@ bool LaneDepartureChecker::checkPathWillLeaveLane(
     }
   }
 
-  LinearRing2d footprint_hull = createHullFromFootprints(vehicle_footprints);
-
-  auto to_basic_polygon = [](const LinearRing2d & footprint_hull) -> lanelet::BasicPolygon2d {
-    lanelet::BasicPolygon2d basic_polygon;
-    for (const auto & point : footprint_hull) {
-      Eigen::Vector2d p(point.x(), point.y());
-      basic_polygon.push_back(p);
-    }
-    return basic_polygon;
-  };
-
-  lanelet::BasicPolygon2d footprint_hull_basic_polygon = to_basic_polygon(footprint_hull);
-  const auto lanelets_distance_pair = lanelet::geometry::findWithin2d(
-    lanelet_map_ptr->laneletLayer, footprint_hull_basic_polygon, 0.0);
-
-  if (lanelets_distance_pair.empty()) return true;
-
-  auto to_polygon2d =
-    [](const lanelet::BasicPolygon2d & poly) -> autoware::universe_utils::Polygon2d {
-    autoware::universe_utils::Polygon2d polygon;
-    auto & outer = polygon.outer();
-
-    for (const auto & p : poly) {
-      autoware::universe_utils::Point2d p2d(p.x(), p.y());
-      outer.push_back(p2d);
-    }
-    boost::geometry::correct(polygon);
-    return polygon;
-  };
-
-  autoware::universe_utils::MultiPolygon2d lanelet_unions;
-  autoware::universe_utils::MultiPolygon2d result;
-
-  if (fused_lanelets_polygon) lanelet_unions.push_back(fused_lanelets_polygon.value());
-
-  for (size_t i = 0; i < lanelets_distance_pair.size(); ++i) {
-    const auto & route_lanelet = lanelets_distance_pair.at(i).second;
-    bool id_exist = std::any_of(
-      fused_lanelets_id.begin(), fused_lanelets_id.end(),
-      [&](const auto & id) { return id == route_lanelet.id(); });
-
-    if (id_exist) continue;
-
-    const auto & p = route_lanelet.polygon2d().basicPolygon();
-    autoware::universe_utils::Polygon2d poly = to_polygon2d(p);
-    boost::geometry::union_(lanelet_unions, poly, result);
-    lanelet_unions = result;
-    result.clear();
-    fused_lanelets_id.push_back(route_lanelet.id());
-  }
-
-  if (lanelet_unions.empty()) {
-    fused_lanelets_polygon = std::nullopt;
-    return true;
-  }
-
-  fused_lanelets_polygon = lanelet_unions.front();
+  const auto updated = updateFusedLaneletPolygonForPath(
+    lanelet_map_ptr, path, fused_lanelets_id, fused_lanelets_polygon);
+  if (!updated) return true;
 
   return !std::all_of(
     vehicle_footprints.begin(), vehicle_footprints.end(), [&](const auto & footprint) {
@@ -567,6 +530,31 @@ bool LaneDepartureChecker::willCrossBoundary(
     }
   }
   return false;
+}
+
+lanelet::BasicPolygon2d LaneDepartureChecker::toBasicPolygon2D(
+  const LinearRing2d & footprint_hull) const
+{
+  lanelet::BasicPolygon2d basic_polygon;
+  for (const auto & point : footprint_hull) {
+    Eigen::Vector2d p(point.x(), point.y());
+    basic_polygon.push_back(p);
+  }
+  return basic_polygon;
+}
+
+autoware::universe_utils::Polygon2d LaneDepartureChecker::toPolygon2D(
+  const lanelet::BasicPolygon2d & poly) const
+{
+  autoware::universe_utils::Polygon2d polygon;
+  auto & outer = polygon.outer();
+
+  for (const auto & p : poly) {
+    autoware::universe_utils::Point2d p2d(p.x(), p.y());
+    outer.push_back(p2d);
+  }
+  boost::geometry::correct(polygon);
+  return polygon;
 }
 
 }  // namespace autoware::lane_departure_checker

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -421,12 +421,14 @@ bool LaneDepartureChecker::checkPathWillLeaveLane(
     return false;
   }
 
-  // Updated the lanelet polygon for the current path
+  // Update the lanelet polygon for the current path
   if (!updateFusedLaneletPolygonForPath(
         lanelet_map_ptr, path, fused_lanelets_id, fused_lanelets_polygon)) {
+    // If update fails, assume the path leaves the lane
     return true;
   }
 
+  // Check if any footprint is outside the updated lanelets polygon
   return !is_all_footprints_within(fused_lanelets_polygon.value());
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -384,7 +384,7 @@ void PlannerManager::print() const
 
   state_publisher_ptr_->publish<DebugStringMsg>("internal_state", string_stream.str());
 
-  RCLCPP_INFO_STREAM(logger_, string_stream.str());
+  RCLCPP_DEBUG_STREAM(logger_, string_stream.str());
 }
 
 void PlannerManager::publishProcessingTime() const

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -384,7 +384,7 @@ void PlannerManager::print() const
 
   state_publisher_ptr_->publish<DebugStringMsg>("internal_state", string_stream.str());
 
-  RCLCPP_DEBUG_STREAM(logger_, string_stream.str());
+  RCLCPP_INFO_STREAM(logger_, string_stream.str());
 }
 
 void PlannerManager::publishProcessingTime() const

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -63,6 +63,9 @@ std::optional<PullOutPath> ShiftPullOut::plan(
 
   const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
 
+  std::vector<lanelet::Id> fused_id_start_to_end{};
+  std::optional<autoware::universe_utils::Polygon2d> fused_polygon_start_to_end = std::nullopt;
+
   // get safe path
   for (auto & pull_out_path : pull_out_paths) {
     universe_utils::ScopedTimeTrack st("get safe path", *time_keeper_);
@@ -99,8 +102,9 @@ std::optional<PullOutPath> ShiftPullOut::plan(
     // computational cost.
 
     if (
-      is_lane_departure_check_required &&
-      lane_departure_checker_->checkPathWillLeaveLane(lanelet_map_ptr, path_shift_start_to_end)) {
+      is_lane_departure_check_required && lane_departure_checker_->checkPathWillLeaveLane(
+                                            lanelet_map_ptr, path_shift_start_to_end,
+                                            fused_id_start_to_end, fused_polygon_start_to_end)) {
       planner_debug_data.conditions_evaluation.emplace_back("lane departure");
       continue;
     }


### PR DESCRIPTION
## Description
The `ShiftPullOut::plan()` function in start planner, checks if a candidate path is safe by using the lane departure module. As the number of candidate path grows, the lane departure check would be called multiple times, which leads to large computational cost calling. This is due to calling the boost::geometry functions several times, as seen below:

```
⏰ Worst Case Execution Time ⏰
100.00% planWaitingApproval: total 92.69 [ms], avg. 5.79 [ms], run count: 16
    ├── 91.30% updatePullOutStatus: total 84.62 [ms], avg. 5.29 [ms], run count: 16
    │   ├── 0.20% calcBackwardPathFromStartPose: total 0.19 [ms], avg. 0.19 [ms], run count: 1
    │   ├── 0.14% searchPullOutStartPoseCandidates: total 0.13 [ms], avg. 0.13 [ms], run count: 1
    │   │   ├── 0.04% filterStopObjectsInPullOutLanes: total 0.04 [ms], avg. 0.02 [ms], run count: 2
    │   │   └── 0.10% rest: 0.09 [ms]
    │   ├── 90.87% planWithPriority: total 84.23 [ms], avg. 84.23 [ms], run count: 1
    │   │   ├── 0.00% determinePriorityOrder: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   ├── 90.86% findPullOutPaths: total 84.22 [ms], avg. 84.22 [ms], run count: 1
    │   │   │   ├── 35.04% calcPullOutPaths: total 32.47 [ms], avg. 1.16 [ms], run count: 28
    │   │   │   ├── 34.14% get safe path: total 31.64 [ms], avg. 0.28 [ms], run count: 112
    │   │   │   │   ├── 24.36% checkPathWillLeaveLane: total 22.58 [ms], avg. 0.20 [ms], run count: 112
    │   │   │   │   │   ├── 21.17% getFusedLaneletPolygonForPath: total 19.62 [ms], avg. 0.18 [ms], run count: 112
    │   │   │   │   │   │   ├── 6.40% getLaneletsFromPath: total 5.93 [ms], avg. 0.05 [ms], run count: 112
    │   │   │   │   │   │   └── 14.77% rest: 13.69 [ms]
    │   │   │   │   │   └── 3.20% rest: 2.96 [ms]
    │   │   │   │   ├── 8.92% cropPointsOutsideOfLanes: total 8.27 [ms], avg. 0.52 [ms], run count: 16
    │   │   │   │   │   ├── 7.80% getFusedLaneletPolygonForPath: total 7.23 [ms], avg. 0.45 [ms], run count: 16
    │   │   │   │   │   │   ├── 2.10% getLaneletsFromPath: total 1.95 [ms], avg. 0.12 [ms], run count: 16
    │   │   │   │   │   │   └── 5.70% rest: 5.29 [ms]
    │   │   │   │   │   ├── 0.63% check if footprint is within fused_lanlets_polygon: total 0.59 [ms], avg. 0.04 [ms], run count: 16
    │   │   │   │   │   └── 0.48% rest: 0.45 [ms]
    │   │   │   │   └── 0.86% rest: 0.80 [ms]
    │   │   │   └── 21.68% rest: 20.10 [ms]
    │   │   └── 0.01% rest: 0.01 [ms]
    │   └── 0.08% rest: 0.08 [ms]
    ├── 0.06% isPreventingRearVehicleFromPassingThrough: total 0.05 [ms], avg. 0.05 [ms], run count: 1
    │   ├── 0.16% isPreventingRearVehicleFromPassingThrough: total 0.15 [ms], avg. 0.07 [ms], run count: 2
    │   └── -0.10% rest: -0.10 [ms]
    ├── 0.04% isSafePath: total 0.04 [ms], avg. 0.04 [ms], run count: 1
    └── 8.61% rest: 7.98 [ms]
```

By applying this PR, redundant calculations are skipped when path candidates are included in the same lanelet. If the obtained lanelets are the same as the previously calculated the `boost::geometry::union_` is skipped. Thus when candidate pull out paths have a similar shape, they lane departure check computational cost would be likely to be decreased.

## Related links
None

## How was this PR tested?
Local scenario simulator. The calculation time for `checkPathWillLeaveLane` function is decreased.
```
⏰ Worst Case Execution Time ⏰
100.00% planWaitingApproval: total 84.78 [ms], avg. 5.30 [ms], run count: 16
    ├── 91.73% updatePullOutStatus: total 77.77 [ms], avg. 4.86 [ms], run count: 16
    │   ├── 0.13% calcBackwardPathFromStartPose: total 0.11 [ms], avg. 0.11 [ms], run count: 1
    │   ├── 0.13% searchPullOutStartPoseCandidates: total 0.11 [ms], avg. 0.11 [ms], run count: 1
    │   │   ├── 0.05% filterStopObjectsInPullOutLanes: total 0.04 [ms], avg. 0.02 [ms], run count: 2
    │   │   └── 0.08% rest: 0.07 [ms]
    │   ├── 91.38% planWithPriority: total 77.47 [ms], avg. 77.47 [ms], run count: 1
    │   │   ├── 0.00% determinePriorityOrder: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   ├── 91.36% findPullOutPaths: total 77.46 [ms], avg. 77.46 [ms], run count: 1
    │   │   │   ├── 39.86% calcPullOutPaths: total 33.80 [ms], avg. 1.21 [ms], run count: 28
    │   │   │   ├── 30.11% get safe path: total 25.53 [ms], avg. 0.23 [ms], run count: 112
    │   │   │   │   ├── 18.69% checkPathWillLeaveLane: total 15.84 [ms], avg. 0.14 [ms], run count: 112
    │   │   │   │   │   ├── 13.36% updateFusedLaneletPolygonForPath: total 11.33 [ms], avg. 0.11 [ms], run count: 100
    │   │   │   │   │   │   ├── 7.53% getLaneletsFromPath: total 6.39 [ms], avg. 0.06 [ms], run count: 100
    │   │   │   │   │   │   └── 5.82% rest: 4.94 [ms]
    │   │   │   │   │   └── 5.33% rest: 4.52 [ms]
    │   │   │   │   ├── 10.40% cropPointsOutsideOfLanes: total 8.82 [ms], avg. 0.55 [ms], run count: 16
    │   │   │   │   │   ├── 9.20% getFusedLaneletPolygonForPath: total 7.80 [ms], avg. 0.49 [ms], run count: 16
    │   │   │   │   │   │   ├── 2.47% getLaneletsFromPath: total 2.10 [ms], avg. 0.13 [ms], run count: 16
    │   │   │   │   │   │   └── 6.73% rest: 5.70 [ms]
    │   │   │   │   │   ├── 0.69% check if footprint is within fused_lanlets_polygon: total 0.58 [ms], avg. 0.04 [ms], run count: 16
    │   │   │   │   │   └── 0.52% rest: 0.44 [ms]
    │   │   │   │   └── 1.02% rest: 0.87 [ms]
    │   │   │   └── 21.39% rest: 18.13 [ms]
    │   │   └── 0.02% rest: 0.02 [ms]
    │   └── 0.09% rest: 0.08 [ms]
    ├── 0.16% isPreventingRearVehicleFromPassingThrough: total 0.14 [ms], avg. 0.14 [ms], run count: 1
    │   ├── 0.37% isPreventingRearVehicleFromPassingThrough: total 0.31 [ms], avg. 0.16 [ms], run count: 2
    │   └── -0.21% rest: -0.18 [ms]
    ├── 0.09% isSafePath: total 0.08 [ms], avg. 0.08 [ms], run count: 1
    └── 8.02% rest: 6.80 [ms]

```

[TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/63858e55-e3db-5e9f-88d8-3dfcb48ac46a?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
