### PR TITLE
fix(mission_planner): improve condition to check if the goal is within the lane

### DIFF
--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -225,7 +225,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(const LaneletRoute & route)
 }
 
 visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
-  autoware::universe_utils::LinearRing2d goal_footprint) const
+  autoware::universe_utils::LinearRing2d goal_footprint)
 {
   visualization_msgs::msg::MarkerArray msg;
   auto marker = autoware::universe_utils::createDefaultMarker(
@@ -304,7 +304,7 @@ bool DefaultPlanner::check_goal_footprint_inside_lanes(
 }
 
 bool DefaultPlanner::is_goal_valid(
-  const geometry_msgs::msg::Pose & goal, lanelet::ConstLanelets path_lanelets)
+  const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelets & path_lanelets)
 {
   const auto logger = node_->get_logger();
 
@@ -384,11 +384,7 @@ bool DefaultPlanner::is_goal_valid(
   // check if goal is in parking lot
   const auto parking_lots =
     lanelet::utils::query::getAllParkingLots(route_handler_.getLaneletMapPtr());
-  if (is_in_parking_lot(parking_lots, goal_lanelet_pt)) {
-    return true;
-  }
-
-  return false;
+  return is_in_parking_lot(parking_lots, goal_lanelet_pt);
 }
 
 PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
@@ -438,7 +434,7 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     return route_msg;
   }
 
-  if (route_handler_.isRouteLooped(route_sections)) {
+  if (route_handler::RouteHandler::isRouteLooped(route_sections)) {
     RCLCPP_WARN(logger, "Loop detected within route!");
     return route_msg;
   }

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -35,11 +35,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
-#include <lanelet2_core/primitives/BoundingBox.h>
-#include <lanelet2_core/primitives/Lanelet.h>
-#include <lanelet2_core/primitives/Polygon.h>
-#include <lanelet2_routing/Route.h>
-#include <lanelet2_routing/RoutingCost.h>
 #include <tf2/utils.h>
 
 #include <limits>

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -17,6 +17,7 @@
 #include "utility_functions.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/route_handler/route_handler.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/math/normalization.hpp>
 #include <autoware/universe_utils/math/unit_conversion.hpp>
@@ -27,8 +28,16 @@
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
+#include <boost/geometry/algorithms/difference.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
+
+#include <lanelet2_core/Forward.h>
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/primitives/BoundingBox.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/Polygon.h>
 #include <lanelet2_routing/Route.h>
 #include <lanelet2_routing/RoutingCost.h>
 #include <tf2/utils.h>
@@ -244,48 +253,54 @@ visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
   return msg;
 }
 
-bool DefaultPlanner::check_goal_footprint_inside_lanes(
-  const lanelet::ConstLanelet & current_lanelet,
-  const lanelet::ConstLanelet & combined_prev_lanelet,
-  const autoware::universe_utils::Polygon2d & goal_footprint, double & next_lane_length,
-  const double search_margin)
+lanelet::ConstLanelets next_lanelets_up_to(
+  const lanelet::ConstLanelet & start_lanelet, const double up_to_distance,
+  const route_handler::RouteHandler & route_handler)
 {
-  // check if goal footprint is in current lane
-  if (boost::geometry::within(goal_footprint, combined_prev_lanelet.polygon2d().basicPolygon())) {
-    return true;
+  lanelet::ConstLanelets lanelets;
+  if (up_to_distance <= 0.0) {
+    return lanelets;
   }
-  const auto following = route_handler_.getNextLanelets(current_lanelet);
-  // check if goal footprint is in between many lanelets in depth-first search manner
-  for (const auto & next_lane : following) {
-    next_lane_length += lanelet::utils::getLaneletLength2d(next_lane);
-    lanelet::ConstLanelets lanelets;
-    lanelets.push_back(combined_prev_lanelet);
+  for (const auto & next_lane : route_handler.getNextLanelets(start_lanelet)) {
     lanelets.push_back(next_lane);
-    lanelet::ConstLanelet combined_lanelets =
-      combine_lanelets_with_shoulder(lanelets, route_handler_);
-
-    // if next lanelet length is longer than vehicle longitudinal offset
-    if (vehicle_info_.max_longitudinal_offset_m + search_margin < next_lane_length) {
-      next_lane_length -= lanelet::utils::getLaneletLength2d(next_lane);
-      // and if the goal_footprint is within the (accumulated) combined_lanelets, terminate the
-      // query
-      if (boost::geometry::within(goal_footprint, combined_lanelets.polygon2d().basicPolygon())) {
-        return true;
-      }
-      // if not, iteration continues to next next_lane, and this subtree is terminated
-    } else {  // if next lanelet length is shorter than vehicle longitudinal offset, check the
-              // overlap with the polygon including the next_lane(s) until the additional lanes get
-              // longer than ego vehicle length
-      if (!check_goal_footprint_inside_lanes(
-            next_lane, combined_lanelets, goal_footprint, next_lane_length)) {
-        next_lane_length -= lanelet::utils::getLaneletLength2d(next_lane);
-        continue;
-      } else {
-        return true;
-      }
-    }
+    const auto next_lanelets = next_lanelets_up_to(
+      next_lane, up_to_distance - lanelet::geometry::length2d(next_lane), route_handler);
+    lanelets.insert(lanelets.end(), next_lanelets.begin(), next_lanelets.end());
   }
-  return false;
+  return lanelets;
+}
+
+bool DefaultPlanner::check_goal_footprint_inside_lanes(
+  const lanelet::ConstLanelet & current_lanelet, const lanelet::ConstLanelets & path_lanelets,
+  const universe_utils::Polygon2d & goal_footprint) const
+{
+  universe_utils::MultiPolygon2d ego_lanes;
+  universe_utils::Polygon2d poly;
+  for (const auto & ll : path_lanelets) {
+    const auto left_shoulder = route_handler_.getLeftShoulderLanelet(ll);
+    if (left_shoulder) {
+      boost::geometry::convert(left_shoulder->polygon2d().basicPolygon(), poly);
+      ego_lanes.push_back(poly);
+    }
+    const auto right_shoulder = route_handler_.getRightShoulderLanelet(ll);
+    if (right_shoulder) {
+      boost::geometry::convert(right_shoulder->polygon2d().basicPolygon(), poly);
+      ego_lanes.push_back(poly);
+    }
+    boost::geometry::convert(ll.polygon2d().basicPolygon(), poly);
+    ego_lanes.push_back(poly);
+  }
+  const auto next_lanelets =
+    next_lanelets_up_to(current_lanelet, vehicle_info_.max_longitudinal_offset_m, route_handler_);
+  for (const auto & ll : next_lanelets) {
+    boost::geometry::convert(ll.polygon2d().basicPolygon(), poly);
+    ego_lanes.push_back(poly);
+  }
+
+  // check if goal footprint is in the ego lane
+  universe_utils::MultiPolygon2d difference;
+  boost::geometry::difference(goal_footprint, ego_lanes, difference);
+  return boost::geometry::is_empty(difference);
 }
 
 bool DefaultPlanner::is_goal_valid(
@@ -337,16 +352,10 @@ bool DefaultPlanner::is_goal_valid(
   pub_goal_footprint_marker_->publish(visualize_debug_footprint(goal_footprint));
   const auto polygon_footprint = convert_linear_ring_to_polygon(goal_footprint);
 
-  double next_lane_length = 0.0;
-  // combine calculated route lanelets
-  const lanelet::ConstLanelet combined_prev_lanelet =
-    combine_lanelets_with_shoulder(path_lanelets, route_handler_);
-
   // check if goal footprint exceeds lane when the goal isn't in parking_lot
   if (
     param_.check_footprint_inside_lanes &&
-    !check_goal_footprint_inside_lanes(
-      closest_lanelet, combined_prev_lanelet, polygon_footprint, next_lane_length) &&
+    !check_goal_footprint_inside_lanes(closest_lanelet, path_lanelets, polygon_footprint) &&
     !is_in_parking_lot(
       lanelet::utils::query::getAllParkingLots(route_handler_.getLaneletMapPtr()),
       lanelet::utils::conversion::toLaneletPoint(goal.position))) {

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -27,7 +27,6 @@
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
-#include <memory>
 #include <vector>
 
 namespace autoware::mission_planner::lanelet2
@@ -44,17 +43,17 @@ struct DefaultPlannerParameters
 class DefaultPlanner : public mission_planner::PlannerPlugin
 {
 public:
-  DefaultPlanner() : is_graph_ready_(false), route_handler_(), param_(), node_(nullptr) {}
+  DefaultPlanner() : vehicle_info_(), is_graph_ready_(false), param_(), node_(nullptr) {}
 
   void initialize(rclcpp::Node * node) override;
   void initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg) override;
-  bool ready() const override;
+  [[nodiscard]] bool ready() const override;
   LaneletRoute plan(const RoutePoints & points) override;
   void updateRoute(const PlannerPlugin::LaneletRoute & route) override;
   void clearRoute() override;
-  MarkerArray visualize(const LaneletRoute & route) const override;
-  MarkerArray visualize_debug_footprint(
-    autoware::universe_utils::LinearRing2d goal_footprint) const;
+  [[nodiscard]] MarkerArray visualize(const LaneletRoute & route) const override;
+  [[nodiscard]] static MarkerArray visualize_debug_footprint(
+    autoware::universe_utils::LinearRing2d goal_footprint);
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
 private:
@@ -93,7 +92,8 @@ private:
    * @brief return true if (1)the goal is in parking area or (2)the goal is on the lanes and the
    * footprint around the goal does not overlap the lanes
    */
-  bool is_goal_valid(const geometry_msgs::msg::Pose & goal, lanelet::ConstLanelets path_lanelets);
+  bool is_goal_valid(
+    const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelets & path_lanelets);
 
   /**
    * @brief project the specified goal pose onto the goal lanelet(the last preferred lanelet of

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -85,11 +85,9 @@ private:
    * @param next_lane_length the accumulated total length from the start lanelet of the search to
    * the lanelet of current goal query
    */
-  bool check_goal_footprint_inside_lanes(
-    const lanelet::ConstLanelet & current_lanelet,
-    const lanelet::ConstLanelet & combined_prev_lanelet,
-    const autoware::universe_utils::Polygon2d & goal_footprint, double & next_lane_length,
-    const double search_margin = 2.0);
+  [[nodiscard]] bool check_goal_footprint_inside_lanes(
+    const lanelet::ConstLanelet & current_lanelet, const lanelet::ConstLanelets & path_lanelets,
+    const universe_utils::Polygon2d & goal_footprint) const;
 
   /**
    * @brief return true if (1)the goal is in parking area or (2)the goal is on the lanes and the

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -27,8 +27,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/LaneletSequence.h>
 
-#include <string>
-#include <unordered_set>
 #include <vector>
 
 template <typename T>
@@ -46,16 +44,6 @@ autoware::universe_utils::Polygon2d convert_linear_ring_to_polygon(
   autoware::universe_utils::LinearRing2d footprint);
 void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
-
-/**
- * @brief create a single merged lanelet whose left/right bounds consist of the leftmost/rightmost
- * bound of the original lanelets or the left/right bound of its adjacent road_shoulder respectively
- * @param lanelets topologically sorted sequence of lanelets
- * @param route_handler route handler to query the lanelet map
- */
-lanelet::ConstLanelet combine_lanelets_with_shoulder(
-  const lanelet::ConstLanelets & lanelets,
-  const autoware::route_handler::RouteHandler & route_handler);
 
 std::vector<geometry_msgs::msg::Point> convertCenterlineToPoints(const lanelet::Lanelet & lanelet);
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(


### PR DESCRIPTION
## Description

This PR fixes an issue occurring when path lanelets overlap, causing `combine_lanelets_with_shoulder()` to generate a self-intersecting polygon which can result in goal poses being wrongfully rejected.

In this PR, we modify the logic to not use the `combine_lanelets_with_shoulder()` function.

## Related links

**Parent Issue:**

- Link


## How was this PR tested?

- [TIER IV interval link](https://evaluation.tier4.jp/evaluation/reports/400707a9-0b3c-591d-8715-7080510143e2?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
