### PR TITLE
fix(static_obstacle_avoidance): change implementation the logic to remove invalid small shift lines

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -812,7 +812,7 @@ AvoidLineArray ShiftLineGenerator::applyFillGapProcess(
 
   // fill gap among shift lines.
   for (size_t i = 0; i < sorted.size() - 1; ++i) {
-    if (sorted.at(i + 1).start_longitudinal < sorted.at(i).end_longitudinal) {
+    if (sorted.at(i + 1).start_longitudinal < sorted.at(i).end_longitudinal + 1e-3) {
       continue;
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -827,8 +827,6 @@ AvoidLineArray ShiftLineGenerator::applyFillGapProcess(
   utils::static_obstacle_avoidance::fillAdditionalInfoFromLongitudinal(
     data, debug.step1_front_shift_line);
 
-  applySmallShiftFilter(ret, 1e-3);
-
   return ret;
 }
 


### PR DESCRIPTION
## Description

Since this process generated invalid shift line whose relative longitudinal distance was ZERO, I added applySmallShiftFilter in https://github.com/autowarefoundation/autoware.universe/pull/8344. But I think there is simpler way to fix the issue.

```c++
  for (size_t i = 0; i < sorted.size() - 1; ++i) {
    if (sorted.at(i + 1).start_longitudinal < sorted.at(i).end_longitudinal) {
      continue;
    }

    const auto new_line = fill(sorted.at(i), sorted.at(i + 1), generateUUID());
    ret.push_back(new_line);
    debug.step1_front_shift_line.push_back(new_line);
  }
```

## Related links

**Parent Issue:**


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [TIER IV INTERNAL SCENARIOS](https://evaluation.ci.tier4.jp/evaluation/reports/10863e56-4bb0-5b16-84ab-6547d1d42b0d?project_id=prd_jt&state=failed)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
