### PR TITLE
perf(costmap_generator): prevent long transform lookup and add timekeeper

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
@@ -3,20 +3,21 @@
   <group if="$(var launch_parking_module)">
     <push-ros-namespace namespace="parking"/>
 
-    <node pkg="autoware_costmap_generator" exec="costmap_generator" name="costmap_generator" namespace="" launch-prefix="konsole -e gdb -ex run --args">
-      <!-- topic remap -->
-      <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-      <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
-      <remap from="~/input/vector_map" to="/map/vector_map"/>
-      <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
-      <remap from="~/output/grid_map" to="costmap_generator/grid_map"/>
-      <remap from="~/output/occupancy_grid" to="costmap_generator/occupancy_grid"/>
-      <!-- params -->
-      <param from="$(var vehicle_param_file)"/>
-      <param from="$(var costmap_generator_param_path)"/>
-      <!-- <extra_arg name="use_intra_process_comms" value="false"/> -->
-    </node>
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
+      <composable_node pkg="autoware_costmap_generator" plugin="autoware::costmap_generator::CostmapGenerator" name="costmap_generator" namespace="">
+        <!-- topic remap -->
+        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+        <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
+        <remap from="~/input/vector_map" to="/map/vector_map"/>
+        <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
+        <remap from="~/output/grid_map" to="costmap_generator/grid_map"/>
+        <remap from="~/output/occupancy_grid" to="costmap_generator/occupancy_grid"/>
+        <!-- params -->
+        <param from="$(var vehicle_param_file)"/>
+        <param from="$(var costmap_generator_param_path)"/>
+        <extra_arg name="use_intra_process_comms" value="false"/>
+      </composable_node>
+
       <composable_node pkg="autoware_freespace_planner" plugin="autoware::freespace_planner::FreespacePlannerNode" name="freespace_planner" namespace="">
         <!-- topic remap -->
         <remap from="~/input/route" to="/planning/mission_planning/route"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
@@ -3,21 +3,20 @@
   <group if="$(var launch_parking_module)">
     <push-ros-namespace namespace="parking"/>
 
+    <node pkg="autoware_costmap_generator" exec="costmap_generator" name="costmap_generator" namespace="" launch-prefix="konsole -e gdb -ex run --args">
+      <!-- topic remap -->
+      <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+      <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
+      <remap from="~/input/vector_map" to="/map/vector_map"/>
+      <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
+      <remap from="~/output/grid_map" to="costmap_generator/grid_map"/>
+      <remap from="~/output/occupancy_grid" to="costmap_generator/occupancy_grid"/>
+      <!-- params -->
+      <param from="$(var vehicle_param_file)"/>
+      <param from="$(var costmap_generator_param_path)"/>
+      <!-- <extra_arg name="use_intra_process_comms" value="false"/> -->
+    </node>
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
-      <composable_node pkg="autoware_costmap_generator" plugin="autoware::costmap_generator::CostmapGenerator" name="costmap_generator" namespace="">
-        <!-- topic remap -->
-        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-        <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
-        <remap from="~/input/vector_map" to="/map/vector_map"/>
-        <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
-        <remap from="~/output/grid_map" to="costmap_generator/grid_map"/>
-        <remap from="~/output/occupancy_grid" to="costmap_generator/occupancy_grid"/>
-        <!-- params -->
-        <param from="$(var vehicle_param_file)"/>
-        <param from="$(var costmap_generator_param_path)"/>
-        <extra_arg name="use_intra_process_comms" value="false"/>
-      </composable_node>
-
       <composable_node pkg="autoware_freespace_planner" plugin="autoware::freespace_planner::FreespacePlannerNode" name="freespace_planner" namespace="">
         <!-- topic remap -->
         <remap from="~/input/route" to="/planning/mission_planning/route"/>

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020-2024 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,22 +50,19 @@
 #include "costmap_generator_node_parameters.hpp"
 
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware/universe_utils/system/time_keeper.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 #include <grid_map_ros/grid_map_ros.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 
 #include <grid_map_msgs/msg/grid_map.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -89,9 +86,11 @@ private:
   sensor_msgs::msg::PointCloud2::ConstSharedPtr points_;
 
   grid_map::GridMap costmap_;
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_costmap_;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_occupancy_grid_;
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr pub_processing_time_;
 
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_points_;
   rclcpp::Subscription<autoware_perception_msgs::msg::PredictedObjects>::SharedPtr sub_objects_;

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
@@ -49,8 +49,8 @@
 #include "autoware_costmap_generator/points_to_costmap.hpp"
 #include "costmap_generator_node_parameters.hpp"
 
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware/universe_utils/system/time_keeper.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 #include <grid_map_ros/grid_map_ros.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020-2024 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,18 +50,13 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <pcl_ros/transforms.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
 #include <tf2/utils.h>
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_eigen/tf2_eigen.h>
-#else
-#include <tf2_eigen/tf2_eigen.hpp>
-#endif
 
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace
@@ -193,6 +188,10 @@ CostmapGenerator::CostmapGenerator(const rclcpp::NodeOptions & node_options)
   pub_costmap_ = this->create_publisher<grid_map_msgs::msg::GridMap>("~/output/grid_map", 1);
   pub_occupancy_grid_ =
     this->create_publisher<nav_msgs::msg::OccupancyGrid>("~/output/occupancy_grid", 1);
+  pub_processing_time_ =
+    create_publisher<autoware::universe_utils::ProcessingTimeDetail>("processing_time", 1);
+  time_keeper_ =
+    std::make_shared<autoware::universe_utils::TimeKeeper>(pub_processing_time_, &std::cerr);
 
   // Timer
   const auto period_ns = rclcpp::Rate(param_->update_rate).period();
@@ -277,11 +276,13 @@ void CostmapGenerator::onScenario(const tier4_planning_msgs::msg::Scenario::Cons
 
 void CostmapGenerator::onTimer()
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   if (!isActive()) {
     return;
   }
 
   // Get current pose
+  time_keeper_->start_track("lookupTransform");
   geometry_msgs::msg::TransformStamped tf;
   try {
     tf = tf_buffer_.lookupTransform(
@@ -291,6 +292,7 @@ void CostmapGenerator::onTimer()
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
     return;
   }
+  time_keeper_->end_track("lookupTransform");
 
   // Set grid center
   grid_map::Position p;
@@ -299,18 +301,24 @@ void CostmapGenerator::onTimer()
   costmap_.setPosition(p);
 
   if ((param_->use_wayarea || param_->use_parkinglot) && lanelet_map_) {
+    autoware::universe_utils::ScopedTimeTrack st("generatePrimitivesCostmap()", *time_keeper_);
     costmap_[LayerName::primitives] = generatePrimitivesCostmap();
   }
 
   if (param_->use_objects && objects_) {
+    autoware::universe_utils::ScopedTimeTrack st("generateObjectsCostmap()", *time_keeper_);
     costmap_[LayerName::objects] = generateObjectsCostmap(objects_);
   }
 
   if (param_->use_points && points_) {
+    autoware::universe_utils::ScopedTimeTrack st("generatePointsCostmap()", *time_keeper_);
     costmap_[LayerName::points] = generatePointsCostmap(points_);
   }
 
-  costmap_[LayerName::combined] = generateCombinedCostmap();
+  {
+    autoware::universe_utils::ScopedTimeTrack st("generateCombinedCostmap()", *time_keeper_);
+    costmap_[LayerName::combined] = generateCombinedCostmap();
+  }
 
   publishCostmap(costmap_);
 }

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
@@ -276,7 +276,7 @@ void CostmapGenerator::onScenario(const tier4_planning_msgs::msg::Scenario::Cons
 
 void CostmapGenerator::onTimer()
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware::universe_utils::ScopedTimeTrack scoped_time_track(__func__, *time_keeper_);
   if (!isActive()) {
     return;
   }

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
@@ -191,8 +191,7 @@ CostmapGenerator::CostmapGenerator(const rclcpp::NodeOptions & node_options)
     this->create_publisher<nav_msgs::msg::OccupancyGrid>("~/output/occupancy_grid", 1);
   pub_processing_time_ =
     create_publisher<autoware::universe_utils::ProcessingTimeDetail>("processing_time", 1);
-  time_keeper_ =
-    std::make_shared<autoware::universe_utils::TimeKeeper>(pub_processing_time_, &std::cerr);
+  time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(pub_processing_time_);
 
   // Timer
   const auto period_ns = rclcpp::Rate(param_->update_rate).period();
@@ -286,8 +285,8 @@ void CostmapGenerator::onTimer()
   time_keeper_->start_track("lookupTransform");
   geometry_msgs::msg::TransformStamped tf;
   try {
-    tf = tf_buffer_.lookupTransform(
-      param_->costmap_frame, param_->vehicle_frame, tf2::TimePointZero);
+    tf =
+      tf_buffer_.lookupTransform(param_->costmap_frame, param_->vehicle_frame, tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
     return;

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
@@ -53,6 +53,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
+#include <tf2/time.h>
 #include <tf2/utils.h>
 
 #include <memory>
@@ -286,8 +287,7 @@ void CostmapGenerator::onTimer()
   geometry_msgs::msg::TransformStamped tf;
   try {
     tf = tf_buffer_.lookupTransform(
-      param_->costmap_frame, param_->vehicle_frame, rclcpp::Time(0),
-      rclcpp::Duration::from_seconds(1.0));
+      param_->costmap_frame, param_->vehicle_frame, tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
     return;

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/object_map_utils.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/object_map_utils.cpp
@@ -32,6 +32,8 @@
 
 #include "autoware_costmap_generator/object_map_utils.hpp"
 
+#include <tf2/time.h>
+
 #include <string>
 #include <vector>
 
@@ -59,8 +61,8 @@ void FillPolygonAreas(
   cv::Mat merged_filled_image = original_image.clone();
 
   geometry_msgs::msg::TransformStamped transform;
-  transform = in_tf_buffer.lookupTransform(
-    in_tf_target_frame, in_tf_source_frame, rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
+  transform =
+    in_tf_buffer.lookupTransform(in_tf_target_frame, in_tf_source_frame, tf2::TimePointZero);
 
   // calculate out_grid_map position
   grid_map::Position map_pos = out_grid_map.getPosition();

--- a/planning/autoware_costmap_generator/package.xml
+++ b/planning/autoware_costmap_generator/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_universe_utils</depend>
   <depend>generate_parameter_library</depend>
   <depend>grid_map_ros</depend>
   <depend>libpcl-all-dev</depend>


### PR DESCRIPTION
## Description

This PR attempt to fix some rare performance issue with the `costmap_generator` by preventing the transform lookup from waiting up to 1s.
The timekeeper is also added to make performance issues easier to understand in the future.

## Related links

**Parent Issue:**

- [TIER IV JIRA link](https://tier4.atlassian.net/browse/RT0-33246)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
