### PR TITLE
refactor(autoware_lidar_centerpoint): use std::size_t instead of size_t

### DIFF
--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/cuda_utils.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/cuda_utils.hpp
@@ -89,13 +89,13 @@ cuda::unique_ptr<T> make_unique()
   return cuda::unique_ptr<T>{p};
 }
 
-constexpr size_t CUDA_ALIGN = 256;
+constexpr std::size_t CUDA_ALIGN = 256;
 
 template <typename T>
-inline size_t get_size_aligned(size_t num_elem)
+inline std::size_t get_size_aligned(size_t num_elem)
 {
-  size_t size = num_elem * sizeof(T);
-  size_t extra_align = 0;
+  std::size_t size = num_elem * sizeof(T);
+  std::size_t extra_align = 0;
   if (size % CUDA_ALIGN != 0) {
     extra_align = CUDA_ALIGN - size % CUDA_ALIGN;
   }
@@ -103,9 +103,9 @@ inline size_t get_size_aligned(size_t num_elem)
 }
 
 template <typename T>
-inline T * get_next_ptr(size_t num_elem, void *& workspace, size_t & workspace_size)
+inline T * get_next_ptr(size_t num_elem, void *& workspace, std::size_t & workspace_size)
 {
-  size_t size = get_size_aligned<T>(num_elem);
+  std::size_t size = get_size_aligned<T>(num_elem);
   if (size > workspace_size) {
     throw ::std::runtime_error("Workspace is too small!");
   }

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/network/tensorrt_wrapper.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/network/tensorrt_wrapper.hpp
@@ -49,7 +49,7 @@ protected:
 private:
   bool parseONNX(
     const std::string & onnx_path, const std::string & engine_path, const std::string & precision,
-    size_t workspace_size = (1ULL << 30));
+    std::size_t workspace_size = (1ULL << 30));
 
   bool saveEngine(const std::string & engine_path);
 

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp
@@ -52,8 +52,8 @@ struct PointCloudWithTransform
 {
   cuda::unique_ptr<float[]> points_d{nullptr};
   std_msgs::msg::Header header;
-  size_t num_points{0};
-  size_t point_step{0};
+  std::size_t num_points{0};
+  std::size_t point_step{0};
   Eigen::Affine3f affine_past2world;
 };
 

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
@@ -25,10 +25,10 @@ cudaError_t generateSweepPoints_launch(
   const float * transform, int num_features, float * output_points, cudaStream_t stream);
 
 cudaError_t generateVoxels_random_launch(
-  const float * points, std::size_t points_size, float min_x_range, float max_x_range, float min_y_range,
-  float max_y_range, float min_z_range, float max_z_range, float pillar_x_size, float pillar_y_size,
-  float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask, float * voxels,
-  cudaStream_t stream);
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range,
+  float min_y_range, float max_y_range, float min_z_range, float max_z_range, float pillar_x_size,
+  float pillar_y_size, float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask,
+  float * voxels, cudaStream_t stream);
 
 cudaError_t generateBaseFeatures_launch(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp
@@ -21,11 +21,11 @@
 namespace autoware::lidar_centerpoint
 {
 cudaError_t generateSweepPoints_launch(
-  const float * input_points, size_t points_size, int input_point_step, float time_lag,
+  const float * input_points, std::size_t points_size, int input_point_step, float time_lag,
   const float * transform, int num_features, float * output_points, cudaStream_t stream);
 
 cudaError_t generateVoxels_random_launch(
-  const float * points, size_t points_size, float min_x_range, float max_x_range, float min_y_range,
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range, float min_y_range,
   float max_y_range, float min_z_range, float max_z_range, float pillar_x_size, float pillar_y_size,
   float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask, float * voxels,
   cudaStream_t stream);

--- a/perception/autoware_lidar_centerpoint/lib/network/tensorrt_wrapper.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/network/tensorrt_wrapper.cpp
@@ -80,7 +80,7 @@ bool TensorRTWrapper::createContext()
 
 bool TensorRTWrapper::parseONNX(
   const std::string & onnx_path, const std::string & engine_path, const std::string & precision,
-  const size_t workspace_size)
+  const std::size_t workspace_size)
 {
   auto builder =
     tensorrt_common::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(logger_));

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -45,7 +45,7 @@ namespace autoware::lidar_centerpoint
 {
 
 __global__ void generateSweepPoints_kernel(
-  const float * input_points, size_t points_size, int input_point_step, float time_lag,
+  const float * input_points, std::size_t points_size, int input_point_step, float time_lag,
   const float * transform_array, int num_features, float * output_points)
 {
   int point_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -69,7 +69,7 @@ __global__ void generateSweepPoints_kernel(
 }
 
 cudaError_t generateSweepPoints_launch(
-  const float * input_points, size_t points_size, int input_point_step, float time_lag,
+  const float * input_points, std::size_t points_size, int input_point_step, float time_lag,
   const float * transform_array, int num_features, float * output_points, cudaStream_t stream)
 {
   auto transform_d = cuda::make_unique<float[]>(16);
@@ -89,7 +89,7 @@ cudaError_t generateSweepPoints_launch(
 }
 
 __global__ void generateVoxels_random_kernel(
-  const float * points, size_t points_size, float min_x_range, float max_x_range, float min_y_range,
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range, float min_y_range,
   float max_y_range, float min_z_range, float max_z_range, float pillar_x_size, float pillar_y_size,
   float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask, float * voxels)
 {
@@ -118,7 +118,7 @@ __global__ void generateVoxels_random_kernel(
 }
 
 cudaError_t generateVoxels_random_launch(
-  const float * points, size_t points_size, float min_x_range, float max_x_range, float min_y_range,
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range, float min_y_range,
   float max_y_range, float min_z_range, float max_z_range, float pillar_x_size, float pillar_y_size,
   float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask, float * voxels,
   cudaStream_t stream)

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -89,9 +89,10 @@ cudaError_t generateSweepPoints_launch(
 }
 
 __global__ void generateVoxels_random_kernel(
-  const float * points, std::size_t points_size, float min_x_range, float max_x_range, float min_y_range,
-  float max_y_range, float min_z_range, float max_z_range, float pillar_x_size, float pillar_y_size,
-  float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask, float * voxels)
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range,
+  float min_y_range, float max_y_range, float min_z_range, float max_z_range, float pillar_x_size,
+  float pillar_y_size, float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask,
+  float * voxels)
 {
   int point_idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (point_idx >= points_size) return;
@@ -118,10 +119,10 @@ __global__ void generateVoxels_random_kernel(
 }
 
 cudaError_t generateVoxels_random_launch(
-  const float * points, std::size_t points_size, float min_x_range, float max_x_range, float min_y_range,
-  float max_y_range, float min_z_range, float max_z_range, float pillar_x_size, float pillar_y_size,
-  float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask, float * voxels,
-  cudaStream_t stream)
+  const float * points, std::size_t points_size, float min_x_range, float max_x_range,
+  float min_y_range, float max_y_range, float min_z_range, float max_z_range, float pillar_x_size,
+  float pillar_y_size, float pillar_z_size, int grid_y_size, int grid_x_size, unsigned int * mask,
+  float * voxels, cudaStream_t stream)
 {
   dim3 blocks((points_size + 256 - 1) / 256);
   dim3 threads(256);

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/voxel_generator.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/voxel_generator.cpp
@@ -51,7 +51,7 @@ bool VoxelGeneratorTemplate::enqueuePointCloud(
 
 std::size_t VoxelGenerator::generateSweepPoints(float * points_d, cudaStream_t stream)
 {
-  size_t point_counter = 0;
+  std::size_t point_counter = 0;
   for (auto pc_cache_iter = pd_ptr_->getPointCloudCacheIter(); !pd_ptr_->isCacheEnd(pc_cache_iter);
        pc_cache_iter++) {
     auto sweep_num_points = pc_cache_iter->num_points;


### PR DESCRIPTION
## Description
Use `std::size_t` instead of `size_t`

## Related links


## How was this PR tested?
Build works

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
