### PR TITLE
fix(pure_pursuit): add autoware_ prefix in launch file

### DIFF
--- a/control/autoware_pure_pursuit/launch/pure_pursuit.launch.xml
+++ b/control/autoware_pure_pursuit/launch/pure_pursuit.launch.xml
@@ -1,11 +1,11 @@
 <launch>
-  <arg name="pure_pursuit_param_path" default="$(find-pkg-share pure_pursuit)/config/pure_pursuit.param.yaml"/>
+  <arg name="pure_pursuit_param_path" default="$(find-pkg-share autoware_pure_pursuit)/config/pure_pursuit.param.yaml"/>
 
   <arg name="input/reference_trajectory" default="/planning/scenario_planning/trajectory"/>
   <arg name="input/current_odometry" default="/localization/kinematic_state"/>
   <arg name="output/control_raw" default="lateral/control_cmd"/>
 
-  <node pkg="pure_pursuit" exec="pure_pursuit" name="pure_pursuit" output="screen">
+  <node pkg="autoware_pure_pursuit" exec="autoware_pure_pursuit_lateral_controller_exe" name="pure_pursuit" output="screen">
     <remap from="input/reference_trajectory" to="$(var input/reference_trajectory)"/>
     <remap from="input/current_odometry" to="$(var input/current_odometry)"/>
     <remap from="output/control_raw" to="$(var output/control_raw)"/>


### PR DESCRIPTION
## Description
This PR fixes a package name referenced by the pure_pursuit.launch.xml.


## Related links
**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/8686


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested locally by running `ros2 run autoware_pure_pursuit pure_pursuit.launch.xml`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
