### PR TITLE
fix(simple_planning_simulator): delete velocity dead band for brake

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
@@ -166,13 +166,10 @@ Eigen::VectorXd SimModelDelaySteerAccGearedWoFallGuard::calcModel(
         return pedal_acc + input(IDX_U::SLOPE_ACCX);
       }
     } else {
-      constexpr double brake_dead_band = 1e-3;
-      if (vel > brake_dead_band) {
+      if (vel > 0.0) {
         return pedal_acc + input(IDX_U::SLOPE_ACCX);
-      } else if (vel < -brake_dead_band) {
+      } else if (vel < 0.0) {
         return -pedal_acc + input(IDX_U::SLOPE_ACCX);
-      } else if (-pedal_acc >= std::abs(input(IDX_U::SLOPE_ACCX))) {
-        return 0.0;
       } else {
         return input(IDX_U::SLOPE_ACCX);
       }

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
@@ -170,6 +170,8 @@ Eigen::VectorXd SimModelDelaySteerAccGearedWoFallGuard::calcModel(
         return pedal_acc + input(IDX_U::SLOPE_ACCX);
       } else if (vel < 0.0) {
         return -pedal_acc + input(IDX_U::SLOPE_ACCX);
+      } else if (-pedal_acc >= std::abs(input(IDX_U::SLOPE_ACCX))) {
+        return 0.0;
       } else {
         return input(IDX_U::SLOPE_ACCX);
       }


### PR DESCRIPTION
## Description
fix stopping behavior issue
In the previous code, when the vehicle velocity is smaller than dead_band velocity, the vehicle do not stop with enough brake.
Currently, stop processing is done within update().

## Related links

## How was this PR tested?
scenario sim tell me this problem, and I tested in psim

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals


### ROS Parameter Changes

#### Additions and removals


## Effects on system behavior

None.
