### PR TITLE
fix(autoware_behavior_path_goal_planner_module): fix unusedFunction

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -51,14 +51,6 @@ lanelet::ConstLanelets getPullOverLanes(
   const RouteHandler & route_handler, const bool left_side, const double backward_distance,
   const double forward_distance);
 
-/*
- * @brief expand pull_over_lanes to the opposite side of drivable roads by bound_offset.
- * bound_offset must be positive regardless of left_side is true/false
- */
-lanelet::ConstLanelets generateExpandedPullOverLanes(
-  const RouteHandler & route_handler, const bool left_side, const double backward_distance,
-  const double forward_distance, const double bound_offset);
-
 lanelet::ConstLanelets generateBetweenEgoAndExpandedPullOverLanes(
   const lanelet::ConstLanelets & pull_over_lanes, const bool left_side,
   const geometry_msgs::msg::Pose ego_pose,
@@ -77,9 +69,6 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
   const lanelet::ConstLanelets & pull_over_lanes, const bool left_side, const double outer_offset,
   const double inner_offset);
 
-PredictedObjects extractObjectsInExpandedPullOverLanes(
-  const RouteHandler & route_handler, const bool left_side, const double backward_distance,
-  const double forward_distance, double bound_offset, const PredictedObjects & objects);
 PredictedObjects filterObjectsByLateralDistance(
   const Pose & ego_pose, const double vehicle_width, const PredictedObjects & objects,
   const double distance_thresh, const bool filter_inside);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -78,17 +78,6 @@ lanelet::ConstLanelets getPullOverLanes(
     outermost_lane, backward_distance_with_buffer, forward_distance, only_route_lanes);
 }
 
-lanelet::ConstLanelets generateExpandedPullOverLanes(
-  const RouteHandler & route_handler, const bool left_side, const double backward_distance,
-  const double forward_distance, const double bound_offset)
-{
-  const auto pull_over_lanes =
-    getPullOverLanes(route_handler, left_side, backward_distance, forward_distance);
-
-  return left_side ? lanelet::utils::getExpandedLanelets(pull_over_lanes, bound_offset, 0.0)
-                   : lanelet::utils::getExpandedLanelets(pull_over_lanes, 0.0, -bound_offset);
-}
-
 static double getOffsetToLanesBoundary(
   const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose target_pose,
   const bool left_side)
@@ -257,21 +246,6 @@ std::optional<Polygon2d> generateObjectExtractionPolygon(
   }
 
   return polygon;
-}
-
-PredictedObjects extractObjectsInExpandedPullOverLanes(
-  const RouteHandler & route_handler, const bool left_side, const double backward_distance,
-  const double forward_distance, double bound_offset, const PredictedObjects & objects)
-{
-  const auto lanes = generateExpandedPullOverLanes(
-    route_handler, left_side, backward_distance, forward_distance, bound_offset);
-
-  const auto [objects_in_lanes, others] = utils::path_safety_checker::separateObjectsByLanelets(
-    objects, lanes, [](const auto & obj, const auto & lanelet, const auto yaw_threshold) {
-      return utils::path_safety_checker::isPolygonOverlapLanelet(obj, lanelet, yaw_threshold);
-    });
-
-  return objects_in_lanes;
 }
 
 PredictedObjects filterObjectsByLateralDistance(


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp:262:0: style: The function 'extractObjectsInExpandedPullOverLanes' is never used. [unusedFunction]
PredictedObjects extractObjectsInExpandedPullOverLanes(
^

planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp:81:0: style: The function 'generateExpandedPullOverLanes' is never used. [unusedFunction]
lanelet::ConstLanelets generateExpandedPullOverLanes(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
