### PR TITLE
feat(autonomous_emergency_braking): speed up aeb

### DIFF
--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -414,6 +414,16 @@ public:
    * @brief Generate the footprint of the path with extra width margin
    * @param path Ego vehicle path
    * @param extra_width_margin Extra width margin for the footprint
+   * @param polygons vector to be filled with the polygons
+   * @return Vector of polygons representing the path footprint
+   */
+  void generatePathFootprint(
+    const Path & path, const double extra_width_margin, std::vector<Polygon2d> & polygons);
+
+  /**
+   * @brief Generate the footprint of the path with extra width margin
+   * @param path Ego vehicle path
+   * @param extra_width_margin Extra width margin for the footprint
    * @return Vector of polygons representing the path footprint
    */
   std::vector<Polygon2d> generatePathFootprint(const Path & path, const double extra_width_margin);

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -436,10 +436,19 @@ public:
    * @param objects Vector to store the created object data
    * @param obstacle_points_ptr Pointer to the point cloud of obstacles
    */
-  void createObjectDataUsingPointCloudClusters(
+  void getClosestObjectsOnPath(
     const Path & ego_path, const std::vector<Polygon2d> & ego_polys, const rclcpp::Time & stamp,
-    std::vector<ObjectData> & objects,
-    const pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_points_ptr);
+    const PointCloud::Ptr points_belonging_to_cluster_hulls, std::vector<ObjectData> & objects);
+
+  /**
+   * @brief Create object data using point cloud clusters
+   * @param obstacle_points_ptr Pointer to the point cloud of obstacles
+   * @param points_belonging_to_cluster_hulls output: pointer to the point cloud of points belonging
+   * to cluster hulls
+   */
+  void getPointsBelongingToClusterHulls(
+    const PointCloud::Ptr obstacle_points_ptr,
+    const PointCloud::Ptr points_belonging_to_cluster_hulls);
 
   /**
    * @brief Create object data using predicted objects

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -24,6 +24,8 @@
 #include <boost/geometry/algorithms/correct.hpp>
 
 #include <tf2/utils.h>
+
+#include <string>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -48,7 +50,7 @@ using geometry_msgs::msg::TransformStamped;
  * @param transform_stamped the tf2 transform
  */
 PredictedObject transformObjectFrame(
-  const PredictedObject & input, geometry_msgs::msg::TransformStamped & transform_stamped);
+  const PredictedObject & input, const geometry_msgs::msg::TransformStamped & transform_stamped);
 
 /**
  * @brief Get the predicted objects polygon as a geometry polygon
@@ -80,6 +82,10 @@ Polygon2d convertBoundingBoxObjectToGeometryPolygon(
  * @param obj the object
  */
 Polygon2d convertObjToPolygon(const PredictedObject & obj);
+
+std::optional<geometry_msgs::msg::TransformStamped> getTransform(
+  const std::string & target_frame, const std::string & source_frame,
+  const tf2_ros::Buffer & tf_buffer, const rclcpp::Logger & logger);
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils
 
 #endif  // AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -446,7 +446,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
     const auto ego_polys = generatePathFootprint(path, expand_width_);
     std::vector<ObjectData> objects;
     // Crop out Pointcloud using an extra wide ego path
-    if (use_pointcloud_data_) {
+    if (use_pointcloud_data_ && !points_belonging_to_cluster_hulls->empty()) {
       const auto current_time = obstacle_ros_pointcloud_ptr_->header.stamp;
       getClosestObjectsOnPath(
         path, ego_polys, current_time, points_belonging_to_cluster_hulls, objects);
@@ -775,6 +775,7 @@ void AEB::getPointsBelongingToClusterHulls(
   autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   // eliminate noisy points by only considering points belonging to clusters of at least a certain
   // size
+  if (obstacle_points_ptr->empty()) return;
   const std::vector<pcl::PointIndices> cluster_indices = std::invoke([&]() {
     std::vector<pcl::PointIndices> cluster_idx;
     pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
@@ -788,7 +789,6 @@ void AEB::getPointsBelongingToClusterHulls(
     ec.extract(cluster_idx);
     return cluster_idx;
   });
-
   for (const auto & indices : cluster_indices) {
     PointCloud::Ptr cluster(new PointCloud);
     bool cluster_surpasses_threshold_height{false};

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -277,7 +277,7 @@ void AEB::onPointCloud(const PointCloud2::ConstSharedPtr input_msg)
     geometry_msgs::msg::TransformStamped transform_stamped{};
     try {
       transform_stamped = tf_buffer_.lookupTransform(
-        "base_link", input_msg->header.frame_id, input_msg->header.stamp,
+        "base_link", input_msg->header.frame_id, rclcpp::Time(0),
         rclcpp::Duration::from_seconds(0.5));
     } catch (tf2::TransformException & ex) {
       RCLCPP_ERROR_STREAM(

--- a/control/autoware_autonomous_emergency_braking/test/test.cpp
+++ b/control/autoware_autonomous_emergency_braking/test/test.cpp
@@ -156,9 +156,12 @@ TEST_F(TestAEB, checkImuPathGeneration)
       obstacle_points_ptr->push_back(p2);
     }
   }
+  PointCloud::Ptr points_belonging_to_cluster_hulls = pcl::make_shared<PointCloud>();
+  aeb_node_->getPointsBelongingToClusterHulls(
+    obstacle_points_ptr, points_belonging_to_cluster_hulls);
   std::vector<ObjectData> objects;
-  aeb_node_->createObjectDataUsingPointCloudClusters(
-    imu_path, footprint, stamp, objects, obstacle_points_ptr);
+  aeb_node_->getClosestObjectsOnPath(
+    imu_path, footprint, stamp, points_belonging_to_cluster_hulls, objects);
   ASSERT_FALSE(objects.empty());
 }
 


### PR DESCRIPTION
## Description
This PR refactors the AEB code to speed up processing time. Clustering and path-based pointcloud cropping are done once per iteration instead of twice. Some other changes are done to increase speed. 

Comparison using driving log replayer: 
before
[aeb_times.txt](https://github.com/user-attachments/files/16887045/aeb_times.txt)

times higher than 70 ms:

`processing_time: 89.683
  processing_time: 74.601
  processing_time: 82.908
  processing_time: 87.936
  processing_time: 93.321
  processing_time: 89.623
  processing_time: 119.028
  processing_time: 99.281
  processing_time: 85.516
  processing_time: 72.685
  processing_time: 85.565
  processing_time: 93.702
  processing_time: 87.082
  processing_time: 72.67
  processing_time: 107.033
  processing_time: 95.981
  processing_time: 73.572
  processing_time: 97.633
  processing_time: 82.361
  processing_time: 95.262
  processing_time: 78.441
  processing_time: 93.552
  processing_time: 72.987
  processing_time: 72.825
  processing_time: 75.752
  processing_time: 76.714
  processing_time: 73.017
  processing_time: 74.023
  processing_time: 81.248
  processing_time: 85.993
  processing_time: 117.669
  processing_time: 109.717` 

After

[aeb_times_after_pr.txt](https://github.com/user-attachments/files/16887046/aeb_times_hope_faster_6.txt)

Only times higher than 30 ms: 

 `processing_time: 32.252
  processing_time: 30.629
  processing_time: 34.249
  processing_time: 32.926
  processing_time: 30.046
  processing_time: 35.681
  processing_time: 33.811
  processing_time: 51.401
  processing_time: 51.346
  processing_time: 39.437
  processing_time: 31.665
  processing_time: 30.943
  processing_time: 35.911
  processing_time: 30.852
  processing_time: 33.021
  processing_time: 30.979
  processing_time: 42.528
  processing_time: 39.72
  processing_time: 32.504
  processing_time: 32.254
  processing_time: 34.45
  processing_time: 33.739
  processing_time: 35.689
  processing_time: 34.073
  processing_time: 42.685
  processing_time: 42.625
  processing_time: 40.024
  processing_time: 36.324
  processing_time: 37.852
  processing_time: 34.826
  processing_time: 30.493
  processing_time: 34.955
  processing_time: 45.721
  processing_time: 34.387`

## Related links
ticket: https://tier4.atlassian.net/browse/RT1-5790
**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim, DLR
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
