### PR TITLE
refactor(cluster_merger): remove unused variable and rename topic

### DIFF
--- a/perception/autoware_cluster_merger/launch/cluster_merger.launch.xml
+++ b/perception/autoware_cluster_merger/launch/cluster_merger.launch.xml
@@ -6,7 +6,7 @@
   <arg name="param_path" default="$(find-pkg-share autoware_cluster_merger)/config/cluster_merger.param.yaml"/>
   <!-- Node -->
   <node pkg="autoware_cluster_merger" exec="cluster_merger_node" name="autoware_cluster_merger" output="screen">
-    <remap from="~/output/clusters" to="$(var output/clusters)"/>
+    <remap from="output/clusters" to="$(var output/clusters)"/>
     <remap from="input/cluster0" to="$(var input/cluster0)"/>
     <remap from="input/cluster1" to="$(var input/cluster1)"/>
     <param from="$(var param_path)"/>

--- a/perception/autoware_cluster_merger/src/cluster_merger_node.cpp
+++ b/perception/autoware_cluster_merger/src/cluster_merger_node.cpp
@@ -37,7 +37,7 @@ ClusterMergerNode::ClusterMergerNode(const rclcpp::NodeOptions & node_options)
   sync_.registerCallback(std::bind(&ClusterMergerNode::objectsCallback, this, _1, _2));
 
   // Publisher
-  pub_objects_ = create_publisher<DetectedObjectsWithFeature>("~/output/clusters", rclcpp::QoS{1});
+  pub_objects_ = create_publisher<DetectedObjectsWithFeature>("output/clusters", rclcpp::QoS{1});
 }
 
 void ClusterMergerNode::objectsCallback(

--- a/perception/autoware_cluster_merger/src/cluster_merger_node.hpp
+++ b/perception/autoware_cluster_merger/src/cluster_merger_node.hpp
@@ -47,7 +47,6 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  rclcpp::Subscription<DetectedObjectsWithFeature>::SharedPtr sub_objects_{};
   message_filters::Subscriber<DetectedObjectsWithFeature> objects0_sub_;
   message_filters::Subscriber<DetectedObjectsWithFeature> objects1_sub_;
   typedef message_filters::sync_policies::ApproximateTime<
@@ -57,9 +56,6 @@ private:
   Sync sync_;
 
   std::string output_frame_id_;
-
-  std::vector<rclcpp::Subscription<DetectedObjectsWithFeature>::SharedPtr> sub_objects_array{};
-  std::shared_ptr<autoware::universe_utils::TransformListener> transform_listener_;
 
   void objectsCallback(
     const DetectedObjectsWithFeature::ConstSharedPtr & input_objects0_msg,


### PR DESCRIPTION
## Description
- This PR:
  - Removes some unused variables
  - Unify topic name for[ node testing PR](https://github.com/autowarefoundation/autoware.universe/pull/8810).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
