### PR TITLE
feat(autoware_mpc_lateral_controller): set steering rate limits and steering limit in predicted trajectory calculation

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp
@@ -37,6 +37,8 @@ protected:
   double m_velocity;   //!< @brief vehicle velocity [m/s]
   double m_curvature;  //!< @brief curvature on the linearized point on path
   double m_wheelbase;  //!< @brief wheelbase of the vehicle [m]
+  Eigen::VectorXd
+    m_steer_rate_limits;  //!< @brief steering rate limit along with the trajectory [rad/s]
 
 public:
   /**
@@ -88,6 +90,12 @@ public:
    * @param [in] curvature curvature on the linearized point on path
    */
   void setCurvature(const double curvature);
+
+  /**
+   * @brief set steering rate limits
+   * @param [in] steer_rate_limits steering rate limit along with the trajectory [rad/s]
+   */
+  void setSteerRateLimits(const Eigen::VectorXd steer_rate_limits);
 
   /**
    * @brief calculate discrete model matrix of x_k+1 = a_d * xk + b_d * uk + w_d, yk = c_d * xk

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -599,6 +599,7 @@ std::pair<bool, VectorXd> MPC::executeOptimization(
 
   // steering angle rate limit
   VectorXd steer_rate_limits = calcSteerRateLimitOnTrajectory(traj, current_velocity);
+  m_vehicle_model_ptr->setSteerRateLimits(steer_rate_limits);
   VectorXd ubA = steer_rate_limits * prediction_dt;
   VectorXd lbA = -steer_rate_limits * prediction_dt;
   ubA(0) = m_raw_steer_cmd_prev + steer_rate_limits(0) * m_ctrl_period;

--- a/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -89,14 +89,15 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
     state(0, 0) = t.x.at(0) - std::sin(t.yaw.at(0)) * lateral_error_0;  // world-x
     state(1, 0) = t.y.at(0) + std::cos(t.yaw.at(0)) * lateral_error_0;  // world-y
     state(2, 0) = t.yaw.at(0) + yaw_error_0;                            // world-yaw
-    state(3, 0) = x0(2);                                                // steering
+    state(3, 0) = std::clamp(x0(2), -m_steer_lim, m_steer_lim);         // steering
     return state;
   }();
 
   // update state in the world coordinate
   const auto updateState = [&](
                              const Eigen::VectorXd & state_w, const Eigen::MatrixXd & input,
-                             const double dt, const double velocity) {
+                             const double dt, const double velocity,
+                             const double steer_rate_limit) {
     const auto yaw = state_w(2);
     const auto steer = state_w(3);
     const auto desired_steer = input(0);
@@ -105,11 +106,17 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
     dstate(0) = velocity * std::cos(yaw);
     dstate(1) = velocity * std::sin(yaw);
     dstate(2) = velocity * std::tan(steer) / m_wheelbase;
-    dstate(3) = -(steer - desired_steer) / m_steer_tau;
 
-    // Note: don't do "return state_w + dstate * dt", which does not work due to the lazy evaluation
-    // in Eigen.
-    const Eigen::VectorXd next_state = state_w + dstate * dt;
+    // Calculate steer_rate considering steer_rate_limit
+    double steer_rate = -(steer - desired_steer) / m_steer_tau;
+    steer_rate = std::clamp(steer_rate, -steer_rate_limit, steer_rate_limit);
+    dstate(3) = steer_rate;
+
+    Eigen::VectorXd next_state = state_w + dstate * dt;
+
+    // Apply steering limit
+    next_state(3) = std::clamp(next_state(3), -m_steer_lim, m_steer_lim);
+
     return next_state;
   };
 
@@ -117,7 +124,8 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
   const auto DIM_U = getDimU();
 
   for (size_t i = 0; i < reference_trajectory.size(); ++i) {
-    state_w = updateState(state_w, Uex.block(i * DIM_U, 0, DIM_U, 1), dt, t.vx.at(i));
+    state_w = updateState(
+      state_w, Uex.block(i * DIM_U, 0, DIM_U, 1), dt, t.vx.at(i), m_steer_rate_limits(i));
     mpc_predicted_trajectory.push_back(
       state_w(0), state_w(1), t.z.at(i), state_w(2), t.vx.at(i), t.k.at(i), t.smooth_k.at(i),
       t.relative_time.at(i));

--- a/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_interface.cpp
+++ b/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_interface.cpp
@@ -44,4 +44,8 @@ void VehicleModelInterface::setCurvature(const double curvature)
 {
   m_curvature = curvature;
 }
+void VehicleModelInterface::setSteerRateLimits(const Eigen::VectorXd steer_rate_limits)
+{
+  m_steer_rate_limits = steer_rate_limits;
+}
 }  // namespace autoware::motion::control::mpc_lateral_controller


### PR DESCRIPTION
## Description

There is an issue where the predicted trajectory generated based on the MPC solution would become unstable when the speed decreased. The method of setting the maximum speed to 1 kph can be reproduced by executing the following command.
```
ros2 topic pub /planning/scenario_planning/max_velocity tier4_planning_msgs/msg/VelocityLimit "{stamp: now, max_velocity: 0.2777777910232544, use_constraints: true, constraints: {min_acceleration: -1.0, max_jerk: 1.0, min_jerk: -1.0}, sender: 'api'}" --once
```
visualized topic in the video is `/control/trajectory_follower/lateral/predicted_trajectory`

https://github.com/user-attachments/assets/90177a24-3cca-4b99-af39-27907e5c7795

When examining the values of each trajectory point in function `calculatePredictedTrajectoryInWorldCoordinate` while generating unstable paths, it was found that the steer angle and steer_rate values exceeded the vehicle's constraints. 
By considering these constraints during calculation, it was confirmed that the generation of unstable paths could be prevented as shown in the following video.

https://github.com/user-attachments/assets/fdb1ed63-e1d6-4de1-ada7-5c1edb612c5f

## How was this PR tested?

run planning_simulator and confirmed problem is solved.

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/0595e732-1a46-5499-be8e-b56dc210d4cb?project_id=prd_jt)

## Notes for reviewers

I believe it is necessary to improve the following integration method derived from the discretized system of equations:
```
    dstate(0) = velocity * std::cos(yaw);
    dstate(1) = velocity * std::sin(yaw);
    dstate(2) = velocity * std::tan(steer) / m_wheelbase;
    dstate(3) = -(steer - desired_steer) / m_steer_tau;
```

In this case, it is likely that similar issues are occurring in the internal model calculations of the MPC as well. Therefore, I think it is necessary to implement improvements in conjunction with those calculations. I'm planning to investigate and address this in a separate PR.

## Interface changes

None.


## Effects on system behavior

None.
