### PR TITLE
fix(tier4_state_rviz_plugin): fix shadowVariable

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -712,19 +712,22 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
 
       case MRMState::PULL_OVER:
         behavior_state = Crash;
-        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.success.c_str());
+        behavior_bgColor =
+          QColor(autoware::state_rviz_plugin::colors::default_colors.success.c_str());
         mrm_behavior = "MRM Behavior | Pull Over";
         break;
 
       case MRMState::COMFORTABLE_STOP:
         behavior_state = Crash;
-        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.warning.c_str());
+        behavior_bgColor =
+          QColor(autoware::state_rviz_plugin::colors::default_colors.warning.c_str());
         mrm_behavior = "MRM Behavior | Comfortable Stop";
         break;
 
       case MRMState::EMERGENCY_STOP:
         behavior_state = Crash;
-        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.danger.c_str());
+        behavior_bgColor =
+          QColor(autoware::state_rviz_plugin::colors::default_colors.danger.c_str());
         mrm_behavior = "MRM Behavior | Emergency Stop";
         break;
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -699,43 +699,43 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
 
   // behavior
   {
-    IconState state;
-    QColor bgColor;
+    IconState behavior_state;
+    QColor behavior_bgColor;
     QString mrm_behavior = "MRM Behavior | Unknown";
 
     switch (msg->behavior) {
       case MRMState::NONE:
-        state = Crash;
-        bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+        behavior_state = Crash;
+        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
         mrm_behavior = "MRM Behavior | Inactive";
         break;
 
       case MRMState::PULL_OVER:
-        state = Crash;
-        bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.success.c_str());
+        behavior_state = Crash;
+        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.success.c_str());
         mrm_behavior = "MRM Behavior | Pull Over";
         break;
 
       case MRMState::COMFORTABLE_STOP:
-        state = Crash;
-        bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.warning.c_str());
+        behavior_state = Crash;
+        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.warning.c_str());
         mrm_behavior = "MRM Behavior | Comfortable Stop";
         break;
 
       case MRMState::EMERGENCY_STOP:
-        state = Crash;
-        bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.danger.c_str());
+        behavior_state = Crash;
+        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.danger.c_str());
         mrm_behavior = "MRM Behavior | Emergency Stop";
         break;
 
       default:
-        state = Crash;
-        bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+        behavior_state = Crash;
+        behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
         mrm_behavior = "MRM Behavior | Unknown";
         break;
     }
 
-    mrm_behavior_icon->updateStyle(state, bgColor);
+    mrm_behavior_icon->updateStyle(behavior_state, behavior_bgColor);
     mrm_behavior_label_ptr_->setText(mrm_behavior);
   }
 }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck shadowVariable warnings.
Preparation for future CI changes.

```
common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp:702:15: style: Local variable 'state' shadows outer variable [shadowVariable]
    IconState state;
              ^

common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp:703:12: style: Local variable 'bgColor' shadows outer variable [shadowVariable]
    QColor bgColor;
           ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
