### PR TITLE
fix(autoware_universe_utils): fix unusedFunction

### DIFF
--- a/common/autoware_universe_utils/src/system/backtrace.cpp
+++ b/common/autoware_universe_utils/src/system/backtrace.cpp
@@ -26,6 +26,7 @@
 namespace autoware::universe_utils
 {
 
+// cppcheck-suppress unusedFunction
 void print_backtrace()
 {
   constexpr size_t max_frames = 100;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
common/autoware_universe_utils/src/system/backtrace.cpp:29:0: style: The function 'print_backtrace' is never used. [unusedFunction]
void print_backtrace()
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
