### PR TITLE
fix(tier4_localization_rviz_plugin): fix constVariableReference

### DIFF
--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp
@@ -211,7 +211,7 @@ void PoseHistoryFootprint::update_footprint()
 
   const float offset_from_baselink = property_offset_->getFloat();
 
-  for (auto & point_idx : history_) {
+  for (const auto & point_idx : history_) {
     const auto & pose = point_idx->pose;
     /*
      * Footprint


### PR DESCRIPTION
## Description
This is a fix based on cppcheck constVariableReference warnings.
Preparation for future CI changes.

```
common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:214:15: style: Variable 'point_idx' can be declared as reference to const [constVariableReference]
  for (auto & point_idx : history_) {
              ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
