### PR TITLE
fix(motion_planning): align the parameters with launcher

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/autoware_obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -12,7 +12,7 @@
       idling_time: 2.0 # idling time to detect front vehicle starting deceleration [s]
       min_ego_accel_for_rss: -1.0 # ego's acceleration to calculate RSS distance [m/ss]
       min_object_accel_for_rss: -1.0 # front obstacle's acceleration to calculate RSS distance [m/ss]
-      safe_distance_margin : 6.0 # This is also used as a stop margin [m]
+      safe_distance_margin : 5.0 # This is also used as a stop margin [m]
       terminal_safe_distance_margin : 3.0 # Stop margin at the goal. This value cannot exceed safe distance margin. [m]
       hold_stop_velocity_threshold: 0.01 # The maximum ego velocity to hold stopping [m/s]
       hold_stop_distance_threshold: 0.3 # The ego keeps stopping if the distance to stop changes within the threshold [m]
@@ -23,10 +23,10 @@
       nearest_yaw_deviation_threshold: 1.57 # [rad] for finding nearest index
       min_behavior_stop_margin: 3.0 # [m]
       stop_on_curve:
-        enable_approaching: true # false
-        additional_safe_distance_margin: 0.0 # [m]
+        enable_approaching: false # false
+        additional_safe_distance_margin: 3.0 # [m]
         min_safe_distance_margin: 3.0 # [m]
-      suppress_sudden_obstacle_stop: true
+      suppress_sudden_obstacle_stop: false
 
       stop_obstacle_type:
         unknown: true
@@ -109,7 +109,7 @@
           ego_obstacle_overlap_time_threshold : 2.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
         yield:
-          enable_yield: false
+          enable_yield: true
           lat_distance_threshold: 5.0 # lateral margin between obstacle in neighbor lanes and trajectory band with ego's width for yielding
           max_lat_dist_between_obstacles: 2.5 # lateral margin between moving obstacle in neighbor lanes and stopped obstacle in front of it
           max_obstacles_collision_time: 10.0 # how far the blocking obstacle
@@ -125,7 +125,7 @@
       # Both the lateral error and the yaw error are assumed to decrease to zero by the time duration "time_to_convergence"
       # The both errors decrease with constant rates against the time.
       consider_current_pose:
-        enable_to_consider_current_pose: false
+        enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
 
     cruise:
@@ -196,29 +196,17 @@
       # parameters to calculate slow down velocity by linear interpolation
       labels:
         - "default"
-        - "pedestrian"
       default:
         moving:
-          min_lat_margin: 0.8
-          max_lat_margin: 1.3
-          min_ego_velocity: 0.5
-          max_ego_velocity: 1.5
+          min_lat_margin: 0.2
+          max_lat_margin: 1.0
+          min_ego_velocity: 2.0
+          max_ego_velocity: 8.0
         static:
           min_lat_margin: 0.2
           max_lat_margin: 1.0
           min_ego_velocity: 4.0
           max_ego_velocity: 8.0
-      pedestrian:
-        moving:
-          min_lat_margin: 0.8
-          max_lat_margin: 1.3
-          min_ego_velocity: 0.5
-          max_ego_velocity: 0.8
-        static:
-          min_lat_margin: 0.8
-          max_lat_margin: 1.3
-          min_ego_velocity: 1.0
-          max_ego_velocity: 2.0
 
       moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"
       moving_object_hysteresis_range: 0.1 # [m/s] hysteresis range used to prevent chattering when obstacle moves close to moving_object_speed_threshold

--- a/planning/autoware_path_optimizer/config/path_optimizer.param.yaml
+++ b/planning/autoware_path_optimizer/config/path_optimizer.param.yaml
@@ -3,12 +3,12 @@
     option:
       enable_skip_optimization: false                              # skip elastic band and model predictive trajectory
       enable_reset_prev_optimization: false                        # If true, optimization has no fix constraint to the previous result.
-      enable_outside_drivable_area_stop: true                      # stop if the ego's trajectory footprint is outside the drivable area
+      enable_outside_drivable_area_stop: false                      # stop if the ego's trajectory footprint is outside the drivable area
       use_footprint_polygon_for_outside_drivable_area_check: false # If false, only the footprint's corner points are considered.
 
       debug:
         # flag to publish
-        enable_pub_debug_marker: true           # publish debug marker
+        enable_pub_debug_marker: false           # publish debug marker
         enable_pub_extra_debug_marker: false    # publish extra debug marker
 
         # flag to show
@@ -31,7 +31,7 @@
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]
-      max_delta_time_sec: 1.0                  # threshold of delta time for replan [second]
+      max_delta_time_sec: 0.0                  # threshold of delta time for replan [second]
 
     # mpt param
     mpt:
@@ -40,7 +40,7 @@
         steer_limit_constraint: false
         visualize_sampling_num: 1
         enable_manual_warm_start: false
-        enable_warm_start: true
+        enable_warm_start: false
         enable_optimization_validation: false
 
       common:
@@ -62,7 +62,7 @@
       # weight parameter for optimization
       weight:
         # collision free
-        soft_collision_free_weight: 1000.0        # soft weight for lateral error around the middle point
+        soft_collision_free_weight: 1.0        # soft weight for lateral error around the middle point
 
         # tracking error
         lat_error_weight: 1.0       # weight for lateral error

--- a/planning/autoware_path_smoother/config/elastic_band_smoother.param.yaml
+++ b/planning/autoware_path_smoother/config/elastic_band_smoother.param.yaml
@@ -40,8 +40,8 @@
       enable: true  # if true, only perform smoothing when the input changes significantly
       max_path_shape_around_ego_lat_dist: 2.0  # threshold of path shape change around ego [m]
       max_path_shape_forward_lon_dist: 100.0   # forward point to check lateral distance difference [m]
-      max_path_shape_forward_lat_dist: 0.1     # threshold of path shape change around forward point [m]
+      max_path_shape_forward_lat_dist: 0.2     # threshold of path shape change around forward point [m]
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]
-      max_delta_time_sec: 1.0                  # threshold of delta time for replan [second]
+      max_delta_time_sec: 0.0                  # threshold of delta time for replan [second]

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -2,19 +2,19 @@
   ros__parameters:
     out_of_lane:  # module to stop or slowdown before overlapping another lane with other objects
       mode: ttc # mode used to consider a conflict with an object. "threshold", or "ttc"
-      skip_if_already_overlapping: true # do not run this module when ego already overlaps another lane
+      skip_if_already_overlapping: false # do not run this module when ego already overlaps another lane
       max_arc_length: 100.0  # [m] maximum trajectory arc length that is checked for out_of_lane collisions
 
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 3.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
+        threshold: 1.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
 
       objects:
         minimum_velocity: 0.5  # [m/s] objects lower than this velocity will be ignored
         predicted_path_min_confidence : 0.1  # when using predicted paths, ignore the ones whose confidence is lower than this value.
         cut_predicted_paths_beyond_red_lights: true # if true, predicted paths are cut beyond the stop line of red traffic lights
-        ignore_behind_ego: true # if true, objects behind the ego vehicle are ignored
+        ignore_behind_ego: false # if true, objects behind the ego vehicle are ignored
 
       action:  # action to insert in the trajectory if an object causes a conflict at an overlap
         precision: 0.1  # [m] precision when inserting a stop pose in the trajectory


### PR DESCRIPTION
## Description

The parameters in the `*.param.yaml` in `autoware.universe` mismatch the parameters in `launcher`.

This PR aligns the parameters in **_motion planning packages_**.
1. Align the parameters in `autoware.universe` with `launcher`. 
2. Delete the redundant parameters not defined in `launcher`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/