### PR TITLE
fix(autoware_pointcloud_preprocessor): instantiate templates so that the symbols exist when linking

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
@@ -422,4 +422,7 @@ inline void DistortionCorrector3D::undistortPointImplementation(
   prev_transformation_matrix_ = transformation_matrix_;
 }
 
+template class DistortionCorrector<DistortionCorrector2D>;
+template class DistortionCorrector<DistortionCorrector3D>;
+
 }  // namespace autoware::pointcloud_preprocessor


### PR DESCRIPTION
## Description

This PR instantiates the DistortionCorrector template so that when linking against it the symbols can be found.

## Related links

**Parent Issue:**

- Link https://github.com/autowarefoundation/autoware.universe/issues/8742

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Built Autoware from source in the buildfarm.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
