### PR TITLE
fix(static_obstacle_avoidance): ignore objects which has already been decided to avoid

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
@@ -561,6 +561,7 @@ MarkerArray createDebugMarkerArray(
     addObjects(data.other_objects, ObjectInfo::DEVIATING_FROM_EGO_LANE);
     addObjects(data.other_objects, ObjectInfo::UNSTABLE_OBJECT);
     addObjects(data.other_objects, ObjectInfo::AMBIGUOUS_STOPPED_VEHICLE);
+    addObjects(data.other_objects, ObjectInfo::INVALID_SHIFT_LINE);
   }
 
   if (parameters->enable_shift_line_marker) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -248,6 +248,11 @@ AvoidOutlines ShiftLineGenerator::generateAvoidOutline(
     return s.start_longitudinal > 0.0 && s.start_longitudinal < s.end_longitudinal;
   };
 
+  const auto is_approved = [this](const auto & object) {
+    return (helper_->getShift(object.getPosition()) > 0.0 && isOnRight(object)) ||
+           (helper_->getShift(object.getPosition()) < 0.0 && !isOnRight(object));
+  };
+
   ObjectDataArray unavoidable_objects;
 
   // target objects are sorted by longitudinal distance.
@@ -284,6 +289,11 @@ AvoidOutlines ShiftLineGenerator::generateAvoidOutline(
     // calculate feasible shift length based on behavior policy
     const auto feasible_shift_profile = get_shift_profile(o, desire_shift_length);
     if (!feasible_shift_profile.has_value()) {
+      if (is_approved(o)) {
+        // the avoidance path for this object has already approved
+        o.is_avoidable = true;
+        continue;
+      }
       if (o.avoid_required && is_forward_object(o) && is_on_path(o)) {
         break;
       } else {
@@ -394,7 +404,7 @@ AvoidOutlines ShiftLineGenerator::generateAvoidOutline(
       outlines.emplace_back(al_avoid, std::nullopt);
     } else if (is_valid_shift_line(al_avoid) && is_valid_shift_line(al_return)) {
       outlines.emplace_back(al_avoid, al_return);
-    } else {
+    } else if (!is_approved(o)) {
       o.info = ObjectInfo::INVALID_SHIFT_LINE;
       continue;
     }


### PR DESCRIPTION
## Description

There is a issue that the avoidance module did wrong avoidable/unavoidable judgement even after it decided to avoid. I found this was caused by the logic to check longitudinal distance, and the module judged it was not avoidable because there was not enough longitudinal distance when the ego got close to avoidance target object.

https://github.com/user-attachments/assets/693c3e24-c33c-4020-9f06-a02e805efa16

In this PR, I fixed the logic to ignore object if the module generates avoidance path for it.

```c++
  const auto is_approved = [this](const auto & object) {
    return (helper_->getShift(object.getPosition()) > 0.0 && isOnRight(object)) ||
           (helper_->getShift(object.getPosition()) < 0.0 && !isOnRight(object));
  };
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://github.com/user-attachments/assets/17fa8073-6d32-41bd-a06d-4ff22b05b7b4

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/10863e56-4bb0-5b16-84ab-6547d1d42b0d?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
