### PR TITLE
refactor(bpp): simplify ExtendedPredictedObject and add new member variables

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -711,12 +711,12 @@ bool isParkedObject(
   using lanelet::geometry::toArcCoordinates;
 
   const double object_vel_norm =
-    std::hypot(object.initial_twist.twist.linear.x, object.initial_twist.twist.linear.y);
+    std::hypot(object.initial_twist.linear.x, object.initial_twist.linear.y);
   if (object_vel_norm > static_object_velocity_threshold) {
     return false;
   }
 
-  const auto & object_pose = object.initial_pose.pose;
+  const auto & object_pose = object.initial_pose;
   const auto object_closest_index =
     autoware::motion_utils::findNearestIndex(path.points, object_pose.position);
   const auto object_closest_pose = path.points.at(object_closest_index).point.pose;
@@ -783,7 +783,7 @@ bool isParkedObject(
 {
   using lanelet::geometry::distance2d;
 
-  const auto & obj_pose = object.initial_pose.pose;
+  const auto & obj_pose = object.initial_pose;
   const auto & obj_shape = object.shape;
   const auto obj_poly = autoware::universe_utils::toPolygon2d(obj_pose, obj_shape);
   const auto obj_point = obj_pose.position;
@@ -842,7 +842,7 @@ bool passed_parked_objects(
   const auto & leading_obj = objects.at(*leading_obj_idx);
   auto debug = utils::path_safety_checker::createObjectDebug(leading_obj);
   const auto leading_obj_poly =
-    autoware::universe_utils::toPolygon2d(leading_obj.initial_pose.pose, leading_obj.shape);
+    autoware::universe_utils::toPolygon2d(leading_obj.initial_pose, leading_obj.shape);
   if (leading_obj_poly.outer().empty()) {
     return true;
   }
@@ -874,7 +874,7 @@ bool passed_parked_objects(
 
   const auto current_pose = common_data_ptr->get_ego_pose();
   const auto dist_ego_to_obj = motion_utils::calcSignedArcLength(
-    current_lane_path.points, current_pose.position, leading_obj.initial_pose.pose.position);
+    current_lane_path.points, current_pose.position, leading_obj.initial_pose.position);
 
   if (dist_ego_to_obj < lane_change_path.info.length.lane_changing) {
     return true;
@@ -903,12 +903,11 @@ std::optional<size_t> getLeadingStaticObjectIdx(
   std::optional<size_t> leading_obj_idx = std::nullopt;
   for (size_t obj_idx = 0; obj_idx < objects.size(); ++obj_idx) {
     const auto & obj = objects.at(obj_idx);
-    const auto & obj_pose = obj.initial_pose.pose;
+    const auto & obj_pose = obj.initial_pose;
 
     // ignore non-static object
     // TODO(shimizu): parametrize threshold
-    const double obj_vel_norm =
-      std::hypot(obj.initial_twist.twist.linear.x, obj.initial_twist.twist.linear.y);
+    const double obj_vel_norm = std::hypot(obj.initial_twist.linear.x, obj.initial_twist.linear.y);
     if (obj_vel_norm > 1.0) {
       continue;
     }
@@ -964,8 +963,8 @@ ExtendedPredictedObject transform(
   const auto & prepare_duration = lane_change_parameters.lane_change_prepare_duration;
   const auto & velocity_threshold = lane_change_parameters.stopped_object_velocity_threshold;
   const auto start_time = check_at_prepare_phase ? 0.0 : prepare_duration;
-  const double obj_vel_norm = std::hypot(
-    extended_object.initial_twist.twist.linear.x, extended_object.initial_twist.twist.linear.y);
+  const double obj_vel_norm =
+    std::hypot(extended_object.initial_twist.linear.x, extended_object.initial_twist.linear.y);
 
   extended_object.predicted_paths.resize(object.kinematics.predicted_paths.size());
   for (size_t i = 0; i < object.kinematics.predicted_paths.size(); ++i) {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -84,7 +84,7 @@ struct ExtendedPredictedObject
   ObjectClassification classification;
   Polygon2d initial_polygon;
   std::vector<PredictedPathWithPolygon> predicted_paths;
-  double dist_from_ego{0.0};
+  double dist_from_ego{0.0};  ///< Distance from ego, can either be arc length or euclidean.
 
   ExtendedPredictedObject() = default;
   explicit ExtendedPredictedObject(const PredictedObject & object)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -84,7 +84,7 @@ struct ExtendedPredictedObject
   ObjectClassification classification;
   Polygon2d initial_polygon;
   std::vector<PredictedPathWithPolygon> predicted_paths;
-  double dist_from_ego{0.0};  ///< Distance from ego, can either be arc length or euclidean.
+  double dist_from_ego{0.0};  ///< Distance from ego to obj, can be arc length or euclidean.
 
   ExtendedPredictedObject() = default;
   explicit ExtendedPredictedObject(const PredictedObject & object)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -82,7 +82,7 @@ struct ExtendedPredictedObject
   Twist initial_twist;
   Shape shape;
   ObjectClassification classification;
-  Polygon2d self_polygon;
+  Polygon2d initial_polygon;
   std::vector<PredictedPathWithPolygon> predicted_paths;
   double dist_from_ego{0.0};
 
@@ -101,7 +101,7 @@ struct ExtendedPredictedObject
       return (max_elem != object.classification.end()) ? max_elem->label
                                                        : ObjectClassification::UNKNOWN;
     });
-    self_polygon = autoware::universe_utils::toPolygon2d(initial_pose, shape);
+    initial_polygon = autoware::universe_utils::toPolygon2d(initial_pose, shape);
   }
 };
 using ExtendedPredictedObjects = std::vector<ExtendedPredictedObject>;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__BEHAVIOR_PATH_PLANNER_COMMON__UTILS__PATH_SAFETY_CHECKER__PATH_SAFETY_CHECKER_PARAMETERS_HPP_  // NOLINT
 
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
+#include <autoware/universe_utils/geometry/boost_polygon_utils.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <geometry_msgs/msg/pose.hpp>
@@ -23,7 +24,7 @@
 
 #include <boost/uuid/uuid_hash.hpp>
 
-#include <cmath>
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -33,7 +34,9 @@ namespace autoware::behavior_path_planner::utils::path_safety_checker
 {
 
 using autoware::universe_utils::Polygon2d;
+using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::Shape;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 
@@ -60,8 +63,8 @@ struct PoseWithVelocityAndPolygonStamped : public PoseWithVelocityStamped
   Polygon2d poly;
 
   PoseWithVelocityAndPolygonStamped(
-    const double time, const Pose & pose, const double velocity, const Polygon2d & poly)
-  : PoseWithVelocityStamped(time, pose, velocity), poly(poly)
+    const double time, const Pose & pose, const double velocity, Polygon2d poly)
+  : PoseWithVelocityStamped(time, pose, velocity), poly(std::move(poly))
   {
   }
 };
@@ -75,22 +78,30 @@ struct PredictedPathWithPolygon
 struct ExtendedPredictedObject
 {
   unique_identifier_msgs::msg::UUID uuid;
-  geometry_msgs::msg::PoseWithCovariance initial_pose;
-  geometry_msgs::msg::TwistWithCovariance initial_twist;
-  geometry_msgs::msg::AccelWithCovariance initial_acceleration;
-  autoware_perception_msgs::msg::Shape shape;
-  std::vector<autoware_perception_msgs::msg::ObjectClassification> classification;
+  Pose initial_pose;
+  Twist initial_twist;
+  Shape shape;
+  ObjectClassification classification;
+  Polygon2d self_polygon;
   std::vector<PredictedPathWithPolygon> predicted_paths;
+  double dist_from_ego{0.0};
 
   ExtendedPredictedObject() = default;
   explicit ExtendedPredictedObject(const PredictedObject & object)
   : uuid(object.object_id),
-    initial_pose(object.kinematics.initial_pose_with_covariance),
-    initial_twist(object.kinematics.initial_twist_with_covariance),
-    initial_acceleration(object.kinematics.initial_acceleration_with_covariance),
-    shape(object.shape),
-    classification(object.classification)
+    initial_pose(object.kinematics.initial_pose_with_covariance.pose),
+    initial_twist(object.kinematics.initial_twist_with_covariance.twist),
+    shape(object.shape)
   {
+    classification.label = std::invoke([&]() {
+      auto max_elem = std::max_element(
+        object.classification.begin(), object.classification.end(),
+        [](const auto & a, const auto & b) { return a.probability < b.probability; });
+
+      return (max_elem != object.classification.end()) ? max_elem->label
+                                                       : ObjectClassification::UNKNOWN;
+    });
+    self_polygon = autoware::universe_utils::toPolygon2d(initial_pose, shape);
   }
 };
 using ExtendedPredictedObjects = std::vector<ExtendedPredictedObject>;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
@@ -608,7 +608,7 @@ MarkerArray showFilteredObjects(
         cube_marker = default_cube_marker(1.0, 1.0, color);
         cube_marker.pose = pose;
       };
-      insert_cube_marker(obj.initial_pose.pose);
+      insert_cube_marker(obj.initial_pose);
     });
 
   return marker_array;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -327,7 +327,7 @@ ExtendedPredictedObject transform(
 {
   ExtendedPredictedObject extended_object(object);
 
-  const auto obj_velocity = extended_object.initial_twist.twist.linear.x;
+  const auto obj_velocity = extended_object.initial_twist.linear.x;
 
   extended_object.predicted_paths.resize(object.kinematics.predicted_paths.size());
   for (size_t i = 0; i < object.kinematics.predicted_paths.size(); ++i) {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -593,7 +593,7 @@ std::vector<Polygon2d> getCollidedPolygons(
   {
     debug.ego_predicted_path = predicted_ego_path;
     debug.obj_predicted_path = target_object_path.path;
-    debug.current_obj_pose = target_object.initial_pose.pose;
+    debug.current_obj_pose = target_object.initial_pose;
   }
 
   std::vector<Polygon2d> collided_polygons{};
@@ -709,11 +709,10 @@ bool checkPolygonsIntersects(
 CollisionCheckDebugPair createObjectDebug(const ExtendedPredictedObject & obj)
 {
   CollisionCheckDebug debug;
-  debug.current_obj_pose = obj.initial_pose.pose;
-  debug.extended_obj_polygon =
-    autoware::universe_utils::toPolygon2d(obj.initial_pose.pose, obj.shape);
+  debug.current_obj_pose = obj.initial_pose;
+  debug.extended_obj_polygon = autoware::universe_utils::toPolygon2d(obj.initial_pose, obj.shape);
   debug.obj_shape = obj.shape;
-  debug.current_twist = obj.initial_twist.twist;
+  debug.current_twist = obj.initial_twist;
   return {autoware::universe_utils::toBoostUUID(obj.uuid), debug};
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -559,7 +559,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough(const Pose & 
       target_objects_on_lane.on_current_lane.begin(), target_objects_on_lane.on_current_lane.end(),
       [&](const auto & o) {
         const auto arc_length = autoware::motion_utils::calcSignedArcLength(
-          centerline_path.points, ego_pose.position, o.initial_pose.pose.position);
+          centerline_path.points, ego_pose.position, o.initial_pose.position);
         if (arc_length > 0.0) return;
         if (std::abs(arc_length) >= std::abs(arc_length_to_closet_object)) return;
         arc_length_to_closet_object = arc_length;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -838,20 +838,20 @@ bool StaticObstacleAvoidanceModule::isSafePath(
     auto current_debug_data = utils::path_safety_checker::createObjectDebug(object);
 
     const auto obj_polygon =
-      autoware::universe_utils::toPolygon2d(object.initial_pose.pose, object.shape);
+      autoware::universe_utils::toPolygon2d(object.initial_pose, object.shape);
 
     const auto is_object_front =
       utils::path_safety_checker::isTargetObjectFront(getEgoPose(), obj_polygon, p.vehicle_info);
 
-    const auto & object_twist = object.initial_twist.twist;
+    const auto & object_twist = object.initial_twist;
     const auto v_norm = std::hypot(object_twist.linear.x, object_twist.linear.y);
-    const auto object_type = utils::getHighestProbLabel(object.classification);
-    const auto object_parameter = parameters_->object_parameters.at(object_type);
+    const auto object_type = object.classification;
+    const auto object_parameter = parameters_->object_parameters.at(object_type.label);
     const auto is_object_moving = v_norm > object_parameter.moving_speed_threshold;
 
     const auto is_object_oncoming =
       is_object_moving &&
-      utils::path_safety_checker::isTargetObjectOncoming(getEgoPose(), object.initial_pose.pose);
+      utils::path_safety_checker::isTargetObjectOncoming(getEgoPose(), object.initial_pose);
 
     const auto obj_predicted_paths = utils::path_safety_checker::getPredictedPathFromObj(
       object, parameters_->check_all_predicted_path);


### PR DESCRIPTION
## Description

`ExtendedPredictedObject` contains several `msg` that is not being used anywhere.
Furthermore, available member variable, classification, can be be directly instantiated.

This PR also adds 2 new member variables, `initial_polygon` and `dist_from_ego`. The module owners are expected to refactor their own module so that we dont have to call `createPolygon` so often.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
