### PR TITLE
feat(autoware_lidar_transfusion): shuffled points before feeding them to the model

### DIFF
--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/cuda_utils.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/cuda_utils.hpp
@@ -89,13 +89,13 @@ cuda::unique_ptr<T> make_unique()
   return cuda::unique_ptr<T>{p};
 }
 
-constexpr size_t CUDA_ALIGN = 256;
+constexpr std::size_t CUDA_ALIGN = 256;
 
 template <typename T>
-inline size_t get_size_aligned(size_t num_elem)
+inline std::size_t get_size_aligned(size_t num_elem)
 {
-  size_t size = num_elem * sizeof(T);
-  size_t extra_align = 0;
+  std::size_t size = num_elem * sizeof(T);
+  std::size_t extra_align = 0;
   if (size % CUDA_ALIGN != 0) {
     extra_align = CUDA_ALIGN - size % CUDA_ALIGN;
   }
@@ -103,9 +103,9 @@ inline size_t get_size_aligned(size_t num_elem)
 }
 
 template <typename T>
-inline T * get_next_ptr(size_t num_elem, void *& workspace, size_t & workspace_size)
+inline T * get_next_ptr(size_t num_elem, void *& workspace, std::size_t & workspace_size)
 {
-  size_t size = get_size_aligned<T>(num_elem);
+  std::size_t size = get_size_aligned<T>(num_elem);
   if (size > workspace_size) {
     throw ::std::runtime_error("Workspace is too small!");
   }
@@ -116,7 +116,7 @@ inline T * get_next_ptr(size_t num_elem, void *& workspace, size_t & workspace_s
 }
 
 template <typename T>
-void clear_async(T * ptr, size_t num_elem, cudaStream_t stream)
+void clear_async(T * ptr, std::size_t num_elem, cudaStream_t stream)
 {
   CHECK_CUDA_ERROR(::cudaMemsetAsync(ptr, 0, sizeof(T) * num_elem, stream));
 }

--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/network/network_trt.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/network/network_trt.hpp
@@ -63,7 +63,7 @@ public:
 private:
   bool parseONNX(
     const std::string & onnx_path, const std::string & engine_path, const std::string & precision,
-    size_t workspace_size = (1ULL << 30));
+    std::size_t workspace_size = (1ULL << 30));
   bool saveEngine(const std::string & engine_path);
   bool loadEngine(const std::string & engine_path);
   bool createContext();

--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/preprocess/pointcloud_densification.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/preprocess/pointcloud_densification.hpp
@@ -53,7 +53,7 @@ struct PointCloudWithTransform
 {
   cuda::unique_ptr<uint8_t[]> data_d{nullptr};
   std_msgs::msg::Header header;
-  size_t num_points{0};
+  std::size_t num_points{0};
   Eigen::Affine3f affine_past2world;
 };
 
@@ -75,11 +75,11 @@ public:
   {
     return iter == pointcloud_cache_.end();
   }
-  size_t getIdx(std::list<PointCloudWithTransform>::iterator iter)
+  std::size_t getIdx(std::list<PointCloudWithTransform>::iterator iter)
   {
     return std::distance(pointcloud_cache_.begin(), iter);
   }
-  size_t getCacheSize()
+  std::size_t getCacheSize()
   {
     return std::distance(pointcloud_cache_.begin(), pointcloud_cache_.end());
   }

--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/preprocess/preprocess_kernel.hpp
@@ -49,16 +49,20 @@ public:
     float * points, unsigned int points_size, unsigned int * pillar_num, float * voxel_features,
     unsigned int * voxel_num, unsigned int * voxel_idxs);
 
+  cudaError_t generateSweepPoints_launch(
+    const uint8_t * input_data, std::size_t points_size, int input_point_step, float time_lag,
+    const float * transform, float * output_points);
+
+  cudaError_t shufflePoints_launch(
+    const float * points, const unsigned int * indices, float * shuffled_points,
+    const std::size_t points_size, const std::size_t max_size, const std::size_t offset);
+
   cudaError_t generateVoxels_random_launch(
     float * points, unsigned int points_size, unsigned int * mask, float * voxels);
 
   cudaError_t generateBaseFeatures_launch(
     unsigned int * mask, float * voxels, unsigned int * pillar_num, float * voxel_features,
     unsigned int * voxel_num, unsigned int * voxel_idxs);
-
-  cudaError_t generateSweepPoints_launch(
-    const uint8_t * input_data, size_t points_size, int input_point_step, float time_lag,
-    const float * transform, float * output_points);
 
 private:
   TransfusionConfig config_;

--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/preprocess/voxel_generator.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/preprocess/voxel_generator.hpp
@@ -38,8 +38,8 @@
 
 namespace autoware::lidar_transfusion
 {
-constexpr size_t AFF_MAT_SIZE = 16;  // 4x4 matrix
-constexpr size_t MAX_CLOUD_STEP_SIZE = sizeof(autoware_point_types::PointXYZIRCAEDT);
+constexpr std::size_t AFF_MAT_SIZE = 16;  // 4x4 matrix
+constexpr std::size_t MAX_CLOUD_STEP_SIZE = sizeof(autoware_point_types::PointXYZIRCAEDT);
 
 class VoxelGenerator
 {

--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/transfusion_trt.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/transfusion_trt.hpp
@@ -100,7 +100,9 @@ protected:
   unsigned int box_size_{0};
   unsigned int dir_cls_size_{0};
   cuda::unique_ptr<float[]> points_d_{nullptr};
+  cuda::unique_ptr<float[]> points_aux_d_{nullptr};
   cuda::unique_ptr<unsigned int> params_input_d_{nullptr};
+  cuda::unique_ptr<unsigned int[]> shuffle_indices_d_{nullptr};
   cuda::unique_ptr<float[]> voxel_features_d_{nullptr};
   cuda::unique_ptr<unsigned int[]> voxel_num_d_{nullptr};
   cuda::unique_ptr<unsigned int[]> voxel_idxs_d_{nullptr};


### PR DESCRIPTION
## Description
shuffled points before feeding them to the model to avoid voxels filling with highly correlated points

Inference time:
After this PR: 9.69ms
Before this PR: 8.49 ms


## Related links

**Parent Issue:**

- Link

Related thread
- [TIER IV](https://star4.slack.com/archives/C03S84LDJGG/p1725614367350419)

<!-- ⬇️🟢
**Private Links:**


⬆️🟢 -->

## How was this PR tested?
Used the X2 data from the thread and a reference bag from XX1.
Tested both centerpoint (the model from x2 and the standard model) and transfusion

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
