### PR TITLE
fix(rtc_interface): update cooperateStatus state transition

### DIFF
--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -298,6 +298,11 @@ void RTCInterface::updateCooperateStatus(
     return;
   }
 
+  if (itr->state.type == state) {
+    update_status(*itr);
+    return;
+  }
+
   RCLCPP_WARN_STREAM(
     getLogger(), "[updateCooperateStatus] uuid : " << uuid_to_string(uuid)
                                                    << " cannot transit from "


### PR DESCRIPTION
## Description
In the previous PR, the below state transition was not allowed.

- FAILED -> FAILED
- SUCCESS -> SUCCESS

This PR allows the above state transition.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/8855

## How was this PR tested?
- [x] [TIER IV internal test](https://evaluation.tier4.jp/evaluation/reports/87e88451-b682-5214-a33f-5af75c9787ef?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.


## Effects on system behavior
None.
