### PR TITLE
feat(crosswalk)!: update stop position caluculation

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/README.md
@@ -12,7 +12,6 @@ This module judges whether the ego should stop in front of the crosswalk in orde
 
 ```plantuml
 @startuml
-skinparam monochrome true
 
 title modifyPathVelocity
 start
@@ -38,8 +37,36 @@ group apply stop
     :planStop;
   endif
 end group
-
 stop
+@enduml
+```
+
+```plantuml
+@startuml
+
+title checkStopForCrosswalkUsers
+start
+group calculate the candidate stop
+  :pick the closest stop point against the pedestrians and stop point on map as the preferred stop;
+  if (the weak brake distance is closer than the preferred stop?) then (yes)
+    :plan to stop at the preferred stop;
+  else (no)
+    if (the weak brake distance is closer than the limit stop position against the nearest pedestrian?) then (yes)
+      :plan to stop by the weak brake distance;
+    else (no)
+      :plan to stop at the limit stop position against the nearest pedestrian;
+    endif
+  endif
+end group
+group check if the candidate stop pose is acceptable for braking distance
+  if (the stop pose candidate is closer than the acceptable stop dist?) then (yes)
+    :abort to stop.;
+  else (no)
+    :plan to stop at the candidate stop pose;
+  endif
+end group
+stop
+
 @enduml
 ```
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -16,7 +16,10 @@
         # For the case where the crosswalk width is very wide
         far_object_threshold: 10.0 # [m] If objects cross X meters behind the stop line, the stop position is determined according to the object position (stop_distance_from_object meters before the object).
         # For the case where the stop position is determined according to the object position.
-        stop_distance_from_object: 3.0 # [m] the vehicle decelerates to be able to stop in front of object with margin
+        stop_distance_from_object_preferred: 3.0 # [m]
+        stop_distance_from_object_limit: 3.0 # [m]
+        min_acc_preferred: -1.0 # min acceleration [m/ss]
+        min_jerk_preferred: -1.0 # min jerk [m/sss]
 
       # params for ego's slow down velocity. These params are not used for the case of "enable_rtc: false".
       slow_down:
@@ -45,11 +48,10 @@
         ego_pass_later_additional_margin: 0.5 # [s] additional time margin for object pass first situation to suppress chattering
         ego_min_assumed_speed: 2.0 # [m/s] assumed speed to calculate the time to collision point
 
-        no_stop_decision: # parameters to determine if it is safe to attempt stopping before the crosswalk
-          max_offset_to_crosswalk_for_yield: 0.0 # [m] maximum offset from ego's front to crosswalk for yield. Positive value means in front of the crosswalk.
-          min_acc: -1.0 # min acceleration [m/ss]
-          min_jerk: -1.0 # min jerk [m/sss]
-          max_jerk: 1.0 # max jerk [m/sss]
+        no_stop_decision: # parameters to determine stop cancel. {-$overrun_threshold_length + f($min_acc, $min_jerk)} is compared against distance to stop pose.
+          min_acc: -1.5 # min acceleration [m/ss]
+          min_jerk: -1.5 # min jerk [m/sss]
+          overrun_threshold_length: 1.0 # [m] required to avoid giving up against backward movement of the stop position due to approaching pedestrians, etc.
 
         stop_object_velocity_threshold: 0.25 # [m/s] velocity threshold for the module to judge whether the objects is stopped (0.28 m/s = 1.0 kmph)
         min_object_velocity: 1.39 # [m/s] minimum object velocity (compare the estimated velocity by perception module with this parameter and adopt the larger one to calculate TTV. 1.39 m/s = 5.0 kmph)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
@@ -47,12 +47,18 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
   // param for stop position
   cp.stop_distance_from_crosswalk =
     getOrDeclareParameter<double>(node, ns + ".stop_position.stop_distance_from_crosswalk");
-  cp.stop_distance_from_object =
-    getOrDeclareParameter<double>(node, ns + ".stop_position.stop_distance_from_object");
+  cp.stop_distance_from_object_preferred =
+    getOrDeclareParameter<double>(node, ns + ".stop_position.stop_distance_from_object_preferred");
+  cp.stop_distance_from_object_limit =
+    getOrDeclareParameter<double>(node, ns + ".stop_position.stop_distance_from_object_limit");
   cp.far_object_threshold =
     getOrDeclareParameter<double>(node, ns + ".stop_position.far_object_threshold");
   cp.stop_position_threshold =
     getOrDeclareParameter<double>(node, ns + ".stop_position.stop_position_threshold");
+  cp.min_acc_preferred =
+    getOrDeclareParameter<double>(node, ns + ".stop_position.min_acc_preferred");
+  cp.min_jerk_preferred =
+    getOrDeclareParameter<double>(node, ns + ".stop_position.min_jerk_preferred");
 
   // param for restart suppression
   cp.min_dist_to_stop_for_restart_suppression =
@@ -98,14 +104,12 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".pass_judge.ego_pass_later_additional_margin");
   cp.ego_min_assumed_speed =
     getOrDeclareParameter<double>(node, ns + ".pass_judge.ego_min_assumed_speed");
-  cp.max_offset_to_crosswalk_for_yield = getOrDeclareParameter<double>(
-    node, ns + ".pass_judge.no_stop_decision.max_offset_to_crosswalk_for_yield");
   cp.min_acc_for_no_stop_decision =
     getOrDeclareParameter<double>(node, ns + ".pass_judge.no_stop_decision.min_acc");
-  cp.max_jerk_for_no_stop_decision =
-    getOrDeclareParameter<double>(node, ns + ".pass_judge.no_stop_decision.max_jerk");
   cp.min_jerk_for_no_stop_decision =
     getOrDeclareParameter<double>(node, ns + ".pass_judge.no_stop_decision.min_jerk");
+  cp.overrun_threshold_length_for_no_stop_decision = getOrDeclareParameter<double>(
+    node, ns + ".pass_judge.no_stop_decision.overrun_threshold_length");
   cp.stop_object_velocity =
     getOrDeclareParameter<double>(node, ns + ".pass_judge.stop_object_velocity_threshold");
   cp.min_object_velocity =

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -112,10 +112,13 @@ public:
   {
     bool show_processing_time;
     // param for stop position
-    double stop_distance_from_object;
+    double stop_distance_from_object_preferred;
+    double stop_distance_from_object_limit;
     double stop_distance_from_crosswalk;
     double far_object_threshold;
     double stop_position_threshold;
+    double min_acc_preferred;
+    double min_jerk_preferred;
     // param for restart suppression
     double min_dist_to_stop_for_restart_suppression;
     double max_dist_to_stop_for_restart_suppression;
@@ -140,10 +143,9 @@ public:
     std::vector<double> ego_pass_later_margin_y;
     double ego_pass_later_additional_margin;
     double ego_min_assumed_speed;
-    double max_offset_to_crosswalk_for_yield;
     double min_acc_for_no_stop_decision;
-    double max_jerk_for_no_stop_decision;
     double min_jerk_for_no_stop_decision;
+    double overrun_threshold_length_for_no_stop_decision;
     double stop_object_velocity;
     double min_object_velocity;
     bool disable_yield_for_new_stopped_object;
@@ -351,6 +353,10 @@ private:
   std::optional<geometry_msgs::msg::Pose> getDefaultStopPose(
     const PathWithLaneId & ego_path,
     const geometry_msgs::msg::Point & first_path_point_on_crosswalk) const;
+
+  std::optional<geometry_msgs::msg::Pose> calcStopPose(
+    const PathWithLaneId & ego_path, double dist_nearest_cp,
+    const std::optional<geometry_msgs::msg::Pose> & default_stop_pose_opt);
 
   std::optional<StopFactor> checkStopForCrosswalkUsers(
     const PathWithLaneId & ego_path, const PathWithLaneId & sparse_resample_path,


### PR DESCRIPTION
## Description
This PR updates the algorithm for calculating the stop position for pedestrians.

Except for the exceptional behavior, the updated algorithm is as follows
1. select the nearest stop position from the map and the pedestrians
2. modify or select the stop position, taking acceleration and limit safety margin distance into account.
3. check if the selected stopping point is appropriate for the braking distance.

## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1162

## How was this PR tested?
psim and tier4 internal tests

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
