### PR TITLE
fix(control): align the parameters with launcher

### DIFF
--- a/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -2,15 +2,15 @@
   ros__parameters:
     # Ego path calculation
     use_predicted_trajectory: true
-    use_imu_path: false
+    use_imu_path: true
     use_pointcloud_data: true
-    use_predicted_object_data: true
+    use_predicted_object_data: false
     use_object_velocity_calculation: true
     check_autoware_state: true
     min_generated_path_length: 0.5
     imu_prediction_time_horizon: 1.5
     imu_prediction_time_interval: 0.1
-    mpc_prediction_time_horizon: 1.5
+    mpc_prediction_time_horizon: 4.5
     mpc_prediction_time_interval: 0.1
 
     # Debug
@@ -29,8 +29,8 @@
     path_footprint_extra_margin: 4.0
 
     # Point cloud clustering
-    cluster_tolerance: 0.1 #[m]
-    cluster_minimum_height: 0.0
+    cluster_tolerance: 0.15 #[m]
+    cluster_minimum_height: 0.1
     minimum_cluster_size: 10
     maximum_cluster_size: 10000
 

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -5,7 +5,7 @@
     #  the next trajectory is valid.)
     diag_error_count_threshold: 0
 
-    display_on_terminal: true # show error msg on terminal
+    display_on_terminal: false # show error msg on terminal
 
     thresholds:
       max_distance_deviation: 1.0

--- a/control/autoware_lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/autoware_lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -1,9 +1,9 @@
 /**:
   ros__parameters:
     # Enable feature
-    will_out_of_lane_checker: true
-    out_of_lane_checker: true
-    boundary_departure_checker: false
+    will_out_of_lane_checker: false
+    out_of_lane_checker: false
+    boundary_departure_checker: true
 
     # Node
     update_rate: 10.0
@@ -12,7 +12,7 @@
     include_left_lanes: false
     include_opposite_lanes: false
     include_conflicting_lanes: false
-    boundary_types_to_detect: [road_border]
+    boundary_types_to_detect: [curbstone]
 
 
     # Core

--- a/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
@@ -14,7 +14,7 @@
     curvature_smoothing_num_ref_steer: 15   # point-to-point index distance used in curvature calculation (for steer command reference): curvature is calculated from three points p(i-num), p(i), p(i+num)
 
     # -- trajectory extending --
-    extend_trajectory_for_end_yaw_control: true  # flag of trajectory extending for terminal yaw control
+    extend_trajectory_for_end_yaw_control: false  # flag of trajectory extending for terminal yaw control
 
     # -- mpc optimization --
     qp_solver_type: "osqp"                       # optimization solver option (unconstraint_fast or osqp)
@@ -47,7 +47,7 @@
     # -- vehicle model --
     vehicle_model_type: "kinematics" # vehicle model type for mpc prediction. option is kinematics, kinematics_no_delay, and dynamics
     input_delay: 0.24                # steering input delay time for delay compensation
-    vehicle_model_steer_tau: 0.3     # steering dynamics time constant (1d approximation) [s]
+    vehicle_model_steer_tau: 0.27     # steering dynamics time constant (1d approximation) [s]
     steer_rate_lim_dps_list_by_curvature: [40.0, 50.0, 60.0]            # steering angle rate limit list depending on curvature [deg/s]
     curvature_list_for_steer_rate_lim: [0.001, 0.002, 0.01]              # curvature list for steering angle rate limit interpolation in ascending order [/m]
     steer_rate_lim_dps_list_by_velocity: [60.0, 50.0, 40.0]             # steering angle rate limit list depending on velocity [deg/s]

--- a/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    delay_compensation_time: 0.17
+    delay_compensation_time: 0.1
 
     enable_smooth_stop: true
     enable_overshoot_emergency: true

--- a/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
+++ b/control/autoware_vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     update_rate: 10.0
     system_emergency_heartbeat_timeout: 0.5
-    use_emergency_handling: false
+    use_emergency_handling: true
     check_external_emergency_heartbeat: $(var check_external_emergency_heartbeat)
     enable_cmd_limit_filter: true
     filter_activated_count_threshold: 5

--- a/control/obstacle_collision_checker/config/obstacle_collision_checker.param.yaml
+++ b/control/obstacle_collision_checker/config/obstacle_collision_checker.param.yaml
@@ -4,8 +4,8 @@
     update_rate: 10.0
 
     # Core
-    delay_time: 0.3 # delay time of vehicle [s]
+    delay_time: 0.03 # delay time of vehicle [s]
     footprint_margin: 0.0 # margin for footprint [m]
-    max_deceleration: 2.0 # max deceleration [m/ss]
+    max_deceleration: 1.5 # max deceleration [m/ss]
     resample_interval: 0.3 # interval distance to resample point cloud [m]
     search_radius: 5.0 # search distance from trajectory to point cloud [m]


### PR DESCRIPTION
## Description

The parameters in the `*.param.yaml` in `autoware.universe` mismatch the parameters in `launcher`.

This PR aligns the parameters in **_control packages_**.
1. Align the parameters in `autoware.universe` with `launcher`. 
2. Delete the redundant parameters not defined in `launcher`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/