### PR TITLE
fix(tier4_dummy_object_rviz_plugin): fix unusedFunction

### DIFF
--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp
@@ -78,6 +78,7 @@ void DeleteAllObjectsTool::updateTopic()
   clock_ = raw_node->get_clock();
 }
 
+// cppcheck-suppress unusedFunction
 void DeleteAllObjectsTool::onPoseSet(
   [[maybe_unused]] double x, [[maybe_unused]] double y, [[maybe_unused]] double theta)
 {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.
Preparation for future CI changes.

```
simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp:81:0: style: The function 'onPoseSet' is never used. [unusedFunction]
void DeleteAllObjectsTool::onPoseSet(
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
