### PR TITLE
refactor(lane_change): add new structs (TransientData) to store commonly used values

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -281,7 +281,7 @@ double AvoidanceByLaneChange::calcMinimumLaneChangeLength() const
     return std::numeric_limits<double>::infinity();
   }
 
-  return utils::lane_change::calculation::calc_minimum_lane_change_length(
+  return utils::lane_change::calculation::calc_minimum_lane_change_buffer(
     common_data_ptr_, current_lanes);
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -282,7 +282,7 @@ double AvoidanceByLaneChange::calcMinimumLaneChangeLength() const
   }
 
   return utils::lane_change::calculation::calc_minimum_lane_change_length(
-    getRouteHandler(), current_lanes.back(), *lane_change_parameters_, direction_);
+    common_data_ptr_, current_lanes);
 }
 
 double AvoidanceByLaneChange::calcLateralOffset() const

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -82,7 +82,7 @@ bool AvoidanceByLaneChange::specialRequiredCheck() const
 
   const auto & nearest_object = data.target_objects.front();
   const auto minimum_avoid_length = calcMinAvoidanceLength(nearest_object);
-  const auto minimum_lane_change_length = calcMinimumLaneChangeLength();
+  const auto minimum_lane_change_length = calc_minimum_dist_buffer();
 
   lane_change_debug_.execution_area = createExecutionArea(
     getCommonParam().vehicle_info, getEgoPose(),
@@ -273,12 +273,12 @@ double AvoidanceByLaneChange::calcMinAvoidanceLength(const ObjectData & nearest_
   return avoidance_helper_->getMinAvoidanceDistance(shift_length);
 }
 
-double AvoidanceByLaneChange::calcMinimumLaneChangeLength() const
+double AvoidanceByLaneChange::calc_minimum_dist_buffer() const
 {
-  const auto min_lc_length_and_dist_buffer =
-    utils::lane_change::calculation::calc_min_lc_length_and_dist_buffer(
+  const auto lc_length_and_dist_buffer =
+    utils::lane_change::calculation::calc_lc_length_and_dist_buffer(
       common_data_ptr_, get_current_lanes());
-  return std::get<1>(min_lc_length_and_dist_buffer);
+  return std::get<1>(lc_length_and_dist_buffer).min;
 }
 
 double AvoidanceByLaneChange::calcLateralOffset() const

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -275,14 +275,10 @@ double AvoidanceByLaneChange::calcMinAvoidanceLength(const ObjectData & nearest_
 
 double AvoidanceByLaneChange::calcMinimumLaneChangeLength() const
 {
-  const auto current_lanes = get_current_lanes();
-  if (current_lanes.empty()) {
-    RCLCPP_DEBUG(logger_, "no empty lanes");
-    return std::numeric_limits<double>::infinity();
-  }
-
-  return utils::lane_change::calculation::calc_minimum_lane_change_buffer(
-    common_data_ptr_, current_lanes);
+  const auto min_lc_length_and_dist_buffer =
+    utils::lane_change::calculation::calc_min_lc_length_and_dist_buffer(
+      common_data_ptr_, get_current_lanes());
+  return std::get<1>(min_lc_length_and_dist_buffer);
 }
 
 double AvoidanceByLaneChange::calcLateralOffset() const

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.hpp
@@ -63,7 +63,7 @@ private:
   void fillAvoidanceTargetObjects(AvoidancePlanningData & data, AvoidanceDebugData & debug) const;
 
   double calcMinAvoidanceLength(const ObjectData & nearest_object) const;
-  double calcMinimumLaneChangeLength() const;
+  double calc_minimum_dist_buffer() const;
   double calcLateralOffset() const;
 };
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -89,10 +89,6 @@ public:
 
   bool isRequiredStop(const bool is_trailing_object) override;
 
-  bool isNearEndOfCurrentLanes(
-    const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
-    const double threshold) const override;
-
   bool hasFinishedLaneChange() const override;
 
   bool isAbleToReturnCurrentLane() const override;
@@ -127,9 +123,7 @@ protected:
     const lanelet::ConstLanelets & current_lanes,
     const lanelet::ConstLanelets & target_lanes) const;
 
-  std::vector<double> calcPrepareDuration(
-    const lanelet::ConstLanelets & current_lanes,
-    const lanelet::ConstLanelets & target_lanes) const;
+  std::vector<double> calcPrepareDuration() const;
 
   lane_change::TargetObjects getTargetObjects(
     const FilteredByLanesExtendedObjects & predicted_objects,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -54,6 +54,8 @@ public:
 
   void update_lanes(const bool is_approved) final;
 
+  void update_transient_data() final;
+
   void update_filtered_objects() final;
 
   void updateLaneChangeStatus() override;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -151,10 +151,6 @@ protected:
     const double target_lane_length, const double lane_changing_length,
     const double lane_changing_velocity, const double buffer_for_next_lane_change) const;
 
-  bool hasEnoughLength(
-    const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
-    const lanelet::ConstLanelets & target_lanes, const Direction direction = Direction::NONE) const;
-
   bool hasEnoughLengthToCrosswalk(
     const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes) const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -112,10 +112,6 @@ public:
   virtual PathSafetyStatus evaluateApprovedPathWithUnsafeHysteresis(
     PathSafetyStatus approve_path_safety_status) = 0;
 
-  virtual bool isNearEndOfCurrentLanes(
-    const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
-    const double threshold) const = 0;
-
   virtual bool isStoppedAtRedTrafficLight() const = 0;
 
   virtual bool calcAbortPath() = 0;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -283,7 +283,6 @@ protected:
   std::shared_ptr<LaneChangePath> abort_path_{};
   std::shared_ptr<const PlannerData> planner_data_{};
   lane_change::CommonDataPtr common_data_ptr_{};
-  lane_change::TransientData transient_data_{};
   FilteredByLanesExtendedObjects filtered_objects_{};
   BehaviorModuleOutput prev_module_output_{};
   std::optional<Pose> lane_change_stop_pose_{std::nullopt};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -67,6 +67,8 @@ public:
 
   virtual void update_lanes(const bool is_approved) = 0;
 
+  virtual void update_transient_data() = 0;
+
   virtual void update_filtered_objects() = 0;
 
   virtual void updateLaneChangeStatus() = 0;
@@ -281,6 +283,7 @@ protected:
   std::shared_ptr<LaneChangePath> abort_path_{};
   std::shared_ptr<const PlannerData> planner_data_{};
   lane_change::CommonDataPtr common_data_ptr_{};
+  lane_change::TransientData transient_data_{};
   FilteredByLanesExtendedObjects filtered_objects_{};
   BehaviorModuleOutput prev_module_output_{};
   std::optional<Pose> lane_change_stop_pose_{std::nullopt};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -124,9 +124,9 @@ double calc_minimum_lane_change_buffer(
 double calc_minimum_lane_change_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 
-double calc_maximum_lane_change_length(
-  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
-  const std::vector<double> & shift_intervals, const double max_acc);
+// double calc_maximum_lane_change_length(
+//   const double current_velocity, const LaneChangeParameters & lane_change_parameters,
+//   const std::vector<double> & shift_intervals, const double max_acc);
 
 double calc_maximum_lane_change_length(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -25,23 +25,6 @@ using autoware::route_handler::RouteHandler;
 using behavior_path_planner::lane_change::CommonDataPtr;
 using behavior_path_planner::lane_change::LCParamPtr;
 
-/**
- * @brief Calculates the distance from the ego vehicle to the terminal point.
- *
- * This function computes the distance from the current position of the ego vehicle
- * to either the goal pose or the end of the current lane, depending on whether
- * the vehicle's current lane is within the goal section.
- *
- * @param common_data_ptr Shared pointer to a CommonData structure, which should include:
- *  - Non null `lanes_ptr` that points to the current lanes data.
- *  - Non null `self_odometry_ptr` that contains the current pose of the ego vehicle.
- *  - Non null `route_handler_ptr` that contains the goal pose of the route.
- *
- * @return The distance to the terminal point (either the goal pose or the end of the current lane)
- * in meters.
- */
-double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr);
-
 double calc_dist_from_pose_to_terminal_end(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
   const Pose & src_pose);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -118,10 +118,10 @@ double calc_ego_dist_to_lanes_start(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
-double calc_minimum_lane_change_length(
-  const LaneChangeParameters & lane_change_parameters, const std::vector<double> & shift_intervals);
+double calc_minimum_lane_change_buffer(
+  const LCParamPtr & lc_param_ptr, const std::vector<double> & shift_intervals);
 
-double calc_minimum_lane_change_length(
+double calc_minimum_lane_change_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 
 double calc_maximum_lane_change_length(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -129,7 +129,7 @@ double calc_minimum_lane_change_buffer(
 //   const std::vector<double> & shift_intervals, const double max_acc);
 
 double calc_maximum_lane_change_length(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
   const double max_acc);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -22,6 +22,7 @@ namespace autoware::behavior_path_planner::utils::lane_change::calculation
 {
 using autoware::route_handler::Direction;
 using autoware::route_handler::RouteHandler;
+using behavior_path_planner::lane_change::Boundary;
 using behavior_path_planner::lane_change::CommonDataPtr;
 using behavior_path_planner::lane_change::LCParamPtr;
 
@@ -101,10 +102,7 @@ double calc_ego_dist_to_lanes_start(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
-std::pair<double, double> calc_min_lc_length_and_dist_buffer(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
-
-std::pair<double, double> calc_max_lc_length_and_dist_buffer(
+std::pair<Boundary, Boundary> calc_lc_length_and_dist_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -101,19 +101,11 @@ double calc_ego_dist_to_lanes_start(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
-double calc_minimum_lane_change_buffer(
-  const LCParamPtr & lc_param_ptr, const std::vector<double> & shift_intervals);
-
-double calc_minimum_lane_change_buffer(
+std::pair<double, double> calc_min_lc_length_and_dist_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 
-// double calc_maximum_lane_change_length(
-//   const double current_velocity, const LaneChangeParameters & lane_change_parameters,
-//   const std::vector<double> & shift_intervals, const double max_acc);
-
-double calc_maximum_lane_change_length(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
-  const double max_acc);
+std::pair<double, double> calc_max_lc_length_and_dist_buffer(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -122,8 +122,7 @@ double calc_minimum_lane_change_length(
   const LaneChangeParameters & lane_change_parameters, const std::vector<double> & shift_intervals);
 
 double calc_minimum_lane_change_length(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lane,
-  const LaneChangeParameters & lane_change_parameters, Direction direction);
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 
 double calc_maximum_lane_change_length(
   const double current_velocity, const LaneChangeParameters & lane_change_parameters,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -275,6 +275,21 @@ struct LanesPolygon
   std::vector<lanelet::BasicPolygon2d> preceding_target;
 };
 
+struct Boundary
+{
+  double min{std::numeric_limits<double>::max()};
+  double max{std::numeric_limits<double>::max()};
+};
+
+struct TransientData
+{
+  Boundary acc;
+  Boundary lane_changing_length;
+  Boundary current_dist_buffer;
+  Boundary next_lc_buffer;
+  double dist_from_ego_to_current_terminal_end{std::numeric_limits<double>::min()};
+};
+
 using RouteHandlerPtr = std::shared_ptr<RouteHandler>;
 using BppParamPtr = std::shared_ptr<BehaviorPathPlannerParameters>;
 using LCParamPtr = std::shared_ptr<Parameters>;
@@ -289,6 +304,7 @@ struct CommonData
   LCParamPtr lc_param_ptr;
   LanesPtr lanes_ptr;
   LanesPolygonPtr lanes_polygon_ptr;
+  TransientData transient_data;
   PathWithLaneId current_lanes_path;
   ModuleType lc_type;
   Direction direction;
@@ -310,31 +326,17 @@ struct CommonData
 
   [[nodiscard]] bool is_data_available() const
   {
-    return route_handler_ptr || self_odometry_ptr || bpp_param_ptr || lc_param_ptr || lanes_ptr ||
+    return route_handler_ptr && self_odometry_ptr && bpp_param_ptr && lc_param_ptr && lanes_ptr &&
            lanes_polygon_ptr;
   }
 
   [[nodiscard]] bool is_lanes_available() const
   {
-    return lanes_ptr || !lanes_ptr->current.empty() || !lanes_ptr->target.empty() ||
+    return lanes_ptr && !lanes_ptr->current.empty() && !lanes_ptr->target.empty() &&
            !lanes_ptr->target_neighbor.empty();
   }
 };
 using CommonDataPtr = std::shared_ptr<CommonData>;
-
-struct TransientData
-{
-  struct Boundary
-  {
-    double min{std::numeric_limits<double>::max()};
-    double max{std::numeric_limits<double>::max()};
-  };
-
-  Boundary acc;
-  Boundary current_lc_buffer;
-  Boundary next_lc_buffer;
-  double dist_from_ego_to_current_terminal_end{std::numeric_limits<double>::min()};
-};
 }  // namespace autoware::behavior_path_planner::lane_change
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -305,6 +305,18 @@ struct CommonData
     const auto y = get_ego_twist().linear.y;
     return std::hypot(x, y);
   }
+
+  [[nodiscard]] bool is_data_available() const
+  {
+    return route_handler_ptr || self_odometry_ptr || bpp_param_ptr || lc_param_ptr || lanes_ptr ||
+           lanes_polygon_ptr;
+  }
+
+  [[nodiscard]] bool is_lanes_available() const
+  {
+    return lanes_ptr || !lanes_ptr->current.empty() || !lanes_ptr->target.empty() ||
+           !lanes_ptr->target_neighbor.empty();
+  }
 };
 using CommonDataPtr = std::shared_ptr<CommonData>;
 }  // namespace autoware::behavior_path_planner::lane_change

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -27,10 +27,10 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/Polygon.h>
 
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <limits>
 
 namespace autoware::behavior_path_planner::lane_change
 {
@@ -289,6 +289,7 @@ struct CommonData
   LCParamPtr lc_param_ptr;
   LanesPtr lanes_ptr;
   LanesPolygonPtr lanes_polygon_ptr;
+  PathWithLaneId current_lanes_path;
   ModuleType lc_type;
   Direction direction;
 
@@ -332,6 +333,7 @@ struct TransientData
   Boundary acc;
   Boundary current_lc_buffer;
   Boundary next_lc_buffer;
+  double dist_from_ego_to_current_terminal_end{std::numeric_limits<double>::min()};
 };
 }  // namespace autoware::behavior_path_planner::lane_change
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -278,7 +278,7 @@ struct LanesPolygon
 
 struct Boundary
 {
-  double min{std::numeric_limits<double>::max()};
+  double min{0.0};
   double max{std::numeric_limits<double>::max()};
 };
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <limits>
 
 namespace autoware::behavior_path_planner::lane_change
 {
@@ -319,6 +320,19 @@ struct CommonData
   }
 };
 using CommonDataPtr = std::shared_ptr<CommonData>;
+
+struct TransientData
+{
+  struct Boundary
+  {
+    double min{std::numeric_limits<double>::max()};
+    double max{std::numeric_limits<double>::max()};
+  };
+
+  Boundary acc;
+  Boundary current_lc_buffer;
+  Boundary next_lc_buffer;
+};
 }  // namespace autoware::behavior_path_planner::lane_change
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -279,7 +279,7 @@ struct LanesPolygon
 struct Boundary
 {
   double min{0.0};
-  double max{std::numeric_limits<double>::max()};
+  double max{0.0};
 };
 
 struct TransientData

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -290,6 +290,7 @@ struct TransientData
   Boundary next_lc_buffer;
   double dist_from_ego_to_current_terminal_end{std::numeric_limits<double>::min()};
   double dist_from_ego_to_current_terminal_start{std::numeric_limits<double>::min()};
+  double maximum_prepare_length{std::numeric_limits<double>::max()};
 
   bool is_ego_near_current_terminal_start{false};
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -197,6 +197,7 @@ struct PhaseInfo
 struct Lanes
 {
   bool current_lane_in_goal_section{false};
+  bool target_lane_in_goal_section{false};
   lanelet::ConstLanelets current;
   lanelet::ConstLanelets target_neighbor;
   lanelet::ConstLanelets target;
@@ -288,6 +289,9 @@ struct TransientData
   Boundary current_dist_buffer;
   Boundary next_lc_buffer;
   double dist_from_ego_to_current_terminal_end{std::numeric_limits<double>::min()};
+  double dist_from_ego_to_current_terminal_start{std::numeric_limits<double>::min()};
+
+  bool is_ego_near_current_terminal_start{false};
 };
 
 using RouteHandlerPtr = std::shared_ptr<RouteHandler>;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -132,8 +132,7 @@ std::vector<DrivableLanes> generateDrivableLanes(
 double getLateralShift(const LaneChangePath & path);
 
 bool hasEnoughLengthToLaneChangeAfterAbort(
-  const CommonDataPtr & common_data_ptr, const TransientData & transient_data,
-  const double abort_return_dist);
+  const TransientData & transient_data, const double abort_return_dist);
 
 CandidateOutput assignToCandidate(
   const LaneChangePath & lane_change_path, const Point & ego_position);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -52,6 +52,7 @@ using autoware_perception_msgs::msg::PredictedPath;
 using behavior_path_planner::lane_change::CommonDataPtr;
 using behavior_path_planner::lane_change::LanesPolygon;
 using behavior_path_planner::lane_change::PathSafetyStatus;
+using behavior_path_planner::lane_change::TransientData;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
@@ -131,7 +132,7 @@ std::vector<DrivableLanes> generateDrivableLanes(
 double getLateralShift(const LaneChangePath & path);
 
 bool hasEnoughLengthToLaneChangeAfterAbort(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
+  const CommonDataPtr & common_data_ptr, const TransientData & transient_data,
   const double abort_return_dist);
 
 CandidateOutput assignToCandidate(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -131,9 +131,8 @@ std::vector<DrivableLanes> generateDrivableLanes(
 double getLateralShift(const LaneChangePath & path);
 
 bool hasEnoughLengthToLaneChangeAfterAbort(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelets & current_lanes,
-  const Pose & curent_pose, const double abort_return_dist,
-  const LaneChangeParameters & lane_change_parameters, const Direction direction);
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
+  const double abort_return_dist);
 
 CandidateOutput assignToCandidate(
   const LaneChangePath & lane_change_path, const Point & ego_position);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -131,9 +131,6 @@ std::vector<DrivableLanes> generateDrivableLanes(
 
 double getLateralShift(const LaneChangePath & path);
 
-bool hasEnoughLengthToLaneChangeAfterAbort(
-  const TransientData & transient_data, const double abort_return_dist);
-
 CandidateOutput assignToCandidate(
   const LaneChangePath & lane_change_path, const Point & ego_position);
 std::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -76,6 +76,7 @@ void LaneChangeInterface::updateData()
   universe_utils::ScopedTimeTrack st(__func__, *getTimeKeeper());
   module_type_->setPreviousModuleOutput(getPreviousModuleOutput());
   module_type_->update_lanes(getCurrentStatus() == ModuleStatus::RUNNING);
+  module_type_->update_transient_data();
   module_type_->update_filtered_objects();
   module_type_->updateSpecialData();
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1364,7 +1364,8 @@ bool NormalLaneChange::hasEnoughLengthToTrafficLight(
 
 bool NormalLaneChange::getLaneChangePaths(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
-  Direction direction, const bool is_stuck, LaneChangePaths * candidate_paths) const
+  [[maybe_unused]] Direction direction, const bool is_stuck,
+  LaneChangePaths * candidate_paths) const
 {
   lane_change_debug_.collision_check_objects.clear();
   if (current_lanes.empty() || target_lanes.empty()) {
@@ -1557,14 +1558,7 @@ bool NormalLaneChange::getLaneChangePaths(
 
         // if multiple lane change is necessary, does the remaining distance is sufficient
         const auto remaining_dist_in_target = std::invoke([&]() {
-          const auto finish_judge_buffer = lane_change_parameters_->lane_change_finish_judge_buffer;
-          const auto num_to_preferred_lane_from_target_lane =
-            std::abs(route_handler.getNumLaneToPreferredLane(target_lanes.back(), direction));
-          const auto backward_len_buffer =
-            lane_change_parameters_->backward_length_buffer_for_end_of_lane;
-          const auto backward_buffer_to_target_lane =
-            num_to_preferred_lane_from_target_lane == 0 ? 0.0 : backward_len_buffer;
-          return lane_changing_length + finish_judge_buffer + backward_buffer_to_target_lane +
+          return prepare_length + lane_changing_length +
                  common_data_ptr_->transient_data.next_lc_buffer.min;
         });
 
@@ -1577,7 +1571,7 @@ bool NormalLaneChange::getLaneChangePaths(
           initial_lane_changing_velocity + longitudinal_acc_on_lane_changing * lane_changing_time,
           getCommonParam().max_vel);
         utils::lane_change::setPrepareVelocity(
-          prepare_segment, current_velocity, terminal_lane_changing_velocity);
+          prepare_segment, current_velocity, initial_lane_changing_velocity);
 
         const auto target_segment = getTargetSegment(
           target_lanes, lane_changing_start_pose, target_lane_length, lane_changing_length,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -189,10 +189,10 @@ bool NormalLaneChange::is_near_regulatory_element() const
   if (current_lanes.empty()) return false;
 
   const auto max_prepare_length = calculation::calc_maximum_prepare_length(common_data_ptr_);
-  const auto current_lc_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, current_lanes);
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
   const auto dist_to_terminal_start =
-    calculation::calc_ego_dist_to_terminal_end(common_data_ptr_) - current_lc_buffer;
+    calculation::calc_ego_dist_to_terminal_end(common_data_ptr_) - current_min_lc_buffer;
 
   if (dist_to_terminal_start <= max_prepare_length) return false;
 
@@ -245,12 +245,10 @@ TurnSignalInfo NormalLaneChange::get_terminal_turn_signal_info() const
 
   const auto original_turn_signal_info = prev_module_output_.turn_signal_info;
 
-  const auto shift_intervals =
-    getRouteHandler()->getLateralIntervalsToPreferredLane(get_current_lanes().back());
-  const double current_lc_buffer =
-    calculation::calc_minimum_lane_change_length(lane_change_param, shift_intervals);
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, get_current_lanes());
 
-  const double buffer = current_lc_buffer +
+  const double buffer = current_min_lc_buffer +
                         lane_change_param.min_length_for_turn_signal_activation +
                         common_param.base_link2front;
   const double path_length = autoware::motion_utils::calcArcLength(path.points);
@@ -402,7 +400,7 @@ void NormalLaneChange::insertStopPoint(
   }
 
   const auto lane_change_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, lanelets);
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, lanelets);
 
   const auto getDistanceAlongLanelet = [&](const geometry_msgs::msg::Pose & target) {
     return utils::getSignedDistance(path.points.front().point.pose, target, lanelets);
@@ -697,8 +695,8 @@ bool NormalLaneChange::isNearEndOfCurrentLanes(
 
   const auto & route_handler = getRouteHandler();
   const auto & current_pose = getEgoPose();
-  const auto current_lc_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, current_lanes);
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
 
   const auto distance_to_lane_change_end = std::invoke([&]() {
     auto distance_to_end = utils::getDistanceToEndOfLane(current_pose, current_lanes);
@@ -709,7 +707,7 @@ bool NormalLaneChange::isNearEndOfCurrentLanes(
         utils::getSignedDistance(current_pose, route_handler->getGoalPose(), current_lanes));
     }
 
-    return std::max(0.0, distance_to_end) - current_lc_buffer;
+    return std::max(0.0, distance_to_end) - current_min_lc_buffer;
   });
 
   lane_change_debug_.distance_to_end_of_current_lane = distance_to_lane_change_end;
@@ -811,13 +809,13 @@ bool NormalLaneChange::is_near_terminal() const
   }
 
   const auto & lc_param_ptr = common_data_ptr_->lc_param_ptr;
-  const auto current_lc_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, current_lanes);
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
 
   const auto backward_buffer = calculation::calc_stopping_distance(lc_param_ptr);
 
   const auto min_lc_dist_with_buffer =
-    backward_buffer + current_lc_buffer + lc_param_ptr->lane_change_finish_judge_buffer;
+    backward_buffer + current_min_lc_buffer + lc_param_ptr->lane_change_finish_judge_buffer;
   const auto dist_from_ego_to_terminal_end =
     calculation::calc_ego_dist_to_terminal_end(common_data_ptr_);
 
@@ -1312,8 +1310,8 @@ bool NormalLaneChange::hasEnoughLength(
   const auto current_pose = getEgoPose();
   const auto & route_handler = getRouteHandler();
   const auto overall_graphs_ptr = route_handler->getOverallGraphPtr();
-  const auto next_lc_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, target_lanes);
+  const auto next_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, target_lanes);
 
   const double lane_change_length = path.info.length.sum();
   if (lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
@@ -1323,14 +1321,14 @@ bool NormalLaneChange::hasEnoughLength(
   const auto goal_pose = route_handler->getGoalPose();
   if (
     route_handler->isInGoalRouteSection(current_lanes.back()) &&
-    lane_change_length + next_lc_buffer >
+    lane_change_length + next_min_lc_buffer >
       utils::getSignedDistance(current_pose, goal_pose, current_lanes)) {
     return false;
   }
 
   // return if there are no target lanes
   if (
-    lane_change_length + next_lc_buffer >
+    lane_change_length + next_min_lc_buffer >
     utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
     return false;
   }
@@ -1417,12 +1415,10 @@ bool NormalLaneChange::getLaneChangePaths(
 
   const auto is_goal_in_route = route_handler.isInGoalRouteSection(target_lanes.back());
 
-  const double current_lc_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()));
-  const double next_lc_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(target_lanes.back()));
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
+  const auto next_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, target_lanes);
 
   const auto dist_to_end_of_current_lanes =
     calculation::calc_ego_dist_to_terminal_end(common_data_ptr_);
@@ -1470,7 +1466,7 @@ bool NormalLaneChange::getLaneChangePaths(
       const auto prepare_length = utils::lane_change::calcPhaseLength(
         current_velocity, getCommonParam().max_vel, longitudinal_acc_on_prepare, prepare_duration);
 
-      const auto ego_dist_to_terminal_start = dist_to_end_of_current_lanes - current_lc_buffer;
+      const auto ego_dist_to_terminal_start = dist_to_end_of_current_lanes - current_min_lc_buffer;
       if (prepare_length > ego_dist_to_terminal_start) {
         RCLCPP_DEBUG(
           logger_,
@@ -1597,7 +1593,7 @@ bool NormalLaneChange::getLaneChangePaths(
           const auto backward_buffer_to_target_lane =
             num_to_preferred_lane_from_target_lane == 0 ? 0.0 : backward_len_buffer;
           return lane_changing_length + finish_judge_buffer + backward_buffer_to_target_lane +
-                 next_lc_buffer;
+                 next_min_lc_buffer;
         });
 
         if (remaining_dist_in_target > dist_lc_start_to_end_of_lanes) {
@@ -1613,7 +1609,7 @@ bool NormalLaneChange::getLaneChangePaths(
 
         const auto target_segment = getTargetSegment(
           target_lanes, lane_changing_start_pose, target_lane_length, lane_changing_length,
-          initial_lane_changing_velocity, next_lc_buffer);
+          initial_lane_changing_velocity, next_min_lc_buffer);
 
         if (target_segment.points.empty()) {
           debug_print_lat("Reject: target segment is empty!! something wrong...");
@@ -1637,7 +1633,7 @@ bool NormalLaneChange::getLaneChangePaths(
         const auto target_lane_reference_path = utils::lane_change::getReferencePathFromTargetLane(
           route_handler, target_lanes, lane_changing_start_pose, target_lane_length,
           lane_changing_length, forward_path_length, resample_interval, is_goal_in_route,
-          next_lc_buffer);
+          next_min_lc_buffer);
 
         if (target_lane_reference_path.points.empty()) {
           debug_print_lat("Reject: target_lane_reference_path is empty!!");
@@ -1666,7 +1662,7 @@ bool NormalLaneChange::getLaneChangePaths(
         if (
           !is_stuck && !utils::lane_change::passed_parked_objects(
                          common_data_ptr_, *candidate_path, filtered_objects_.target_lane_leading,
-                         current_lc_buffer, lane_change_debug_.collision_check_objects)) {
+                         current_min_lc_buffer, lane_change_debug_.collision_check_objects)) {
           debug_print_lat(
             "Reject: parking vehicle exists in the target lane, and the ego is not in stuck. Skip "
             "lane change.");
@@ -1728,12 +1724,10 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
 
   const auto is_goal_in_route = route_handler.isInGoalRouteSection(target_lanes.back());
 
-  const double current_lc_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()));
-  const double next_lc_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(target_lanes.back()));
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
+  const auto next_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, target_lanes);
 
   const auto target_lane_length = lanelet::utils::getLaneletLength2d(target_lanes);
 
@@ -1759,7 +1753,7 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
 
   const auto lane_changing_start_pose = autoware::motion_utils::calcLongitudinalOffsetPose(
     prev_module_output_.path.points, current_lane_terminal_point,
-    -(current_lc_buffer + next_lc_buffer + distance_to_terminal_from_goal));
+    -(current_min_lc_buffer + next_min_lc_buffer + distance_to_terminal_from_goal));
 
   if (!lane_changing_start_pose) {
     RCLCPP_DEBUG(logger_, "Reject: lane changing start pose not found!!!");
@@ -1785,8 +1779,8 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
     shift_length, lane_change_parameters_->lane_changing_lateral_jerk, max_lateral_acc);
 
   const auto target_segment = getTargetSegment(
-    target_lanes, lane_changing_start_pose.value(), target_lane_length, current_lc_buffer,
-    minimum_lane_changing_velocity, next_lc_buffer);
+    target_lanes, lane_changing_start_pose.value(), target_lane_length, current_min_lc_buffer,
+    minimum_lane_changing_velocity, next_min_lc_buffer);
 
   if (target_segment.points.empty()) {
     RCLCPP_DEBUG(logger_, "Reject: target segment is empty!! something wrong...");
@@ -1807,7 +1801,7 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
   lane_change_info.duration = LaneChangePhaseInfo{0.0, lane_changing_time};
   lane_change_info.velocity =
     LaneChangePhaseInfo{minimum_lane_changing_velocity, minimum_lane_changing_velocity};
-  lane_change_info.length = LaneChangePhaseInfo{0.0, current_lc_buffer};
+  lane_change_info.length = LaneChangePhaseInfo{0.0, current_min_lc_buffer};
   lane_change_info.lane_changing_start = lane_changing_start_pose.value();
   lane_change_info.lane_changing_end = target_segment.points.front().point.pose;
   lane_change_info.lateral_acceleration = max_lateral_acc;
@@ -1822,10 +1816,11 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
   }
 
   const auto resample_interval = utils::lane_change::calcLaneChangeResampleInterval(
-    current_lc_buffer, minimum_lane_changing_velocity);
+    current_min_lc_buffer, minimum_lane_changing_velocity);
   const auto target_lane_reference_path = utils::lane_change::getReferencePathFromTargetLane(
     route_handler, target_lanes, lane_changing_start_pose.value(), target_lane_length,
-    current_lc_buffer, forward_path_length, resample_interval, is_goal_in_route, next_lc_buffer);
+    current_min_lc_buffer, forward_path_length, resample_interval, is_goal_in_route,
+    next_min_lc_buffer);
 
   if (target_lane_reference_path.points.empty()) {
     RCLCPP_DEBUG(logger_, "Reject: target_lane_reference_path is empty!!");
@@ -1866,12 +1861,12 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 
   CollisionCheckDebugMap debug_data;
 
-  const auto current_lc_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    common_data_ptr_->route_handler_ptr->getLateralIntervalsToPreferredLane(current_lanes.back()));
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
 
   const auto has_passed_parked_objects = utils::lane_change::passed_parked_objects(
-    common_data_ptr_, path, filtered_objects_.target_lane_leading, current_lc_buffer, debug_data);
+    common_data_ptr_, path, filtered_objects_.target_lane_leading, current_min_lc_buffer,
+    debug_data);
 
   if (!has_passed_parked_objects) {
     RCLCPP_DEBUG(logger_, "Lane change has been delayed.");
@@ -1987,15 +1982,15 @@ bool NormalLaneChange::calcAbortPath()
   const auto ego_nearest_dist_threshold = common_param.ego_nearest_dist_threshold;
   const auto ego_nearest_yaw_threshold = common_param.ego_nearest_yaw_threshold;
 
-  const auto current_lc_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, get_current_lanes());
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, get_current_lanes());
 
   const auto & lane_changing_path = selected_path.path;
   const auto & reference_lanelets = get_current_lanes();
   const auto lane_changing_end_pose_idx = std::invoke([&]() {
     constexpr double s_start = 0.0;
     const double s_end =
-      std::max(lanelet::utils::getLaneletLength2d(reference_lanelets) - current_lc_buffer, 0.0);
+      std::max(lanelet::utils::getLaneletLength2d(reference_lanelets) - current_min_lc_buffer, 0.0);
 
     const auto ref = route_handler->getCenterLinePath(reference_lanelets, s_start, s_end);
     return autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
@@ -2306,10 +2301,10 @@ bool NormalLaneChange::isVehicleStuck(
     route_handler->isInGoalRouteSection(current_lanes.back())
       ? utils::getSignedDistance(getEgoPose(), route_handler->getGoalPose(), current_lanes)
       : utils::getDistanceToEndOfLane(getEgoPose(), current_lanes);
-  const auto current_lc_buffer =
-    calculation::calc_minimum_lane_change_length(common_data_ptr_, current_lanes);
+  const auto current_min_lc_buffer =
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr_, current_lanes);
   const double stop_point_buffer = lane_change_parameters_->backward_length_buffer_for_end_of_lane;
-  const double terminal_judge_buffer = current_lc_buffer + stop_point_buffer + 1.0;
+  const double terminal_judge_buffer = current_min_lc_buffer + stop_point_buffer + 1.0;
   if (distance_to_terminal < terminal_judge_buffer) {
     return true;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -943,7 +943,7 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
 
   // calculate maximum lane change length
   const double max_lane_change_length =
-    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes.back(), max_acc);
+    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes, max_acc);
 
   if (max_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     RCLCPP_DEBUG(
@@ -2339,7 +2339,7 @@ bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lan
 
   const auto [min_acc, max_acc] = calcCurrentMinMaxAcceleration();
   const auto max_lane_change_length =
-    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes.back(), max_acc);
+    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes, max_acc);
   const auto rss_dist = calcRssDistance(
     0.0, lane_change_parameters_->minimum_lane_changing_velocity,
     lane_change_parameters_->rss_params);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1544,7 +1544,7 @@ bool NormalLaneChange::getLaneChangePaths(
         }
 
         if (
-          lane_changing_length + prepare_length + transient_data_.next_lc_buffer.min>
+          lane_changing_length + prepare_length + transient_data_.next_lc_buffer.min >
           transient_data_.dist_from_ego_to_current_terminal_end) {
           debug_print_lat("Reject: length of lane changing path is longer than length to goal!!");
           continue;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1973,7 +1973,8 @@ bool NormalLaneChange::calcAbortPath()
   }
 
   if (
-    abort_return_dist + common_data_ptr_->transient_data.current_dist_buffer.min >
+    abort_return_dist + calculation::calc_stopping_distance(common_data_ptr_->lc_param_ptr) +
+      common_data_ptr_->transient_data.current_dist_buffer.min >
     common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end) {
     RCLCPP_ERROR(logger_, "insufficient distance to abort.");
     return false;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -138,9 +138,9 @@ void NormalLaneChange::update_transient_data()
     calculation::calc_maximum_prepare_length(common_data_ptr_);
 
   common_data_ptr_->transient_data.is_ego_near_current_terminal_start = std::invoke([&]() -> bool {
-    return common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start < common_data_ptr_->transient_data.maximum_prepare_length;
+    return common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start <
+           common_data_ptr_->transient_data.maximum_prepare_length;
   });
-
 }
 
 void NormalLaneChange::update_filtered_objects()
@@ -198,7 +198,9 @@ bool NormalLaneChange::isLaneChangeRequired()
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  if(!common_data_ptr_ || !common_data_ptr_->is_data_available() || !common_data_ptr_->is_lanes_available()){
+  if (
+    !common_data_ptr_ || !common_data_ptr_->is_data_available() ||
+    !common_data_ptr_->is_lanes_available()) {
     return false;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -230,9 +230,7 @@ bool NormalLaneChange::is_near_regulatory_element() const
 
   const auto max_prepare_length = common_data_ptr_->transient_data.maximum_prepare_length;
   const auto dist_to_terminal_start =
-    calculation::calc_dist_from_pose_to_terminal_end(
-      common_data_ptr_, current_lanes, common_data_ptr_->get_ego_pose()) -
-    common_data_ptr_->transient_data.current_dist_buffer.min;
+    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start;
 
   if (dist_to_terminal_start <= max_prepare_length) return false;
 
@@ -1424,8 +1422,8 @@ bool NormalLaneChange::getLaneChangePaths(
         current_velocity, getCommonParam().max_vel, longitudinal_acc_on_prepare, prepare_duration);
 
       const auto ego_dist_to_terminal_start =
-        common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end -
-        common_data_ptr_->transient_data.current_dist_buffer.min;
+        common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start;
+
       if (prepare_length > ego_dist_to_terminal_start) {
         RCLCPP_DEBUG(
           logger_,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -131,7 +131,7 @@ void NormalLaneChange::update_transient_data()
     calculation::calc_dist_from_pose_to_terminal_end(
       common_data_ptr_, common_data_ptr_->lanes_ptr->current, common_data_ptr_->get_ego_pose());
   common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start =
-    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start -
+    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end -
     common_data_ptr_->transient_data.current_dist_buffer.min;
 
   common_data_ptr_->transient_data.maximum_prepare_length =
@@ -1972,8 +1972,9 @@ bool NormalLaneChange::calcAbortPath()
     return false;
   }
 
-  if (!utils::lane_change::hasEnoughLengthToLaneChangeAfterAbort(
-        common_data_ptr_->transient_data, abort_return_dist)) {
+  if (
+    abort_return_dist + common_data_ptr_->transient_data.current_dist_buffer.min >
+    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end) {
     RCLCPP_ERROR(logger_, "insufficient distance to abort.");
     return false;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1973,7 +1973,7 @@ bool NormalLaneChange::calcAbortPath()
   }
 
   if (!utils::lane_change::hasEnoughLengthToLaneChangeAfterAbort(
-        common_data_ptr_, common_data_ptr_->transient_data, abort_return_dist)) {
+        common_data_ptr_->transient_data, abort_return_dist)) {
     RCLCPP_ERROR(logger_, "insufficient distance to abort.");
     return false;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -230,7 +230,7 @@ std::vector<double> calc_shift_intervals(
   return route_handler_ptr->getLateralIntervalsToPreferredLane(lanes.back(), direction);
 }
 
-std::pair<double, double> calc_min_lc_length_and_dist_buffer(
+std::pair<Boundary, Boundary> calc_lc_length_and_dist_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes)
 {
   if (!common_data_ptr || !common_data_ptr->is_data_available() || lanes.empty()) {
@@ -243,22 +243,22 @@ std::pair<double, double> calc_min_lc_length_and_dist_buffer(
     !all_min_lc_lengths.empty() ? all_min_lc_lengths.front() : std::numeric_limits<double>::max();
   const auto min_dist_buffer =
     calculation::calc_distance_buffer(common_data_ptr->lc_param_ptr, all_min_lc_lengths);
-  return {min_lc_length, min_dist_buffer};
-}
 
-std::pair<double, double> calc_max_lc_length_and_dist_buffer(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes)
-{
-  if (!common_data_ptr || !common_data_ptr->is_data_available() || lanes.empty()) {
-    return {};
-  }
-  const auto shift_intervals = calculation::calc_shift_intervals(common_data_ptr, lanes);
   const auto all_max_lc_lengths =
     calculation::calc_all_max_lc_lengths(common_data_ptr, shift_intervals);
   const auto max_lc_length =
     !all_max_lc_lengths.empty() ? all_max_lc_lengths.front() : std::numeric_limits<double>::max();
   const auto max_dist_buffer =
     calculation::calc_distance_buffer(common_data_ptr->lc_param_ptr, all_max_lc_lengths);
-  return {max_lc_length, max_dist_buffer};
+
+  Boundary lc_length;
+  lc_length.min = min_lc_length;
+  lc_length.max = max_lc_length;
+
+  Boundary dist_buffer;
+  dist_buffer.min = min_dist_buffer;
+  dist_buffer.max = max_dist_buffer;
+
+  return {lc_length, dist_buffer};
 }
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -223,12 +223,16 @@ double calc_maximum_lane_change_length(
 }
 
 double calc_maximum_lane_change_length(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
   const double max_acc)
 {
+  if(!common_data_ptr || !common_data_ptr->is_data_available() || lanes.empty()){
+    return std::numeric_limits<double>::max();
+  }
+
   const auto shift_intervals =
     common_data_ptr->route_handler_ptr->getLateralIntervalsToPreferredLane(
-      current_terminal_lanelet);
+      lanes.back());
   const auto vel = std::max(
     common_data_ptr->get_ego_speed(),
     common_data_ptr->lc_param_ptr->minimum_lane_changing_velocity);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -20,15 +20,6 @@
 
 namespace autoware::behavior_path_planner::utils::lane_change::calculation
 {
-double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr)
-{
-  const auto & lanes_ptr = common_data_ptr->lanes_ptr;
-  const auto & current_lanes = lanes_ptr->current;
-  const auto & current_pose = common_data_ptr->get_ego_pose();
-
-  return calc_dist_from_pose_to_terminal_end(common_data_ptr, current_lanes, current_pose);
-}
-
 double calc_dist_from_pose_to_terminal_end(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
   const Pose & src_pose)
@@ -37,10 +28,10 @@ double calc_dist_from_pose_to_terminal_end(
     return 0.0;
   }
 
-  const auto & lanes_ptr = common_data_ptr->lanes_ptr;
-  const auto & goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
-
-  if (lanes_ptr->current_lane_in_goal_section) {
+  const auto in_goal_route_section =
+    common_data_ptr->route_handler_ptr->isInGoalRouteSection(lanes.back());
+  if (in_goal_route_section) {
+    const auto & goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
     return utils::getSignedDistance(src_pose, goal_pose, lanes);
   }
   return utils::getDistanceToEndOfLane(src_pose, lanes);
@@ -129,8 +120,7 @@ double calc_ego_dist_to_lanes_start(
     return std::numeric_limits<double>::max();
   }
 
-  const auto path =
-    route_handler_ptr->getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto & path = common_data_ptr->current_lanes_path;
 
   if (path.points.empty()) {
     return std::numeric_limits<double>::max();

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -214,7 +214,7 @@ double calc_distance_buffer(
   const auto lengths_sum = std::accumulate(min_lc_lengths.begin(), min_lc_lengths.end(), 0.0);
   const auto num_of_lane_changes = static_cast<double>(min_lc_lengths.size());
   return lengths_sum + (num_of_lane_changes * finish_judge_buffer) +
-         ((num_of_lane_changes - 1) * backward_buffer);
+         ((num_of_lane_changes - 1.0) * backward_buffer);
 }
 
 std::vector<double> calc_shift_intervals(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -169,15 +169,21 @@ double calc_minimum_lane_change_length(
 }
 
 double calc_minimum_lane_change_length(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lane,
-  const LaneChangeParameters & lane_change_parameters, Direction direction)
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes)
 {
-  if (!route_handler) {
+  if (
+    !common_data_ptr || !common_data_ptr->route_handler_ptr ||
+    !common_data_ptr->self_odometry_ptr || lanes.empty()) {
     return std::numeric_limits<double>::max();
   }
 
-  const auto shift_intervals = route_handler->getLateralIntervalsToPreferredLane(lane, direction);
-  return calc_minimum_lane_change_length(lane_change_parameters, shift_intervals);
+  const auto & route_handler_ptr = common_data_ptr->route_handler_ptr;
+  const auto direction = common_data_ptr->direction;
+
+  const auto shift_intervals =
+    route_handler_ptr->getLateralIntervalsToPreferredLane(lanes.back(), direction);
+  const auto lc_param = *common_data_ptr->lc_param_ptr;
+  return calc_minimum_lane_change_length(lc_param, shift_intervals);
 }
 
 double calc_maximum_lane_change_length(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -581,7 +581,7 @@ bool hasEnoughLengthToLaneChangeAfterAbort(
   }
 
   const auto minimum_lane_change_length =
-    calculation::calc_minimum_lane_change_length(common_data_ptr, current_lanes);
+    calculation::calc_minimum_lane_change_buffer(common_data_ptr, current_lanes);
   const auto abort_plus_lane_change_length = abort_return_dist + minimum_lane_change_length;
   const auto current_pose = common_data_ptr->get_ego_pose();
   if (

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -569,14 +569,6 @@ double getLateralShift(const LaneChangePath & path)
   return path.shifted_path.shift_length.at(end_idx) - path.shifted_path.shift_length.at(start_idx);
 }
 
-bool hasEnoughLengthToLaneChangeAfterAbort(
-  const TransientData & transient_data, const double abort_return_dist)
-{
-  const auto abort_plus_lane_change_length =
-    abort_return_dist + transient_data.current_dist_buffer.min;
-  return abort_plus_lane_change_length <= transient_data.dist_from_ego_to_current_terminal_end;
-}
-
 std::vector<std::vector<int64_t>> getSortedLaneIds(
   const RouteHandler & route_handler, const Pose & current_pose,
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes)

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -573,7 +573,7 @@ bool hasEnoughLengthToLaneChangeAfterAbort(
   const TransientData & transient_data, const double abort_return_dist)
 {
   const auto abort_plus_lane_change_length =
-    abort_return_dist + transient_data.current_lc_buffer.min;
+    abort_return_dist + transient_data.current_dist_buffer.min;
   return abort_plus_lane_change_length <= transient_data.dist_from_ego_to_current_terminal_end;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -573,24 +573,28 @@ double getLateralShift(const LaneChangePath & path)
 }
 
 bool hasEnoughLengthToLaneChangeAfterAbort(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelets & current_lanes,
-  const Pose & current_pose, const double abort_return_dist,
-  const LaneChangeParameters & lane_change_parameters, const Direction direction)
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
+  const double abort_return_dist)
 {
   if (current_lanes.empty()) {
     return false;
   }
 
-  const auto minimum_lane_change_length = calculation::calc_minimum_lane_change_length(
-    route_handler, current_lanes.back(), lane_change_parameters, direction);
+  const auto minimum_lane_change_length =
+    calculation::calc_minimum_lane_change_length(common_data_ptr, current_lanes);
   const auto abort_plus_lane_change_length = abort_return_dist + minimum_lane_change_length;
-  if (abort_plus_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
+  const auto current_pose = common_data_ptr->get_ego_pose();
+  if (
+    abort_plus_lane_change_length >
+    utils::getDistanceToEndOfLane(common_data_ptr->get_ego_pose(), current_lanes)) {
     return false;
   }
 
+  const auto goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
+
   if (
     abort_plus_lane_change_length >
-    utils::getSignedDistance(current_pose, route_handler->getGoalPose(), current_lanes)) {
+    utils::getSignedDistance(current_pose, goal_pose, current_lanes)) {
     return false;
   }
 


### PR DESCRIPTION
## Description

This PR adds `TransientData` to standardize commonly used values in the lane change module, such as the current lanes' buffer and the distance to the terminal start and end. The goal is to ensure consistency when calculating limits and lengths.

## Related links

**Parent Issue:**

- None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. Build complete
2. PSIM
3. Scenario Test TBD

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
