### PR TITLE
refactor(goal_planner): remove unnecessary member from pull_over_planner

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/freespace_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/freespace_pull_over.hpp
@@ -41,13 +41,15 @@ public:
 
   PullOverPlannerType getPlannerType() const override { return PullOverPlannerType::FREESPACE; }
 
-  std::optional<PullOverPath> plan(const Pose & goal_pose) override;
+  std::optional<PullOverPath> plan(
+    const std::shared_ptr<const PlannerData> planner_data,
+    const BehaviorModuleOutput & previous_module_output, const Pose & goal_pose) override;
 
 protected:
+  const double velocity_;
+  const bool left_side_parking_;
+  const bool use_back_;
   std::unique_ptr<AbstractPlanningAlgorithm> planner_;
-  double velocity_;
-  bool use_back_;
-  bool left_side_parking_;
 };
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/geometric_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/geometric_pull_over.hpp
@@ -42,7 +42,9 @@ public:
   Pose getCr() const { return planner_.getCr(); }
   Pose getCl() const { return planner_.getCl(); }
 
-  std::optional<PullOverPath> plan(const Pose & goal_pose) override;
+  std::optional<PullOverPath> plan(
+    const std::shared_ptr<const PlannerData> planner_data,
+    const BehaviorModuleOutput & previous_module_output, const Pose & goal_pose) override;
 
   std::vector<PullOverPath> generatePullOverPaths(
     const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,
@@ -56,10 +58,10 @@ public:
     const bool is_in_goal_route_section, const Pose & goal_pose) const;
 
 protected:
-  ParallelParkingParameters parallel_parking_parameters_;
-  LaneDepartureChecker lane_departure_checker_{};
-  bool is_forward_{true};
-  bool left_side_parking_{true};
+  const ParallelParkingParameters parallel_parking_parameters_;
+  const LaneDepartureChecker lane_departure_checker_;
+  const bool is_forward_;
+  const bool left_side_parking_;
 
   GeometricParallelParking planner_;
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp
@@ -177,32 +177,21 @@ class PullOverPlannerBase
 {
 public:
   PullOverPlannerBase(rclcpp::Node & node, const GoalPlannerParameters & parameters)
+  : vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
+    vehicle_footprint_{vehicle_info_.createFootprint()},
+    parameters_{parameters}
   {
-    vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
-    vehicle_footprint_ = vehicle_info_.createFootprint();
-    parameters_ = parameters;
   }
   virtual ~PullOverPlannerBase() = default;
 
-  void setPreviousModuleOutput(const BehaviorModuleOutput & previous_module_output)
-  {
-    previous_module_output_ = previous_module_output;
-  }
-
-  void setPlannerData(const std::shared_ptr<const PlannerData> planner_data)
-  {
-    planner_data_ = planner_data;
-  }
-
   virtual PullOverPlannerType getPlannerType() const = 0;
-  virtual std::optional<PullOverPath> plan(const Pose & goal_pose) = 0;
+  virtual std::optional<PullOverPath> plan(
+    const std::shared_ptr<const PlannerData> planner_data,
+    const BehaviorModuleOutput & previous_module_output, const Pose & goal_pose) = 0;
 
 protected:
-  std::shared_ptr<const PlannerData> planner_data_;
-  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
-  LinearRing2d vehicle_footprint_;
-  GoalPlannerParameters parameters_;
-
-  BehaviorModuleOutput previous_module_output_;
+  const autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+  const LinearRing2d vehicle_footprint_;
+  const GoalPlannerParameters parameters_;
 };
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/shift_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/shift_pull_over.hpp
@@ -35,16 +35,21 @@ public:
     rclcpp::Node & node, const GoalPlannerParameters & parameters,
     const LaneDepartureChecker & lane_departure_checker);
   PullOverPlannerType getPlannerType() const override { return PullOverPlannerType::SHIFT; };
-  std::optional<PullOverPath> plan(const Pose & goal_pose) override;
+  std::optional<PullOverPath> plan(
+    const std::shared_ptr<const PlannerData> planner_data,
+    const BehaviorModuleOutput & previous_module_output, const Pose & goal_pose) override;
 
 protected:
   PathWithLaneId generateReferencePath(
+    const std::shared_ptr<const PlannerData> planner_data,
     const lanelet::ConstLanelets & road_lanes, const Pose & end_pose) const;
   std::optional<PathWithLaneId> cropPrevModulePath(
     const PathWithLaneId & prev_module_path, const Pose & shift_end_pose) const;
   std::optional<PullOverPath> generatePullOverPath(
-    const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,
-    const Pose & goal_pose, const double lateral_jerk) const;
+    const std::shared_ptr<const PlannerData> planner_data,
+    const BehaviorModuleOutput & previous_module_output, const lanelet::ConstLanelets & road_lanes,
+    const lanelet::ConstLanelets & shoulder_lanes, const Pose & goal_pose,
+    const double lateral_jerk) const;
   static double calcBeforeShiftedArcLength(
     const PathWithLaneId & path, const double after_shifted_arc_length, const double dr);
   static std::vector<double> splineTwoPoints(
@@ -53,9 +58,9 @@ protected:
   static std::vector<Pose> interpolatePose(
     const Pose & start_pose, const Pose & end_pose, const double resample_interval);
 
-  LaneDepartureChecker lane_departure_checker_{};
+  const LaneDepartureChecker lane_departure_checker_;
 
-  bool left_side_parking_{true};
+  const bool left_side_parking_;
 };
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -306,9 +306,8 @@ void GoalPlannerModule::onTimer()
   const auto planCandidatePaths = [&](
                                     const std::shared_ptr<PullOverPlannerBase> & planner,
                                     const GoalCandidate & goal_candidate) {
-    planner->setPlannerData(local_planner_data);
-    planner->setPreviousModuleOutput(previous_module_output);
-    auto pull_over_path = planner->plan(goal_candidate.goal_pose);
+    auto pull_over_path =
+      planner->plan(local_planner_data, previous_module_output, goal_candidate.goal_pose);
     if (pull_over_path && pull_over_path->getParkingPath().points.size() >= 3) {
       pull_over_path->goal_id = goal_candidate.id;
       pull_over_path->id = path_candidates.size();
@@ -754,8 +753,9 @@ bool GoalPlannerModule::planFreespacePath(
     if (!goal_candidate.is_safe) {
       continue;
     }
-    freespace_planner_->setPlannerData(planner_data);
-    auto freespace_path = freespace_planner_->plan(goal_candidate.goal_pose);
+    auto freespace_path = freespace_planner_->plan(
+      planner_data, BehaviorModuleOutput{},  // NOTE: not used so passing {} is OK
+      goal_candidate.goal_pose);
     freespace_path->goal_id = goal_candidate.id;
     if (!freespace_path) {
       continue;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -37,13 +37,15 @@ GeometricPullOver::GeometricPullOver(
   planner_.setParameters(parallel_parking_parameters_);
 }
 
-std::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
+std::optional<PullOverPath> GeometricPullOver::plan(
+  const std::shared_ptr<const PlannerData> planner_data,
+  [[maybe_unused]] const BehaviorModuleOutput & previous_module_output, const Pose & goal_pose)
 {
-  const auto & route_handler = planner_data_->route_handler;
+  const auto & route_handler = planner_data->route_handler;
 
   // prepare road nad shoulder lanes
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
+    planner_data, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
     /*forward_only_in_route*/ false);
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, parameters_.backward_goal_search_length,
@@ -56,8 +58,8 @@ std::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
   const auto & p = parallel_parking_parameters_;
   const double max_steer_angle =
     is_forward_ ? p.forward_parking_max_steer_angle : p.backward_parking_max_steer_angle;
-  planner_.setTurningRadius(planner_data_->parameters, max_steer_angle);
-  planner_.setPlannerData(planner_data_);
+  planner_.setTurningRadius(planner_data->parameters, max_steer_angle);
+  planner_.setPlannerData(planner_data);
 
   const bool found_valid_path =
     planner_.planPullOver(goal_pose, road_lanes, pull_over_lanes, is_forward_, left_side_parking_);


### PR DESCRIPTION
## Description

depends https://github.com/autowarefoundation/autoware.universe/pull/8696

- added const to members
- planner_data and previous_module_output do not need to be member, so pass as arguments

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

refactoring

https://evaluation.tier4.jp/evaluation/reports/772f4aa3-227d-521c-819c-57d9c1118635?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
