### PR TITLE
feat(planning_topic_converter): integrate generate_parameter_library

### DIFF
--- a/planning/autoware_planning_topic_converter/CMakeLists.txt
+++ b/planning/autoware_planning_topic_converter/CMakeLists.txt
@@ -12,8 +12,16 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+generate_parameter_library(converter_base_parameters
+  param/converter_base_parameters.yaml
+)
+
 ament_auto_add_library(planning_topic_converter SHARED
   src/path_to_trajectory.cpp
+)
+
+target_link_libraries(planning_topic_converter
+  converter_base_parameters
 )
 
 rclcpp_components_register_node(planning_topic_converter

--- a/planning/autoware_planning_topic_converter/include/autoware/planning_topic_converter/converter_base.hpp
+++ b/planning/autoware_planning_topic_converter/include/autoware/planning_topic_converter/converter_base.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__PLANNING_TOPIC_CONVERTER__CONVERTER_BASE_HPP_
 #define AUTOWARE__PLANNING_TOPIC_CONVERTER__CONVERTER_BASE_HPP_
 
+#include "converter_base_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include <memory>
@@ -30,18 +31,21 @@ public:
   ConverterBase(const std::string & node_name, const rclcpp::NodeOptions & options)
   : rclcpp::Node(node_name, options)
   {
-    const auto input_topic = this->declare_parameter<std::string>("input_topic");
-    const auto output_topic = this->declare_parameter<std::string>("output_topic");
+    param_listener_ =
+      std::make_shared<converter_base::ParamListener>(this->get_node_parameters_interface());
+    const auto p = param_listener_->get_params();
 
-    pub_ = this->create_publisher<OutputType>(output_topic, 1);
+    pub_ = this->create_publisher<OutputType>(p.output_topic, 1);
     sub_ = this->create_subscription<InputType>(
-      input_topic, 1, std::bind(&ConverterBase::process, this, std::placeholders::_1));
+      p.input_topic, 1, std::bind(&ConverterBase::process, this, std::placeholders::_1));
   }
 
 protected:
   virtual void process(const typename InputType::ConstSharedPtr msg) = 0;
   typename rclcpp::Publisher<OutputType>::SharedPtr pub_;
   typename rclcpp::Subscription<InputType>::SharedPtr sub_;
+
+  std::shared_ptr<converter_base::ParamListener> param_listener_;
 
 private:
 };

--- a/planning/autoware_planning_topic_converter/package.xml
+++ b/planning/autoware_planning_topic_converter/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>generate_parameter_library</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/planning/autoware_planning_topic_converter/param/converter_base_parameters.yaml
+++ b/planning/autoware_planning_topic_converter/param/converter_base_parameters.yaml
@@ -1,0 +1,7 @@
+converter_base:
+  input_topic:
+    type: string
+    description: Input topic name.
+  output_topic:
+    type: string
+    description: Output topic name.


### PR DESCRIPTION
## Description

This PR enables planning_topic_converter to handle parameters using [generate_parameter_library](https://github.com/PickNikRobotics/generate_parameter_library).

## How was this PR tested?

Psim

- [x] errors occur if any parameters are missing in the config file in remaining_distance_time_calculator package

Evaluator: https://evaluation.tier4.jp/evaluation/reports/a1910f40-4ff2-551c-ac91-6365c1e63379?project_id=prd_jt

## Notes for reviewers

The node `path_to_trajectory_converter` does not have dynamic parameters.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
