### PR TITLE
feat(autonomous_emergency_braking): add timekeeper to AEB

### DIFF
--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__NODE_HPP_
 #define AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__NODE_HPP_
 
+#include "autoware/universe_utils/system/time_keeper.hpp"
+
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/polling_subscriber.hpp>
@@ -334,9 +336,11 @@ public:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_obstacle_pointcloud_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_publisher_;
   rclcpp::Publisher<MarkerArray>::SharedPtr info_marker_publisher_;
-
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    debug_processing_time_detail_pub_;
   // timer
   rclcpp::TimerBase::SharedPtr timer_;
+  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
 
   // callback
   /**
@@ -508,6 +512,7 @@ public:
   // Member variables
   bool publish_debug_pointcloud_;
   bool publish_debug_markers_;
+  bool publish_debug_time_;
   bool use_predicted_trajectory_;
   bool use_imu_path_;
   bool use_pointcloud_data_;

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -181,6 +181,12 @@ AEB::AEB(const rclcpp::NodeOptions & node_options)
   const double aeb_hz = declare_parameter<double>("aeb_hz");
   const auto period_ns = rclcpp::Rate(aeb_hz).period();
   timer_ = rclcpp::create_timer(this, this->get_clock(), period_ns, std::bind(&AEB::onTimer, this));
+
+  debug_processing_time_detail_pub_ =
+    create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+      "~/debug/processing_time_detail_ms", 1);
+  time_keeper_ =
+    std::make_shared<autoware::universe_utils::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
 rcl_interfaces::msg::SetParametersResult AEB::onParameter(
@@ -259,6 +265,7 @@ void AEB::onImu(const Imu::ConstSharedPtr input_msg)
 
 void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   PointCloud::Ptr pointcloud_ptr(new PointCloud);
   pcl::fromROSMsg(*input_msg, *pointcloud_ptr);
 
@@ -401,7 +408,6 @@ void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
         addCollisionMarker(data.value(), debug_markers);
       }
     }
-
     addVirtualStopWallMarker(info_markers);
   } else {
     const std::string error_msg = "[AEB]: No Collision";
@@ -416,6 +422,7 @@ void AEB::onCheckCollision(DiagnosticStatusWrapper & stat)
 
 bool AEB::checkCollision(MarkerArray & debug_markers)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   using colorTuple = std::tuple<double, double, double, double>;
 
   // step1. check data
@@ -495,6 +502,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   };
 
   // step3. make function to check collision with ego path created with sensor data
+  time_keeper_->start_track("has_collision_imu_path");
   const auto has_collision_ego = [&](pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects) -> bool {
     if (!use_imu_path_ || !angular_velocity_ptr_) return false;
     const double current_w = angular_velocity_ptr_->z;
@@ -504,8 +512,10 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
     return check_collision(ego_path, debug_color, ns, filtered_objects);
   };
+  time_keeper_->end_track("has_collision_imu_path");
 
   // step4. make function to check collision with predicted trajectory from control module
+  time_keeper_->start_track("has_collision_mpc_path");
   const auto has_collision_predicted =
     [&](pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects) -> bool {
     if (!use_predicted_trajectory_ || !predicted_traj_ptr_) return false;
@@ -519,6 +529,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
     return check_collision(predicted_path, debug_color, ns, filtered_objects);
   };
+  time_keeper_->end_track("has_collision_mpc_path");
 
   // Data of filtered point cloud
   pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects =
@@ -538,10 +549,10 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
 
 bool AEB::hasCollision(const double current_v, const ObjectData & closest_object)
 {
-  const double & obj_v = closest_object.velocity;
-  const double & t = t_response_;
-
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   const double rss_dist = std::invoke([&]() {
+    const double & obj_v = closest_object.velocity;
+    const double & t = t_response_;
     const double pre_braking_covered_distance = std::abs(current_v) * t;
     const double braking_distance = (current_v * current_v) / (2 * std::fabs(a_ego_min_));
     const double ego_stopping_distance = pre_braking_covered_distance + braking_distance;
@@ -551,19 +562,19 @@ bool AEB::hasCollision(const double current_v, const ObjectData & closest_object
     return ego_stopping_distance + obj_braking_distance + longitudinal_offset_;
   });
 
-  if (closest_object.distance_to_object < rss_dist) {
-    // collision happens
-    ObjectData collision_data = closest_object;
-    collision_data.rss = rss_dist;
-    collision_data.distance_to_object = closest_object.distance_to_object;
-    collision_data_keeper_.setCollisionData(collision_data);
-    return true;
-  }
-  return false;
+  if (closest_object.distance_to_object > rss_dist) return false;
+
+  // collision happens
+  ObjectData collision_data = closest_object;
+  collision_data.rss = rss_dist;
+  collision_data.distance_to_object = closest_object.distance_to_object;
+  collision_data_keeper_.setCollisionData(collision_data);
+  return true;
 }
 
 Path AEB::generateEgoPath(const double curr_v, const double curr_w)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   Path path;
   double curr_x = 0.0;
   double curr_y = 0.0;
@@ -612,6 +623,7 @@ Path AEB::generateEgoPath(const double curr_v, const double curr_w)
 
 std::optional<Path> AEB::generateEgoPath(const Trajectory & predicted_traj)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   if (predicted_traj.points.empty()) {
     return std::nullopt;
   }
@@ -644,6 +656,7 @@ std::optional<Path> AEB::generateEgoPath(const Trajectory & predicted_traj)
 std::vector<Polygon2d> AEB::generatePathFootprint(
   const Path & path, const double extra_width_margin)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   std::vector<Polygon2d> polygons;
   for (size_t i = 0; i < path.size() - 1; ++i) {
     polygons.push_back(
@@ -656,6 +669,7 @@ void AEB::createObjectDataUsingPredictedObjects(
   const Path & ego_path, const std::vector<Polygon2d> & ego_polys,
   std::vector<ObjectData> & object_data_vector)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   if (predicted_objects_ptr_->objects.empty()) return;
 
   const double current_ego_speed = current_velocity_ptr_->longitudinal_velocity;
@@ -743,6 +757,7 @@ void AEB::createObjectDataUsingPointCloudClusters(
   const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
   std::vector<ObjectData> & objects, const pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_points_ptr)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   // check if the predicted path has valid number of points
   if (ego_path.size() < 2 || ego_polys.empty() || obstacle_points_ptr->empty()) {
     return;
@@ -827,6 +842,7 @@ void AEB::createObjectDataUsingPointCloudClusters(
 void AEB::cropPointCloudWithEgoFootprintPath(
   const std::vector<Polygon2d> & ego_polys, pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_objects)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   PointCloud::Ptr full_points_ptr(new PointCloud);
   pcl::fromROSMsg(*obstacle_ros_pointcloud_ptr_, *full_points_ptr);
   // Create a Point cloud with the points of the ego footprint
@@ -860,6 +876,7 @@ void AEB::addMarker(
   const double color_r, const double color_g, const double color_b, const double color_a,
   const std::string & ns, MarkerArray & debug_markers)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   auto path_marker = autoware::universe_utils::createDefaultMarker(
     "base_link", current_time, ns + "_path", 0L, Marker::LINE_STRIP,
     autoware::universe_utils::createMarkerScale(0.2, 0.2, 0.2),
@@ -922,6 +939,7 @@ void AEB::addMarker(
 
 void AEB::addVirtualStopWallMarker(MarkerArray & markers)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   const auto ego_map_pose = std::invoke([this]() -> std::optional<geometry_msgs::msg::Pose> {
     geometry_msgs::msg::TransformStamped tf_current_pose;
     geometry_msgs::msg::Pose p;
@@ -952,6 +970,7 @@ void AEB::addVirtualStopWallMarker(MarkerArray & markers)
 
 void AEB::addCollisionMarker(const ObjectData & data, MarkerArray & debug_markers)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   auto point_marker = autoware::universe_utils::createDefaultMarker(
     "base_link", data.stamp, "collision_point", 0, Marker::SPHERE,
     autoware::universe_utils::createMarkerScale(0.3, 0.3, 0.3),


### PR DESCRIPTION
## Description
This PR adds the timekeeper to the main functions of the AEB module to ease debugging when looking for performance bottlenecks.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
![cap- 2024-09-02-15-35-31](https://github.com/user-attachments/assets/b8a32791-bb93-4817-84d6-098268bc6663)

Example

`
ros2 topic echo /control/autonomous_emergency_braking/debug/processing_time_detail_ms
nodes:
- id: 1
  name: checkCollision
  processing_time: 23.268
  parent_id: 0
  comment: ''
- id: 2
  name: onPointCloud
  processing_time: 0.855
  parent_id: 1
  comment: ''
- id: 3
  name: has_collision_imu_path
  processing_time: 0.002
  parent_id: 1
  comment: ''
- id: 4
  name: has_collision_mpc_path
  processing_time: 0.001
  parent_id: 1
  comment: ''
- id: 5
  name: generateEgoPath
  processing_time: 0.011
  parent_id: 1
  comment: ''
- id: 6
  name: generatePathFootprint
  processing_time: 0.269
  parent_id: 1
  comment: ''
- id: 7
  name: generatePathFootprint
  processing_time: 0.242
  parent_id: 1
  comment: ''
- id: 8
  name: cropPointCloudWithEgoFootprintPath
  processing_time: 0.402
  parent_id: 1
  comment: ''
- id: 9
  name: createObjectDataUsingPointCloudClusters
  processing_time: 0.001
  parent_id: 1
  comment: ''
- id: 10
  name: addMarker
  processing_time: 0.034
  parent_id: 1
  comment: ''
- id: 11
  name: generateEgoPath
  processing_time: 20.233
  parent_id: 1
  comment: ''
- id: 12
  name: generatePathFootprint
  processing_time: 0.332
  parent_id: 1
  comment: ''
- id: 13
  name: generatePathFootprint
  processing_time: 0.343
  parent_id: 1
  comment: ''
- id: 14
  name: cropPointCloudWithEgoFootprintPath
  processing_time: 0.313
  parent_id: 1
  comment: ''
- id: 15
  name: createObjectDataUsingPointCloudClusters
  processing_time: 0.0
  parent_id: 1
  comment: ''
- id: 16
  name: addMarker
  processing_time: 0.039
  parent_id: 1
  comment: ''
`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
