### PR TITLE
perf(motion_velocity_smoother): remove some heavy debug logging

### DIFF
--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -249,15 +249,6 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   const auto acc_at_wp = interpolation::lerp(xs, as, distances);
   const auto jerk_at_wp = interpolation::lerp(xs, js, distances);
 
-  // for debug
-  std::stringstream ssi;
-  for (unsigned int i = 0; i < distances.size(); ++i) {
-    ssi << "d: " << distances.at(i) << ", v: " << vel_at_wp.at(i) << ", a: " << acc_at_wp.at(i)
-        << ", j: " << jerk_at_wp.at(i) << std::endl;
-  }
-  RCLCPP_DEBUG(
-    rclcpp::get_logger("velocity_planning_utils"), "Interpolated = %s", ssi.str().c_str());
-
   for (size_t i = 0; i < vel_at_wp.size(); ++i) {
     output_trajectory.at(start_index + i).longitudinal_velocity_mps = vel_at_wp.at(i);
     output_trajectory.at(start_index + i).acceleration_mps2 = acc_at_wp.at(i);


### PR DESCRIPTION
## Description

Some debug logging of the `analytical_jerk_constrained_smoother` can take a lot of time (I observed up to 20ms when running locally), even when debug logging is disabled.
I have not found a nice solution so this PR simply removes the logging code.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
