### PR TITLE
fix(autoware_object_merger): default merger priority within enum range

### DIFF
--- a/perception/autoware_object_merger/config/object_association_merger.param.yaml
+++ b/perception/autoware_object_merger/config/object_association_merger.param.yaml
@@ -5,4 +5,4 @@
     recall_threshold_to_judge_overlapped: 0.5
     remove_overlapped_unknown_objects: true
     base_link_frame_id: base_link
-    priority_mode: 3  # PriorityMode::Confidence
+    priority_mode: 2  # PriorityMode::Confidence


### PR DESCRIPTION
## Description
The default value of the merger priority was out of the enum range.
Fixed the default value to the explained mode `PriorityMode::Confidence = 2`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
