### PR TITLE
feat(autonomous_emergency_braking): increase aeb speed by getting last transform

### DIFF
--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -250,7 +250,7 @@ void AEB::onImu(const Imu::ConstSharedPtr input_msg)
   geometry_msgs::msg::TransformStamped transform_stamped{};
   try {
     transform_stamped = tf_buffer_.lookupTransform(
-      "base_link", input_msg->header.frame_id, input_msg->header.stamp,
+      "base_link", input_msg->header.frame_id, rclcpp::Time(0),
       rclcpp::Duration::from_seconds(0.5));
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR_STREAM(
@@ -631,7 +631,7 @@ std::optional<Path> AEB::generateEgoPath(const Trajectory & predicted_traj)
   geometry_msgs::msg::TransformStamped transform_stamped{};
   try {
     transform_stamped = tf_buffer_.lookupTransform(
-      "base_link", predicted_traj.header.frame_id, predicted_traj.header.stamp,
+      "base_link", predicted_traj.header.frame_id, rclcpp::Time(0),
       rclcpp::Duration::from_seconds(0.5));
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR_STREAM(
@@ -705,7 +705,7 @@ void AEB::createObjectDataUsingPredictedObjects(
   geometry_msgs::msg::TransformStamped transform_stamped{};
   try {
     transform_stamped = tf_buffer_.lookupTransform(
-      "base_link", predicted_objects_ptr_->header.frame_id, stamp,
+      "base_link", predicted_objects_ptr_->header.frame_id, rclcpp::Time(0),
       rclcpp::Duration::from_seconds(0.5));
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR_STREAM(get_logger(), "[AEB] Failed to look up transform from base_link to map");


### PR DESCRIPTION
## Description
tf_buffer_.lookupTransform seems to be a costly operation that significantly slows down AEB processing time. 

As measured with timekeeper: 
[timekeeper_with_lookup_stamp.txt](https://github.com/user-attachments/files/16845540/timekeeper_with_lookup_stamp.txt)
Peak processing time: > 31 ms

With this PR, we ask the AEB to use directly the latest transform from map to base link, dramatically speeding up the process: 
[timekeeper_no_lookup_stamp.txt](https://github.com/user-attachments/files/16845550/timekeeper_no_lookup_stamp.txt)
Peak processing time: 5.54 ms

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
