### PR TITLE
fix(autoware_route_handler): fix unusedFunction

### DIFF
--- a/planning/autoware_route_handler/test/test_route_handler.cpp
+++ b/planning/autoware_route_handler/test/test_route_handler.cpp
@@ -81,7 +81,6 @@ TEST_F(TestRouteHandler, getLaneletSequenceWhenOverlappingRoute)
 TEST_F(TestRouteHandler, getClosestRouteLaneletFromLaneletWhenOverlappingRoute)
 {
   set_route_handler("overlap_map.osm");
-  set_test_route("overlap_test_route.yaml");
   ASSERT_TRUE(route_handler_->isHandlerReady());
 
   geometry_msgs::msg::Pose reference_pose;

--- a/planning/autoware_route_handler/test/test_route_handler.cpp
+++ b/planning/autoware_route_handler/test/test_route_handler.cpp
@@ -81,6 +81,7 @@ TEST_F(TestRouteHandler, getLaneletSequenceWhenOverlappingRoute)
 TEST_F(TestRouteHandler, getClosestRouteLaneletFromLaneletWhenOverlappingRoute)
 {
   set_route_handler("overlap_map.osm");
+  set_test_route("overlap_test_route.yaml");
   ASSERT_TRUE(route_handler_->isHandlerReady());
 
   geometry_msgs::msg::Pose reference_pose;

--- a/planning/autoware_route_handler/test/test_route_handler.hpp
+++ b/planning/autoware_route_handler/test/test_route_handler.hpp
@@ -41,10 +41,7 @@ using autoware_map_msgs::msg::LaneletMapBin;
 class TestRouteHandler : public ::testing::Test
 {
 public:
-  TestRouteHandler()
-  {
-    set_route_handler("2km_test.osm");
-  }
+  TestRouteHandler() { set_route_handler("2km_test.osm"); }
 
   TestRouteHandler(const TestRouteHandler &) = delete;
   TestRouteHandler(TestRouteHandler &&) = delete;

--- a/planning/autoware_route_handler/test/test_route_handler.hpp
+++ b/planning/autoware_route_handler/test/test_route_handler.hpp
@@ -37,7 +37,6 @@ namespace autoware::route_handler::test
 {
 
 using autoware::test_utils::get_absolute_path_to_lanelet_map;
-using autoware::test_utils::get_absolute_path_to_route;
 using autoware_map_msgs::msg::LaneletMapBin;
 class TestRouteHandler : public ::testing::Test
 {
@@ -45,7 +44,6 @@ public:
   TestRouteHandler()
   {
     set_route_handler("2km_test.osm");
-    set_test_route(lane_change_right_test_route_filename);
   }
 
   TestRouteHandler(const TestRouteHandler &) = delete;
@@ -62,13 +60,6 @@ public:
     const auto map_bin_msg =
       autoware::test_utils::make_map_bin_msg(lanelet2_path, center_line_resolution);
     route_handler_ = std::make_shared<RouteHandler>(map_bin_msg);
-  }
-
-  void set_test_route(const std::string & route_filename)
-  {
-    const auto rh_test_route =
-      get_absolute_path_to_route(autoware_route_handler_dir, route_filename);
-    route_handler_->setRoute(autoware::test_utils::parse_lanelet_route_file(rh_test_route));
   }
 
   lanelet::ConstLanelets get_current_lanes()

--- a/planning/autoware_route_handler/test/test_route_handler.hpp
+++ b/planning/autoware_route_handler/test/test_route_handler.hpp
@@ -19,6 +19,7 @@
 #include "autoware_test_utils/mock_data_parser.hpp"
 #include "gtest/gtest.h"
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
 #include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>

--- a/planning/autoware_route_handler/test/test_route_handler.hpp
+++ b/planning/autoware_route_handler/test/test_route_handler.hpp
@@ -41,7 +41,11 @@ using autoware_map_msgs::msg::LaneletMapBin;
 class TestRouteHandler : public ::testing::Test
 {
 public:
-  TestRouteHandler() { set_route_handler("2km_test.osm"); }
+  TestRouteHandler()
+  {
+    set_route_handler("2km_test.osm");
+    set_test_route(lane_change_right_test_route_filename);
+  }
 
   TestRouteHandler(const TestRouteHandler &) = delete;
   TestRouteHandler(TestRouteHandler &&) = delete;
@@ -57,6 +61,20 @@ public:
     const auto map_bin_msg =
       autoware::test_utils::make_map_bin_msg(lanelet2_path, center_line_resolution);
     route_handler_ = std::make_shared<RouteHandler>(map_bin_msg);
+  }
+
+  std::string get_absolute_path_to_route(
+    const std::string & package_name, const std::string & route_filename)
+  {
+    const auto dir = ament_index_cpp::get_package_share_directory(package_name);
+    return dir + "/test_route/" + route_filename;
+  }
+
+  void set_test_route(const std::string & route_filename)
+  {
+    const auto rh_test_route =
+      get_absolute_path_to_route(autoware_route_handler_dir, route_filename);
+    route_handler_->setRoute(autoware::test_utils::parse_lanelet_route_file(rh_test_route));
   }
 
   lanelet::ConstLanelets get_current_lanes()


### PR DESCRIPTION
## Description

This is a fix based on cppcheck unusedFunction warnings.

```
common/autoware_test_utils/src/autoware_test_utils.cpp:141:0: style: The function 'get_absolute_path_to_route' is never used. [unusedFunction]
std::string get_absolute_path_to_route(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
