### PR TITLE
fix(autoware_behavior_path_planner): align the parameters with launcher

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
@@ -59,7 +59,7 @@
         lat_offset_from_obstacle: 1.0 # [m]
         margin_distance_around_pedestrian: 2.0 # [m]
         predicted_path:
-          end_time_to_consider: 3.0 # [s]
+          end_time_to_consider: 2.0 # [s]
           threshold_confidence: 0.0 # [] not probability
         max_lat_offset_to_avoid: 0.5 # [m]
         max_time_for_object_lat_shift: 0.0 # [s]

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -14,14 +14,14 @@
           lateral_weight: 40.0
         prioritize_goals_before_objects: true
         parking_policy: "left_side" # "left_side" or "right_side"
-        forward_goal_search_length: 20.0
+        forward_goal_search_length: 40.0
         backward_goal_search_length: 20.0
         goal_search_interval: 2.0
         longitudinal_margin: 3.0
-        max_lateral_offset: 0.5
-        lateral_offset_interval: 0.25
+        max_lateral_offset: 1.0
+        lateral_offset_interval: 0.5
         ignore_distance_from_lane_start: 0.0
-        margin_from_boundary: 0.5
+        margin_from_boundary: 0.75
         high_curvature_threshold: 0.1
 
       # occupancy grid map
@@ -35,7 +35,7 @@
 
       # object recognition
       object_recognition:
-        use_object_recognition: false
+        use_object_recognition: true
         collision_check_soft_margins: [5.0, 4.5, 4.0, 3.5, 3.0, 2.5, 2.0, 1.5, 1.0]  # the maximum margin when ego and objects are oriented.
         collision_check_hard_margins: [0.6]  # this should be larger than `surround_check_distance` of surround_obstacle_checker.
         object_recognition_collision_check_max_extra_stopping_margin: 1.0
@@ -46,7 +46,7 @@
 
       # pull over
       pull_over:
-        minimum_request_length: 100.0
+        minimum_request_length: 0.0
         pull_over_velocity: 3.0
         pull_over_minimum_velocity: 1.38
         decide_path_distance: 10.0
@@ -91,13 +91,13 @@
           velocity: 1.0
           vehicle_shape_margin: 1.0
           time_limit: 3000.0
-          max_turning_ratio: 0.7
+          max_turning_ratio: 0.5
           turning_steps: 1
           # search configs
           search_configs:
-            theta_size: 144
+            theta_size: 120
             angle_goal_range: 6.0
-            curve_weight: 1.2
+            curve_weight: 0.5
             reverse_weight: 1.0
             lateral_goal_range: 0.5
             longitudinal_goal_range: 2.0
@@ -108,8 +108,8 @@
           astar:
             search_method: "forward"  # options: forward, backward
             only_behind_solutions: false
-            use_back: false
-            distance_heuristic_weight: 1.0
+            use_back: true
+            distance_heuristic_weight: 2.0
           # -- RRT* search Configurations --
           rrtstar:
             enable_update: true
@@ -124,7 +124,7 @@
       path_safety_check:
         # EgoPredictedPath
         ego_predicted_path:
-          min_velocity: 0.0
+          min_velocity: 1.0
           min_acceleration: 1.0
           time_horizon_for_front_object: 10.0
           time_horizon_for_rear_object: 10.0
@@ -135,7 +135,7 @@
           safety_check_time_horizon: 10.0
           safety_check_time_resolution: 1.0
           # detection range
-          object_check_forward_distance: 10.0
+          object_check_forward_distance: 100.0
           object_check_backward_distance: 100.0
           ignore_object_velocity_threshold: 1.0
           # ObjectTypesToCheck
@@ -184,7 +184,7 @@
           hysteresis_factor_expand_rate: 1.0
           collision_check_yaw_diff_threshold: 3.1416
           # temporary
-          backward_path_length: 100.0
+          backward_path_length: 30.0
           forward_path_length: 100.0
 
       # debug

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -28,8 +28,8 @@
 
       skip_process:
         longitudinal_distance_diff_threshold:
-          prepare: 0.5
-          lane_changing: 0.5
+          prepare: 1.0
+          lane_changing: 1.0
 
       # safety check
       safety_check:
@@ -42,7 +42,7 @@
           rear_vehicle_safety_time_margin: 1.0
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
-          longitudinal_velocity_delta_time: 0.8
+          longitudinal_velocity_delta_time: 0.0
         parked:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -2.0
@@ -58,7 +58,7 @@
           rear_vehicle_safety_time_margin: 0.8
           lateral_distance_max_threshold: 1.0
           longitudinal_distance_min_threshold: 2.5
-          longitudinal_velocity_delta_time: 0.6
+          longitudinal_velocity_delta_time: 0.0
         stuck:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0
@@ -66,18 +66,18 @@
           rear_vehicle_safety_time_margin: 1.0
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
-          longitudinal_velocity_delta_time: 0.8
+          longitudinal_velocity_delta_time: 0.0
 
         # lane expansion for object filtering
         lane_expansion:
-          left_offset: 0.0 # [m]
-          right_offset: 0.0 # [m]
+          left_offset: 1.0 # [m]
+          right_offset: 1.0 # [m]
 
       # lateral acceleration map
       lateral_acceleration:
         velocity: [0.0, 4.0, 10.0]
-        min_values: [0.15, 0.15, 0.15]
-        max_values: [0.5, 0.5, 0.5]
+        min_values: [0.4,0.4,0.4]
+        max_values: [0.65,0.65,0.65]
 
       # target object
       target_object:
@@ -85,20 +85,20 @@
         truck: true
         bus: true
         trailer: true
-        unknown: true
+        unknown: false
         bicycle: true
         motorcycle: true
         pedestrian: true
 
       # lane change regulations
       regulation:
-        crosswalk: false
-        intersection: false
+        crosswalk: true
+        intersection: true
         traffic_light: true
 
       # ego vehicle stuck detection
       stuck_detection:
-        velocity: 0.1 # [m/s]
+        velocity: 0.5 # [m/s]
         stop_time: 3.0 # [s]
 
       # collision check
@@ -107,9 +107,9 @@
         intersection: true
         turns: true
       stopped_object_velocity_threshold: 1.0 # [m/s]
-      check_objects_on_current_lanes: true
-      check_objects_on_other_lanes: true
-      use_all_predicted_path: true
+      check_objects_on_current_lanes: false
+      check_objects_on_other_lanes: false
+      use_all_predicted_path: false
 
       # lane change cancel
       cancel:
@@ -117,9 +117,9 @@
         enable_on_lane_changing_phase: true
         delta_time: 1.0                     # [s]
         duration: 5.0                       # [s]
-        max_lateral_jerk: 1000.0            # [m/s3]
+        max_lateral_jerk: 100.0            # [m/s3]
         overhang_tolerance: 0.0             # [m]
-        unsafe_hysteresis_threshold: 10     # [/]
+        unsafe_hysteresis_threshold: 5     # [/]
         deceleration_sampling_num: 5 # [/]
 
       lane_change_finish_judge_buffer: 2.0      # [m]
@@ -127,4 +127,4 @@
       finish_judge_lateral_angle_deviation: 1.0 # [deg]
 
       # debug
-      publish_debug_marker: false
+      publish_debug_marker: true

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -23,7 +23,3 @@
     enable_cog_on_centerline: false
     input_path_interval: 2.0
     output_path_interval: 2.0
-
-    closest_lanelet:
-      distance_threshold: 5.0 # [m]
-      yaw_threshold: 0.79 # [rad]

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -10,7 +10,7 @@
       enabled: true
       print_runtime: false
       max_expansion_distance: 0.0 # [m] maximum distance by which the drivable area can be expended (0.0 means no limit)
-      min_bound_interval: 0.1  # [m] minimum interval between two consecutive bound points (before expansion)
+      min_bound_interval: 1.0  # [m] minimum interval between two consecutive bound points (before expansion)
       smoothing:
         curvature_average_window: 3  # window size used for smoothing the curvatures using a moving window average
         max_bound_rate: 1.0  # [m/m] maximum rate of change of the bound lateral distance over its arc length
@@ -20,17 +20,18 @@
         extra_front_overhang: 0.5 # [m] extra length to add to the front overhang
         extra_width: 1.0 # [m] extra length to add to the width
       dynamic_objects:
-        avoid: true # if true, the drivable area is not expanded in the predicted path of dynamic objects
+        avoid: false # if true, the drivable area is not expanded in the predicted path of dynamic objects
         extra_footprint_offset:
           front: 0.5 # [m] extra length to add to the front of the dynamic object footprint
           rear: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
           left: 0.5 # [m] extra length to add to the left of the dynamic object footprint
           right: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
       path_preprocessing:
-        max_arc_length: 50.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
+        max_arc_length: 100.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
         resample_interval: 2.0 # [m] fixed interval between resampled path points (0.0 means path points are directly used)
         reuse_max_deviation: 0.5 # [m] if the path changes by more than this value, the curvatures are recalculated. Otherwise they are reused.
       avoid_linestring:
         types: # linestring types in the lanelet maps that will not be crossed when expanding the drivable area
           - road_border
+          - curbstone
         distance: 0.0 # [m] distance to keep between the drivable area and the linestrings to avoid

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/scene_module_manager.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/scene_module_manager.param.yaml
@@ -47,7 +47,7 @@
 
     start_planner:
       enable_rtc: false
-      enable_simultaneous_execution_as_approved_module: false
+      enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
 
     side_shift:
@@ -57,7 +57,7 @@
 
     goal_planner:
       enable_rtc: false
-      enable_simultaneous_execution_as_approved_module: false
+      enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
 
     static_obstacle_avoidance:

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/config/sampling_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/config/sampling_planner.param.yaml
@@ -1,20 +1,3 @@
 /**:
   ros__parameters:
     start_planner:
-      max_curvature: 0.1
-      min_curvature: -0.1
-      lateral_deviation_weight: 1.0
-      length_weight: 1.0
-      curvature_weight: 1.0
-      enable_frenet: true
-      enable_bezier: false
-      resolution: 0.5
-      previous_path_reuse_points_nb: 2
-      nb_target_lateral_positions: {10.0, 20.0}
-      target_lengths: {-2.0, -1.0, 0.0, 1.0, 2.0}
-      target_lateral_positions: 2
-      target_lateral_velocities: {-0.1, 0.0, 0.1}
-      target_lateral_accelerations: {0.0}
-      force_zero_deviation: true
-      force_zero_heading: true
-      smooth_reference: false

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -32,7 +32,7 @@
       minimum_lateral_acc: 0.15
       maximum_lateral_acc: 0.5
       maximum_curvature: 0.07
-      end_pose_curvature_threshold: 0.01
+      end_pose_curvature_threshold: 0.1
       # geometric pull out
       enable_geometric_pull_out: true
       geometric_collision_check_distance_from_end: 0.0
@@ -66,9 +66,9 @@
         turning_steps: 1
         # search configs
         search_configs:
-          theta_size: 144
+          theta_size: 120
           angle_goal_range: 6.0
-          curve_weight: 1.2
+          curve_weight: 0.5
           reverse_weight: 1.0
           lateral_goal_range: 0.5
           longitudinal_goal_range: 2.0
@@ -79,8 +79,8 @@
         astar:
           search_method: "forward"  # options: forward, backward
           only_behind_solutions: false
-          use_back: false
-          distance_heuristic_weight: 1.0
+          use_back: true
+          distance_heuristic_weight: 2.0
         # -- RRT* search Configurations --
         rrtstar:
           enable_update: true
@@ -103,7 +103,7 @@
           delay_until_departure: 1.0
         # For target object filtering
         target_filtering:
-          safety_check_time_horizon: 5.0
+          safety_check_time_horizon: 10.0
           safety_check_time_resolution: 1.0
           # detection range
           object_check_forward_distance: 10.0

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -23,44 +23,44 @@
           th_moving_time: 2.0                           # [s]
           longitudinal_margin: 0.0                      # [m]
           lateral_margin:
-            soft_margin: 0.3                            # [m]
+            soft_margin: 0.7                            # [m]
             hard_margin: 0.2                            # [m]
             hard_margin_for_parked_vehicle: 0.7         # [m]
           max_expand_ratio: 0.0                         # [-] FOR DEVELOPER
-          envelope_buffer_margin: 0.5                   # [m] FOR DEVELOPER
+          envelope_buffer_margin: 0.1                   # [m] FOR DEVELOPER
           th_error_eclipse_long_radius : 0.6            # [m]
         truck:
           th_moving_speed: 1.0
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.3
+            soft_margin: 0.7
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.7
           max_expand_ratio: 0.0
-          envelope_buffer_margin: 0.5
+          envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
         bus:
           th_moving_speed: 1.0
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.3
+            soft_margin: 0.7
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.7
           max_expand_ratio: 0.0
-          envelope_buffer_margin: 0.5
+          envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
         trailer:
           th_moving_speed: 1.0
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.3
+            soft_margin: 0.7
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.7
           max_expand_ratio: 0.0
-          envelope_buffer_margin: 0.5
+          envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
         unknown:
           th_moving_speed: 0.28
@@ -150,16 +150,16 @@
           # "auto"   : generate candidate path. if RTC is running as AUTO mode, the ego avoids it automatically.
           # "manual" : generate candidate path and wait operator approval even if RTC is running as AUTO mode.
           # "ignore" : never avoid it.
-          policy: "auto"                                # [-]
+          policy: "manual"                                # [-]
           condition:
             th_stopped_time: 3.0                        # [s]
             th_moving_distance: 1.0                     # [m]
           ignore_area:
             traffic_light:
-              front_distance: 100.0                     # [m]
+              front_distance: 20.0                     # [m]
             crosswalk:
-              front_distance: 30.0                      # [m]
-              behind_distance: 30.0                     # [m]
+              front_distance: 20.0                      # [m]
+              behind_distance: 0.0                     # [m]
           wait_and_see:
             target_behaviors: ["MERGING", "DEVIATING"]  # [-]
             th_closest_distance: 10.0                   # [m]
@@ -232,7 +232,7 @@
         # avoidance distance parameters
         longitudinal:
           min_prepare_time: 1.0                         # [s]
-          max_prepare_time: 2.0                         # [s]
+          max_prepare_time: 3.0                         # [s]
           min_prepare_distance: 1.0                     # [m]
           min_slow_down_speed: 1.38                     # [m/s]
           buf_slow_down_speed: 0.56                     # [m/s] FOR DEVELOPER
@@ -291,7 +291,7 @@
       constraints:
         # lateral constraints
         lateral:
-          velocity: [1.0, 1.38, 11.1]                   # [m/s]
+          velocity: [1.39, 4.17, 11.1]                   # [m/s]
           max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
           min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
           max_jerk_values: [1.0, 1.0, 1.0]              # [m/sss]
@@ -327,8 +327,8 @@
 
       # for debug
       debug:
-        enable_other_objects_marker: false
-        enable_other_objects_info: false
+        enable_other_objects_marker: true
+        enable_other_objects_info: true
         enable_detection_area_marker: false
         enable_drivable_bound_marker: false
         enable_safety_check_marker: false


### PR DESCRIPTION
## Description

The parameters in the `*.param.yaml` in `autoware.universe` mismatch the parameters in `launcher`.

This PR aligns the parameters in **_behavior path planner_**.
1. Align the parameters in `autoware.universe` with `launcher`. 
2. Delete the redundant parameters not defined in `launcher`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/