### PR TITLE
feat(goal_planner): extend pull over lanes inward to extract objects

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -277,6 +277,7 @@ struct GoalPlannerDebugData
   FreespacePlannerDebugData freespace_planner{};
   std::vector<Polygon2d> ego_polygons_expanded{};
   lanelet::ConstLanelet expanded_pull_over_lane_between_ego{};
+  Polygon2d objects_extraction_polygon{};
 };
 
 struct LastApprovalData

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher.hpp
@@ -31,13 +31,12 @@ class GoalSearcher : public GoalSearcherBase
 public:
   GoalSearcher(const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint);
 
-  GoalCandidates search(
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) override;
+  GoalCandidates search(const std::shared_ptr<const PlannerData> & planner_data) override;
   void update(
     GoalCandidates & goal_candidates,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const override;
+    const std::shared_ptr<const PlannerData> & planner_data,
+    const PredictedObjects & objects) const override;
 
   // todo(kosuke55): Functions for this specific use should not be in the interface,
   // so it is better to consider interface design when we implement other goal searchers.
@@ -47,7 +46,8 @@ public:
   bool isSafeGoalWithMarginScaleFactor(
     const GoalCandidate & goal_candidate, const double margin_scale_factor,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const override;
+    const std::shared_ptr<const PlannerData> & planner_data,
+    const PredictedObjects & objects) const override;
 
 private:
   void countObjectsToAvoid(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher_base.hpp
@@ -53,13 +53,12 @@ public:
   const Pose & getReferenceGoal() const { return reference_goal_pose_; }
 
   MultiPolygon2d getAreaPolygons() const { return area_polygons_; }
-  virtual GoalCandidates search(
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) = 0;
+  virtual GoalCandidates search(const std::shared_ptr<const PlannerData> & planner_data) = 0;
   virtual void update(
     [[maybe_unused]] GoalCandidates & goal_candidates,
     [[maybe_unused]] const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    [[maybe_unused]] const std::shared_ptr<const PlannerData> & planner_data) const
+    [[maybe_unused]] const std::shared_ptr<const PlannerData> & planner_data,
+    [[maybe_unused]] const PredictedObjects & objects) const
   {
     return;
   }
@@ -69,7 +68,8 @@ public:
   virtual bool isSafeGoalWithMarginScaleFactor(
     const GoalCandidate & goal_candidate, const double margin_scale_factor,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const std::shared_ptr<const PlannerData> & planner_data) const = 0;
+    const std::shared_ptr<const PlannerData> & planner_data,
+    const PredictedObjects & objects) const = 0;
 
 protected:
   GoalPlannerParameters parameters_{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -73,7 +73,7 @@ lanelet::ConstLanelets generateBetweenEgoAndExpandedPullOverLanes(
  * @param inner_offset inner offset from pull over lane boundary
  * @return polygon to extract objects
  */
-Polygon2d generateObjectExtractionPolygon(
+std::optional<Polygon2d> generateObjectExtractionPolygon(
   const lanelet::ConstLanelets & pull_over_lanes, const bool left_side, const double outer_offset,
   const double inner_offset);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -64,6 +64,19 @@ lanelet::ConstLanelets generateBetweenEgoAndExpandedPullOverLanes(
   const geometry_msgs::msg::Pose ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double outer_road_offset,
   const double inner_road_offset);
+
+/*
+ * @brief generate polygon to extract objects
+ * @param pull_over_lanes pull over lanes
+ * @param left_side left side or right side
+ * @param outer_offset outer offset from pull over lane boundary
+ * @param inner_offset inner offset from pull over lane boundary
+ * @return polygon to extract objects
+ */
+Polygon2d generateObjectExtractionPolygon(
+  const lanelet::ConstLanelets & pull_over_lanes, const bool left_side, const double outer_offset,
+  const double inner_offset);
+
 PredictedObjects extractObjectsInExpandedPullOverLanes(
   const RouteHandler & route_handler, const bool left_side, const double backward_distance,
   const double forward_distance, double bound_offset, const PredictedObjects & objects);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -459,18 +459,30 @@ void GoalPlannerModule::updateData()
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  // extract static and dynamic objects in expanded pull over lanes
+  // extract static and dynamic objects in extraction polygon for path coliision check
   {
     const auto & p = parameters_;
     const auto & rh = *(planner_data_->route_handler);
     const auto objects = *(planner_data_->dynamic_object);
-    const auto static_target_objects =
-      goal_planner_utils::extractStaticObjectsInExpandedPullOverLanes(
-        rh, left_side_parking_, p->backward_goal_search_length, p->forward_goal_search_length,
-        p->detection_bound_offset, objects, p->th_moving_object_velocity);
-    const auto dynamic_target_objects = goal_planner_utils::extractObjectsInExpandedPullOverLanes(
-      rh, left_side_parking_, p->backward_goal_search_length, p->forward_goal_search_length,
-      p->detection_bound_offset, objects);
+    const double vehicle_width = planner_data_->parameters.vehicle_width;
+    const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
+      rh, left_side_parking_, p->backward_goal_search_length, p->forward_goal_search_length);
+    const auto objects_extraction_polygon = goal_planner_utils::generateObjectExtractionPolygon(
+      pull_over_lanes, left_side_parking_, p->detection_bound_offset,
+      p->margin_from_boundary + p->max_lateral_offset + vehicle_width);
+    debug_data_.objects_extraction_polygon = objects_extraction_polygon;
+
+    PredictedObjects dynamic_target_objects{};
+    for (const auto & object : objects.objects) {
+      const auto object_polygon = universe_utils::toPolygon2d(object);
+      if (boost::geometry::intersects(object_polygon, objects_extraction_polygon)) {
+        dynamic_target_objects.objects.push_back(object);
+      }
+    }
+    const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
+      dynamic_target_objects, p->th_moving_object_velocity);
+
+    // these objects are used for path collision check not for safety check
     thread_safe_data_.set_static_target_objects(static_target_objects);
     thread_safe_data_.set_dynamic_target_objects(dynamic_target_objects);
   }
@@ -739,7 +751,9 @@ bool GoalPlannerModule::planFreespacePath(
 {
   GoalCandidates goal_candidates{};
   goal_candidates = thread_safe_data_.get_goal_candidates();
-  goal_searcher->update(goal_candidates, occupancy_grid_map, planner_data);
+  goal_searcher->update(
+    goal_candidates, occupancy_grid_map, planner_data,
+    thread_safe_data_.get_static_target_objects());
   thread_safe_data_.set_goal_candidates(goal_candidates);
   debug_data_.freespace_planner.num_goal_candidates = goal_candidates.size();
   debug_data_.freespace_planner.is_planning = true;
@@ -823,7 +837,7 @@ GoalCandidates GoalPlannerModule::generateGoalCandidates() const
   // calculate goal candidates
   const auto & route_handler = planner_data_->route_handler;
   if (utils::isAllowedGoalModification(route_handler)) {
-    return goal_searcher_->search(occupancy_grid_map_, planner_data_);
+    return goal_searcher_->search(planner_data_);
   }
 
   // NOTE:
@@ -1281,9 +1295,9 @@ DecidingPathStatusWithStamp GoalPlannerModule::checkDecidingPathStatus(
     // check goal pose collision
     const auto modified_goal_opt = thread_safe_data_.get_modified_goal_pose();
     if (
-      modified_goal_opt &&
-      !goal_searcher->isSafeGoalWithMarginScaleFactor(
-        modified_goal_opt.value(), hysteresis_factor, occupancy_grid_map, planner_data)) {
+      modified_goal_opt && !goal_searcher->isSafeGoalWithMarginScaleFactor(
+                             modified_goal_opt.value(), hysteresis_factor, occupancy_grid_map,
+                             planner_data, thread_safe_data_.get_static_target_objects())) {
       RCLCPP_DEBUG(getLogger(), "[DecidingPathStatus]: DECIDING->NOT_DECIDED. goal is not safe");
       return {DecidingPathStatus::NOT_DECIDED, clock_->now()};
     }
@@ -1442,7 +1456,9 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsOutput()
 
     // update goal candidates
     auto goal_candidates = thread_safe_data_.get_goal_candidates();
-    goal_searcher_->update(goal_candidates, occupancy_grid_map_, planner_data_);
+    goal_searcher_->update(
+      goal_candidates, occupancy_grid_map_, planner_data_,
+      thread_safe_data_.get_static_target_objects());
 
     // Select a path that is as safe as possible and has a high priority.
     const auto pull_over_path_candidates = thread_safe_data_.get_pull_over_path_candidates();
@@ -2518,6 +2534,24 @@ void GoalPlannerModule::setDebugData()
     // Visualize goal candidates
     const auto goal_candidates = thread_safe_data_.get_goal_candidates();
     add(goal_planner_utils::createGoalCandidatesMarkerArray(goal_candidates, color));
+
+    // Visualize objects extraction polygon
+    auto marker = autoware::universe_utils::createDefaultMarker(
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "objects_extraction_polygon", 0, Marker::LINE_LIST,
+      autoware::universe_utils::createMarkerScale(0.1, 0.0, 0.0),
+      autoware::universe_utils::createMarkerColor(0.0, 1.0, 1.0, 0.999));
+    const double ego_z = planner_data_->self_odometry->pose.pose.position.z;
+    for (size_t i = 0; i < debug_data_.objects_extraction_polygon.outer().size(); ++i) {
+      const auto & current_point = debug_data_.objects_extraction_polygon.outer().at(i);
+      const auto & next_point = debug_data_.objects_extraction_polygon.outer().at(
+        (i + 1) % debug_data_.objects_extraction_polygon.outer().size());
+      marker.points.push_back(
+        autoware::universe_utils::createPoint(current_point.x(), current_point.y(), ego_z));
+      marker.points.push_back(
+        autoware::universe_utils::createPoint(next_point.x(), next_point.y(), ego_z));
+    }
+
+    debug_marker_.markers.push_back(marker);
   }
 
   // Visualize previous module output

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -470,12 +470,15 @@ void GoalPlannerModule::updateData()
     const auto objects_extraction_polygon = goal_planner_utils::generateObjectExtractionPolygon(
       pull_over_lanes, left_side_parking_, p->detection_bound_offset,
       p->margin_from_boundary + p->max_lateral_offset + vehicle_width);
-    debug_data_.objects_extraction_polygon = objects_extraction_polygon;
-
+    if (objects_extraction_polygon.has_value()) {
+      debug_data_.objects_extraction_polygon = objects_extraction_polygon.value();
+    }
     PredictedObjects dynamic_target_objects{};
     for (const auto & object : objects.objects) {
       const auto object_polygon = universe_utils::toPolygon2d(object);
-      if (boost::geometry::intersects(object_polygon, objects_extraction_polygon)) {
+      if (
+        objects_extraction_polygon.has_value() &&
+        boost::geometry::intersects(object_polygon, objects_extraction_polygon.value())) {
         dynamic_target_objects.objects.push_back(object);
       }
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -97,9 +97,7 @@ GoalSearcher::GoalSearcher(
 {
 }
 
-GoalCandidates GoalSearcher::search(
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data)
+GoalCandidates GoalSearcher::search(const std::shared_ptr<const PlannerData> & planner_data)
 {
   GoalCandidates goal_candidates{};
 
@@ -193,8 +191,6 @@ GoalCandidates GoalSearcher::search(
   }
   createAreaPolygons(original_search_poses, planner_data);
 
-  update(goal_candidates, occupancy_grid_map, planner_data);
-
   return goal_candidates;
 }
 
@@ -268,16 +264,10 @@ void GoalSearcher::countObjectsToAvoid(
 void GoalSearcher::update(
   GoalCandidates & goal_candidates,
   const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+  const std::shared_ptr<const PlannerData> & planner_data, const PredictedObjects & objects) const
 {
-  const auto pull_over_lane_stop_objects =
-    goal_planner_utils::extractStaticObjectsInExpandedPullOverLanes(
-      *(planner_data->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
-      parameters_.forward_goal_search_length, parameters_.detection_bound_offset,
-      *(planner_data->dynamic_object), parameters_.th_moving_object_velocity);
-
   if (parameters_.prioritize_goals_before_objects) {
-    countObjectsToAvoid(goal_candidates, pull_over_lane_stop_objects, planner_data);
+    countObjectsToAvoid(goal_candidates, objects, planner_data);
   }
 
   if (parameters_.goal_priority == "minimum_weighted_distance") {
@@ -297,7 +287,7 @@ void GoalSearcher::update(
     const Pose goal_pose = goal_candidate.goal_pose;
 
     // check collision with footprint
-    if (checkCollision(goal_pose, pull_over_lane_stop_objects, occupancy_grid_map)) {
+    if (checkCollision(goal_pose, objects, occupancy_grid_map)) {
       goal_candidate.is_safe = false;
       continue;
     }
@@ -305,7 +295,7 @@ void GoalSearcher::update(
     // check longitudinal margin with pull over lane objects
     constexpr bool filter_inside = true;
     const auto target_objects = goal_planner_utils::filterObjectsByLateralDistance(
-      goal_pose, planner_data->parameters.vehicle_width, pull_over_lane_stop_objects,
+      goal_pose, planner_data->parameters.vehicle_width, objects,
       parameters_.object_recognition_collision_check_hard_margins.back(), filter_inside);
     if (checkCollisionWithLongitudinalDistance(
           goal_pose, target_objects, occupancy_grid_map, planner_data)) {
@@ -323,33 +313,25 @@ void GoalSearcher::update(
 bool GoalSearcher::isSafeGoalWithMarginScaleFactor(
   const GoalCandidate & goal_candidate, const double margin_scale_factor,
   const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-  const std::shared_ptr<const PlannerData> & planner_data) const
+  const std::shared_ptr<const PlannerData> & planner_data, const PredictedObjects & objects) const
 {
   if (!parameters_.use_object_recognition) {
     return true;
   }
 
   const Pose goal_pose = goal_candidate.goal_pose;
-
-  const auto pull_over_lane_stop_objects =
-    goal_planner_utils::extractStaticObjectsInExpandedPullOverLanes(
-      *(planner_data->route_handler), left_side_parking_, parameters_.backward_goal_search_length,
-      parameters_.forward_goal_search_length, parameters_.detection_bound_offset,
-      *(planner_data->dynamic_object), parameters_.th_moving_object_velocity);
-
   const double margin =
     parameters_.object_recognition_collision_check_hard_margins.back() * margin_scale_factor;
 
   if (utils::checkCollisionBetweenFootprintAndObjects(
-        vehicle_footprint_, goal_pose, pull_over_lane_stop_objects, margin)) {
+        vehicle_footprint_, goal_pose, objects, margin)) {
     return false;
   }
 
   // check longitudinal margin with pull over lane objects
   constexpr bool filter_inside = true;
   const auto target_objects = goal_planner_utils::filterObjectsByLateralDistance(
-    goal_pose, planner_data->parameters.vehicle_width, pull_over_lane_stop_objects, margin,
-    filter_inside);
+    goal_pose, planner_data->parameters.vehicle_width, objects, margin, filter_inside);
   if (checkCollisionWithLongitudinalDistance(
         goal_pose, target_objects, occupancy_grid_map, planner_data)) {
     return false;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -191,7 +191,7 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
     constexpr double INTERSECTION_CHECK_DISTANCE = 10.0;
     std::vector<Point> modified_bound{};
     size_t i = 0;
-    while (i < bound.size() - 1) {
+    while (i < bound.size() - 2) {
       BoostPoint p1(bound.at(i).x, bound.at(i).y);
       BoostPoint p2(bound.at(i + 1).x, bound.at(i + 1).y);
       LineString p_line{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -39,6 +39,7 @@
 namespace autoware::behavior_path_planner::goal_planner_utils
 {
 
+using autoware::universe_utils::calcDistance2d;
 using autoware::universe_utils::calcOffsetPose;
 using autoware::universe_utils::createDefaultMarker;
 using autoware::universe_utils::createMarkerColor;
@@ -136,6 +137,122 @@ lanelet::ConstLanelets generateBetweenEgoAndExpandedPullOverLanes(
                    : lanelet::utils::getExpandedLanelets(
                        pull_over_lanes, ego_offset_to_closer_boundary + inner_road_offset,
                        -outer_road_offset);
+}
+
+Polygon2d generateObjectExtractionPolygon(
+  const lanelet::ConstLanelets & pull_over_lanes, const bool left_side, const double outer_offset,
+  const double inner_offset)
+{
+  // generate base boundary poses without orientation
+  std::vector<Pose> base_boundary_poses{};
+  for (const auto & lane : pull_over_lanes) {
+    const auto & bound = left_side ? lane.leftBound() : lane.rightBound();
+    for (const auto & p : bound) {
+      Pose pose{};
+      pose.position = createPoint(p.x(), p.y(), p.z());
+      if (std::any_of(base_boundary_poses.begin(), base_boundary_poses.end(), [&](const auto & p) {
+            return calcDistance2d(p.position, pose.position) < 0.1;
+          })) {
+        continue;
+      }
+      base_boundary_poses.push_back(pose);
+    }
+  }
+  if (base_boundary_poses.size() < 2) {
+    return Polygon2d{};
+  }
+
+  // set orientation to next point
+  for (size_t i = 0; i < base_boundary_poses.size() - 1; ++i) {
+    const auto & p = base_boundary_poses[i].position;
+    const auto & next_p = base_boundary_poses[i + 1].position;
+    const double yaw = autoware::universe_utils::calcAzimuthAngle(p, next_p);
+    base_boundary_poses[i].orientation = autoware::universe_utils::createQuaternionFromYaw(yaw);
+  }
+  base_boundary_poses.back().orientation =
+    base_boundary_poses[base_boundary_poses.size() - 2].orientation;
+
+  // generate outer and inner boundary poses
+  std::vector<Point> outer_boundary_points{};
+  std::vector<Point> inner_boundary_points{};
+  const double outer_direction_sign = left_side ? 1.0 : -1.0;
+  for (const auto & base_pose : base_boundary_poses) {
+    const Pose outer_pose = calcOffsetPose(base_pose, 0, outer_direction_sign * outer_offset, 0);
+    const Pose inner_pose = calcOffsetPose(base_pose, 0, -outer_direction_sign * inner_offset, 0);
+    outer_boundary_points.push_back(outer_pose.position);
+    inner_boundary_points.push_back(inner_pose.position);
+  }
+
+  // fix intersected bound
+  // if bound is intersected, remove them and insert intersection point
+  using BoostPoint = boost::geometry::model::d2::point_xy<double>;
+  using LineString = boost::geometry::model::linestring<BoostPoint>;
+  const auto modify_bound_intersection = [](const std::vector<Point> & bound) {
+    constexpr double INTERSECTION_CHECK_DISTANCE = 10.0;
+    std::vector<Point> modified_bound{};
+    size_t i = 0;
+    while (i < bound.size() - 1) {
+      BoostPoint p1(bound.at(i).x, bound.at(i).y);
+      BoostPoint p2(bound.at(i + 1).x, bound.at(i + 1).y);
+      LineString p_line{};
+      p_line.push_back(p1);
+      p_line.push_back(p2);
+      bool intersection_found = false;
+      for (size_t j = i + 2; j < bound.size() - 1; j++) {
+        const double distance = autoware::universe_utils::calcDistance2d(bound.at(i), bound.at(j));
+        if (distance > INTERSECTION_CHECK_DISTANCE) {
+          break;
+        }
+        LineString q_line{};
+        BoostPoint q1(bound.at(j).x, bound.at(j).y);
+        BoostPoint q2(bound.at(j + 1).x, bound.at(j + 1).y);
+        q_line.push_back(q1);
+        q_line.push_back(q2);
+        std::vector<BoostPoint> intersection_points;
+        boost::geometry::intersection(p_line, q_line, intersection_points);
+        if (intersection_points.empty()) {
+          continue;
+        }
+        modified_bound.push_back(bound.at(i));
+        Point intersection_point{};
+        intersection_point.x = intersection_points.at(0).x();
+        intersection_point.y = intersection_points.at(0).y();
+        intersection_point.z = bound.at(i).z;
+        modified_bound.push_back(intersection_point);
+        i = j + 1;
+        intersection_found = true;
+        break;
+      }
+      if (!intersection_found) {
+        modified_bound.push_back(bound.at(i));
+        i++;
+      }
+    }
+    modified_bound.push_back(bound.back());
+    return modified_bound;
+  };
+  outer_boundary_points = modify_bound_intersection(outer_boundary_points);
+  inner_boundary_points = modify_bound_intersection(inner_boundary_points);
+
+  // create clockwise polygon
+  Polygon2d polygon{};
+  const auto & left_boundary_points = left_side ? outer_boundary_points : inner_boundary_points;
+  const auto & right_boundary_points = left_side ? inner_boundary_points : outer_boundary_points;
+  std::vector<Point> reversed_right_boundary_points = right_boundary_points;
+  std::reverse(reversed_right_boundary_points.begin(), reversed_right_boundary_points.end());
+  for (const auto & left_point : left_boundary_points) {
+    autoware::universe_utils::Point2d point{left_point.x, left_point.y};
+    polygon.outer().push_back(point);
+  }
+  for (const auto & right_point : reversed_right_boundary_points) {
+    autoware::universe_utils::Point2d point{right_point.x, right_point.y};
+    polygon.outer().push_back(point);
+  }
+  autoware::universe_utils::Point2d first_point{
+    left_boundary_points.front().x, left_boundary_points.front().y};
+  polygon.outer().push_back(first_point);
+
+  return polygon;
 }
 
 PredictedObjects extractObjectsInExpandedPullOverLanes(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -183,11 +183,11 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
     inner_boundary_points.push_back(inner_pose.position);
   }
 
-  // fix intersected bound
+  // remove self intersection
   // if bound is intersected, remove them and insert intersection point
   using BoostPoint = boost::geometry::model::d2::point_xy<double>;
   using LineString = boost::geometry::model::linestring<BoostPoint>;
-  const auto modify_bound_intersection = [](const std::vector<Point> & bound) {
+  const auto remove_self_intersection = [](const std::vector<Point> & bound) {
     constexpr double INTERSECTION_CHECK_DISTANCE = 10.0;
     std::vector<Point> modified_bound{};
     size_t i = 0;
@@ -231,8 +231,8 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
     modified_bound.push_back(bound.back());
     return modified_bound;
   };
-  outer_boundary_points = modify_bound_intersection(outer_boundary_points);
-  inner_boundary_points = modify_bound_intersection(inner_boundary_points);
+  outer_boundary_points = remove_self_intersection(outer_boundary_points);
+  inner_boundary_points = remove_self_intersection(inner_boundary_points);
 
   // create clockwise polygon
   Polygon2d polygon{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -159,7 +159,7 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
     }
   }
   if (base_boundary_poses.size() < 2) {
-    return Polygon2d{};
+    return std::nullopt;
   }
 
   // set orientation to next point
@@ -251,6 +251,10 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
   autoware::universe_utils::Point2d first_point{
     left_boundary_points.front().x, left_boundary_points.front().y};
   polygon.outer().push_back(first_point);
+
+  if(polygon.outer().size() < 3) {
+    return std::nullopt;
+  }
 
   return polygon;
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -139,7 +139,7 @@ lanelet::ConstLanelets generateBetweenEgoAndExpandedPullOverLanes(
                        -outer_road_offset);
 }
 
-Polygon2d generateObjectExtractionPolygon(
+std::optional<Polygon2d> generateObjectExtractionPolygon(
   const lanelet::ConstLanelets & pull_over_lanes, const bool left_side, const double outer_offset,
   const double inner_offset)
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -163,11 +163,11 @@ Polygon2d generateObjectExtractionPolygon(
   }
 
   // set orientation to next point
-  for (size_t i = 0; i < base_boundary_poses.size() - 1; ++i) {
-    const auto & p = base_boundary_poses[i].position;
-    const auto & next_p = base_boundary_poses[i + 1].position;
+  for (auto it = base_boundary_poses.begin(); it != std::prev(base_boundary_poses.end()); ++it) {
+    const auto & p = it->position;
+    const auto & next_p = std::next(it)->position;
     const double yaw = autoware::universe_utils::calcAzimuthAngle(p, next_p);
-    base_boundary_poses[i].orientation = autoware::universe_utils::createQuaternionFromYaw(yaw);
+    it->orientation = autoware::universe_utils::createQuaternionFromYaw(yaw);
   }
   base_boundary_poses.back().orientation =
     base_boundary_poses[base_boundary_poses.size() - 2].orientation;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -252,7 +252,7 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
     left_boundary_points.front().x, left_boundary_points.front().y};
   polygon.outer().push_back(first_point);
 
-  if(polygon.outer().size() < 3) {
+  if (polygon.outer().size() < 3) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
## Description

The current algorithm expands the pull over lane only outward and extracts objects in it. In this case, if an object exists without overlapping the narrow shoulder lane, the object is not extracted. For example, since the object does not overlap the shoulder lane at 8509, it is not included in the collision check. As a result, the route is generated ignoring the object, and it gets stuck.

![image](https://github.com/user-attachments/assets/e834fddc-65a2-4c22-815f-3d0616017ed3)

![image](https://github.com/user-attachments/assets/af6a87aa-0bf7-4691-873c-d77e57f8d7a4)


In this PR, pull over lanes are expanded inward so that objects can be extracted regardless of the width of the lane. The length to be expanded is determined by the goal search area. the extraction plygon is the sky blue one.

![image](https://github.com/user-attachments/assets/682a1f5c-cb6d-43ef-81cb-d597391dc1c1)

![image](https://github.com/user-attachments/assets/5164db64-3ae2-4a3f-a215-56e74cd141f2)


![image](https://github.com/user-attachments/assets/b0cdf514-9f52-4eef-8e5d-e19b6fb4f9e5)



## Related links
psim

https://evaluation.tier4.jp/evaluation/reports/41bd57af-9931-5c32-ae12-bbb927ad0dd8?project_id=prd_jt&state=failed
4133/4136

baseline: 4132/4136([2024/09/03](https://evaluation.tier4.jp/evaluation/reports/f91ea6c8-5403-5392-83dd-7adb9961eacc/?project_id=prd_jt))

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
