### PR TITLE
feat(autonomous_emergency_braking): add markers showing aeb convex hull polygons for debugging purposes

### DIFF
--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -41,6 +41,7 @@
 #include <pcl/common/transforms.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl/surface/convex_hull.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -50,6 +51,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 namespace autoware::motion::control::autonomous_emergency_braking
@@ -72,6 +74,7 @@ using Path = std::vector<geometry_msgs::msg::Pose>;
 using Vector3 = geometry_msgs::msg::Vector3;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+using colorTuple = std::tuple<double, double, double, double>;
 
 /**
  * @brief Struct to store object data
@@ -448,7 +451,7 @@ public:
    */
   void getPointsBelongingToClusterHulls(
     const PointCloud::Ptr obstacle_points_ptr,
-    const PointCloud::Ptr points_belonging_to_cluster_hulls);
+    const PointCloud::Ptr points_belonging_to_cluster_hulls, MarkerArray & debug_markers);
 
   /**
    * @brief Create object data using predicted objects
@@ -475,18 +478,26 @@ public:
    * @param polygons Polygons representing the ego vehicle footprint
    * @param objects Vector of object data
    * @param closest_object Optional data of the closest object
-   * @param color_r Red color component
-   * @param color_g Green color component
-   * @param color_b Blue color component
-   * @param color_a Alpha (transparency) component
+   * @param colors Tuple of RGBA colors
    * @param ns Namespace for the marker
    * @param debug_markers Marker array for debugging
    */
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,
     const std::vector<ObjectData> & objects, const std::optional<ObjectData> & closest_object,
-    const double color_r, const double color_g, const double color_b, const double color_a,
-    const std::string & ns, MarkerArray & debug_markers);
+    const colorTuple & debug_colors, const std::string & ns, MarkerArray & debug_markers);
+
+  /**
+   * @brief Add a marker for debugging
+   * @param current_time Current time
+   * @param
+   * @param colors Tuple of RGBA colors
+   * @param ns Namespace for the marker
+   * @param debug_markers Marker array for debugging
+   */
+  void addClusterHullMarkers(
+    const rclcpp::Time & current_time, const std::vector<Polygon2d> & hulls,
+    const colorTuple & debug_colors, const std::string & ns, MarkerArray & debug_markers);
 
   /**
    * @brief Add a collision marker for debugging

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -478,7 +478,7 @@ public:
    * @param polygons Polygons representing the ego vehicle footprint
    * @param objects Vector of object data
    * @param closest_object Optional data of the closest object
-   * @param colors Tuple of RGBA colors
+   * @param debug_colors Tuple of RGBA colors
    * @param ns Namespace for the marker
    * @param debug_markers Marker array for debugging
    */
@@ -488,10 +488,10 @@ public:
     const colorTuple & debug_colors, const std::string & ns, MarkerArray & debug_markers);
 
   /**
-   * @brief Add a marker for debugging
+   * @brief Add a marker of a convex hull for debugging
    * @param current_time Current time
-   * @param
-   * @param colors Tuple of RGBA colors
+   * @param hulls vector of polygons of the convex hulls
+   * @param debug_colors Tuple of RGBA colors
    * @param ns Namespace for the marker
    * @param debug_markers Marker array for debugging
    */

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -488,7 +488,7 @@ public:
     const colorTuple & debug_colors, const std::string & ns, MarkerArray & debug_markers);
 
   /**
-   * @brief Add a marker of a convex hull for debugging
+   * @brief Add a marker of convex hulls for debugging
    * @param current_time Current time
    * @param hulls vector of polygons of the convex hulls
    * @param debug_colors Tuple of RGBA colors

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -88,7 +88,7 @@ Polygon2d convertBoundingBoxObjectToGeometryPolygon(
 Polygon2d convertObjToPolygon(const PredictedObject & obj);
 
 /**
- * @brief Get the predicted object's shape as a geometry polygon
+ * @brief Get the transform from source to target frame
  * @param target_frame target frame
  * @param source_frame source frame
  * @param tf_buffer buffer of tf transforms

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -26,6 +26,8 @@
 #include <tf2/utils.h>
 
 #include <string>
+#include <vector>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -33,6 +35,8 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+
 #endif
 
 namespace autoware::motion::control::autonomous_emergency_braking::utils
@@ -83,9 +87,24 @@ Polygon2d convertBoundingBoxObjectToGeometryPolygon(
  */
 Polygon2d convertObjToPolygon(const PredictedObject & obj);
 
+/**
+ * @brief Get the predicted object's shape as a geometry polygon
+ * @param target_frame target frame
+ * @param source_frame source frame
+ * @param tf_buffer buffer of tf transforms
+ * @param logger node logger
+ */
 std::optional<geometry_msgs::msg::TransformStamped> getTransform(
   const std::string & target_frame, const std::string & source_frame,
   const tf2_ros::Buffer & tf_buffer, const rclcpp::Logger & logger);
+
+/**
+ * @brief Get the predicted object's shape as a geometry polygon
+ * @param polygons vector of Polygon2d
+ * @param polygon_marker marker to be filled with polygon points
+ */
+void fillMarkerFromPolygon(
+  const std::vector<Polygon2d> & polygons, visualization_msgs::msg::Marker & polygon_marker);
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils
 
 #endif  // AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_

--- a/control/autoware_autonomous_emergency_braking/src/utils.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/utils.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <autoware/autonomous_emergency_braking/utils.hpp>
+#include <autoware/universe_utils/geometry/geometry.hpp>
 
 #include <optional>
 
@@ -167,4 +168,22 @@ std::optional<geometry_msgs::msg::TransformStamped> getTransform(
   }
   return std::make_optional(tf_current_pose);
 }
+
+void fillMarkerFromPolygon(
+  const std::vector<Polygon2d> & polygons, visualization_msgs::msg::Marker & polygon_marker)
+{
+  for (const auto & poly : polygons) {
+    for (size_t dp_idx = 0; dp_idx < poly.outer().size(); ++dp_idx) {
+      const auto & boost_cp = poly.outer().at(dp_idx);
+      const auto & boost_np = poly.outer().at((dp_idx + 1) % poly.outer().size());
+      const auto curr_point =
+        autoware::universe_utils::createPoint(boost_cp.x(), boost_cp.y(), 0.0);
+      const auto next_point =
+        autoware::universe_utils::createPoint(boost_np.x(), boost_np.y(), 0.0);
+      polygon_marker.points.push_back(curr_point);
+      polygon_marker.points.push_back(next_point);
+    }
+  }
+}
+
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils

--- a/control/autoware_autonomous_emergency_braking/test/test.cpp
+++ b/control/autoware_autonomous_emergency_braking/test/test.cpp
@@ -157,8 +157,9 @@ TEST_F(TestAEB, checkImuPathGeneration)
     }
   }
   PointCloud::Ptr points_belonging_to_cluster_hulls = pcl::make_shared<PointCloud>();
+  MarkerArray debug_markers;
   aeb_node_->getPointsBelongingToClusterHulls(
-    obstacle_points_ptr, points_belonging_to_cluster_hulls);
+    obstacle_points_ptr, points_belonging_to_cluster_hulls, debug_markers);
   std::vector<ObjectData> objects;
   aeb_node_->getClosestObjectsOnPath(
     imu_path, footprint, stamp, points_belonging_to_cluster_hulls, objects);


### PR DESCRIPTION
## Description
This PR adds a debug marker for the convex hulls created by the AEB, which can help debugging and tuning point cloud parameters for the module. 

Example
![cap- 2024-09-12-17-53-18](https://github.com/user-attachments/assets/c08f0a4f-3710-40d8-9c50-544f1978d0aa)
![cap- 2024-09-12-17-53-42](https://github.com/user-attachments/assets/f2b7cb46-8c58-453c-84e6-3921a9e5a2e9)
![cap- 2024-09-12-17-53-49](https://github.com/user-attachments/assets/c837b875-1798-4210-b3ab-efe56e4afe47)
![Screenshot from 2024-09-12 18-18-33](https://github.com/user-attachments/assets/53acd2fc-5c05-4964-8d0b-9883bce573ba)



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
