### PR TITLE
fix(autoware_shape_estimation): resolve undefined reference to `~TrtShapeEstimator()`

### DIFF
--- a/perception/autoware_shape_estimation/include/autoware/shape_estimation/tensorrt_shape_estimator.hpp
+++ b/perception/autoware_shape_estimation/include/autoware/shape_estimation/tensorrt_shape_estimator.hpp
@@ -53,7 +53,7 @@ public:
     const tensorrt_common::BuildConfig build_config =
       tensorrt_common::BuildConfig("MinMax", -1, false, false, false, 0.0));
 
-  ~TrtShapeEstimator();
+  ~TrtShapeEstimator() = default;
 
   bool inference(const DetectedObjectsWithFeature & input, DetectedObjectsWithFeature & output);
 


### PR DESCRIPTION
## Description

While building `autoware_shape_estimation`, I got the following error:

```shell
Starting >>> autoware_shape_estimation                                                                                                                                                        
--- stderr: autoware_shape_estimation                                                                                                                                                         
CUDA found, including CUDA-specific sources
/usr/bin/ld: libautoware_shape_estimation.so: undefined reference to `autoware::shape_estimation::TrtShapeEstimator::~TrtShapeEstimator()'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/test_autoware_shape_estimation.dir/build.make:830: test_autoware_shape_estimation] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:242: CMakeFiles/test_autoware_shape_estimation.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< autoware_shape_estimation [5.64s, exited with code 2]
```

This PR added the definition of `~TrtShapeEstimator()` as `=default`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
