### PR TITLE
feat(lane_change): add checks to ensure the edge of vehicle do not exceed target lane boundary when changing lanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -34,6 +34,7 @@
       # safety check
       safety_check:
         allow_loose_check_for_cancel: true
+        enable_target_lane_bound_check: true
         collision_check_yaw_diff_threshold: 3.1416
         execution:
           expected_front_deceleration: -1.0

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -154,6 +154,7 @@ struct Parameters
 
   // safety check
   bool allow_loose_check_for_cancel{true};
+  bool enable_target_lane_bound_check{true};
   double collision_check_yaw_diff_threshold{3.1416};
   utils::path_safety_checker::RSSparams rss_params{};
   utils::path_safety_checker::RSSparams rss_params_for_parked{};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -45,6 +45,7 @@ using autoware::behavior_path_planner::utils::path_safety_checker::PoseWithVeloc
 using autoware::behavior_path_planner::utils::path_safety_checker::PredictedPathWithPolygon;
 using autoware::route_handler::Direction;
 using autoware::universe_utils::Polygon2d;
+using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
@@ -93,6 +94,9 @@ lanelet::ConstLanelets getTargetNeighborLanes(
 bool isPathInLanelets(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
+
+bool pathFootprintExceedsTargetLaneBound(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info);
 
 std::optional<LaneChangePath> constructCandidatePath(
   const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,
@@ -217,8 +221,9 @@ rclcpp::Logger getLogger(const std::string & type);
  *
  * @return Polygon2d A polygon representing the current 2D footprint of the ego vehicle.
  */
-Polygon2d getEgoCurrentFootprint(
-  const Pose & ego_pose, const autoware::vehicle_info_utils::VehicleInfo & ego_info);
+Polygon2d getEgoCurrentFootprint(const Pose & ego_pose, const VehicleInfo & ego_info);
+
+Point getEgoFrontVertex(const Pose & ego_pose, const VehicleInfo & ego_info, bool left);
 
 /**
  * @brief Checks if the given polygon is within an intersection area.
@@ -305,8 +310,8 @@ namespace autoware::behavior_path_planner::utils::lane_change::debug
 geometry_msgs::msg::Point32 create_point32(const geometry_msgs::msg::Pose & pose);
 
 geometry_msgs::msg::Polygon createExecutionArea(
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const Pose & pose,
-  double additional_lon_offset, double additional_lat_offset);
+  const VehicleInfo & vehicle_info, const Pose & pose, double additional_lon_offset,
+  double additional_lat_offset);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::debug
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -96,7 +96,8 @@ bool isPathInLanelets(
   const lanelet::ConstLanelets & target_lanes);
 
 bool pathFootprintExceedsTargetLaneBound(
-  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info);
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info,
+  const double margin = 0.1);
 
 std::optional<LaneChangePath> constructCandidatePath(
   const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -102,6 +102,8 @@ void LaneChangeModuleManager::initParams(rclcpp::Node * node)
   // safety check
   p.allow_loose_check_for_cancel =
     getOrDeclareParameter<bool>(*node, parameter("safety_check.allow_loose_check_for_cancel"));
+  p.enable_target_lane_bound_check =
+    getOrDeclareParameter<bool>(*node, parameter("safety_check.enable_target_lane_bound_check"));
   p.collision_check_yaw_diff_threshold = getOrDeclareParameter<double>(
     *node, parameter("safety_check.collision_check_yaw_diff_threshold"));
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1691,7 +1691,7 @@ bool NormalLaneChange::getLaneChangePaths(
           utils::lane_change::pathFootprintExceedsTargetLaneBound(
             common_data_ptr_, candidate_path.value().shifted_path.path,
             common_parameters.vehicle_info)) {
-          debug_print_lat("Reject: Path footprint excceds target lane boundary. Skip lane change.");
+          debug_print_lat("Reject: Path footprint exceeds target lane boundary. Skip lane change.");
           return false;
         }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1689,7 +1689,8 @@ bool NormalLaneChange::getLaneChangePaths(
         if (
           lane_change_parameters_->enable_target_lane_bound_check &&
           utils::lane_change::pathFootprintExceedsTargetLaneBound(
-            common_data_ptr_, candidate_path.value().path, common_parameters.vehicle_info)) {
+            common_data_ptr_, candidate_path.value().shifted_path.path,
+            common_parameters.vehicle_info)) {
           debug_print_lat("Reject: Path footprint excceds target lane boundary. Skip lane change.");
           return false;
         }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1686,8 +1686,10 @@ bool NormalLaneChange::getLaneChangePaths(
           return false;
         }
 
-        if (utils::lane_change::pathFootprintExceedsTargetLaneBound(
-              common_data_ptr_, candidate_path.value().path, common_parameters.vehicle_info)) {
+        if (
+          lane_change_parameters_->enable_target_lane_bound_check &&
+          utils::lane_change::pathFootprintExceedsTargetLaneBound(
+            common_data_ptr_, candidate_path.value().path, common_parameters.vehicle_info)) {
           debug_print_lat("Reject: Path footprint excceds target lane boundary. Skip lane change.");
           return false;
         }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1686,6 +1686,12 @@ bool NormalLaneChange::getLaneChangePaths(
           return false;
         }
 
+        if (utils::lane_change::pathFootprintExceedsTargetLaneBound(
+              common_data_ptr_, candidate_path.value().path, common_parameters.vehicle_info)) {
+          debug_print_lat("Reject: Path footprint excceds target lane boundary. Skip lane change.");
+          return false;
+        }
+
         const auto is_safe = std::invoke([&]() {
           constexpr size_t decel_sampling_num = 1;
           const auto safety_check_with_normal_rss = isLaneChangePathSafe(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -213,7 +213,8 @@ bool isPathInLanelets(
 }
 
 bool pathFootprintExceedsTargetLaneBound(
-  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info)
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info,
+  const double margin)
 {
   if (common_data_ptr->direction == Direction::NONE || path.points.empty()) {
     return false;
@@ -233,7 +234,7 @@ bool pathFootprintExceedsTargetLaneBound(
     const auto dist_to_boundary =
       sign * utils::getSignedDistanceFromLaneBoundary(combined_target_lane, front_vertex, is_left);
 
-    if (dist_to_boundary < 0.0) {
+    if (dist_to_boundary < margin) {
       return true;
     }
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -225,16 +225,16 @@ bool pathFootprintExceedsTargetLaneBound(
 
   const auto combined_target_lane = lanelet::utils::combineLaneletsShape(target_lanes);
 
-  auto it = path.points.rbegin();
-  for (; it < path.points.rend(); ++it) {
-    const auto & pose = it->point.pose;
-    const auto & front_vertex = getEgoFrontVertex(pose, ego_info, is_left);
+  for (const auto & path_point : path.points) {
+    const auto & pose = path_point.point.pose;
+    const auto front_vertex = getEgoFrontVertex(pose, ego_info, is_left);
 
-    const double sign = is_left ? -1.0 : 1.0;
+    const auto sign = is_left ? -1.0 : 1.0;
     const auto dist_to_boundary =
       sign * utils::getSignedDistanceFromLaneBoundary(combined_target_lane, front_vertex, is_left);
 
     if (dist_to_boundary < margin) {
+      RCLCPP_DEBUG(get_logger(), "Path footprint exceeds target lane boundary");
       return true;
     }
   }
@@ -1083,9 +1083,7 @@ Point getEgoFrontVertex(
 {
   const double lon_offset = ego_info.wheel_base_m + ego_info.front_overhang_m;
   const double lat_offset = 0.5 * (left ? ego_info.vehicle_width_m : -ego_info.vehicle_width_m);
-  const auto vertex =
-    autoware::universe_utils::calcOffsetPose(ego_pose, lon_offset, lat_offset, 0.0).position;
-  return vertex;
+  return autoware::universe_utils::calcOffsetPose(ego_pose, lon_offset, lat_offset, 0.0).position;
 }
 
 bool isWithinIntersection(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -212,6 +212,35 @@ bool isPathInLanelets(
   return true;
 }
 
+bool pathFootprintExceedsTargetLaneBound(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info)
+{
+  if (common_data_ptr->direction == Direction::NONE || path.points.empty()) {
+    return false;
+  }
+
+  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
+  const bool is_left = common_data_ptr->direction == Direction::LEFT;
+
+  const auto combined_target_lane = lanelet::utils::combineLaneletsShape(target_lanes);
+
+  auto it = path.points.rbegin();
+  for (; it < path.points.rend(); ++it) {
+    const auto & pose = it->point.pose;
+    const auto & front_vertex = getEgoFrontVertex(pose, ego_info, is_left);
+
+    const double sign = is_left ? -1.0 : 1.0;
+    const auto dist_to_boundary =
+      sign * utils::getSignedDistanceFromLaneBoundary(combined_target_lane, front_vertex, is_left);
+
+    if (dist_to_boundary < 0.0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 std::optional<LaneChangePath> constructCandidatePath(
   const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
@@ -1046,6 +1075,16 @@ Polygon2d getEgoCurrentFootprint(
   const auto width = ego_info.vehicle_width_m;
 
   return autoware::universe_utils::toFootprint(ego_pose, base_to_front, base_to_rear, width);
+}
+
+Point getEgoFrontVertex(
+  const Pose & ego_pose, const autoware::vehicle_info_utils::VehicleInfo & ego_info, bool left)
+{
+  const double lon_offset = ego_info.wheel_base_m + ego_info.front_overhang_m;
+  const double lat_offset = 0.5 * (left ? ego_info.vehicle_width_m : -ego_info.vehicle_width_m);
+  const auto vertex =
+    autoware::universe_utils::calcOffsetPose(ego_pose, lon_offset, lat_offset, 0.0).position;
+  return vertex;
 }
 
 bool isWithinIntersection(


### PR DESCRIPTION
## Description

Currently, LC path does not guarantee that ego vehicle is within target lane boundaries at all times during LC maneuver. Specifically for larger vehicles (such as bus or trucks), it is more likely that the vehicle frame exceeds the target lane boundary into the next lane during the maneuver, which can result in an unsafe interaction with other vehicles on the road.

This PR adds a safety check for LC candidate path to ensure ego footprint maintains a safe distance from the target lane far boundary for all path points.

If a candidate path does not satisfy the condition it will still be added as a valid path, but will not be considered a safe path.

## Related links

[autoware_launch PR](https://github.com/autowarefoundation/autoware_launch/pull/1157)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PSIM.

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `enable_target_lane_bound_check`   | `bool` | `true` | Flag to enable / disable target lane boundary check |

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

LC candidates path that result in ego foot print exceeding target lane far boundary will be considered unsafe.
