### PR TITLE
feat(rtc_interface, lane_change): check state transition for cooperate status

### DIFF
--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -292,15 +292,9 @@ void RTCInterface::updateCooperateStatus(
     return;
   }
 
-  // State: update FAILED or SUCCEEDED
-  if (itr->state.type == state) {
-    update_status(*itr);
-    return;
-  }
-
   RCLCPP_WARN_STREAM(
-    getLogger(), "[updateCooperateStatus] uuid : " << uuid_to_string(uuid) << " cannot transit from"
-                                                   << state_to_string(itr->state.type) << " to"
+    getLogger(), "[updateCooperateStatus] uuid : " << uuid_to_string(uuid) << " cannot transit from "
+                                                   << state_to_string(itr->state.type) << " to "
                                                    << state_to_string(state) << std::endl);
 }
 

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -258,11 +258,17 @@ void RTCInterface::updateCooperateStatus(
     status.module = module_;
     status.safe = safe;
     status.command_status.type = Command::DEACTIVATE;
-    status.state.type = state;
+    status.state.type = State::WAITING_FOR_EXECUTION;
     status.start_distance = start_distance;
     status.finish_distance = finish_distance;
     status.auto_mode = is_auto_mode_enabled_;
     registered_status_.statuses.push_back(status);
+
+    if (state != State::WAITING_FOR_EXECUTION)
+      RCLCPP_WARN_STREAM(
+        getLogger(), "[updateCooperateStatus]  Cannot register "
+                       << state_to_string(state) << " as initial state" << std::endl);
+
     return;
   }
 

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -293,7 +293,8 @@ void RTCInterface::updateCooperateStatus(
   }
 
   RCLCPP_WARN_STREAM(
-    getLogger(), "[updateCooperateStatus] uuid : " << uuid_to_string(uuid) << " cannot transit from "
+    getLogger(), "[updateCooperateStatus] uuid : " << uuid_to_string(uuid)
+                                                   << " cannot transit from "
                                                    << state_to_string(itr->state.type) << " to "
                                                    << state_to_string(state) << std::endl);
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -160,9 +160,6 @@ BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
   stop_pose_ = module_type_->getStopPose();
 
   if (!module_type_->isValidPath()) {
-    updateRTCStatus(
-      std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), false,
-      State::FAILED);
     path_candidate_ = std::make_shared<PathWithLaneId>();
     return out;
   }


### PR DESCRIPTION
## Description
A new filed `tier4_rtc_msgs/State state` was introduced in the rt cooperate status previously. This field is used to observe the state transition of the rtc message. However, inappropriate state transition could be occurred since there was no limitation in the rtc interface module.

In this PR, I have checked the state transition inside the `updateCooperateStatus` function.
Additionally, the RTC state transition is fixed in the lane change module.
The cooperateState status would transit to failure when the module can only transit to FAILURE.
Being specific, it should not transit to FAILED inside `planWaitingApproval` function, although the lane change module status could be kept `WAITING_APPROVAL` due to `canTransitFailureState` function.

## Related links
https://github.com/tier4/tier4_autoware_msgs/pull/119
https://github.com/autowarefoundation/autoware.universe/pull/8604

## How was this PR tested?
- [x] [TIER IV internal test](https://evaluation.tier4.jp/evaluation/reports/db4ba057-bc7b-55fb-978c-6bd66e718463?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.


## Effects on system behavior
None.
