### PR TITLE
fix(behavior_velocity_planner): align the parameters with launcher

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -38,7 +38,7 @@
       # params for the pass judge logic against the crosswalk users such as pedestrians or bicycles
       pass_judge:
         ego_pass_first_margin_x: [0.0] # [[s]] time to collision margin vector for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
-        ego_pass_first_margin_y: [3.0] # [[s]] time to vehicle margin vector for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
+        ego_pass_first_margin_y: [4.0] # [[s]] time to vehicle margin vector for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
         ego_pass_first_additional_margin: 0.5 # [s] additional time margin for ego pass first situation to suppress chattering
         ego_pass_later_margin_x: [0.0] # [[s]] time to vehicle margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
         ego_pass_later_margin_y: [13.0] # [[s]] time to collision margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
@@ -75,8 +75,8 @@
         enable: true  # if true, ego will slowdown around crosswalks that are occluded
         occluded_object_velocity: 1.0 # [m/s] assumed velocity of objects that may come out of the occluded space
         slow_down_velocity: 1.0  # [m/s]
-        time_buffer: 1.0  # [s] consecutive time with/without an occlusion to add/remove the slowdown
-        min_size: 0.5  # [m] minimum size of an occlusion (square side size)
+        time_buffer: 0.5  # [s] consecutive time with/without an occlusion to add/remove the slowdown
+        min_size: 1.0  # [m] minimum size of an occlusion (square side size)
         free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
         occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid
         ignore_with_traffic_light: true  # [-] if true, occlusions at crosswalks with traffic lights are ignored

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -90,19 +90,19 @@
           object_time_margin_to_collision_point: 4.0
 
       occlusion:
-        enable: false
+        enable: true
         occlusion_attention_area_length: 70.0
         free_space_max: 43
         occupied_min: 58
         denoise_kernel: 1.0
         attention_lane_crop_curvature_threshold: 0.25
-        attention_lane_curvature_calculation_ds: 0.5
+        attention_lane_curvature_calculation_ds: 0.6
         creep_during_peeking:
           enable: false
           creep_velocity: 0.8333
         peeking_offset: -0.5
         occlusion_required_clearance_distance: 55.0
-        possible_object_bbox: [1.5, 2.5]
+        possible_object_bbox: [1.9, 2.5]
         ignore_parked_vehicle_speed_threshold: 0.8333
         occlusion_detection_hold_time: 1.5
         temporal_stop_time_before_peeking: 0.1

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/config/occlusion_spot.param.yaml
@@ -21,8 +21,8 @@
         search_angle: 0.63                  # [rad] PI/5.0
       motion:
         safety_ratio: 0.8                   # [-] jerk/acceleration ratio for safety
-        max_slow_down_jerk: -0.5            # [m/s^3] minimum jerk deceleration for safe brake.
-        max_slow_down_accel: -1.8           # [m/s^2] minimum accel deceleration for safe brake.
+        max_slow_down_jerk: -0.3            # [m/s^3] minimum jerk deceleration for safe brake.
+        max_slow_down_accel: -1.5           # [m/s^2] minimum accel deceleration for safe brake.
         non_effective_jerk: -0.3            # [m/s^3] weak jerk for velocity planning.
         non_effective_acceleration: -1.0    # [m/s^2] weak deceleration for velocity planning.
         min_allowed_velocity: 1.0           # [m/s] minimum velocity allowed
@@ -31,7 +31,7 @@
         min_occlusion_spot_size: 1.0     # [m] occupancy grid must contain an UNKNOWN area of at least size NxN to be considered a hidden obstacle.
         slice_length: 10.0               # [m] size of slices in both length and distance relative to the ego path.
         min_longitudinal_offset: 1.0     # [m] detection area safety buffer from front bumper.
-        max_lateral_distance: 6.0        # [m] buffer around the ego path used to build the detection area.
+        max_lateral_distance: 5.0        # [m] buffer around the ego path used to build the detection area.
       grid:
         free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
-        occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid
+        occupied_min: 57    # [-] minimum value of an occupied cell in the occupancy grid

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/config/run_out.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/config/run_out.param.yaml
@@ -29,7 +29,7 @@
         std_dev_multiplier: 1.96  # [-] min and max velocity of the obstacles are calculated from this value and covariance
         diameter: 0.1             # [m] diameter of obstacles. used for creating dynamic obstacles from points
         height: 2.0               # [m] height of obstacles. used for creating dynamic obstacles from points
-        max_prediction_time: 10.0 # [sec] create predicted path until this time
+        max_prediction_time: 3.0  # [sec] create predicted path until this time
         time_step: 0.5            # [sec] time step for each path step. used for creating dynamic obstacles from points or objects without path
         points_interval: 0.1      # [m] divide obstacle points into groups with this interval, and detect only lateral nearest point. used only for Points method
 
@@ -44,7 +44,7 @@
       # Parameter to prevent abrupt stops caused by false positives in perception
       ignore_momentary_detection:
         enable: true
-        time_threshold: 0.15  # [sec] ignores detections that persist for less than this duration
+        time_threshold: 0.5  # [sec] ignores detections that persist for less than this duration
 
       # Typically used when the "detection_method" is set to ObjectWithoutPath or Points
       # Approach if the ego has stopped in front of the obstacle for a certain period


### PR DESCRIPTION
## Description

The parameters in the `*.param.yaml` in `autoware.universe` mismatch the parameters in `launcher`.

This PR aligns the parameters in **_behavior velocity planner_**.
1. Align the parameters in `autoware.universe` with `launcher`. 
2. Delete the redundant parameters not defined in `launcher`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/