### PR TITLE
fix(compare_map_segmentation): use squared distance to compare threshold

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/distance_based_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/distance_based_compare_map_filter/node.cpp
@@ -59,14 +59,14 @@ bool DistanceBasedStaticMapLoader::is_close_to_map(
   }
 
   std::vector<int> nn_indices(1);
-  std::vector<float> nn_distances(1);
+  std::vector<float> nn_sqr_distances(1);
   if (!isFinite(point)) {
     return false;
   }
-  if (!tree_->nearestKSearch(point, 1, nn_indices, nn_distances)) {
+  if (!tree_->nearestKSearch(point, 1, nn_indices, nn_sqr_distances)) {
     return false;
   }
-  if (nn_distances[0] > distance_threshold) {
+  if (nn_sqr_distances[0] > distance_threshold * distance_threshold) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Description

In current compare map, we use following code to compare distance and its threshold.

```cpp
    if (nn_distances[0] <= distance_threshold) {
```

However, `nn_distances` from `radiusKsearch` in PCL is said to be **suqared distance**. [c.f. documents](https://pointclouds.org/documentation/classpcl_1_1search_1_1_kd_tree.html#a20501b588a7971de1dbe92a634deafc5).
This PR fix this issue by squaring the distance threshold.



## Related links


- Confirmed in slack discussion: https://star4.slack.com/archives/C076ZGRC15X/p1725369477014509?thread_ts=1725345541.550159&cid=C076ZGRC15X

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
