### PR TITLE
ci(build-and-test): reset ccache stats before build

### DIFF
--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -57,8 +57,10 @@ runs:
         restore-keys: |
           ccache-main-${{ runner.arch }}-${{ inputs.rosdistro }}-
 
-    - name: Show ccache stats before build
-      run: du -sh ${CCACHE_DIR} && ccache -s
+    - name: Show ccache stats before build and reset stats
+      run: |
+        du -sh ${CCACHE_DIR} && ccache -s
+        ccache --zero-stats
       shell: bash
 
     - name: Export CUDA state as a variable for adding to cache key

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -69,8 +69,10 @@ jobs:
           echo -e "# Set maximum cache size\nmax_size = 600MB" >> "${CCACHE_DIR}/ccache.conf"
         shell: bash
 
-      - name: Show ccache stats before build
-        run: du -sh ${CCACHE_DIR} && ccache -s
+      - name: Show ccache stats before build and reset stats
+        run: |
+          du -sh ${CCACHE_DIR} && ccache -s
+          ccache --zero-stats
         shell: bash
 
       - name: Export CUDA state as a variable for adding to cache key

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+// test change
 namespace autoware::gnss_poser
 {
 GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <vector>
 
-// test change
 namespace autoware::gnss_poser
 {
 GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)


### PR DESCRIPTION
## Description

Right now ccache stats are not correct because it accumulates over time.

> https://linux.die.net/man/1/ccache
> 
> ```
> -z, --zero-stats
> Zero the cache statistics (but not the configured limits).
> ```

This command will reset it before the build. So we can get to know the real stats after build.

## Related links

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
