### PR TITLE
feat(remaining_distance_time_calculator): integrate generate_parameter_library

### DIFF
--- a/planning/autoware_remaining_distance_time_calculator/CMakeLists.txt
+++ b/planning/autoware_remaining_distance_time_calculator/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(${PROJECT_NAME}
   remaining_distance_time_calculator_parameters
 )
 
-target_compile_options(${PROJECT_NAME} PUBLIC
+target_compile_options(${PROJECT_NAME} PRIVATE
   -Wno-error=deprecated-declarations
 )
 

--- a/planning/autoware_remaining_distance_time_calculator/CMakeLists.txt
+++ b/planning/autoware_remaining_distance_time_calculator/CMakeLists.txt
@@ -4,8 +4,16 @@ project(autoware_remaining_distance_time_calculator)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+generate_parameter_library(remaining_distance_time_calculator_parameters
+  param/remaining_distance_time_calculator_parameters.yaml
+)
+
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/remaining_distance_time_calculator_node.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  remaining_distance_time_calculator_parameters
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/planning/autoware_remaining_distance_time_calculator/CMakeLists.txt
+++ b/planning/autoware_remaining_distance_time_calculator/CMakeLists.txt
@@ -16,6 +16,10 @@ target_link_libraries(${PROJECT_NAME}
   remaining_distance_time_calculator_parameters
 )
 
+target_compile_options(${PROJECT_NAME} PUBLIC
+  -Wno-error=deprecated-declarations
+)
+
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::remaining_distance_time_calculator::RemainingDistanceTimeCalculatorNode"
   EXECUTABLE ${PROJECT_NAME}_node

--- a/planning/autoware_remaining_distance_time_calculator/package.xml
+++ b/planning/autoware_remaining_distance_time_calculator/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_test_utils</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/planning/autoware_remaining_distance_time_calculator/param/remaining_distance_time_calculator_parameters.yaml
+++ b/planning/autoware_remaining_distance_time_calculator/param/remaining_distance_time_calculator_parameters.yaml
@@ -1,0 +1,4 @@
+remaining_distance_time_calculator:
+  update_rate:
+    type: double
+    description: Timer callback period. [Hz]

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
@@ -62,9 +62,11 @@ RemainingDistanceTimeCalculatorNode::RemainingDistanceTimeCalculatorNode(
     "~/output/mission_remaining_distance_time",
     rclcpp::QoS(rclcpp::KeepLast(10)).durability_volatile().reliable());
 
-  node_param_.update_rate = declare_parameter<double>("update_rate");
+  param_listener_ = std::make_shared<::remaining_distance_time_calculator::ParamListener>(
+    this->get_node_parameters_interface());
+  const auto param = param_listener_->get_params();
 
-  const auto period_ns = rclcpp::Rate(node_param_.update_rate).period();
+  const auto period_ns = rclcpp::Rate(param.update_rate).period();
   timer_ = rclcpp::create_timer(
     this, get_clock(), period_ns, std::bind(&RemainingDistanceTimeCalculatorNode::on_timer, this));
 }

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <remaining_distance_time_calculator_parameters.hpp>
 
 #include <autoware_internal_msgs/msg/mission_remaining_distance_time.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -37,11 +38,6 @@
 
 namespace autoware::remaining_distance_time_calculator
 {
-
-struct NodeParam
-{
-  double update_rate{0.0};
-};
 
 class RemainingDistanceTimeCalculatorNode : public rclcpp::Node
 {
@@ -82,7 +78,7 @@ private:
   double remaining_time_;
 
   // Parameter
-  NodeParam node_param_;
+  std::shared_ptr<::remaining_distance_time_calculator::ParamListener> param_listener_;
 
   // Callbacks
   void on_timer();


### PR DESCRIPTION
## Description

This PR enables remaining_distance_time_calculator to handle parameters using [generate_parameter_library](https://github.com/PickNikRobotics/generate_parameter_library).

## How was this PR tested?

Psim

- [x] errors occur if any parameters are missing in the config file in remaining_distance_time_calculator package

Evaluator: https://evaluation.tier4.jp/evaluation/reports/51089edf-cf82-58b3-b7c9-c571753ad766?project_id=prd_jt

## Notes for reviewers

The node `remaining_distance_time_calculator` does not have dynamic parameters.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
