### PR TITLE
fix(autoware_perception_rviz_plugin): fix unusedFunction

### DIFF
--- a/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -538,6 +538,7 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   return marker_ptr;
 }
 
+// cppcheck-suppress unusedFunction
 visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
   const autoware_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,


### PR DESCRIPTION
## Description

This is a fix based on cppcheck unusedFunction warnings.
`get_2d_shape_marker_ptr` was suppressed because it is used in the template function `get_shape_marker_ptr`, which is used in other packages.

```
common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp:541:0: style: The function 'get_2d_shape_marker_ptr' is never used. [unusedFunction]
visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
