### PR TITLE
fix(autoware_surround_obstacle_checker): fix unusedFunction

### DIFF
--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -236,14 +236,4 @@ PolygonStamped SurroundObstacleCheckerDebugNode::boostPolygonToPolygonStamped(
   return polygon_stamped;
 }
 
-void SurroundObstacleCheckerDebugNode::updateFootprintMargin(
-  const std::string & object_label, const double front_distance, const double side_distance,
-  const double back_distance)
-{
-  object_label_ = object_label;
-  surround_check_front_distance_ = front_distance;
-  surround_check_side_distance_ = side_distance;
-  surround_check_back_distance_ = back_distance;
-}
-
 }  // namespace autoware::surround_obstacle_checker

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
@@ -66,9 +66,6 @@ public:
   bool pushObstaclePoint(const geometry_msgs::msg::Point & obstacle_point, const PointType & type);
   void publish();
   void publishFootprints();
-  void updateFootprintMargin(
-    const std::string & object_label, const double front_distance, const double side_distance,
-    const double back_distance);
 
 private:
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/autoware_surround_obstacle_checker/src/debug_marker.cpp:239:0: style: The function 'updateFootprintMargin' is never used. [unusedFunction]
void SurroundObstacleCheckerDebugNode::updateFootprintMargin(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
