### PR TITLE
fix(shape_estimation): unintented roi shape estimation

### DIFF
--- a/perception/autoware_shape_estimation/lib/corrector/utils.cpp
+++ b/perception/autoware_shape_estimation/lib/corrector/utils.cpp
@@ -108,100 +108,110 @@ bool correctWithDefaultValue(
   // rule based correction
   Eigen::Vector2d correction_vector = Eigen::Vector2d::Zero();
 
-  // 1,3 pair or 0,2 pair is most far index
+  // check diagonal pair: 1,3 pair or 0,2 pair is most far index
   if (
     static_cast<int>(std::abs(
       static_cast<int>(first_most_distant_index) - static_cast<int>(second_most_distant_index))) %
       2 ==
     0) {
-    if (
+    if ( // check if width is within threshold
       param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
       (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) {
+      // check if length is within threshold
       if ((v_point.at(third_most_distant_index) * 2.0).norm() < param.max_length) {
         correction_vector = v_point.at(third_most_distant_index);
-        if (correction_vector.x() == 0.0) {
+        // adjust length if it is too short
+        if (correction_vector.x() == 0.0) { // parallel to y-axis
           correction_vector.y() =
             std::max(std::abs(correction_vector.y()), param.default_length / 2.0) *
               (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
             correction_vector.y();
-        } else if (correction_vector.y() == 0.0) {
+        } else if (correction_vector.y() == 0.0) { // parallel to x-axis
           correction_vector.x() =
             std::max(std::abs(correction_vector.x()), param.default_length / 2.0) *
               (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
             correction_vector.x();
         }
-      } else {
+      } else { // length is too long
         return false;
       }
     } else if (  // NOLINT
+      // check if length is within threshold
       param.min_length < (v_point.at(first_most_distant_index) * 2.0).norm() &&
       (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_length) {
+      // check if width is within threshold
       if ((v_point.at(third_most_distant_index) * 2.0).norm() < param.max_width) {
         correction_vector = v_point.at(third_most_distant_index);
-        if (correction_vector.x() == 0.0) {
+        // adjust width if it is too short
+        if (correction_vector.x() == 0.0) { // parallel to y-axis
           correction_vector.y() =
             std::max(std::abs(correction_vector.y()), param.default_width / 2.0) *
               (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
             correction_vector.y();
-        } else if (correction_vector.y() == 0.0) {
+        } else if (correction_vector.y() == 0.0) { // parallel to x-axis
           correction_vector.x() =
             std::max(std::abs(correction_vector.x()), param.default_width / 2.0) *
               (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
             correction_vector.x();
         }
-      } else {
+      } else { // width is too long
         return false;
       }
-    } else {
+    } else { // both of width and length are out of threshold
       return false;
     }
-  }
+  }  // end of diagonal check
   // fit width
   else if (  // NOLINT
+    // not diagonal and both of edges are within width threshold
     (param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
      (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) &&
     (param.min_width < (v_point.at(second_most_distant_index) * 2.0).norm() &&
      (v_point.at(second_most_distant_index) * 2.0).norm() <
-       param.max_width))  // both of edge is within width threshold
+       param.max_width))
   {
     correction_vector = v_point.at(first_most_distant_index);
-    if (correction_vector.x() == 0.0) {
+    // adjust length if it is too short
+    if (correction_vector.x() == 0.0) { // parallel to y-axis
       correction_vector.y() =
         std::max(std::abs(correction_vector.y()), param.default_length / 2.0) *
           (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
         correction_vector.y();
-    } else if (correction_vector.y() == 0.0) {
+    } else if (correction_vector.y() == 0.0) { // parallel to x-axis
       correction_vector.x() =
         std::max(std::abs(correction_vector.x()), param.default_length / 2.0) *
           (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
         correction_vector.x();
     }
   } else if (  // NOLINT
+    // not diagonal and check if width is within threshold
     param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
     (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) {
-    correction_vector = v_point.at(second_most_distant_index);
-    if (correction_vector.x() == 0.0) {
+    correction_vector = v_point.at(first_most_distant_index);
+    // adjust length if it is too short
+    if (correction_vector.x() == 0.0) { // parallel to y-axis
       correction_vector.y() =
         std::max(std::abs(correction_vector.y()), param.default_length / 2.0) *
           (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
         correction_vector.y();
-    } else if (correction_vector.y() == 0.0) {
+    } else if (correction_vector.y() == 0.0) { // parallel to x-axis
       correction_vector.x() =
         std::max(std::abs(correction_vector.x()), param.default_length / 2.0) *
           (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
         correction_vector.x();
     }
   } else if (  // NOLINT
+    // not diagonal and check if width is within threshold
     param.min_width < (v_point.at(second_most_distant_index) * 2.0).norm() &&
     (v_point.at(second_most_distant_index) * 2.0).norm() < param.max_width) {
     correction_vector = v_point.at(first_most_distant_index);
-
-    if (correction_vector.x() == 0.0) {
+    // adjust length if it is too short
+    if (correction_vector.x() == 0.0) { // parallel to y-axis
       correction_vector.y() =
         std::max(std::abs(correction_vector.y()), param.default_length / 2.0) *
           (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
         correction_vector.y();
-    } else if (correction_vector.y() == 0.0) {
+    } else if (correction_vector.y() == 0.0) { // parallel to x-axis
       correction_vector.x() =
         std::max(std::abs(correction_vector.x()), param.default_length / 2.0) *
           (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
@@ -210,31 +220,33 @@ bool correctWithDefaultValue(
   }
   // fit length
   else if (  // NOLINT
+    // not diagonal and both of edges are within length and width threshold
     (param.min_length < (v_point.at(first_most_distant_index) * 2.0).norm() &&
      (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_length) &&
     (v_point.at(second_most_distant_index) * 2.0).norm() < param.max_width) {
     correction_vector = v_point.at(second_most_distant_index);
-
-    if (correction_vector.x() == 0.0) {
+    // adjust width if it is too short
+    if (correction_vector.x() == 0.0) { // parallel to y-axis
       correction_vector.y() = std::max(std::abs(correction_vector.y()), param.default_width / 2.0) *
                                 (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
                               correction_vector.y();
-    } else if (correction_vector.y() == 0.0) {
+    } else if (correction_vector.y() == 0.0) { // parallel to x-axis
       correction_vector.x() = std::max(std::abs(correction_vector.x()), param.default_width / 2.0) *
                                 (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
                               correction_vector.x();
     }
   } else if (  // NOLINT
+    // not diagonal and both of edges are within length and width threshold
     (param.min_length < (v_point.at(second_most_distant_index) * 2.0).norm() &&
      (v_point.at(second_most_distant_index) * 2.0).norm() < param.max_length) &&
     (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) {
     correction_vector = v_point.at(first_most_distant_index);
-
-    if (correction_vector.x() == 0.0) {
+    // adjust width if it is too short
+    if (correction_vector.x() == 0.0) { // parallel to y-axis
       correction_vector.y() = std::max(std::abs(correction_vector.y()), param.default_width / 2.0) *
                                 (correction_vector.y() < 0.0 ? -1.0 : 1.0) -
                               correction_vector.y();
-    } else if (correction_vector.y() == 0.0) {
+    } else if (correction_vector.y() == 0.0) { // parallel to x-axis
       correction_vector.x() = std::max(std::abs(correction_vector.x()), param.default_width / 2.0) *
                                 (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
                               correction_vector.x();


### PR DESCRIPTION
## Description
ROI is different than expected and comes out horizontally.
![Screenshot from 2024-08-26 16-51-21](https://github.com/user-attachments/assets/3f9d8ae4-142b-4d0e-9896-000049641faa)

In the function “[correctWithDefaultValue](https://github.com/arayabrain/autoware.universe.origin/blob/a1d55ca42e40b25d20bc9decf2fbf46e1aecd703/perception/autoware_shape_estimation/lib/corrector/utils.cpp#L44)” of the corrector, which corrects the point cluster to the size according to the object type, a judgment is made as to which side of the ROI should be corrected.
The decision is made based on the relative positional relationship between the vehicle and the point cluster. In this case, the ROI was corrected in an unintended direction because the second farthest edge was corrected instead of the farthest edge, especially when the point cluster was located right next to the vehicle.

![image](https://github.com/user-attachments/assets/d36ef1fc-54d8-4fd2-958d-9ef72e39479b)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- https://tier4.atlassian.net/browse/RT1-4647
- https://tier4.atlassian.net/browse/RT1-883
- Test with this [ros bag data](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/bbc8bad5-1702-4ca1-abfd-b7c9457a7293).

⬆️🟢 -->

## How was this PR tested?
Test with specified rosbag.

[shape_estimation_before.webm](https://github.com/user-attachments/assets/f9365120-64a7-48d1-b4a5-a3c5c9313ca2)

[shape_estimation_after.webm](https://github.com/user-attachments/assets/7622eaa8-16a0-49c9-9546-408c14a3710e)


## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
