### PR TITLE
fix(tier4_localization_rviz_plugin): fix unusedFunction

### DIFF
--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp
@@ -95,13 +95,6 @@ void PoseHistoryFootprint::update_vehicle_info()
   }
 }
 
-void PoseHistoryFootprint::update_visualization()
-{
-  if (last_msg_ptr_) {
-    processMessage(last_msg_ptr_);
-  }
-}
-
 void PoseHistoryFootprint::onInitialize()
 {
   MFDClass::onInitialize();

--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.hpp
@@ -61,7 +61,6 @@ protected:
   void update_footprint();
 
 private Q_SLOTS:
-  void update_visualization();
   void update_vehicle_info();
 
 private:  // NOLINT : suppress redundancy warnings


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.
Preparation for future CI changes.

I have tested and confirmed this, but would like to know if it is being used.

```
common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp:98:0: style: The function 'update_visualization' is never used. [unusedFunction]
void PoseHistoryFootprint::update_visualization()
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Confirm that the planning simulation works.
- Confirm that print debugging is not used.
- Confirm that the build passes.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
