### PR TITLE
feat(external_velocity_limit_selector): integrate generate_parameter_library

### DIFF
--- a/planning/autoware_external_velocity_limit_selector/CMakeLists.txt
+++ b/planning/autoware_external_velocity_limit_selector/CMakeLists.txt
@@ -4,8 +4,16 @@ project(autoware_external_velocity_limit_selector)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+generate_parameter_library(external_velocity_limit_selector_parameters
+  param/external_velocity_limit_selector_parameters.yaml
+)
+
 ament_auto_add_library(external_velocity_limit_selector_node SHARED
   src/external_velocity_limit_selector_node.cpp
+)
+
+target_link_libraries(external_velocity_limit_selector_node
+  external_velocity_limit_selector_parameters
 )
 
 rclcpp_components_register_node(external_velocity_limit_selector_node

--- a/planning/autoware_external_velocity_limit_selector/include/autoware/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
+++ b/planning/autoware_external_velocity_limit_selector/include/autoware/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__EXTERNAL_VELOCITY_LIMIT_SELECTOR__EXTERNAL_VELOCITY_LIMIT_SELECTOR_NODE_HPP_
 #define AUTOWARE__EXTERNAL_VELOCITY_LIMIT_SELECTOR__EXTERNAL_VELOCITY_LIMIT_SELECTOR_NODE_HPP_
 
+#include <external_velocity_limit_selector_parameters.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_debug_msgs/msg/string_stamped.hpp>
@@ -45,21 +46,6 @@ public:
   void onVelocityLimitFromInternal(const VelocityLimit::ConstSharedPtr msg);
   void onVelocityLimitClearCommand(const VelocityLimitClearCommand::ConstSharedPtr msg);
 
-  struct NodeParam
-  {
-    double max_velocity;
-    // constraints for normal driving
-    double normal_min_acc;
-    double normal_max_acc;
-    double normal_min_jerk;
-    double normal_max_jerk;
-    // constraints to be observed
-    double limit_min_acc;
-    double limit_max_acc;
-    double limit_min_jerk;
-    double limit_max_jerk;
-  };
-
 private:
   rclcpp::Subscription<VelocityLimit>::SharedPtr sub_external_velocity_limit_from_api_;
   rclcpp::Subscription<VelocityLimit>::SharedPtr sub_external_velocity_limit_from_internal_;
@@ -76,7 +62,7 @@ private:
   VelocityLimit getCurrentVelocityLimit() { return hardest_limit_; }
 
   // Parameters
-  NodeParam node_param_{};
+  std::shared_ptr<::external_velocity_limit_selector::ParamListener> param_listener_;
   VelocityLimit hardest_limit_{};
   VelocityLimitTable velocity_limit_table_;
 };

--- a/planning/autoware_external_velocity_limit_selector/package.xml
+++ b/planning/autoware_external_velocity_limit_selector/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>generate_parameter_library</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_debug_msgs</depend>

--- a/planning/autoware_external_velocity_limit_selector/param/external_velocity_limit_selector_parameters.yaml
+++ b/planning/autoware_external_velocity_limit_selector/param/external_velocity_limit_selector_parameters.yaml
@@ -1,0 +1,30 @@
+external_velocity_limit_selector:
+  max_vel:
+    type: double
+    description: Default max velocity [m/s]
+  normal:
+    min_acc:
+      type: double
+      description: Minimum deceleration [m/ss]
+    max_acc:
+      type: double
+      description: Maximum deceleration [m/ss]
+    min_jerk:
+      type: double
+      description: Minimum jerk [m/sss]
+    max_jerk:
+      type: double
+      description: Maximum jerk [m/sss]
+  limit:
+    min_acc:
+      type: double
+      description: Minimum acceleration to be observed [m/ss]
+    max_acc:
+      type: double
+      description: Maximum acceleration to be observed [m/ss]
+    min_jerk:
+      type: double
+      description: Minimum jerk to be observed [m/sss]
+    max_jerk:
+      type: double
+      description: Maximum jerk to be observed [m/sss]


### PR DESCRIPTION
## Description

This PR enables external_velocity_limit_selector to handle parameters using [generate_parameter_library](https://github.com/PickNikRobotics/generate_parameter_library).

## How was this PR tested?

Psim

- [x] changes in rqt reconfigure are reflected to the behavior of the node
- [x] errors occur if any parameters are missing in the config file in autoware_launch

[Screencast from 2024年09月10日 15時17分23秒.webm](https://github.com/user-attachments/assets/56a73fc0-3b0f-41d5-a537-2ca2ede88a64)

Evaluator: https://evaluation.tier4.jp/evaluation/reports/ed62fc35-1ece-581a-ba66-03fad335a207?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
