### PR TITLE
fix(autoware_behavior_velocity_run_out_module): fix unusedFunction

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.hpp
@@ -50,12 +50,6 @@ public:
   };
 
   /**
-   * @brief get the index corresponding to the given value TYPE
-   * @param [in] type the TYPE enum for which to get the index
-   * @return index of the type
-   */
-  static int getValuesIdx(const TYPE type) { return static_cast<int>(type); }
-  /**
    * @brief get all the debug values as an std::array
    * @return array of all debug values
    */


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.hpp:57:0: style: The function 'getValuesIdx' is never used. [unusedFunction]
  static int getValuesIdx(const TYPE type) { return static_cast<int>(type); }
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
