### PR TITLE
fix(other_planning_packages): align the parameters with launcher

### DIFF
--- a/planning/autoware_costmap_generator/config/costmap_generator.param.yaml
+++ b/planning/autoware_costmap_generator/config/costmap_generator.param.yaml
@@ -7,7 +7,7 @@
     activate_by_scenario: false
     grid_min_value: 0.0
     grid_max_value: 1.0
-    grid_resolution: 0.2
+    grid_resolution: 0.3
     grid_length_x: 70.0
     grid_length_y: 70.0
     grid_position_x: 0.0
@@ -18,5 +18,5 @@
     use_parkinglot: true
     use_objects: true
     use_points: true
-    expand_polygon_size: 1.0
+    expand_polygon_size: 0.5
     size_of_expansion_kernel: 9

--- a/planning/autoware_freespace_planner/config/freespace_planner.param.yaml
+++ b/planning/autoware_freespace_planner/config/freespace_planner.param.yaml
@@ -9,7 +9,7 @@
     th_stopped_velocity_mps: 0.01
     th_course_out_distance_m: 1.0
     th_obstacle_time_sec: 1.0
-    vehicle_shape_margin_m: 1.0
+    vehicle_shape_margin_m: 0.5
     replan_when_obstacle_found: true
     replan_when_course_out: true
 
@@ -19,13 +19,13 @@
     max_turning_ratio: 0.5 # ratio of actual turning limit of vehicle
     turning_steps: 1
     # search configs
-    theta_size: 144
+    theta_size: 120
     angle_goal_range: 6.0
     lateral_goal_range: 0.5
     longitudinal_goal_range: 1.0
     curve_weight: 0.5
-    reverse_weight: 1.0
-    direction_change_weight: 1.5
+    reverse_weight: 0.7
+    direction_change_weight: 2.0
     # costmap configs
     obstacle_threshold: 100
 
@@ -36,10 +36,10 @@
       use_back: true
       adapt_expansion_distance: true
       expansion_distance: 0.5
-      near_goal_distance: 4.0
-      distance_heuristic_weight: 1.5
+      near_goal_distance: 3.0
+      distance_heuristic_weight: 2.0
       smoothness_weight: 0.5
-      obstacle_distance_weight: 1.5
+      obstacle_distance_weight: 1.75
       goal_lat_distance_weight: 5.0
 
     # -- RRT* search Configurations --

--- a/planning/autoware_obstacle_stop_planner/config/common.param.yaml
+++ b/planning/autoware_obstacle_stop_planner/config/common.param.yaml
@@ -4,9 +4,9 @@
     max_vel: 11.1           # max velocity limit [m/s]
 
     normal:
-      min_acc: -0.5         # min deceleration [m/ss]
+      min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]
-      min_jerk: -0.5        # min jerk [m/sss]
+      min_jerk: -1.0        # min jerk [m/sss]
       max_jerk: 1.0         # max jerk [m/sss]
 
     # constraints to be observed

--- a/planning/autoware_obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/autoware_obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -2,8 +2,6 @@
   ros__parameters:
     chattering_threshold: 0.5                 # even if the obstacle disappears, the stop judgment continues for chattering_threshold [s]
     max_velocity: 20.0                        # max velocity [m/s]
-    ego_nearest_dist_threshold: 3.0           # [m]
-    ego_nearest_yaw_threshold: 1.046          # [rad] = 60 [deg]
     enable_slow_down: False                   # whether to use slow down planner [-]
     enable_z_axis_obstacle_filtering: True    # filter obstacles in z axis (height) [-]
     z_axis_filtering_buffer: 0.0              # additional buffer for z axis filtering [m]
@@ -18,8 +16,8 @@
       # params for stop position
       stop_position:
         max_longitudinal_margin: 5.0             # stop margin distance from obstacle on the path [m]
-        max_longitudinal_margin_behind_goal: 3.0 # stop margin distance from obstacle behind the goal on the path [m]
-        min_longitudinal_margin: 2.0             # stop margin distance when any other stop point is inserted in stop margin [m]
+        max_longitudinal_margin_behind_goal: 2.5 # stop margin distance from obstacle behind the goal on the path [m]
+        min_longitudinal_margin: 5.0             # stop margin distance when any other stop point is inserted in stop margin [m]
         hold_stop_margin_distance: 0.0           # the ego keeps stopping if the ego is in this margin [m]
 
       # params for detection area
@@ -36,7 +34,7 @@
       # params for slow down section
       slow_down_section:
         longitudinal_forward_margin: 5.0     # margin distance from slow down point to vehicle front [m]
-        longitudinal_backward_margin: 5.0    # margin distance from slow down point to vehicle rear [m]
+        longitudinal_backward_margin: 0.0    # margin distance from slow down point to vehicle rear [m]
         longitudinal_margin_span: -0.1       # fineness param for relaxing slow down margin (use this param if consider_constraints is True) [m/s]
         min_longitudinal_forward_margin: 1.0 # min margin for relaxing slow down margin (use this param if consider_constraints is True) [m/s]
 
@@ -55,7 +53,7 @@
 
       # params for deceleration constraints (use this param if consider_constraints is True)
       constraints:
-        jerk_min_slow_down: -0.3             # min slow down jerk constraint [m/sss]
+        jerk_min_slow_down: -0.6             # min slow down jerk constraint [m/sss]
         jerk_span: -0.01                     # fineness param for planning deceleration jerk [m/sss]
         jerk_start: -0.1                     # init jerk used for deceleration planning [m/sss]
 

--- a/planning/autoware_obstacle_stop_planner/schema/obstacle_stop_planner.schema.json
+++ b/planning/autoware_obstacle_stop_planner/schema/obstacle_stop_planner.schema.json
@@ -16,16 +16,6 @@
           "description": "max velocity [m/s]",
           "default": "20.0"
         },
-        "ego_nearest_dist_threshold": {
-          "type": "number",
-          "description": "[m]",
-          "default": "3.0"
-        },
-        "ego_nearest_yaw_threshold": {
-          "type": "number",
-          "description": "[rad] = 60 [deg]",
-          "default": "1.046"
-        },
         "enable_slow_down": {
           "type": "boolean",
           "description": "whether to use slow down planner [-]",
@@ -288,8 +278,6 @@
       "required": [
         "chattering_threshold",
         "max_velocity",
-        "ego_nearest_dist_threshold",
-        "ego_nearest_yaw_threshold",
         "enable_slow_down",
         "enable_z_axis_obstacle_filtering",
         "z_axis_filtering_buffer",

--- a/planning/autoware_static_centerline_generator/config/common.param.yaml
+++ b/planning/autoware_static_centerline_generator/config/common.param.yaml
@@ -4,9 +4,9 @@
     max_vel: 11.1           # max velocity limit [m/s]
 
     normal:
-      min_acc: -0.5         # min deceleration [m/ss]
+      min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]
-      min_jerk: -0.5        # min jerk [m/sss]
+      min_jerk: -1.0        # min jerk [m/sss]
       max_jerk: 1.0         # max jerk [m/sss]
 
     # constraints to be observed

--- a/planning/autoware_surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
+++ b/planning/autoware_surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
@@ -9,7 +9,7 @@
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
     unknown:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
@@ -17,22 +17,22 @@
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     truck:
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     bus:
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     trailer:
       enable_check: true
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
-      surround_check_back_distance: 0.5
+      surround_check_back_distance: 0.0
     motorcycle:
       enable_check: true
       surround_check_front_distance: 0.5
@@ -49,9 +49,9 @@
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
 
-    surround_check_hysteresis_distance: 0.3
+    surround_check_hysteresis_distance: 0.1
 
-    state_clear_time: 2.0
+    state_clear_time: 0.2
 
     # ego stop state
     stop_state_ego_speed: 0.1 #[m/s]


### PR DESCRIPTION
## Description

The parameters in the `*.param.yaml` in `autoware.universe` mismatch the parameters in `launcher`.

This PR aligns the parameters in **_other planning packages_**.
1. Align the parameters in `autoware.universe` with `launcher`. 
2. Delete the redundant parameters not defined in `launcher`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/