### PR TITLE
fix(tier4_camera_view_rviz_plugin): fix uninitMemberVar

### DIFF
--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp
@@ -52,17 +52,17 @@
 namespace tier4_camera_view_rviz_plugin
 {
 BirdEyeViewTool::BirdEyeViewTool()
-  : m_sceneNode(nullptr),
-    m_fly_mode(false),
-    m_left_hand_mode(false),
-    m_removed_select(false),
-    m_pos_offset(0.0),
-    m_boost(0.0),
-    step_length_property_(nullptr),
-    boost_property_(nullptr),
-    fly_property_(nullptr),
-    left_hand_property_(nullptr),
-    fallback_view_controller_property_(nullptr)
+: m_sceneNode(nullptr),
+  m_fly_mode(false),
+  m_left_hand_mode(false),
+  m_removed_select(false),
+  m_pos_offset(0.0),
+  m_boost(0.0),
+  step_length_property_(nullptr),
+  boost_property_(nullptr),
+  fly_property_(nullptr),
+  left_hand_property_(nullptr),
+  fallback_view_controller_property_(nullptr)
 {
   shortcut_key_ = 'r';
 }

--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp
@@ -52,6 +52,17 @@
 namespace tier4_camera_view_rviz_plugin
 {
 BirdEyeViewTool::BirdEyeViewTool()
+  : m_sceneNode(nullptr),
+    m_fly_mode(false),
+    m_left_hand_mode(false),
+    m_removed_select(false),
+    m_pos_offset(0.0),
+    m_boost(0.0),
+    step_length_property_(nullptr),
+    boost_property_(nullptr),
+    fly_property_(nullptr),
+    left_hand_property_(nullptr),
+    fallback_view_controller_property_(nullptr)
 {
   shortcut_key_ = 'r';
 }

--- a/common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp
@@ -53,6 +53,17 @@
 namespace tier4_camera_view_rviz_plugin
 {
 ThirdPersonViewTool::ThirdPersonViewTool()
+  : m_sceneNode(nullptr),
+    m_fly_mode(false),
+    m_left_hand_mode(false),
+    m_removed_select(false),
+    m_pos_offset(0.0),
+    m_boost(0.0),
+    step_length_property_(nullptr),
+    boost_property_(nullptr),
+    fly_property_(nullptr),
+    left_hand_property_(nullptr),
+    fallback_view_controller_property_(nullptr)
 {
   shortcut_key_ = 'o';
 }

--- a/common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp
@@ -53,17 +53,17 @@
 namespace tier4_camera_view_rviz_plugin
 {
 ThirdPersonViewTool::ThirdPersonViewTool()
-  : m_sceneNode(nullptr),
-    m_fly_mode(false),
-    m_left_hand_mode(false),
-    m_removed_select(false),
-    m_pos_offset(0.0),
-    m_boost(0.0),
-    step_length_property_(nullptr),
-    boost_property_(nullptr),
-    fly_property_(nullptr),
-    left_hand_property_(nullptr),
-    fallback_view_controller_property_(nullptr)
+: m_sceneNode(nullptr),
+  m_fly_mode(false),
+  m_left_hand_mode(false),
+  m_removed_select(false),
+  m_pos_offset(0.0),
+  m_boost(0.0),
+  step_length_property_(nullptr),
+  boost_property_(nullptr),
+  fly_property_(nullptr),
+  left_hand_property_(nullptr),
+  fallback_view_controller_property_(nullptr)
 {
   shortcut_key_ = 'o';
 }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck uninitMemberVar warnings.
Prevention against future CI changes.

```
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::m_sceneNode' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::m_fly_mode' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::m_left_hand_mode' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::m_removed_select' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::m_pos_offset' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::m_boost' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::step_length_property_' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::boost_property_' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::fly_property_' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::left_hand_property_' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:54:18: warning: Member variable 'BirdEyeViewTool::fallback_view_controller_property_' is not initialized in the constructor. [uninitMemberVar]
BirdEyeViewTool::BirdEyeViewTool()
                 ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::m_sceneNode' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::m_fly_mode' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::m_left_hand_mode' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::m_removed_select' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::m_pos_offset' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::m_boost' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::step_length_property_' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::boost_property_' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::fly_property_' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::left_hand_property_' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
common/tier4_camera_view_rviz_plugin/src/third_person_view_tool.cpp:55:22: warning: Member variable 'ThirdPersonViewTool::fallback_view_controller_property_' is not initialized in the constructor. [uninitMemberVar]
ThirdPersonViewTool::ThirdPersonViewTool()
                     ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
