### PR TITLE
fix(autoware_behavior_path_planner_common): fix unusedFunction

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -173,14 +173,7 @@ public:
   /**
    * @brief Called on the first time when the module goes into RUNNING.
    */
-  void onEntry()
-  {
-    RCLCPP_DEBUG(getLogger(), "%s %s", name_.c_str(), __func__);
-
-    stop_reason_ = StopReason();
-
-    processOnEntry();
-  }
+  void onEntry();
 
   /**
    * @brief Called when the module exit from RUNNING.

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
@@ -57,15 +57,7 @@ public:
 
   virtual void init(rclcpp::Node * node) = 0;
 
-  void updateIdleModuleInstance()
-  {
-    if (idle_module_ptr_) {
-      idle_module_ptr_->onEntry();
-      return;
-    }
-
-    idle_module_ptr_ = createNewSceneModuleInstance();
-  }
+  void updateIdleModuleInstance();
 
   bool isExecutionRequested(const BehaviorModuleOutput & previous_module_output) const
   {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_interface.cpp
@@ -21,4 +21,13 @@ void SceneModuleInterface::setDrivableLanes(const std::vector<DrivableLanes> & d
   drivable_lanes_marker_ =
     marker_utils::createDrivableLanesMarkerArray(drivable_lanes, "drivable_lanes");
 }
+
+void SceneModuleInterface::onEntry()
+{
+  RCLCPP_DEBUG(getLogger(), "%s %s", name_.c_str(), __func__);
+
+  stop_reason_ = StopReason();
+
+  processOnEntry();
+}
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_manager_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_manager_interface.cpp
@@ -70,4 +70,14 @@ void SceneModuleManagerInterface::initInterface(
     node_ = node;
   }
 }
+
+void SceneModuleManagerInterface::updateIdleModuleInstance()
+{
+  if (idle_module_ptr_) {
+    idle_module_ptr_->onEntry();
+    return;
+  }
+
+  idle_module_ptr_ = createNewSceneModuleInstance();
+}
 }  // namespace autoware::behavior_path_planner


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

This is a fix to the warning in #8651 
The warning can be resolved by moving the file in which the target function is used from `.hpp` to .`cpp.`

```
planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.cpp:50:0: style: The function 'processOnEntry' is never used. [unusedFunction]
void AvoidanceByLaneChangeInterface::processOnEntry()
^

planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.cpp:191:0: style: The function 'createNewSceneModuleInstance' is never used. [unusedFunction]
AvoidanceByLaneChangeModuleManager::createNewSceneModuleInstance()
^
```
## Related links

- #8651 

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
`ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit`

Confirmation that it works.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
