### PR TITLE
fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -92,28 +92,6 @@ size_t findFirstNearestIndex(const T & points, const geometry_msgs::msg::Point &
   return min_idx;
 }
 
-template <class T>
-size_t findFirstNearestSegmentIndex(const T & points, const geometry_msgs::msg::Point & point)
-{
-  const size_t nearest_idx = findFirstNearestIndex(points, point);
-
-  if (nearest_idx == 0) {
-    return 0;
-  }
-  if (nearest_idx == points.size() - 1) {
-    return points.size() - 2;
-  }
-
-  const double signed_length =
-    autoware::motion_utils::calcLongitudinalOffsetToSegment(points, nearest_idx, point);
-
-  if (signed_length <= 0) {
-    return nearest_idx - 1;
-  }
-
-  return nearest_idx;
-}
-
 geometry_msgs::msg::Polygon createVehiclePolygon(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double offset)
 {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp:96:0: style: The function 'findFirstNearestSegmentIndex' is never used. [unusedFunction]
size_t findFirstNearestSegmentIndex(const T & points, const geometry_msgs::msg::Point & point)
^
```

This function was removed because it is only used in the readme and not used on the actual code.

The readme is a separate package and has been fixed in a #8733 

## Related links

- #8733 

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
