### PR TITLE
refactor(ndt_scan_marcher): add namespace "autoware::ndt_scan_matcher::"

### DIFF
--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -35,7 +35,7 @@ link_directories(${PCL_LIBRARY_DIRS})
 target_link_libraries(ndt_scan_matcher ${PCL_LIBRARIES})
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "NDTScanMatcher"
+  PLUGIN "autoware::ndt_scan_matcher::NDTScanMatcher"
   EXECUTABLE ${PROJECT_NAME}_node
   EXECUTOR MultiThreadedExecutor
 )

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/hyper_parameters.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/hyper_parameters.hpp
@@ -24,6 +24,9 @@
 #include <string>
 #include <vector>
 
+namespace autoware::ndt_scan_matcher
+{
+
 enum class ConvergedParamType {
   TRANSFORM_PROBABILITY = 0,
   NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD = 1
@@ -190,5 +193,7 @@ public:
       node->declare_parameter<double>("dynamic_map_loading.lidar_radius");
   }
 };
+
+}  // namespace autoware::ndt_scan_matcher
 
 #endif  // NDT_SCAN_MATCHER__HYPER_PARAMETERS_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
@@ -40,6 +40,9 @@
 #include <thread>
 #include <vector>
 
+namespace autoware::ndt_scan_matcher
+{
+
 class MapUpdateModule
 {
   using PointSource = pcl::PointXYZ;
@@ -94,5 +97,7 @@ private:
   // Keep the last_update_position_ unchanged while checking map range
   std::mutex last_update_position_mtx_;
 };
+
+}  // namespace autoware::ndt_scan_matcher
 
 #endif  // NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -69,6 +69,9 @@
 #include <tuple>
 #include <vector>
 
+namespace autoware::ndt_scan_matcher
+{
+
 class NDTScanMatcher : public rclcpp::Node
 {
   using PointSource = pcl::PointXYZ;
@@ -208,5 +211,7 @@ private:
 
   HyperParameters param_;
 };
+
+}  // namespace autoware::ndt_scan_matcher
 
 #endif  // NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_CORE_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/particle.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/particle.hpp
@@ -20,6 +20,9 @@
 
 #include <string>
 
+namespace autoware::ndt_scan_matcher
+{
+
 struct Particle
 {
   Particle(
@@ -37,5 +40,7 @@ struct Particle
 void push_debug_markers(
   visualization_msgs::msg::MarkerArray & marker_array, const builtin_interfaces::msg::Time & stamp,
   const std::string & map_frame_, const Particle & particle, const size_t i);
+
+}  // namespace autoware::ndt_scan_matcher
 
 #endif  // NDT_SCAN_MATCHER__PARTICLE_HPP_

--- a/localization/ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/ndt_scan_matcher/src/map_update_module.cpp
@@ -14,6 +14,9 @@
 
 #include "ndt_scan_matcher/map_update_module.hpp"
 
+namespace autoware::ndt_scan_matcher
+{
+
 MapUpdateModule::MapUpdateModule(
   rclcpp::Node * node, std::mutex * ndt_ptr_mutex, NdtPtrType & ndt_ptr,
   HyperParameters::DynamicMapLoading param)
@@ -312,3 +315,5 @@ void MapUpdateModule::publish_partial_pcd_map()
 
   loaded_pcd_pub_->publish(map_msg);
 }
+
+}  // namespace autoware::ndt_scan_matcher

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -37,6 +37,9 @@
 #include <iomanip>
 #include <thread>
 
+namespace autoware::ndt_scan_matcher
+{
+
 tier4_debug_msgs::msg::Float32Stamped make_float32_stamped(
   const builtin_interfaces::msg::Time & stamp, const float data)
 {
@@ -1111,5 +1114,7 @@ std::tuple<geometry_msgs::msg::PoseWithCovarianceStamped, double> NDTScanMatcher
   return std::make_tuple(result_pose_with_cov_msg, best_particle_ptr->score);
 }
 
+}  // namespace autoware::ndt_scan_matcher
+
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(NDTScanMatcher)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::ndt_scan_matcher::NDTScanMatcher)

--- a/localization/ndt_scan_matcher/src/particle.cpp
+++ b/localization/ndt_scan_matcher/src/particle.cpp
@@ -15,6 +15,8 @@
 #include "ndt_scan_matcher/particle.hpp"
 
 #include "localization_util/util_func.hpp"
+namespace autoware::ndt_scan_matcher
+{
 
 void push_debug_markers(
   visualization_msgs::msg::MarkerArray & marker_array, const builtin_interfaces::msg::Time & stamp,
@@ -61,3 +63,5 @@ void push_debug_markers(
   marker.color = exchange_color_crc(static_cast<double>(i) / 100.0);
   marker_array.markers.push_back(marker);
 }
+
+}  // namespace autoware::ndt_scan_matcher

--- a/localization/ndt_scan_matcher/test/test_fixture.hpp
+++ b/localization/ndt_scan_matcher/test/test_fixture.hpp
@@ -53,7 +53,7 @@ protected:
         node_options.parameter_overrides().push_back(param);
       }
     }
-    node_ = std::make_shared<NDTScanMatcher>(node_options);
+    node_ = std::make_shared<autoware::ndt_scan_matcher::NDTScanMatcher>(node_options);
     rcl_yaml_node_struct_fini(params_st);
 
     // prepare tf_static "base_link -> sensor_frame"
@@ -79,7 +79,7 @@ protected:
     sensor_pcd_publisher_ = std::make_shared<StubSensorPcdPublisher>();
   }
 
-  std::shared_ptr<NDTScanMatcher> node_;
+  std::shared_ptr<autoware::ndt_scan_matcher::NDTScanMatcher> node_;
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
   std::shared_ptr<StubPcdLoader> pcd_loader_;
   std::shared_ptr<StubInitialposeClient> initialpose_client_;


### PR DESCRIPTION
## Description
Add `namespace autoware::ndt_scan_marcher::` to ndt_scan_marcher package.

## How was this PR tested?

I have confirmed autoware with [autoware_tools](https://github.com/autowarefoundation/autoware_tools) and [localization_evaluation_tools (TIER IV INTERNAL)](https://github.com/tier4/localization_evaluator_tools) can be built.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
