### PR TITLE
refactor(tier4_localization_rviz_plugin): apply static analysis

### DIFF
--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
@@ -44,6 +44,7 @@ PoseHistory::PoseHistory() : last_stamp_(0, 0, RCL_ROS_TIME)
 
 PoseHistory::~PoseHistory() = default;  // Properties are deleted by Qt
 
+// cppcheck-suppress unusedFunction
 void PoseHistory::onInitialize()
 {
   MFDClass::onInitialize();
@@ -70,7 +71,7 @@ void PoseHistory::update(float wall_dt, float ros_dt)
   if (!history_.empty()) {
     lines_->clear();
     if (property_line_view_->getBool()) {
-      updateLines();
+      update_lines();
     }
   }
 }
@@ -103,10 +104,10 @@ void PoseHistory::processMessage(const geometry_msgs::msg::PoseStamped::ConstSha
   history_.emplace_back(message);
   last_stamp_ = message->header.stamp;
 
-  updateHistory();
+  update_history();
 }
 
-void PoseHistory::updateHistory()
+void PoseHistory::update_history()
 {
   const auto buffer_size = static_cast<size_t>(property_buffer_size_->getInt());
   while (buffer_size < history_.size()) {
@@ -114,7 +115,7 @@ void PoseHistory::updateHistory()
   }
 }
 
-void PoseHistory::updateLines()
+void PoseHistory::update_lines()
 {
   Ogre::ColourValue color = rviz_common::properties::qtToOgre(property_line_color_->getColor());
   color.a = property_line_alpha_->getFloat();
@@ -136,9 +137,9 @@ void PoseHistory::updateLines()
 
   for (const auto & message : history_) {
     Ogre::Vector3 point;
-    point.x = message->pose.position.x;
-    point.y = message->pose.position.y;
-    point.z = message->pose.position.z;
+    point.x = static_cast<float>(message->pose.position.x);
+    point.y = static_cast<float>(message->pose.position.y);
+    point.z = static_cast<float>(message->pose.position.z);
     lines_->addPoint(point);
   }
 }

--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp
@@ -59,8 +59,8 @@ private:
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
-  void updateHistory();
-  void updateLines();
+  void update_history();
+  void update_lines();
 
   std::string target_frame_;
   std::deque<geometry_msgs::msg::PoseStamped::ConstSharedPtr> history_;

--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
@@ -40,7 +40,6 @@ namespace rviz_plugins
 {
 
 using autoware::vehicle_info_utils::VehicleInfo;
-using autoware::vehicle_info_utils::VehicleInfoUtils;
 
 class PoseHistoryFootprint
 : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::PoseStamped>
@@ -59,17 +58,17 @@ protected:
   void onInitialize() override;
   void onEnable() override;
   void onDisable() override;
-  void updateFootprint();
+  void update_footprint();
 
 private Q_SLOTS:
-  void updateVisualization();
-  void updateVehicleInfo();
+  void update_visualization();
+  void update_vehicle_info();
 
-private:
+private:  // NOLINT
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
-  void updateHistory(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message);
+  void update_history(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message);
 
   std::string target_frame_;
   std::deque<geometry_msgs::msg::PoseStamped::ConstSharedPtr> history_;
@@ -79,7 +78,7 @@ private:
   rviz_common::properties::IntProperty * property_buffer_size_;
 
   // trajectory footprint
-  Ogre::ManualObject * trajectory_footprint_manual_object_;
+  Ogre::ManualObject * trajectory_footprint_manual_object_{};
   rviz_common::properties::BoolProperty * property_trajectory_footprint_view_;
   rviz_common::properties::ColorProperty * property_trajectory_footprint_color_;
   rviz_common::properties::FloatProperty * property_trajectory_footprint_alpha_;

--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
@@ -64,7 +64,7 @@ private Q_SLOTS:
   void update_visualization();
   void update_vehicle_info();
 
-private:  // NOLINT
+private:  // NOLINT : suppress redundancy warnings; cannot be declared with the Q_SLOTS macro
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;

--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
@@ -64,7 +64,8 @@ private Q_SLOTS:
   void update_visualization();
   void update_vehicle_info();
 
-private:  // NOLINT : suppress redundancy warnings; cannot be declared with the Q_SLOTS macro
+private:  // NOLINT : suppress redundancy warnings
+          //          followings cannot be declared with the Q_SLOTS macro
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;

--- a/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp
@@ -92,16 +92,19 @@ void PoseWithCovarianceHistory::onInitialize()
   lines_ = std::make_unique<rviz_rendering::BillboardLine>(scene_manager_, scene_node_);
 }
 
+// cppcheck-suppress unusedFunction
 void PoseWithCovarianceHistory::onEnable()
 {
   subscribe();
 }
 
+// cppcheck-suppress unusedFunction
 void PoseWithCovarianceHistory::onDisable()
 {
   unsubscribe();
 }
 
+// cppcheck-suppress unusedFunction
 void PoseWithCovarianceHistory::update(float wall_dt, float ros_dt)
 {
   (void)wall_dt;
@@ -111,8 +114,8 @@ void PoseWithCovarianceHistory::update(float wall_dt, float ros_dt)
     lines_->clear();
     arrows_.clear();
     spheres_.clear();
-    updateShapeType();
-    updateShapes();
+    update_shape_type();
+    update_shapes();
   }
 }
 
@@ -131,7 +134,7 @@ void PoseWithCovarianceHistory::unsubscribe()
   spheres_.clear();
 }
 
-void PoseWithCovarianceHistory::updateShapeType()
+void PoseWithCovarianceHistory::update_shape_type()
 {
   bool is_line = property_shape_type_->getOptionInt() == 0;
   bool is_arrow = property_shape_type_->getOptionInt() == 1;
@@ -148,6 +151,7 @@ void PoseWithCovarianceHistory::updateShapeType()
   property_arrow_color_->setHidden(!is_arrow);
 }
 
+// cppcheck-suppress unusedFunction
 void PoseWithCovarianceHistory::processMessage(
   const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr message)
 {
@@ -166,10 +170,10 @@ void PoseWithCovarianceHistory::processMessage(
   }
   history_.emplace_back(message);
   last_stamp_ = message->header.stamp;
-  updateHistory();
+  update_history();
 }
 
-void PoseWithCovarianceHistory::updateHistory()
+void PoseWithCovarianceHistory::update_history()
 {
   const auto buffer_size = static_cast<size_t>(property_buffer_size_->getInt());
   while (buffer_size < history_.size()) {
@@ -177,7 +181,7 @@ void PoseWithCovarianceHistory::updateHistory()
   }
 }
 
-void PoseWithCovarianceHistory::updateShapes()
+void PoseWithCovarianceHistory::update_shapes()
 {
   int shape_type = property_shape_type_->getOptionInt();
   Ogre::ColourValue color_line =
@@ -218,15 +222,15 @@ void PoseWithCovarianceHistory::updateShapes()
     const auto & message = history_[i];
 
     Ogre::Vector3 position;
-    position.x = message->pose.pose.position.x;
-    position.y = message->pose.pose.position.y;
-    position.z = message->pose.pose.position.z;
+    position.x = static_cast<float>(message->pose.pose.position.x);
+    position.y = static_cast<float>(message->pose.pose.position.y);
+    position.z = static_cast<float>(message->pose.pose.position.z);
 
     Ogre::Quaternion orientation;
-    orientation.w = message->pose.pose.orientation.w;
-    orientation.x = message->pose.pose.orientation.x;
-    orientation.y = message->pose.pose.orientation.y;
-    orientation.z = message->pose.pose.orientation.z;
+    orientation.w = static_cast<float>(message->pose.pose.orientation.w);
+    orientation.x = static_cast<float>(message->pose.pose.orientation.x);
+    orientation.y = static_cast<float>(message->pose.pose.orientation.y);
+    orientation.z = static_cast<float>(message->pose.pose.orientation.z);
 
     Eigen::Matrix3d covariance_3d_map;
     covariance_3d_map(0, 0) = message->pose.covariance[0];
@@ -242,11 +246,14 @@ void PoseWithCovarianceHistory::updateShapes()
     if (property_sphere_view_->getBool()) {
       Eigen::Matrix3d covariance_3d_base_link;
       Eigen::Translation3f translation(
-        message->pose.pose.position.x, message->pose.pose.position.y,
-        message->pose.pose.position.z);
+        static_cast<float>(message->pose.pose.position.x),
+        static_cast<float>(message->pose.pose.position.y),
+        static_cast<float>(message->pose.pose.position.z));
       Eigen::Quaternionf rotation(
-        message->pose.pose.orientation.w, message->pose.pose.orientation.x,
-        message->pose.pose.orientation.y, message->pose.pose.orientation.z);
+        static_cast<float>(message->pose.pose.orientation.w),
+        static_cast<float>(message->pose.pose.orientation.x),
+        static_cast<float>(message->pose.pose.orientation.y),
+        static_cast<float>(message->pose.pose.orientation.z));
       Eigen::Matrix4f pose_matrix4f = (translation * rotation).matrix();
       const Eigen::Matrix3d rot = pose_matrix4f.topLeftCorner<3, 3>().cast<double>();
       covariance_3d_base_link = rot.transpose() * covariance_3d_map * rot;
@@ -256,9 +263,12 @@ void PoseWithCovarianceHistory::updateShapes()
       sphere->setOrientation(orientation);
       sphere->setColor(color_sphere.r, color_sphere.g, color_sphere.b, color_sphere.a);
       sphere->setScale(Ogre::Vector3(
-        property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(0, 0)),
-        property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(1, 1)),
-        property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(2, 2))));
+        static_cast<float>(
+          property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(0, 0))),
+        static_cast<float>(
+          property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(1, 1))),
+        static_cast<float>(
+          property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(2, 2)))));
     }
 
     if (property_path_view_->getBool()) {

--- a/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp
@@ -65,7 +65,7 @@ protected:
 private Q_SLOTS:
   void update_shape_type();
 
-private:  // NOLINT
+private:  // NOLINT : suppress redundancy warnings; cannot be declared with the Q_SLOTS macro
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(

--- a/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp
@@ -63,15 +63,15 @@ protected:
   void update(float wall_dt, float ros_dt) override;
 
 private Q_SLOTS:
-  void updateShapeType();
+  void update_shape_type();
 
-private:
+private:  // NOLINT
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(
     const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr message) override;
-  void updateHistory();
-  void updateShapes();
+  void update_history();
+  void update_shapes();
 
   std::string target_frame_;
   std::deque<geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr> history_;
@@ -80,19 +80,19 @@ private:
   std::vector<std::unique_ptr<rviz_rendering::Arrow>> arrows_;
   rclcpp::Time last_stamp_;
 
-  rviz_common::properties::BoolProperty * property_line_view_;
+  rviz_common::properties::BoolProperty * property_line_view_{};
   rviz_common::properties::FloatProperty * property_line_width_;
   rviz_common::properties::FloatProperty * property_line_alpha_;
   rviz_common::properties::ColorProperty * property_line_color_;
   rviz_common::properties::IntProperty * property_buffer_size_;
 
   rviz_common::properties::BoolProperty * property_sphere_view_;
-  rviz_common::properties::FloatProperty * property_sphere_width_;
+  rviz_common::properties::FloatProperty * property_sphere_width_{};
   rviz_common::properties::FloatProperty * property_sphere_alpha_;
   rviz_common::properties::ColorProperty * property_sphere_color_;
   rviz_common::properties::FloatProperty * property_sphere_scale_;
 
-  rviz_common::properties::BoolProperty * property_arrow_view_;
+  rviz_common::properties::BoolProperty * property_arrow_view_{};
   rviz_common::properties::FloatProperty * property_arrow_shaft_length_;
   rviz_common::properties::FloatProperty * property_arrow_shaft_diameter_;
   rviz_common::properties::FloatProperty * property_arrow_head_length_;

--- a/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp
@@ -65,7 +65,8 @@ protected:
 private Q_SLOTS:
   void update_shape_type();
 
-private:  // NOLINT : suppress redundancy warnings; cannot be declared with the Q_SLOTS macro
+private:  // NOLINT : suppress redundancy warnings
+          //          followings cannot be declared with the Q_SLOTS macro
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(


### PR DESCRIPTION
## Description
This PR applies some suggestions from the linter to `tier4_localization_rviz_plugin`.

Fixed:
- camelCase to snake_case
- use explicit cast
- add initialization to uninitialized variable

suppressed:
- cppcheck unusedFunction
- redundant access specifier (readability-redundant-access-specifiers)
  - redundant private specifier in class definition
    - e.g. https://github.com/autowarefoundation/autoware.universe/blob/0cee96143239e16ead4a464d83662bca7a5aef1e/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp#L65-L68
  - removing the regular `private`  will lead to `Error: Not a signal or slot declaration` from Qt.
  - added `// NOLINT`  for suppression

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1).

Use `.cppcheck_suppressions` for suppressing some notation from cppcheck.

<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh tier4_localization_rviz_plugin
...
27753 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp:62:8: warning: invalid case style for function 'updateHistory' [readability-identifier-naming]
  void updateHistory();
       ^~~~~~~~~~~~~
       update_history
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp:63:8: warning: invalid case style for function 'updateLines' [readability-identifier-naming]
  void updateLines();
       ^~~~~~~~~~~
       update_lines
Suppressed 27762 warnings (27751 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
34277 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp:66:8: warning: invalid case style for function 'updateShapeType' [readability-identifier-naming]
  void updateShapeType();
       ^~~~~~~~~~~~~~~
       update_shape_type
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp:68:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
private:
^~~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp:65:1: note: previously declared here
private Q_SLOTS:
^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp:73:8: warning: invalid case style for function 'updateHistory' [readability-identifier-naming]
  void updateHistory();
       ^~~~~~~~~~~~~
       update_history
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.hpp:74:8: warning: invalid case style for function 'updateShapes' [readability-identifier-naming]
  void updateShapes();
       ^~~~~~~~~~~~
       update_shapes
Suppressed 34286 warnings (34273 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43909 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:43:37: error: using decl 'VehicleInfoUtils' is unused [misc-unused-using-decls,-warnings-as-errors]
using autoware::vehicle_info_utils::VehicleInfoUtils;
                                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:43:37: note: remove the using
using autoware::vehicle_info_utils::VehicleInfoUtils;
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:62:8: warning: invalid case style for function 'updateFootprint' [readability-identifier-naming]
  void updateFootprint();
       ^~~~~~~~~~~~~~~
       update_footprint
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:65:8: warning: invalid case style for function 'updateVisualization' [readability-identifier-naming]
  void updateVisualization();
       ^~~~~~~~~~~~~~~~~~~
       update_visualization
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:66:8: warning: invalid case style for function 'updateVehicleInfo' [readability-identifier-naming]
  void updateVehicleInfo();
       ^~~~~~~~~~~~~~~~~
       update_vehicle_info
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:68:1: warning: redundant access specifier has the same accessibility as the previous access specifier [readability-redundant-access-specifiers]
private:
^~~~~~~~
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:64:1: note: previously declared here
private Q_SLOTS:
^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp:72:8: warning: invalid case style for function 'updateHistory' [readability-identifier-naming]
  void updateHistory(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message);
       ^~~~~~~~~~~~~
       update_history
Suppressed 43916 warnings (43903 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
31071 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp:139:15: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    point.x = message->pose.position.x;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp:140:15: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    point.y = message->pose.position.y;
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp:141:15: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    point.z = message->pose.position.z;
              ^
Suppressed 31079 warnings (31068 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
50674 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:37:1: warning: constructor does not initialize these fields: trajectory_footprint_manual_object_ [cppcoreguidelines-pro-type-member-init]
PoseHistoryFootprint::PoseHistoryFootprint() : last_stamp_(0, 0, RCL_ROS_TIME)
^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:213:5: warning: use range-based for loop instead [modernize-loop-convert]
    for (size_t point_idx = 0; point_idx < history_.size(); ++point_idx) {
    ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        (auto & point_idx : history_)
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:226:28: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
        const float left = -info->width / 2.0;
                           ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:227:29: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
        const float right = info->width / 2.0;
                            ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:235:41: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_w_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
          const Eigen::Quaternionf quat(o.w, o.x, o.y, o.z);
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:235:46: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_x_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
          const Eigen::Quaternionf quat(o.w, o.x, o.y, o.z);
                                             ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:235:51: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_y_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
          const Eigen::Quaternionf quat(o.w, o.x, o.y, o.z);
                                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:235:56: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_z_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
          const Eigen::Quaternionf quat(o.w, o.x, o.y, o.z);
                                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:241:15: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
              p.x + offset_to_edge.x(), p.y + offset_to_edge.y(), p.z);
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:241:41: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
              p.x + offset_to_edge.x(), p.y + offset_to_edge.y(), p.z);
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:241:67: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'float' [cppcoreguidelines-narrowing-conversions]
              p.x + offset_to_edge.x(), p.y + offset_to_edge.y(), p.z);
                                                                  ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:249:15: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
              p.x + offset_to_edge.x(), p.y + offset_to_edge.y(), p.z);
              ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:249:41: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
              p.x + offset_to_edge.x(), p.y + offset_to_edge.y(), p.z);
                                        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:249:67: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'float' [cppcoreguidelines-narrowing-conversions]
              p.x + offset_to_edge.x(), p.y + offset_to_edge.y(), p.z);
                                                                  ^
Suppressed 50673 warnings (50660 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
42858 warnings generated.
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:32:1: warning: constructor does not initialize these fields: property_line_view_, property_sphere_width_, property_arrow_view_ [cppcoreguidelines-pro-type-member-init]
PoseWithCovarianceHistory::PoseWithCovarianceHistory() : last_stamp_(0, 0, RCL_ROS_TIME)
^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:221:18: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    position.x = message->pose.pose.position.x;
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:222:18: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    position.y = message->pose.pose.position.y;
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:223:18: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    position.z = message->pose.pose.position.z;
                 ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:226:21: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_w_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    orientation.w = message->pose.pose.orientation.w;
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:227:21: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_x_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    orientation.x = message->pose.pose.orientation.x;
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:228:21: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_y_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    orientation.y = message->pose.pose.orientation.y;
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:229:21: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_z_type' (aka 'double') to 'Ogre::Real' (aka 'float') [cppcoreguidelines-narrowing-conversions]
    orientation.z = message->pose.pose.orientation.z;
                    ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:245:9: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_x_type' (aka 'double') to 'Eigen::Translation<float, 3>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.position.x, message->pose.pose.position.y,
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:245:40: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_y_type' (aka 'double') to 'Eigen::Translation<float, 3>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.position.x, message->pose.pose.position.y,
                                       ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:246:9: warning: narrowing conversion from 'geometry_msgs::msg::Point_::_z_type' (aka 'double') to 'Eigen::Translation<float, 3>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.position.z);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:248:9: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_w_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.orientation.w, message->pose.pose.orientation.x,
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:248:43: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_x_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.orientation.w, message->pose.pose.orientation.x,
                                          ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:249:9: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_y_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.orientation.y, message->pose.pose.orientation.z);
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:249:43: warning: narrowing conversion from 'geometry_msgs::msg::Quaternion_::_z_type' (aka 'double') to 'Eigen::Quaternion<float, 0>::Scalar' (aka 'float') [cppcoreguidelines-narrowing-conversions]
        message->pose.pose.orientation.y, message->pose.pose.orientation.z);
                                          ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:259:9: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
        property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(0, 0)),
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:260:9: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
        property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(1, 1)),
        ^
/home/masakibaba/autoware/src/universe/autoware.universe/common/tier4_localization_rviz_plugin/src/pose_with_covariance_history/pose_with_covariance_history_display.cpp:261:9: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
        property_sphere_scale_->getFloat() * 2 * std::sqrt(covariance_3d_base_link(2, 2))));
        ^
Suppressed 42853 warnings (42840 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

Check with cppcheck:
<details>
<summary>output</summary>

```
(in tier4_localization_rviz_plugin)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive --suppressions-list=path/to/autoware.universe/.cppcheck_suppressions .

Checking src/pose_history/pose_history_display.cpp ...
1/3 files checked 17% done
Checking src/pose_history_footprint/display.cpp ...
src/pose_history_footprint/display.hpp:64:9: error: There is an unknown macro here somewhere. Configuration is required. If Q_SLOTS is a macro then please configure it. [unknownMacro]
private Q_SLOTS:
        ^
2/3 files checked 55% done
Checking src/pose_with_covariance_history/pose_with_covariance_history_display.cpp ...
src/pose_with_covariance_history/pose_with_covariance_history_display.hpp:65:9: error: There is an unknown macro here somewhere. Configuration is required. If Q_SLOTS is a macro then please configure it. [unknownMacro]
private Q_SLOTS:
        ^
3/3 files checked 100% done
src/pose_history/pose_history_display.cpp:54:0: style: The function 'onEnable' is never used. [unusedFunction]
void PoseHistory::onEnable()
^
src/pose_history/pose_history_display.cpp:60:0: style: The function 'onDisable' is never used. [unusedFunction]
void PoseHistory::onDisable()
^
src/pose_history/pose_history_display.cpp:65:0: style: The function 'update' is never used. [unusedFunction]
void PoseHistory::update(float wall_dt, float ros_dt)
^
src/pose_history/pose_history_display.cpp:91:0: style: The function 'processMessage' is never used. [unusedFunction]
void PoseHistory::processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message)

```
</details>

---

After this PR:

<details open>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh tier4_localization_rviz_plugin
...
27751 warnings generated.
Suppressed 27762 warnings (27751 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
34273 warnings generated.
Suppressed 34286 warnings (34273 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
43903 warnings generated.
Suppressed 43916 warnings (43903 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
31066 warnings generated.
Suppressed 31077 warnings (31066 in non-user code, 11 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
42836 warnings generated.
Suppressed 42849 warnings (42836 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
50655 warnings generated.
Suppressed 50668 warnings (50655 in non-user code, 13 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

<details open>
<summary>Check with cppcheck </summary>

```
(in tier4_localization_rviz_plugin)
$ cppcheck --enable=warning --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive --suppressions-list=/path/to/autoware.universe/.cppcheck_suppressions .

Checking src/pose_history/pose_history_display.cpp ...
1/3 files checked 17% done
Checking src/pose_history_footprint/display.cpp ...
2/3 files checked 55% done
Checking src/pose_with_covariance_history/pose_with_covariance_history_display.cpp ...
3/3 files checked 100% done
```
</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
