### PR TITLE
fix(tier4_state_rviz_plugin): fix constVariablePointer

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -171,7 +171,7 @@ void AutowareStatePanel::onInitialize()
       return;
     }
 
-    QPushButton * button = qobject_cast<QPushButton *>(abstractButton);
+    const QPushButton * button = qobject_cast<QPushButton *>(abstractButton);
     if (button) {
       // Call the corresponding function for each button
       if (button == auto_button_ptr_) {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariablePointer warnings.
Preparation for future CI changes.

```
common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp:174:19: style: Variable 'button' can be declared as pointer to const [constVariablePointer]
    QPushButton * button = qobject_cast<QPushButton *>(abstractButton);
                  ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
