### PR TITLE
refactor(goal_planner): initialize parameter with free function

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/manager.hpp
@@ -29,6 +29,9 @@ namespace autoware::behavior_path_planner
 
 class GoalPlannerModuleManager : public SceneModuleManagerInterface
 {
+  static GoalPlannerParameters initGoalPlannerParameters(
+    rclcpp::Node * node, const std::string & base_ns);
+
 public:
   GoalPlannerModuleManager() : SceneModuleManagerInterface{"goal_planner"} {}
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -25,14 +25,11 @@
 
 namespace autoware::behavior_path_planner
 {
-void GoalPlannerModuleManager::init(rclcpp::Node * node)
+
+GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
+  rclcpp::Node * node, const std::string & base_ns)
 {
-  // init manager interface
-  initInterface(node, {""});
-
   GoalPlannerParameters p;
-
-  const std::string base_ns = "goal_planner.";
   // general params
   {
     p.th_stopped_velocity = node->declare_parameter<double>(base_ns + "th_stopped_velocity");
@@ -71,7 +68,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
       p.parking_policy = ParkingPolicy::RIGHT_SIDE;
     } else {
       RCLCPP_ERROR_STREAM(
-        node->get_logger().get_child(name()),
+        node->get_logger(),
         "[goal_planner] invalid parking_policy: " << parking_policy_name << std::endl);
       exit(EXIT_FAILURE);
     }
@@ -115,7 +112,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
       p.object_recognition_collision_check_soft_margins.empty() ||
       p.object_recognition_collision_check_hard_margins.empty()) {
       RCLCPP_FATAL_STREAM(
-        node->get_logger().get_child(name()),
+        node->get_logger(),
         "object_recognition.collision_check_soft_margins and "
           << "object_recognition.collision_check_hard_margins must not be empty. "
           << "Terminating the program...");
@@ -400,22 +397,28 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
   // validation of parameters
   if (p.shift_sampling_num < 1) {
     RCLCPP_FATAL_STREAM(
-      node->get_logger().get_child(name()),
-      "shift_sampling_num must be positive integer. Given parameter: "
-        << p.shift_sampling_num << std::endl
-        << "Terminating the program...");
+      node->get_logger(), "shift_sampling_num must be positive integer. Given parameter: "
+                            << p.shift_sampling_num << std::endl
+                            << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
   if (p.maximum_deceleration < 0.0) {
     RCLCPP_FATAL_STREAM(
-      node->get_logger().get_child(name()),
-      "maximum_deceleration cannot be negative value. Given parameter: "
-        << p.maximum_deceleration << std::endl
-        << "Terminating the program...");
+      node->get_logger(), "maximum_deceleration cannot be negative value. Given parameter: "
+                            << p.maximum_deceleration << std::endl
+                            << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
+  return p;
+}
 
-  parameters_ = std::make_shared<GoalPlannerParameters>(p);
+void GoalPlannerModuleManager::init(rclcpp::Node * node)
+{
+  // init manager interface
+  initInterface(node, {""});
+
+  const std::string base_ns = "goal_planner.";
+  parameters_ = std::make_shared<GoalPlannerParameters>(initGoalPlannerParameters(node, base_ns));
 }
 
 void GoalPlannerModuleManager::updateModuleParams(


### PR DESCRIPTION
## Description

initialize parameters using static function for portability

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

goal_planner works

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
