### PR TITLE
fix(tier4_camera_view_rviz_plugin): fix unusedFunction

### DIFF
--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp
@@ -154,6 +154,7 @@ void BirdEyeViewTool::activate()
   setFallbackViewControllerProperty();
 }
 
+// cppcheck-suppress unusedFunction
 void BirdEyeViewTool::deactivate()
 {
 }


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.
Preparation for future CI changes.

```
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_tool.cpp:157:0: style: The function 'deactivate' is never used. [unusedFunction]
void BirdEyeViewTool::deactivate()
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
