### PR TITLE
fix: align the parameters with launcher

### DIFF
--- a/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -2,15 +2,15 @@
   ros__parameters:
     # Ego path calculation
     use_predicted_trajectory: true
-    use_imu_path: false
+    use_imu_path: true
     use_pointcloud_data: true
-    use_predicted_object_data: true
+    use_predicted_object_data: false
     use_object_velocity_calculation: true
     check_autoware_state: true
     min_generated_path_length: 0.5
     imu_prediction_time_horizon: 1.5
     imu_prediction_time_interval: 0.1
-    mpc_prediction_time_horizon: 1.5
+    mpc_prediction_time_horizon: 4.5
     mpc_prediction_time_interval: 0.1
 
     # Debug
@@ -29,8 +29,8 @@
     path_footprint_extra_margin: 4.0
 
     # Point cloud clustering
-    cluster_tolerance: 0.1 #[m]
-    cluster_minimum_height: 0.0
+    cluster_tolerance: 0.15 #[m]
+    cluster_minimum_height: 0.1
     minimum_cluster_size: 10
     maximum_cluster_size: 10000
 

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -5,7 +5,7 @@
     #  the next trajectory is valid.)
     diag_error_count_threshold: 0
 
-    display_on_terminal: true # show error msg on terminal
+    display_on_terminal: false # show error msg on terminal
 
     thresholds:
       max_distance_deviation: 1.0

--- a/control/autoware_lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/autoware_lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -1,9 +1,9 @@
 /**:
   ros__parameters:
     # Enable feature
-    will_out_of_lane_checker: true
-    out_of_lane_checker: true
-    boundary_departure_checker: false
+    will_out_of_lane_checker: false
+    out_of_lane_checker: false
+    boundary_departure_checker: true
 
     # Node
     update_rate: 10.0
@@ -12,7 +12,7 @@
     include_left_lanes: false
     include_opposite_lanes: false
     include_conflicting_lanes: false
-    boundary_types_to_detect: [road_border]
+    boundary_types_to_detect: [curbstone]
 
 
     # Core

--- a/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
@@ -13,7 +13,7 @@
     curvature_smoothing_num_ref_steer: 15   # point-to-point index distance used in curvature calculation (for steer command reference): curvature is calculated from three points p(i-num), p(i), p(i+num)
 
     # -- trajectory extending --
-    extend_trajectory_for_end_yaw_control: true  # flag of trajectory extending for terminal yaw control
+    extend_trajectory_for_end_yaw_control: false  # flag of trajectory extending for terminal yaw control
 
     # -- mpc optimization --
     qp_solver_type: "osqp"                       # optimization solver option (unconstraint_fast or osqp)
@@ -46,7 +46,7 @@
     # -- vehicle model --
     vehicle_model_type: "kinematics" # vehicle model type for mpc prediction. option is kinematics, kinematics_no_delay, and dynamics
     input_delay: 0.24                # steering input delay time for delay compensation
-    vehicle_model_steer_tau: 0.3     # steering dynamics time constant (1d approximation) [s]
+    vehicle_model_steer_tau: 0.27     # steering dynamics time constant (1d approximation) [s]
     steer_rate_lim_dps_list_by_curvature: [40.0, 50.0, 60.0]            # steering angle rate limit list depending on curvature [deg/s]
     curvature_list_for_steer_rate_lim: [0.001, 0.002, 0.01]              # curvature list for steering angle rate limit interpolation in ascending order [/m]
     steer_rate_lim_dps_list_by_velocity: [60.0, 50.0, 40.0]             # steering angle rate limit list depending on velocity [deg/s]
@@ -75,4 +75,4 @@
       average_num: 1000
       steering_offset_limit: 0.02
 
-    debug_publish_predicted_trajectory: false  # publish debug predicted trajectory in Frenet coordinate
+    debug_publish_predicted_trajectory: true  # publish debug predicted trajectory in Frenet coordinate

--- a/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    delay_compensation_time: 0.17
+    delay_compensation_time: 0.1
 
     enable_smooth_stop: true
     enable_overshoot_emergency: true

--- a/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
+++ b/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     update_rate: 10.0
     system_emergency_heartbeat_timeout: 0.5
-    use_emergency_handling: false
+    use_emergency_handling: true
     check_external_emergency_heartbeat: $(var check_external_emergency_heartbeat)
     enable_cmd_limit_filter: true
     filter_activated_count_threshold: 5

--- a/control/obstacle_collision_checker/config/obstacle_collision_checker.param.yaml
+++ b/control/obstacle_collision_checker/config/obstacle_collision_checker.param.yaml
@@ -4,8 +4,8 @@
     update_rate: 10.0
 
     # Core
-    delay_time: 0.3 # delay time of vehicle [s]
+    delay_time: 0.03 # delay time of vehicle [s]
     footprint_margin: 0.0 # margin for footprint [m]
-    max_deceleration: 2.0 # max deceleration [m/ss]
+    max_deceleration: 1.5 # max deceleration [m/ss]
     resample_interval: 0.3 # interval distance to resample point cloud [m]
     search_radius: 5.0 # search distance from trajectory to point cloud [m]

--- a/planning/autoware_costmap_generator/config/costmap_generator.param.yaml
+++ b/planning/autoware_costmap_generator/config/costmap_generator.param.yaml
@@ -7,7 +7,7 @@
     activate_by_scenario: false
     grid_min_value: 0.0
     grid_max_value: 1.0
-    grid_resolution: 0.2
+    grid_resolution: 0.3
     grid_length_x: 70.0
     grid_length_y: 70.0
     grid_position_x: 0.0
@@ -18,5 +18,5 @@
     use_parkinglot: true
     use_objects: true
     use_points: true
-    expand_polygon_size: 1.0
+    expand_polygon_size: 0.5
     size_of_expansion_kernel: 9

--- a/planning/autoware_freespace_planner/config/freespace_planner.param.yaml
+++ b/planning/autoware_freespace_planner/config/freespace_planner.param.yaml
@@ -9,7 +9,7 @@
     th_stopped_velocity_mps: 0.01
     th_course_out_distance_m: 1.0
     th_obstacle_time_sec: 1.0
-    vehicle_shape_margin_m: 1.0
+    vehicle_shape_margin_m: 0.5
     replan_when_obstacle_found: true
     replan_when_course_out: true
 
@@ -19,13 +19,13 @@
     max_turning_ratio: 0.5 # ratio of actual turning limit of vehicle
     turning_steps: 1
     # search configs
-    theta_size: 144
+    theta_size: 120
     angle_goal_range: 6.0
     lateral_goal_range: 0.5
     longitudinal_goal_range: 1.0
     curve_weight: 0.5
-    reverse_weight: 1.0
-    direction_change_weight: 1.5
+    reverse_weight: 0.7
+    direction_change_weight: 2.0
     # costmap configs
     obstacle_threshold: 100
 
@@ -36,10 +36,10 @@
       use_back: true
       adapt_expansion_distance: true
       expansion_distance: 0.5
-      near_goal_distance: 4.0
-      distance_heuristic_weight: 1.5
+      near_goal_distance: 3.0
+      distance_heuristic_weight: 2.0
       smoothness_weight: 0.5
-      obstacle_distance_weight: 1.5
+      obstacle_distance_weight: 1.75
       goal_lat_distance_weight: 5.0
 
     # -- RRT* search Configurations --

--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -12,7 +12,7 @@
       idling_time: 2.0 # idling time to detect front vehicle starting deceleration [s]
       min_ego_accel_for_rss: -1.0 # ego's acceleration to calculate RSS distance [m/ss]
       min_object_accel_for_rss: -1.0 # front obstacle's acceleration to calculate RSS distance [m/ss]
-      safe_distance_margin : 6.0 # This is also used as a stop margin [m]
+      safe_distance_margin : 5.0 # This is also used as a stop margin [m]
       terminal_safe_distance_margin : 3.0 # Stop margin at the goal. This value cannot exceed safe distance margin. [m]
       hold_stop_velocity_threshold: 0.01 # The maximum ego velocity to hold stopping [m/s]
       hold_stop_distance_threshold: 0.3 # The ego keeps stopping if the distance to stop changes within the threshold [m]
@@ -23,10 +23,10 @@
       nearest_yaw_deviation_threshold: 1.57 # [rad] for finding nearest index
       min_behavior_stop_margin: 3.0 # [m]
       stop_on_curve:
-        enable_approaching: true # false
-        additional_safe_distance_margin: 0.0 # [m]
+        enable_approaching: false # false
+        additional_safe_distance_margin: 3.0 # [m]
         min_safe_distance_margin: 3.0 # [m]
-      suppress_sudden_obstacle_stop: true
+      suppress_sudden_obstacle_stop: false
 
       stop_obstacle_type:
         unknown: true
@@ -109,7 +109,7 @@
           ego_obstacle_overlap_time_threshold : 2.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
         yield:
-          enable_yield: false
+          enable_yield: true
           lat_distance_threshold: 5.0 # lateral margin between obstacle in neighbor lanes and trajectory band with ego's width for yielding
           max_lat_dist_between_obstacles: 2.5 # lateral margin between moving obstacle in neighbor lanes and stopped obstacle in front of it
           max_obstacles_collision_time: 10.0 # how far the blocking obstacle
@@ -125,7 +125,7 @@
       # Both the lateral error and the yaw error are assumed to decrease to zero by the time duration "time_to_convergence"
       # The both errors decrease with constant rates against the time.
       consider_current_pose:
-        enable_to_consider_current_pose: false
+        enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
 
     cruise:
@@ -196,13 +196,12 @@
       # parameters to calculate slow down velocity by linear interpolation
       labels:
         - "default"
-        - "pedestrian"
       default:
         moving:
-          min_lat_margin: 0.8
-          max_lat_margin: 1.3
-          min_ego_velocity: 0.5
-          max_ego_velocity: 1.5
+          min_lat_margin: 0.2
+          max_lat_margin: 1.0
+          min_ego_velocity: 2.0
+          max_ego_velocity: 8.0
         static:
           min_lat_margin: 0.2
           max_lat_margin: 1.0

--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -207,17 +207,6 @@
           max_lat_margin: 1.0
           min_ego_velocity: 4.0
           max_ego_velocity: 8.0
-      pedestrian:
-        moving:
-          min_lat_margin: 0.8
-          max_lat_margin: 1.3
-          min_ego_velocity: 0.5
-          max_ego_velocity: 0.8
-        static:
-          min_lat_margin: 0.8
-          max_lat_margin: 1.3
-          min_ego_velocity: 1.0
-          max_ego_velocity: 2.0
 
       moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"
       moving_object_hysteresis_range: 0.1 # [m/s] hysteresis range used to prevent chattering when obstacle moves close to moving_object_speed_threshold

--- a/planning/autoware_obstacle_stop_planner/config/common.param.yaml
+++ b/planning/autoware_obstacle_stop_planner/config/common.param.yaml
@@ -4,9 +4,9 @@
     max_vel: 11.1           # max velocity limit [m/s]
 
     normal:
-      min_acc: -0.5         # min deceleration [m/ss]
+      min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]
-      min_jerk: -0.5        # min jerk [m/sss]
+      min_jerk: -1.0        # min jerk [m/sss]
       max_jerk: 1.0         # max jerk [m/sss]
 
     # constraints to be observed

--- a/planning/autoware_obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/autoware_obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -18,8 +18,8 @@
       # params for stop position
       stop_position:
         max_longitudinal_margin: 5.0             # stop margin distance from obstacle on the path [m]
-        max_longitudinal_margin_behind_goal: 3.0 # stop margin distance from obstacle behind the goal on the path [m]
-        min_longitudinal_margin: 2.0             # stop margin distance when any other stop point is inserted in stop margin [m]
+        max_longitudinal_margin_behind_goal: 2.5 # stop margin distance from obstacle behind the goal on the path [m]
+        min_longitudinal_margin: 5.0             # stop margin distance when any other stop point is inserted in stop margin [m]
         hold_stop_margin_distance: 0.0           # the ego keeps stopping if the ego is in this margin [m]
 
       # params for detection area
@@ -36,7 +36,7 @@
       # params for slow down section
       slow_down_section:
         longitudinal_forward_margin: 5.0     # margin distance from slow down point to vehicle front [m]
-        longitudinal_backward_margin: 5.0    # margin distance from slow down point to vehicle rear [m]
+        longitudinal_backward_margin: 0.0    # margin distance from slow down point to vehicle rear [m]
         longitudinal_margin_span: -0.1       # fineness param for relaxing slow down margin (use this param if consider_constraints is True) [m/s]
         min_longitudinal_forward_margin: 1.0 # min margin for relaxing slow down margin (use this param if consider_constraints is True) [m/s]
 
@@ -55,7 +55,7 @@
 
       # params for deceleration constraints (use this param if consider_constraints is True)
       constraints:
-        jerk_min_slow_down: -0.3             # min slow down jerk constraint [m/sss]
+        jerk_min_slow_down: -0.6             # min slow down jerk constraint [m/sss]
         jerk_span: -0.01                     # fineness param for planning deceleration jerk [m/sss]
         jerk_start: -0.1                     # init jerk used for deceleration planning [m/sss]
 

--- a/planning/autoware_obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/autoware_obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -2,8 +2,6 @@
   ros__parameters:
     chattering_threshold: 0.5                 # even if the obstacle disappears, the stop judgment continues for chattering_threshold [s]
     max_velocity: 20.0                        # max velocity [m/s]
-    ego_nearest_dist_threshold: 3.0           # [m]
-    ego_nearest_yaw_threshold: 1.046          # [rad] = 60 [deg]
     enable_slow_down: False                   # whether to use slow down planner [-]
     enable_z_axis_obstacle_filtering: True    # filter obstacles in z axis (height) [-]
     z_axis_filtering_buffer: 0.0              # additional buffer for z axis filtering [m]

--- a/planning/autoware_path_optimizer/config/path_optimizer.param.yaml
+++ b/planning/autoware_path_optimizer/config/path_optimizer.param.yaml
@@ -3,12 +3,12 @@
     option:
       enable_skip_optimization: false                              # skip elastic band and model predictive trajectory
       enable_reset_prev_optimization: false                        # If true, optimization has no fix constraint to the previous result.
-      enable_outside_drivable_area_stop: true                      # stop if the ego's trajectory footprint is outside the drivable area
+      enable_outside_drivable_area_stop: false                      # stop if the ego's trajectory footprint is outside the drivable area
       use_footprint_polygon_for_outside_drivable_area_check: false # If false, only the footprint's corner points are considered.
 
       debug:
         # flag to publish
-        enable_pub_debug_marker: true           # publish debug marker
+        enable_pub_debug_marker: false           # publish debug marker
         enable_pub_extra_debug_marker: false    # publish extra debug marker
 
         # flag to show
@@ -31,7 +31,7 @@
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]
-      max_delta_time_sec: 1.0                  # threshold of delta time for replan [second]
+      max_delta_time_sec: 0.0                  # threshold of delta time for replan [second]
 
     # mpt param
     mpt:
@@ -40,7 +40,7 @@
         steer_limit_constraint: false
         visualize_sampling_num: 1
         enable_manual_warm_start: false
-        enable_warm_start: true
+        enable_warm_start: false
         enable_optimization_validation: false
 
       common:
@@ -62,7 +62,7 @@
       # weight parameter for optimization
       weight:
         # collision free
-        soft_collision_free_weight: 1000.0        # soft weight for lateral error around the middle point
+        soft_collision_free_weight: 1.0        # soft weight for lateral error around the middle point
 
         # tracking error
         lat_error_weight: 1.0       # weight for lateral error

--- a/planning/autoware_path_smoother/config/elastic_band_smoother.param.yaml
+++ b/planning/autoware_path_smoother/config/elastic_band_smoother.param.yaml
@@ -40,8 +40,8 @@
       enable: true  # if true, only perform smoothing when the input changes significantly
       max_path_shape_around_ego_lat_dist: 2.0  # threshold of path shape change around ego [m]
       max_path_shape_forward_lon_dist: 100.0   # forward point to check lateral distance difference [m]
-      max_path_shape_forward_lat_dist: 0.1     # threshold of path shape change around forward point [m]
+      max_path_shape_forward_lat_dist: 0.2     # threshold of path shape change around forward point [m]
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]
-      max_delta_time_sec: 1.0                  # threshold of delta time for replan [second]
+      max_delta_time_sec: 0.0                  # threshold of delta time for replan [second]

--- a/planning/autoware_static_centerline_generator/config/common.param.yaml
+++ b/planning/autoware_static_centerline_generator/config/common.param.yaml
@@ -4,9 +4,9 @@
     max_vel: 11.1           # max velocity limit [m/s]
 
     normal:
-      min_acc: -0.5         # min deceleration [m/ss]
+      min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]
-      min_jerk: -0.5        # min jerk [m/sss]
+      min_jerk: -1.0        # min jerk [m/sss]
       max_jerk: 1.0         # max jerk [m/sss]
 
     # constraints to be observed

--- a/planning/autoware_surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
+++ b/planning/autoware_surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
@@ -9,7 +9,7 @@
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
     unknown:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
@@ -17,22 +17,22 @@
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     truck:
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     bus:
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     trailer:
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     motorcycle:
       enable_check: true
       surround_check_front_distance: 0.5
@@ -49,9 +49,9 @@
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
 
-    surround_check_hysteresis_distance: 0.3
+    surround_check_hysteresis_distance: 0.1
 
-    state_clear_time: 2.0
+    state_clear_time: 0.2
 
     # ego stop state
     stop_state_ego_speed: 0.1 #[m/s]

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
@@ -58,7 +58,7 @@
         lat_offset_from_obstacle: 1.0 # [m]
         margin_distance_around_pedestrian: 2.0 # [m]
         predicted_path:
-          end_time_to_consider: 3.0 # [s]
+          end_time_to_consider: 2.0 # [s]
           threshold_confidence: 0.0 # [] not probability
         max_lat_offset_to_avoid: 0.5 # [m]
         max_time_for_object_lat_shift: 0.0 # [s]

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -14,14 +14,14 @@
           lateral_weight: 40.0
         prioritize_goals_before_objects: true
         parking_policy: "left_side" # "left_side" or "right_side"
-        forward_goal_search_length: 20.0
+        forward_goal_search_length: 40.0
         backward_goal_search_length: 20.0
         goal_search_interval: 2.0
         longitudinal_margin: 3.0
-        max_lateral_offset: 0.5
-        lateral_offset_interval: 0.25
+        max_lateral_offset: 1.0
+        lateral_offset_interval: 0.5
         ignore_distance_from_lane_start: 0.0
-        margin_from_boundary: 0.5
+        margin_from_boundary: 0.75
         high_curvature_threshold: 0.1
 
       # occupancy grid map
@@ -35,7 +35,7 @@
 
       # object recognition
       object_recognition:
-        use_object_recognition: false
+        use_object_recognition: true
         collision_check_soft_margins: [5.0, 4.5, 4.0, 3.5, 3.0, 2.5, 2.0, 1.5, 1.0]  # the maximum margin when ego and objects are oriented.
         collision_check_hard_margins: [0.6]  # this should be larger than `surround_check_distance` of surround_obstacle_checker.
         object_recognition_collision_check_max_extra_stopping_margin: 1.0
@@ -46,7 +46,7 @@
 
       # pull over
       pull_over:
-        minimum_request_length: 100.0
+        minimum_request_length: 0.0
         pull_over_velocity: 3.0
         pull_over_minimum_velocity: 1.38
         decide_path_distance: 10.0
@@ -91,13 +91,13 @@
           velocity: 1.0
           vehicle_shape_margin: 1.0
           time_limit: 3000.0
-          max_turning_ratio: 0.7
+          max_turning_ratio: 0.5
           turning_steps: 1
           # search configs
           search_configs:
-            theta_size: 144
+            theta_size: 120
             angle_goal_range: 6.0
-            curve_weight: 1.2
+            curve_weight: 0.5
             reverse_weight: 1.0
             lateral_goal_range: 0.5
             longitudinal_goal_range: 2.0
@@ -108,8 +108,8 @@
           astar:
             search_method: "forward"  # options: forward, backward
             only_behind_solutions: false
-            use_back: false
-            distance_heuristic_weight: 1.0
+            use_back: true
+            distance_heuristic_weight: 2.0
           # -- RRT* search Configurations --
           rrtstar:
             enable_update: true
@@ -124,7 +124,7 @@
       path_safety_check:
         # EgoPredictedPath
         ego_predicted_path:
-          min_velocity: 0.0
+          min_velocity: 1.0
           min_acceleration: 1.0
           time_horizon_for_front_object: 10.0
           time_horizon_for_rear_object: 10.0
@@ -135,7 +135,7 @@
           safety_check_time_horizon: 10.0
           safety_check_time_resolution: 1.0
           # detection range
-          object_check_forward_distance: 10.0
+          object_check_forward_distance: 100.0
           object_check_backward_distance: 100.0
           ignore_object_velocity_threshold: 1.0
           # ObjectTypesToCheck
@@ -184,7 +184,7 @@
           hysteresis_factor_expand_rate: 1.0
           collision_check_yaw_diff_threshold: 3.1416
           # temporary
-          backward_path_length: 100.0
+          backward_path_length: 30.0
           forward_path_length: 100.0
 
       # debug

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -28,8 +28,8 @@
 
       skip_process:
         longitudinal_distance_diff_threshold:
-          prepare: 0.5
-          lane_changing: 0.5
+          prepare: 1.0
+          lane_changing: 1.0
 
       # safety check
       safety_check:
@@ -42,7 +42,7 @@
           rear_vehicle_safety_time_margin: 1.0
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
-          longitudinal_velocity_delta_time: 0.8
+          longitudinal_velocity_delta_time: 0.0
         parked:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -2.0
@@ -58,7 +58,7 @@
           rear_vehicle_safety_time_margin: 0.8
           lateral_distance_max_threshold: 1.0
           longitudinal_distance_min_threshold: 2.5
-          longitudinal_velocity_delta_time: 0.6
+          longitudinal_velocity_delta_time: 0.0
         stuck:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0
@@ -66,18 +66,18 @@
           rear_vehicle_safety_time_margin: 1.0
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
-          longitudinal_velocity_delta_time: 0.8
+          longitudinal_velocity_delta_time: 0.0
 
         # lane expansion for object filtering
         lane_expansion:
-          left_offset: 0.0 # [m]
-          right_offset: 0.0 # [m]
+          left_offset: 1.0 # [m]
+          right_offset: 1.0 # [m]
 
       # lateral acceleration map
       lateral_acceleration:
         velocity: [0.0, 4.0, 10.0]
-        min_values: [0.15, 0.15, 0.15]
-        max_values: [0.5, 0.5, 0.5]
+        min_values: [0.4,0.4,0.4]
+        max_values: [0.65,0.65,0.65]
 
       # target object
       target_object:
@@ -85,20 +85,20 @@
         truck: true
         bus: true
         trailer: true
-        unknown: true
+        unknown: false
         bicycle: true
         motorcycle: true
         pedestrian: true
 
       # lane change regulations
       regulation:
-        crosswalk: false
-        intersection: false
+        crosswalk: true
+        intersection: true
         traffic_light: true
 
       # ego vehicle stuck detection
       stuck_detection:
-        velocity: 0.1 # [m/s]
+        velocity: 0.5 # [m/s]
         stop_time: 3.0 # [s]
 
       # collision check
@@ -107,9 +107,9 @@
         intersection: true
         turns: true
       stopped_object_velocity_threshold: 1.0 # [m/s]
-      check_objects_on_current_lanes: true
-      check_objects_on_other_lanes: true
-      use_all_predicted_path: true
+      check_objects_on_current_lanes: false
+      check_objects_on_other_lanes: false
+      use_all_predicted_path: false
 
       # lane change cancel
       cancel:
@@ -117,9 +117,9 @@
         enable_on_lane_changing_phase: true
         delta_time: 1.0                     # [s]
         duration: 5.0                       # [s]
-        max_lateral_jerk: 1000.0            # [m/s3]
+        max_lateral_jerk: 100.0            # [m/s3]
         overhang_tolerance: 0.0             # [m]
-        unsafe_hysteresis_threshold: 10     # [/]
+        unsafe_hysteresis_threshold: 5     # [/]
         deceleration_sampling_num: 5 # [/]
 
       lane_change_finish_judge_buffer: 2.0      # [m]
@@ -127,4 +127,4 @@
       finish_judge_lateral_angle_deviation: 1.0 # [deg]
 
       # debug
-      publish_debug_marker: false
+      publish_debug_marker: true

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -23,4 +23,3 @@
     enable_cog_on_centerline: false
     input_path_interval: 2.0
     output_path_interval: 2.0
-

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -24,6 +24,3 @@
     input_path_interval: 2.0
     output_path_interval: 2.0
 
-    closest_lanelet:
-      distance_threshold: 5.0 # [m]
-      yaw_threshold: 0.79 # [rad]

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -10,7 +10,7 @@
       enabled: true
       print_runtime: false
       max_expansion_distance: 0.0 # [m] maximum distance by which the drivable area can be expended (0.0 means no limit)
-      min_bound_interval: 0.1  # [m] minimum interval between two consecutive bound points (before expansion)
+      min_bound_interval: 1.0  # [m] minimum interval between two consecutive bound points (before expansion)
       smoothing:
         curvature_average_window: 3  # window size used for smoothing the curvatures using a moving window average
         max_bound_rate: 1.0  # [m/m] maximum rate of change of the bound lateral distance over its arc length
@@ -20,17 +20,18 @@
         extra_front_overhang: 0.5 # [m] extra length to add to the front overhang
         extra_width: 1.0 # [m] extra length to add to the width
       dynamic_objects:
-        avoid: true # if true, the drivable area is not expanded in the predicted path of dynamic objects
+        avoid: false # if true, the drivable area is not expanded in the predicted path of dynamic objects
         extra_footprint_offset:
           front: 0.5 # [m] extra length to add to the front of the dynamic object footprint
           rear: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
           left: 0.5 # [m] extra length to add to the left of the dynamic object footprint
           right: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
       path_preprocessing:
-        max_arc_length: 50.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
+        max_arc_length: 100.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
         resample_interval: 2.0 # [m] fixed interval between resampled path points (0.0 means path points are directly used)
         reuse_max_deviation: 0.5 # [m] if the path changes by more than this value, the curvatures are recalculated. Otherwise they are reused.
       avoid_linestring:
         types: # linestring types in the lanelet maps that will not be crossed when expanding the drivable area
           - road_border
+          - curbstone
         distance: 0.0 # [m] distance to keep between the drivable area and the linestrings to avoid

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/scene_module_manager.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/scene_module_manager.param.yaml
@@ -47,7 +47,7 @@
 
     start_planner:
       enable_rtc: false
-      enable_simultaneous_execution_as_approved_module: false
+      enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
 
     side_shift:
@@ -57,7 +57,7 @@
 
     goal_planner:
       enable_rtc: false
-      enable_simultaneous_execution_as_approved_module: false
+      enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
 
     static_obstacle_avoidance:

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/config/sampling_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/config/sampling_planner.param.yaml
@@ -1,20 +1,3 @@
 /**:
   ros__parameters:
     start_planner:
-      max_curvature: 0.1
-      min_curvature: -0.1
-      lateral_deviation_weight: 1.0
-      length_weight: 1.0
-      curvature_weight: 1.0
-      enable_frenet: true
-      enable_bezier: false
-      resolution: 0.5
-      previous_path_reuse_points_nb: 2
-      nb_target_lateral_positions: {10.0, 20.0}
-      target_lengths: {-2.0, -1.0, 0.0, 1.0, 2.0}
-      target_lateral_positions: 2
-      target_lateral_velocities: {-0.1, 0.0, 0.1}
-      target_lateral_accelerations: {0.0}
-      force_zero_deviation: true
-      force_zero_heading: true
-      smooth_reference: false

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -32,7 +32,7 @@
       minimum_lateral_acc: 0.15
       maximum_lateral_acc: 0.5
       maximum_curvature: 0.07
-      end_pose_curvature_threshold: 0.01
+      end_pose_curvature_threshold: 0.1
       # geometric pull out
       enable_geometric_pull_out: true
       geometric_collision_check_distance_from_end: 0.0
@@ -66,9 +66,9 @@
         turning_steps: 1
         # search configs
         search_configs:
-          theta_size: 144
+          theta_size: 120
           angle_goal_range: 6.0
-          curve_weight: 1.2
+          curve_weight: 0.5
           reverse_weight: 1.0
           lateral_goal_range: 0.5
           longitudinal_goal_range: 2.0
@@ -79,8 +79,8 @@
         astar:
           search_method: "forward"  # options: forward, backward
           only_behind_solutions: false
-          use_back: false
-          distance_heuristic_weight: 1.0
+          use_back: true
+          distance_heuristic_weight: 2.0
         # -- RRT* search Configurations --
         rrtstar:
           enable_update: true
@@ -103,7 +103,7 @@
           delay_until_departure: 1.0
         # For target object filtering
         target_filtering:
-          safety_check_time_horizon: 5.0
+          safety_check_time_horizon: 10.0
           safety_check_time_resolution: 1.0
           # detection range
           object_check_forward_distance: 10.0

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -23,44 +23,44 @@
           th_moving_time: 2.0                           # [s]
           longitudinal_margin: 0.0                      # [m]
           lateral_margin:
-            soft_margin: 0.3                            # [m]
+            soft_margin: 0.7                            # [m]
             hard_margin: 0.2                            # [m]
             hard_margin_for_parked_vehicle: 0.7         # [m]
           max_expand_ratio: 0.0                         # [-] FOR DEVELOPER
-          envelope_buffer_margin: 0.5                   # [m] FOR DEVELOPER
+          envelope_buffer_margin: 0.1                   # [m] FOR DEVELOPER
           th_error_eclipse_long_radius : 0.6            # [m]
         truck:
           th_moving_speed: 1.0
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.3
+            soft_margin: 0.7
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.7
           max_expand_ratio: 0.0
-          envelope_buffer_margin: 0.5
+          envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
         bus:
           th_moving_speed: 1.0
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.3
+            soft_margin: 0.7
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.7
           max_expand_ratio: 0.0
-          envelope_buffer_margin: 0.5
+          envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
         trailer:
           th_moving_speed: 1.0
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.3
+            soft_margin: 0.7
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.7
           max_expand_ratio: 0.0
-          envelope_buffer_margin: 0.5
+          envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
         unknown:
           th_moving_speed: 0.28
@@ -150,16 +150,16 @@
           # "auto"   : generate candidate path. if RTC is running as AUTO mode, the ego avoids it automatically.
           # "manual" : generate candidate path and wait operator approval even if RTC is running as AUTO mode.
           # "ignore" : never avoid it.
-          policy: "auto"                                # [-]
+          policy: "manual"                                # [-]
           condition:
             th_stopped_time: 3.0                        # [s]
             th_moving_distance: 1.0                     # [m]
           ignore_area:
             traffic_light:
-              front_distance: 100.0                     # [m]
+              front_distance: 20.0                     # [m]
             crosswalk:
-              front_distance: 30.0                      # [m]
-              behind_distance: 30.0                     # [m]
+              front_distance: 20.0                      # [m]
+              behind_distance: 0.0                     # [m]
           wait_and_see:
             target_behaviors: ["MERGING", "DEVIATING"]  # [-]
             th_closest_distance: 10.0                   # [m]
@@ -232,7 +232,7 @@
         # avoidance distance parameters
         longitudinal:
           min_prepare_time: 1.0                         # [s]
-          max_prepare_time: 2.0                         # [s]
+          max_prepare_time: 3.0                         # [s]
           min_prepare_distance: 1.0                     # [m]
           min_slow_down_speed: 1.38                     # [m/s]
           buf_slow_down_speed: 0.56                     # [m/s] FOR DEVELOPER
@@ -291,7 +291,7 @@
       constraints:
         # lateral constraints
         lateral:
-          velocity: [1.0, 1.38, 11.1]                   # [m/s]
+          velocity: [1.39, 4.17, 11.1]                   # [m/s]
           max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
           min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
           max_jerk_values: [1.0, 1.0, 1.0]              # [m/sss]
@@ -327,8 +327,8 @@
 
       # for debug
       debug:
-        enable_other_objects_marker: false
-        enable_other_objects_info: false
+        enable_other_objects_marker: true
+        enable_other_objects_info: true
         enable_detection_area_marker: false
         enable_drivable_bound_marker: false
         enable_safety_check_marker: false

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -38,7 +38,7 @@
       # params for the pass judge logic against the crosswalk users such as pedestrians or bicycles
       pass_judge:
         ego_pass_first_margin_x: [0.0] # [[s]] time to collision margin vector for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
-        ego_pass_first_margin_y: [3.0] # [[s]] time to vehicle margin vector for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
+        ego_pass_first_margin_y: [4.0] # [[s]] time to vehicle margin vector for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
         ego_pass_first_additional_margin: 0.5 # [s] additional time margin for ego pass first situation to suppress chattering
         ego_pass_later_margin_x: [0.0] # [[s]] time to vehicle margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
         ego_pass_later_margin_y: [13.0] # [[s]] time to collision margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
@@ -75,8 +75,8 @@
         enable: true  # if true, ego will slowdown around crosswalks that are occluded
         occluded_object_velocity: 1.0 # [m/s] assumed velocity of objects that may come out of the occluded space
         slow_down_velocity: 1.0  # [m/s]
-        time_buffer: 1.0  # [s] consecutive time with/without an occlusion to add/remove the slowdown
-        min_size: 0.5  # [m] minimum size of an occlusion (square side size)
+        time_buffer: 0.5  # [s] consecutive time with/without an occlusion to add/remove the slowdown
+        min_size: 1.0  # [m] minimum size of an occlusion (square side size)
         free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
         occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid
         ignore_with_traffic_light: true  # [-] if true, occlusions at crosswalks with traffic lights are ignored

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -90,19 +90,19 @@
           object_time_margin_to_collision_point: 4.0
 
       occlusion:
-        enable: false
+        enable: true
         occlusion_attention_area_length: 70.0
         free_space_max: 43
         occupied_min: 58
         denoise_kernel: 1.0
         attention_lane_crop_curvature_threshold: 0.25
-        attention_lane_curvature_calculation_ds: 0.5
+        attention_lane_curvature_calculation_ds: 0.6
         creep_during_peeking:
           enable: false
           creep_velocity: 0.8333
         peeking_offset: -0.5
         occlusion_required_clearance_distance: 55.0
-        possible_object_bbox: [1.5, 2.5]
+        possible_object_bbox: [1.9, 2.5]
         ignore_parked_vehicle_speed_threshold: 0.8333
         occlusion_detection_hold_time: 1.5
         temporal_stop_time_before_peeking: 0.1

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/config/occlusion_spot.param.yaml
@@ -21,8 +21,8 @@
         search_angle: 0.63                  # [rad] PI/5.0
       motion:
         safety_ratio: 0.8                   # [-] jerk/acceleration ratio for safety
-        max_slow_down_jerk: -0.5            # [m/s^3] minimum jerk deceleration for safe brake.
-        max_slow_down_accel: -1.8           # [m/s^2] minimum accel deceleration for safe brake.
+        max_slow_down_jerk: -0.3            # [m/s^3] minimum jerk deceleration for safe brake.
+        max_slow_down_accel: -1.5           # [m/s^2] minimum accel deceleration for safe brake.
         non_effective_jerk: -0.3            # [m/s^3] weak jerk for velocity planning.
         non_effective_acceleration: -1.0    # [m/s^2] weak deceleration for velocity planning.
         min_allowed_velocity: 1.0           # [m/s] minimum velocity allowed
@@ -31,7 +31,7 @@
         min_occlusion_spot_size: 1.0     # [m] occupancy grid must contain an UNKNOWN area of at least size NxN to be considered a hidden obstacle.
         slice_length: 10.0               # [m] size of slices in both length and distance relative to the ego path.
         min_longitudinal_offset: 1.0     # [m] detection area safety buffer from front bumper.
-        max_lateral_distance: 6.0        # [m] buffer around the ego path used to build the detection area.
+        max_lateral_distance: 5.0        # [m] buffer around the ego path used to build the detection area.
       grid:
         free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
-        occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid
+        occupied_min: 57    # [-] minimum value of an occupied cell in the occupancy grid

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/config/run_out.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/config/run_out.param.yaml
@@ -29,7 +29,7 @@
         std_dev_multiplier: 1.96  # [-] min and max velocity of the obstacles are calculated from this value and covariance
         diameter: 0.1             # [m] diameter of obstacles. used for creating dynamic obstacles from points
         height: 2.0               # [m] height of obstacles. used for creating dynamic obstacles from points
-        max_prediction_time: 10.0 # [sec] create predicted path until this time
+        max_prediction_time: 3.0  # [sec] create predicted path until this time
         time_step: 0.5            # [sec] time step for each path step. used for creating dynamic obstacles from points or objects without path
         points_interval: 0.1      # [m] divide obstacle points into groups with this interval, and detect only lateral nearest point. used only for Points method
 
@@ -44,7 +44,7 @@
       # Parameter to prevent abrupt stops caused by false positives in perception
       ignore_momentary_detection:
         enable: true
-        time_threshold: 0.15  # [sec] ignores detections that persist for less than this duration
+        time_threshold: 0.5  # [sec] ignores detections that persist for less than this duration
 
       # Typically used when the "detection_method" is set to ObjectWithoutPath or Points
       # Approach if the ego has stopped in front of the obstacle for a certain period

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -2,19 +2,19 @@
   ros__parameters:
     out_of_lane:  # module to stop or slowdown before overlapping another lane with other objects
       mode: ttc # mode used to consider a conflict with an object. "threshold", or "ttc"
-      skip_if_already_overlapping: true # do not run this module when ego already overlaps another lane
+      skip_if_already_overlapping: false # do not run this module when ego already overlaps another lane
       max_arc_length: 100.0  # [m] maximum trajectory arc length that is checked for out_of_lane collisions
 
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 3.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
+        threshold: 1.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
 
       objects:
         minimum_velocity: 0.5  # [m/s] objects lower than this velocity will be ignored
         predicted_path_min_confidence : 0.1  # when using predicted paths, ignore the ones whose confidence is lower than this value.
         cut_predicted_paths_beyond_red_lights: true # if true, predicted paths are cut beyond the stop line of red traffic lights
-        ignore_behind_ego: true # if true, objects behind the ego vehicle are ignored
+        ignore_behind_ego: false # if true, objects behind the ego vehicle are ignored
 
       action:  # action to insert in the trajectory if an object causes a conflict at an overlap
         precision: 0.1  # [m] precision when inserting a stop pose in the trajectory


### PR DESCRIPTION
## Description

The parameters in the `*.param.yaml` in `autoware.universe` mismatch the parameters in `launcher`.

This PR:
1. Align the parameters in `autoware.universe` with `launcher`. 
2. Delete the redundant parameters not defined in `launcher`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/