### PR TITLE
fix(autoware_test_utils): fix unusedFunction

### DIFF
--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -138,6 +138,7 @@ std::string get_absolute_path_to_lanelet_map(
   return dir + "/test_map/" + map_filename;
 }
 
+// cppcheck-suppress unusedFunction
 std::string get_absolute_path_to_route(
   const std::string & package_name, const std::string & route_filename)
 {
@@ -228,6 +229,7 @@ Scenario makeScenarioMsg(const std::string & scenario)
   return scenario_msg;
 }
 
+// cppcheck-suppress unusedFunction
 RouteSections combineConsecutiveRouteSections(
   const RouteSections & route_sections1, const RouteSections & route_sections2)
 {

--- a/common/autoware_test_utils/src/mock_data_parser.cpp
+++ b/common/autoware_test_utils/src/mock_data_parser.cpp
@@ -75,6 +75,7 @@ std::vector<LaneletSegment> parse_segments(const YAML::Node & node)
   return segments;
 }
 
+// cppcheck-suppress unusedFunction
 LaneletRoute parse_lanelet_route_file(const std::string & filename)
 {
   LaneletRoute lanelet_route;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unusedFunction warnings.

```
common/autoware_test_utils/src/autoware_test_utils.cpp:141:0: style: The function 'get_absolute_path_to_route' is never used. [unusedFunction]
std::string get_absolute_path_to_route(
^
common/autoware_test_utils/src/autoware_test_utils.cpp:231:0: style: The function 'combineConsecutiveRouteSections' is never used. [unusedFunction]
RouteSections combineConsecutiveRouteSections(
^
common/autoware_test_utils/src/mock_data_parser.cpp:78:0: style: The function 'parse_lanelet_route_file' is never used. [unusedFunction]
LaneletRoute parse_lanelet_route_file(const std::string & filename)
^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
