### PR TITLE
refactor(universe_utils): remove raw pointers from the triangulation function

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -89,12 +89,17 @@ std::size_t eliminate_holes(
   std::vector<LinkedPoint> & points);
 
 /**
- * @brief triangulates a polygon into multiple convex triangles
- * @details simplifies a concave polygon (with or without holes) into a set of triangles
- * @return a vector of convex triangles forming the triangulated polygon
+ * @brief triangulates a polygon into convex triangles
+ * @details simplifies a concave polygon, with or without holes, into a set of triangles
+ * the size of the `points` vector at the end of the perform_triangulation algorithm is described as
+ * follow:
+ * - `outer_points`: Number of points in the initial outer linked list.
+ * - `hole_points`: Number of points in all inner polygons.
+ * - `2 * n_holes`: Additional points for bridging holes, where `n_holes` is the number of holes.
+ * the final size of `points` vector is: `outer_points + hole_points + 2 * n_holes`.
+ * @return A vector of convex triangles representing the triangulated polygon.
  */
 std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
-
 }  // namespace autoware::universe_utils
 
 #endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -18,7 +18,6 @@
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 
 #include <optional>
-#include <utility>
 #include <vector>
 
 namespace autoware::universe_utils
@@ -28,9 +27,9 @@ using Polygon2d = autoware::universe_utils::Polygon2d;
 using Point2d = autoware::universe_utils::Point2d;
 using LinearRing2d = autoware::universe_utils::LinearRing2d;
 
-struct Point
+struct LinkedPoint
 {
-  Point(std::size_t index, const Point2d & point)
+  LinkedPoint(std::size_t index, const Point2d & point)
   : i(index), pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt)
   {
   }
@@ -43,58 +42,13 @@ struct Point
   [[nodiscard]] double x() const { return pt.x(); }
   [[nodiscard]] double y() const { return pt.y(); }
 };
-
-std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
-
-std::vector<Point> perform_triangulation(
-  const Polygon2d & polygon, std::vector<std::size_t> & indices);
-std::size_t construct_point(std::size_t index, const Point2d & point, std::vector<Point> & points);
-void remove_point(std::size_t index, std::vector<Point> & points);
-bool is_ear(std::size_t ear_index, const std::vector<Point> & points);
-bool sector_contains_sector(
-  std::size_t m_index, std::size_t p_index, const std::vector<Point> & points);
-bool point_in_triangle(
-  double ax, double ay, double bx, double by, double cx, double cy, double px, double py);
-bool is_valid_diagonal(std::size_t a_index, std::size_t b_index, const std::vector<Point> & points);
-bool equals(std::size_t p1_index, std::size_t p2_index, const std::vector<Point> & points);
-bool intersects(
-  std::size_t p1_index, std::size_t q1_index, std::size_t p2_index, std::size_t q2_index,
-  const std::vector<Point> & points);
-bool on_segment(
-  const std::vector<Point> & points, std::size_t p_index, std::size_t q_index, std::size_t r_index);
-bool intersects_polygon(
-  const std::vector<Point> & points, std::size_t a_index, std::size_t b_index);
-bool locally_inside(std::size_t a_index, std::size_t b_index, const std::vector<Point> & points);
-bool middle_inside(std::size_t a_index, std::size_t b_index, const std::vector<Point> & points);
-int sign(double val);
-double area(
-  const std::vector<Point> & points, std::size_t p_index, std::size_t q_index, std::size_t r_index);
-
-std::optional<std::size_t> linked_list(
-  const LinearRing2d & points, bool clockwise, std::size_t & vertices,
-  std::vector<Point> & points_vec);
-std::size_t filter_points(
-  std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point> & points_vec);
-std::size_t cure_local_intersections(
-  std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec);
-std::size_t get_leftmost(std::size_t start_index, const std::vector<Point> & points);
-std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points);
-std::size_t insert_point(
-  std::size_t i, const Point2d & pt, std::vector<Point> & points_vec,
-  std::optional<std::size_t> last_index, bool clockwise);
-std::size_t eliminate_holes(
-  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
-  std::vector<Point> & points);
-std::size_t eliminate_hole(
-  std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points);
-std::optional<std::size_t> find_hole_bridge(
-  std::size_t hole_index, std::size_t outer_index, const std::vector<Point> & points);
 void ear_clipping_linked(
   std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices,
-  std::vector<Point> & points, int pass = 0);
+  std::vector<LinkedPoint> & points, int pass = 0);
 void split_ear_clipping(
-  std::vector<Point> & points, std::size_t startIdx, std::vector<std::size_t> & indices);
+  std::vector<LinkedPoint> & points, std::size_t start_index, std::vector<std::size_t> & indices);
 
+std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
 }  // namespace autoware::universe_utils
 
 #endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -37,14 +37,13 @@ struct Point {
     bool steiner;                     
     std::optional<std::size_t> prev_index;  
     std::optional<std::size_t> next_index;
-    // Convenience functions to access coordinates
     [[nodiscard]] double x() const { return pt.x(); }
     [[nodiscard]] double y() const { return pt.y(); }
 };
 
 std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
 
-void perform_triangulation(const Polygon2d & polygon, std::vector<std::size_t> & indices);
+std::vector<Point> perform_triangulation(const Polygon2d & polygon, std::vector<std::size_t> & indices);
 std::size_t construct_point(std::size_t index, const Point2d & point, std::vector<Point> & points);
 void remove_point(std::size_t index, std::vector<Point> & points);
 bool is_ear(std::size_t ear_index, const std::vector<Point> & points);
@@ -60,16 +59,16 @@ bool middle_inside(std::size_t a_index, std::size_t b_index, const std::vector<P
 int sign(double val);
 double area(const std::vector<Point>& points, std::size_t pIdx, std::size_t qIdx, std::size_t rIdx);
 
-std::size_t linked_list(const LinearRing2d& points, bool clockwise, std::size_t& vertices, std::vector<Point> & points_vec);
-std::size_t filter_points(std::size_t start_index, std::size_t end_index, std::vector<Point> & points_vec);
+std::optional<std::size_t> linked_list(const LinearRing2d& points, bool clockwise, std::size_t& vertices, std::vector<Point> & points_vec);
+std::size_t filter_points(std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point> & points_vec);
 std::size_t cure_local_intersections(std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec);
 std::size_t get_leftmost(std::size_t start_index, const std::vector<Point> & points);
 std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points);
-std::size_t insert_point(std::size_t i, const Point2d & p, std::vector<Point> & points, std::size_t last_index);
+std::size_t insert_point(std::size_t i, const Point2d& pt, std::vector<Point>& points_vec, std::optional<std::size_t> last_index, bool clockwise);
 std::size_t eliminate_holes(const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t& vertices, std::vector<Point> & points);
 std::size_t eliminate_hole(std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points);
-std::size_t find_hole_bridge(std::size_t hole_index, std::size_t outer_index, const std::vector<Point> & points);
-void ear_clipping_linked(std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<Point> & points, int pass = 0);
+std::optional<std::size_t> find_hole_bridge(std::size_t hole_index, std::size_t outer_index, const std::vector<Point> & points);
+void ear_clipping_linked(std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices, std::vector<Point> & points, int pass = 0);
 void split_ear_clipping(std::vector<Point>& points, std::size_t startIdx, std::vector<std::size_t>& indices);
 
 }  // namespace autoware::universe_utils

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -56,7 +56,7 @@ void split_ear_clipping(
 /**
  * @brief creates a linked list from a ring of points
  * @details converts a polygon ring into a doubly linked list with optional clockwise ordering
- * @return outer index of the linked list
+ * @return the last index of the created linked list
  */
 std::size_t linked_list(
   const LinearRing2d & ring, const bool clockwise, std::size_t & vertices,

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -18,7 +18,6 @@
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 
 #include <optional>
-#include <vector>
 
 namespace autoware::universe_utils
 {
@@ -42,13 +41,22 @@ struct LinkedPoint
   [[nodiscard]] double x() const { return pt.x(); }
   [[nodiscard]] double y() const { return pt.y(); }
 };
+
+/**
+ * @brief main ear slicing loop which triangulates a polygon using linked list
+ */
 void ear_clipping_linked(
   std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices,
   std::vector<LinkedPoint> & points, int pass = 0);
 void split_ear_clipping(
   std::vector<LinkedPoint> & points, std::size_t start_index, std::vector<std::size_t> & indices);
 
+/**
+ * @brief Triangulate polygon into multiple convex triangle
+ * @details to simplify concave polygons with/without holes into convex polygon
+ */
 std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
+
 }  // namespace autoware::universe_utils
 
 #endif  // AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -18,6 +18,7 @@
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
 
 #include <optional>
+#include <vector>
 
 namespace autoware::universe_utils
 {

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -16,8 +16,8 @@
 #define AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_
 
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
-#include <optional>
 
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -28,48 +28,72 @@ using Polygon2d = autoware::universe_utils::Polygon2d;
 using Point2d = autoware::universe_utils::Point2d;
 using LinearRing2d = autoware::universe_utils::LinearRing2d;
 
-struct Point {
-    Point(std::size_t index, const Point2d& point) 
-        : i(index), pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt) {}
+struct Point
+{
+  Point(std::size_t index, const Point2d & point)
+  : i(index), pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt)
+  {
+  }
 
-    std::size_t i;                    
-    Point2d pt;                       
-    bool steiner;                     
-    std::optional<std::size_t> prev_index;  
-    std::optional<std::size_t> next_index;
-    [[nodiscard]] double x() const { return pt.x(); }
-    [[nodiscard]] double y() const { return pt.y(); }
+  std::size_t i;
+  Point2d pt;
+  bool steiner;
+  std::optional<std::size_t> prev_index;
+  std::optional<std::size_t> next_index;
+  [[nodiscard]] double x() const { return pt.x(); }
+  [[nodiscard]] double y() const { return pt.y(); }
 };
 
 std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
 
-std::vector<Point> perform_triangulation(const Polygon2d & polygon, std::vector<std::size_t> & indices);
+std::vector<Point> perform_triangulation(
+  const Polygon2d & polygon, std::vector<std::size_t> & indices);
 std::size_t construct_point(std::size_t index, const Point2d & point, std::vector<Point> & points);
 void remove_point(std::size_t index, std::vector<Point> & points);
 bool is_ear(std::size_t ear_index, const std::vector<Point> & points);
-bool sector_contains_sector(std::size_t m_index, std::size_t p_index, const std::vector<Point> & points);
-bool point_in_triangle(double ax, double ay, double bx, double by, double cx, double cy, double px, double py);
+bool sector_contains_sector(
+  std::size_t m_index, std::size_t p_index, const std::vector<Point> & points);
+bool point_in_triangle(
+  double ax, double ay, double bx, double by, double cx, double cy, double px, double py);
 bool is_valid_diagonal(std::size_t a_index, std::size_t b_index, const std::vector<Point> & points);
 bool equals(std::size_t p1_index, std::size_t p2_index, const std::vector<Point> & points);
-bool intersects(std::size_t p1_index, std::size_t q1_index, std::size_t p2_index, std::size_t q2_index, const std::vector<Point> & points);
-bool on_segment(const std::vector<Point>& points, std::size_t pIdx, std::size_t qIdx, std::size_t rIdx);
-bool intersects_polygon(const std::vector<Point>& points, std::size_t aIdx, std::size_t bIdx);
+bool intersects(
+  std::size_t p1_index, std::size_t q1_index, std::size_t p2_index, std::size_t q2_index,
+  const std::vector<Point> & points);
+bool on_segment(
+  const std::vector<Point> & points, std::size_t p_index, std::size_t q_index, std::size_t r_index);
+bool intersects_polygon(
+  const std::vector<Point> & points, std::size_t a_index, std::size_t b_index);
 bool locally_inside(std::size_t a_index, std::size_t b_index, const std::vector<Point> & points);
 bool middle_inside(std::size_t a_index, std::size_t b_index, const std::vector<Point> & points);
 int sign(double val);
-double area(const std::vector<Point>& points, std::size_t pIdx, std::size_t qIdx, std::size_t rIdx);
+double area(
+  const std::vector<Point> & points, std::size_t p_index, std::size_t q_index, std::size_t r_index);
 
-std::optional<std::size_t> linked_list(const LinearRing2d& points, bool clockwise, std::size_t& vertices, std::vector<Point> & points_vec);
-std::size_t filter_points(std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point> & points_vec);
-std::size_t cure_local_intersections(std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec);
+std::optional<std::size_t> linked_list(
+  const LinearRing2d & points, bool clockwise, std::size_t & vertices,
+  std::vector<Point> & points_vec);
+std::size_t filter_points(
+  std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point> & points_vec);
+std::size_t cure_local_intersections(
+  std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec);
 std::size_t get_leftmost(std::size_t start_index, const std::vector<Point> & points);
 std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points);
-std::size_t insert_point(std::size_t i, const Point2d& pt, std::vector<Point>& points_vec, std::optional<std::size_t> last_index, bool clockwise);
-std::size_t eliminate_holes(const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t& vertices, std::vector<Point> & points);
-std::size_t eliminate_hole(std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points);
-std::optional<std::size_t> find_hole_bridge(std::size_t hole_index, std::size_t outer_index, const std::vector<Point> & points);
-void ear_clipping_linked(std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices, std::vector<Point> & points, int pass = 0);
-void split_ear_clipping(std::vector<Point>& points, std::size_t startIdx, std::vector<std::size_t>& indices);
+std::size_t insert_point(
+  std::size_t i, const Point2d & pt, std::vector<Point> & points_vec,
+  std::optional<std::size_t> last_index, bool clockwise);
+std::size_t eliminate_holes(
+  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
+  std::vector<Point> & points);
+std::size_t eliminate_hole(
+  std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points);
+std::optional<std::size_t> find_hole_bridge(
+  std::size_t hole_index, std::size_t outer_index, const std::vector<Point> & points);
+void ear_clipping_linked(
+  std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices,
+  std::vector<Point> & points, int pass = 0);
+void split_ear_clipping(
+  std::vector<Point> & points, std::size_t startIdx, std::vector<std::size_t> & indices);
 
 }  // namespace autoware::universe_utils
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_
 
 #include "autoware/universe_utils/geometry/boost_geometry.hpp"
+#include <optional>
 
 #include <utility>
 #include <vector>
@@ -28,15 +29,15 @@ using Point2d = autoware::universe_utils::Point2d;
 using LinearRing2d = autoware::universe_utils::LinearRing2d;
 
 struct Point {
-    Point(std::size_t index, Point2d point) 
-        : i(index), pt(std::move(point)), steiner(false), prev_index(0), next_index(0) {}
+    Point(std::size_t index, const Point2d& point) 
+        : i(index), pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt) {}
 
-    std::size_t i;
-    Point2d pt;
-    bool steiner;
-    std::size_t prev_index; // Use index for prev
-    std::size_t next_index; // Use index for next
-
+    std::size_t i;                    
+    Point2d pt;                       
+    bool steiner;                     
+    std::optional<std::size_t> prev_index;  
+    std::optional<std::size_t> next_index;
+    // Convenience functions to access coordinates
     [[nodiscard]] double x() const { return pt.x(); }
     [[nodiscard]] double y() const { return pt.y(); }
 };
@@ -64,7 +65,7 @@ std::size_t filter_points(std::size_t start_index, std::size_t end_index, std::v
 std::size_t cure_local_intersections(std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec);
 std::size_t get_leftmost(std::size_t start_index, const std::vector<Point> & points);
 std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points);
-std::size_t insert_point(std::size_t i, const Point2d & p, std::vector<Point> & points, bool clockwise);
+std::size_t insert_point(std::size_t i, const Point2d & p, std::vector<Point> & points, std::size_t last_index);
 std::size_t eliminate_holes(const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t& vertices, std::vector<Point> & points);
 std::size_t eliminate_hole(std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points);
 std::size_t find_hole_bridge(std::size_t hole_index, std::size_t outer_index, const std::vector<Point> & points);

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -29,12 +29,11 @@ using LinearRing2d = autoware::universe_utils::LinearRing2d;
 
 struct LinkedPoint
 {
-  LinkedPoint(std::size_t index, const Point2d & point)
-  : i(index), pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt)
+  explicit LinkedPoint(const Point2d & point)
+  : pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt)
   {
   }
 
-  std::size_t i;
   Point2d pt;
   bool steiner;
   std::optional<std::size_t> prev_index;
@@ -45,16 +44,54 @@ struct LinkedPoint
 
 /**
  * @brief main ear slicing loop which triangulates a polygon using linked list
+ * @details iterates over the linked list of polygon points, cutting off triangular ears one by one
+ * handles different stages for fixing intersections and splitting if necessary
  */
 void ear_clipping_linked(
-  std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices,
-  std::vector<LinkedPoint> & points, int pass = 0);
+  std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & points,
+  const int pass = 0);
 void split_ear_clipping(
   std::vector<LinkedPoint> & points, std::size_t start_index, std::vector<std::size_t> & indices);
 
 /**
- * @brief Triangulate polygon into multiple convex triangle
- * @details to simplify concave polygons with/without holes into convex polygon
+ * @brief creates a linked list from a ring of points
+ * @details converts a polygon ring into a doubly linked list with optional clockwise ordering
+ * @return outer index of the linked list
+ */
+std::size_t linked_list(
+  const LinearRing2d & ring, const bool clockwise, std::size_t & vertices,
+  std::vector<LinkedPoint> & points);
+
+/**
+ * @brief David Eberly's algorithm for finding a bridge between hole and outer polygon
+ * @details connects a hole to the outer polygon by finding the closest bridge point
+ * @return index of the bridge point
+ */
+std::size_t find_hole_bridge(
+  const std::size_t hole_index, const std::size_t outer_point_index,
+  const std::vector<LinkedPoint> & points);
+
+/**
+ * @brief eliminates a single hole by connecting it to the outer polygon
+ * @details finds a bridge and modifies the linked list to remove the hole
+ * @return the updated outer_index after the hole is eliminated
+ */
+std::size_t eliminate_hole(
+  const std::size_t hole_index, const std::size_t outer_index, std::vector<LinkedPoint> & points);
+
+/**
+ * @brief eliminates all holes from a polygon
+ * @details processes multiple holes by connecting each to the outer polygon in sequence
+ * @return the updated outer_index after all holes are eliminated
+ */
+std::size_t eliminate_holes(
+  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
+  std::vector<LinkedPoint> & points);
+
+/**
+ * @brief triangulates a polygon into multiple convex triangles
+ * @details simplifies a concave polygon (with or without holes) into a set of triangles
+ * @return a vector of convex triangles forming the triangulated polygon
  */
 std::vector<Polygon2d> triangulate(const Polygon2d & polygon);
 

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -250,12 +250,12 @@ std::size_t linked_list(
   }
 
   if (clockwise == (sum > 0)) {
-    for (std::size_t i = 0; i < len; i++) {
-      last_index = insert_point(ring[i], points, last_index);
+    for (const auto & point : ring) {
+      last_index = insert_point(point, points, last_index);
     }
   } else {
-    for (std::size_t i = len; i-- > 0;) {
-      last_index = insert_point(ring[i], points, last_index);
+    for (auto it = ring.rbegin(); it != ring.rend(); ++it) {
+      last_index = insert_point(*it, points, last_index);
     }
   }
 
@@ -420,11 +420,10 @@ std::size_t eliminate_holes(
   const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
   std::vector<LinkedPoint> & points)
 {
-  const std::size_t len = inners.size();
   std::vector<std::size_t> queue;
 
-  for (std::size_t i = 0; i < len; ++i) {
-    auto inner_index = linked_list(inners[i], false, vertices, points);
+  for (const auto & ring : inners) {
+    auto inner_index = linked_list(ring, false, vertices, points);
 
     if (points[inner_index].next_index.value() == inner_index) {
       points[inner_index].steiner = true;

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -18,7 +18,6 @@ namespace autoware::universe_utils
 {
 
 /// Utils Function
-/// @brief insert a point inside the linked linst on an index
 std::size_t construct_point(
   const std::size_t index, const Point2d & point, std::vector<LinkedPoint> & points)
 {
@@ -26,7 +25,6 @@ std::size_t construct_point(
   return index;
 }
 
-/// @brief remove a Point from the linked list
 void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
   std::size_t prev_index = points[p_index].prev_index.value();
@@ -36,7 +34,6 @@ void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
   points[next_index].prev_index = prev_index;
 }
 
-/// @brief find the leftmost Point of a polygon ring
 std::size_t get_leftmost(const std::size_t start_idx, const std::vector<LinkedPoint> & points)
 {
   std::size_t p_idx = start_idx;
@@ -54,7 +51,6 @@ std::size_t get_leftmost(const std::size_t start_idx, const std::vector<LinkedPo
   return left_most_idx;
 }
 
-/// @brief check if a point lies within a convex triangle
 bool point_in_triangle(
   const double ax, const double ay, const double bx, const double by, const double cx,
   const double cy, const double px, const double py)
@@ -64,7 +60,6 @@ bool point_in_triangle(
          (bx - px) * (cy - py) >= (cx - px) * (by - py);
 }
 
-/// @brief signed area of a triangle
 double area(
   const std::vector<LinkedPoint> & points, const std::size_t p_idx, const std::size_t q_idx,
   const std::size_t r_idx)
@@ -75,7 +70,6 @@ double area(
   return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
 }
 
-/// @brief check if the middle vertex of a polygon diagonal is inside the polygon
 bool middle_inside(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
@@ -99,20 +93,16 @@ bool middle_inside(
   return inside;
 }
 
-/// @brief check if two points are equal
-bool equals(
-  const std::size_t p1_idx, const std::size_t p2_idx, const std::vector<LinkedPoint> & points)
+bool equals(const std::size_t p1_idx, const std::size_t p2_idx, const std::vector<LinkedPoint> & points)
 {
   return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
 }
 
-/// @brief sign function for area calculation
 int sign(const double val)
 {
   return (0.0 < val) - (val < 0.0);
 }
 
-/// @brief for collinear points p, q, r, check if point q lies on segment pr
 bool on_segment(
   const std::vector<LinkedPoint> & points, const std::size_t p_idx, const std::size_t q_idx,
   const std::size_t r_idx)
@@ -124,7 +114,6 @@ bool on_segment(
          q.y() <= std::max<double>(p.y(), r.y()) && q.y() >= std::min<double>(p.y(), r.y());
 }
 
-/// @brief check if a polygon diagonal is locally inside the polygon
 bool locally_inside(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
@@ -135,7 +124,6 @@ bool locally_inside(
                area(points, a_idx, points[a_idx].next_index.value(), b_idx) < 0;
 }
 
-/// @brief check if two segments intersect
 bool intersects(
   const std::size_t p1_idx, const std::size_t q1_idx, const std::size_t p2_idx,
   const std::size_t q2_idx, const std::vector<LinkedPoint> & points)
@@ -155,7 +143,6 @@ bool intersects(
   return false;
 }
 
-/// @brief check if a polygon diagonal intersects any polygon segments
 bool intersects_polygon(
   const std::vector<LinkedPoint> & points, const std::size_t a_idx, const std::size_t b_idx)
 {
@@ -175,22 +162,18 @@ bool intersects_polygon(
   return false;
 }
 
-/// @brief check if a diagonal between two polygon Points is valid
 bool is_valid_diagonal(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  // Extract indices for the next and previous points
   std::size_t a_next_idx = points[a_idx].next_index.value();
   std::size_t a_prev_idx = points[a_idx].prev_index.value();
   std::size_t b_next_idx = points[b_idx].next_index.value();
   std::size_t b_prev_idx = points[b_idx].prev_index.value();
 
-  // Check if diagonal does not connect adjacent or same points
   if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx)) {
     return false;
   }
 
-  // Check if diagonals are locally inside and not intersecting
   bool is_locally_inside_ab = locally_inside(a_idx, b_idx, points);
   bool is_locally_inside_ba = locally_inside(b_idx, a_idx, points);
   bool is_middle_inside = middle_inside(a_idx, b_idx, points);
@@ -205,9 +188,6 @@ bool is_valid_diagonal(
   return is_valid_diagonal;
 }
 
-// Main Earclipping Function
-/// @brief create a Point and optionally link it with the previous one (in a circular doubly linked
-/// list)
 std::size_t insert_point(
   const std::size_t i, const Point2d & pt, std::vector<LinkedPoint> & pointsvec,
   const std::optional<std::size_t> last_index)
@@ -230,7 +210,6 @@ std::size_t insert_point(
   return p_idx;
 }
 
-/// @brief create a circular doubly linked list from polygon points in the specified winding order
 std::size_t linked_list(
   const LinearRing2d & points, const bool clockwise, std::size_t & vertices,
   std::vector<LinkedPoint> & pointsvec)
@@ -266,8 +245,6 @@ std::size_t linked_list(
   return last_index.value();
 }
 
-/// @brief check whether the sector in vertex m contains the sector in vertex p in the same
-/// coordinates
 bool sector_contains_sector(
   const std::size_t m_idx, const std::size_t p_idx, const std::vector<LinkedPoint> & points)
 {
@@ -275,12 +252,8 @@ bool sector_contains_sector(
          area(points, p_idx, points[m_idx].next_index.value(), m_idx) < 0;
 }
 
-// cspell: ignore Eberly
-/// @brief David Eberly's algorithm for finding a bridge between hole and outer polygon using vector
-/// indices
 std::size_t find_hole_bridge(
-  const std::size_t hole_index, const std::size_t outer_point_index,
-  const std::vector<LinkedPoint> & points)
+  const std::size_t hole_index, const std::size_t outer_point_index, const std::vector<LinkedPoint> & points)
 {
   std::size_t p = outer_point_index;
   double hx = points[hole_index].x();
@@ -335,39 +308,33 @@ std::size_t find_hole_bridge(
   return bridge_point.value();
 }
 
-/// @brief link two polygon vertices with a bridge
 std::size_t split_polygon(
-  const std::size_t a_index, const std::size_t b_index, std::vector<LinkedPoint> & points)
+  std::size_t a_index, std::size_t b_index, std::vector<LinkedPoint> & points)
 {
-  Point2d a_point(points[a_index].x(), points[a_index].y());
-  Point2d b_point(points[b_index].x(), points[b_index].y());
-
-  std::size_t a2_idx = construct_point(a_index, a_point, points);
-  std::size_t b2_idx = construct_point(b_index, b_point, points);
-
   std::size_t an_idx = points[a_index].next_index.value();
   std::size_t bp_idx = points[b_index].prev_index.value();
 
+  std::size_t a2_idx = points.size();
+  std::size_t b2_idx = points.size() + 1;
+  points.emplace_back(a_index, points[a_index].pt);
+  points.emplace_back(b_index, points[b_index].pt);
+
   points[a_index].next_index = b_index;
-  points[b_index].prev_index = a_index;
-
-  points[a2_idx].next_index = an_idx;
-  if (an_idx != a_index) {
-    points[an_idx].prev_index = a2_idx;
-  }
-
-  points[b2_idx].next_index = a2_idx;
   points[a2_idx].prev_index = b2_idx;
+  points[a2_idx].next_index = an_idx;
+
+  points[b_index].prev_index = a_index;
+  points[an_idx].prev_index = b2_idx;
+  points[b2_idx].next_index = a2_idx;
+  points[b2_idx].prev_index = bp_idx;
 
   if (bp_idx != b_index) {
     points[bp_idx].next_index = b2_idx;
   }
-  points[b2_idx].prev_index = bp_idx;
 
   return b2_idx;
 }
 
-/// @brief eliminate colinear or duplicate points
 std::size_t filter_points(
   const std::size_t start_index, const std::size_t end_index, std::vector<LinkedPoint> & pointsvec)
 {
@@ -393,7 +360,6 @@ std::size_t filter_points(
   return end_index;
 }
 
-/// @brief find a bridge between vertices that connects hole with an outer ring and link it
 std::size_t eliminate_hole(
   const std::size_t hole_index, const std::size_t outer_index, std::vector<LinkedPoint> & pointsvec)
 {
@@ -409,18 +375,16 @@ std::size_t eliminate_holes(
   std::vector<LinkedPoint> & pointsvec)
 {
   const std::size_t len = inners.size();
-
   std::vector<std::size_t> queue;
   for (std::size_t i = 0; i < len; i++) {
-    auto list = linked_list(inners[i], false, vertices, pointsvec);
+    auto pointsvec_inner = linked_list(inners[i], false, vertices, pointsvec);
 
-    if (pointsvec[list].next_index == list) {
-      pointsvec[list].steiner = true;
+    if (pointsvec[pointsvec_inner].next_index == pointsvec_inner) {
+      pointsvec[pointsvec_inner].steiner = true;
     }
 
-    queue.push_back(get_leftmost(list, pointsvec));
+    queue.push_back(get_leftmost(pointsvec_inner, pointsvec));
   }
-
   std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {
     return pointsvec[a].x() < pointsvec[b].x();
   });
@@ -428,11 +392,9 @@ std::size_t eliminate_holes(
   for (const auto & q : queue) {
     outer_index = eliminate_hole(q, outer_index, pointsvec);
   }
-
   return outer_index;
 }
 
-/// @brief check whether ear is valid
 bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & pointsvec)
 {
   const auto a_index = pointsvec[ear_index].prev_index.value();
@@ -443,8 +405,7 @@ bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points
   const auto b = pointsvec[b_index];
   const auto c = pointsvec[c_index];
 
-  if (area(pointsvec, a_index, b_index, c_index) >= 0) return false;  // Reflex, can't be an ear
-
+  if (area(pointsvec, a_index, b_index, c_index) >= 0) return false;
   auto p_index = pointsvec[c_index].next_index.value();
   while (p_index != a_index) {
     const auto p = pointsvec[p_index];
@@ -459,7 +420,6 @@ bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points
   return true;
 }
 
-/// @brief go through all polygon Points and cure small local self-intersections
 std::size_t cure_local_intersections(
   std::size_t start_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & pointsvec)
 {
@@ -485,33 +445,29 @@ std::size_t cure_local_intersections(
     } else {
       p = pointsvec[p].next_index.value();
     }
+
   } while (p != start_index && updated);
 
   return filter_points(p, p, pointsvec);
 }
 
-/// @brief main ear slicing loop which triangulates a polygon using linked list
 void ear_clipping_linked(
   std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & pointsvec,
   const int pass = 0)
 {
-  auto stop = ear_index;  // Stopping point for the loop
+  auto stop = ear_index; 
   std::optional<std::size_t> next = std::nullopt;
 
-  // Iterate through ears, slicing them one by one
   while (pointsvec[ear_index].prev_index.value() != pointsvec[ear_index].next_index.value()) {
     next = pointsvec[ear_index].next_index;
 
     if (is_ear(ear_index, pointsvec)) {
-      // Cut off the triangle and store the indices
       indices.emplace_back(pointsvec[ear_index].prev_index.value());
       indices.emplace_back(ear_index);
       indices.emplace_back(next.value());
 
-      // Remove the ear and update the ear_index to continue
       remove_point(ear_index, pointsvec);
 
-      // Move to the next ear after removal
       ear_index = pointsvec[next.value()].next_index.value();
       stop = pointsvec[next.value()].next_index.value();
       continue;
@@ -534,10 +490,8 @@ void ear_clipping_linked(
   }
 }
 
-/// @brief split the polygon using ear clipping
 void split_ear_clipping(
-  std::vector<LinkedPoint> & points, const std::size_t start_idx,
-  std::vector<std::size_t> & indices)
+  std::vector<LinkedPoint> & points, const std::size_t start_idx, std::vector<std::size_t> & indices)
 {
   std::size_t a_idx = start_idx;
   do {
@@ -587,8 +541,6 @@ std::vector<LinkedPoint> perform_triangulation(
   return points;
 }
 
-// Main Function
-/// @brief main triangulate function
 std::vector<Polygon2d> triangulate(const Polygon2d & poly)
 {
   std::vector<std::size_t> indices;

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -93,7 +93,8 @@ bool middle_inside(
   return inside;
 }
 
-bool equals(const std::size_t p1_idx, const std::size_t p2_idx, const std::vector<LinkedPoint> & points)
+bool equals(
+  const std::size_t p1_idx, const std::size_t p2_idx, const std::vector<LinkedPoint> & points)
 {
   return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
 }
@@ -253,7 +254,8 @@ bool sector_contains_sector(
 }
 
 std::size_t find_hole_bridge(
-  const std::size_t hole_index, const std::size_t outer_point_index, const std::vector<LinkedPoint> & points)
+  const std::size_t hole_index, const std::size_t outer_point_index,
+  const std::vector<LinkedPoint> & points)
 {
   std::size_t p = outer_point_index;
   double hx = points[hole_index].x();
@@ -455,7 +457,7 @@ void ear_clipping_linked(
   std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & pointsvec,
   const int pass = 0)
 {
-  auto stop = ear_index; 
+  auto stop = ear_index;
   std::optional<std::size_t> next = std::nullopt;
 
   while (pointsvec[ear_index].prev_index.value() != pointsvec[ear_index].next_index.value()) {
@@ -491,7 +493,8 @@ void ear_clipping_linked(
 }
 
 void split_ear_clipping(
-  std::vector<LinkedPoint> & points, const std::size_t start_idx, std::vector<std::size_t> & indices)
+  std::vector<LinkedPoint> & points, const std::size_t start_idx,
+  std::vector<std::size_t> & indices)
 {
   std::size_t a_idx = start_idx;
   do {

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "autoware/universe_utils/geometry/ear_clipping.hpp"
+#include <iostream>
+
 
 #ifndef EAR_CUT_IMPL_HPP
 #define EAR_CUT_IMPL_HPP
@@ -20,517 +22,632 @@
 namespace autoware::universe_utils
 {
 
-void EarClipping::operator()(const Polygon2d & polygon)
-{
-  indices.clear();
-  vertices = 0;
-
-  if (polygon.outer().size() == 0) return;
-
-  std::size_t len = 0;
-
-  const auto & outer_ring = polygon.outer();
-  len = outer_ring.size();
-  points_.reserve(len * 3 / 2);
-  indices.reserve(len + outer_ring.size());
-
-  EarClipping::Point * outer_point = linked_list(outer_ring, true);
-  if (!outer_point || outer_point->prev == outer_point->next) return;
-  if (polygon.inners().size() > 0) outer_point = eliminate_holes(polygon.inners(), outer_point);
-  ear_clipping_linked(outer_point);
-  points_.clear();
+std::size_t construct_point(std::size_t index, const Point2d& point, std::vector<Point> & points) {
+    points.emplace_back(index, point);
+    return index;
 }
 
-/// @brief create a circular doubly linked list from polygon points in the specified winding order
-EarClipping::Point * EarClipping::linked_list(const LinearRing2d & points, bool clockwise)
+void perform_triangulation(const Polygon2d & polygon, std::vector<std::size_t> & indices) {
+    indices.clear();
+    if (polygon.outer().empty()) return;
+
+    std::size_t vertices = 0;
+    const auto & outer_ring = polygon.outer();
+    std::size_t len = outer_ring.size();
+
+    std::vector<Point> points_;
+    points_.reserve(len * 3 / 2);
+    indices.reserve(len + outer_ring.size());
+
+    std::cout << "Outer ring size: " << len << std::endl;
+    auto outer_point = linked_list(outer_ring, true, vertices, points_);
+    std::cout << "Linked list created. Last point index: " << outer_point  << "last_point prev index" << points_[outer_point].prev_index << std::endl;
+
+    if (outer_point == points_[outer_point].prev_index) {
+        std::cerr << "Invalid linked list. Exiting triangulation." << std::endl;
+        return;
+    }
+
+    if (!polygon.inners().empty()) {
+        outer_point = eliminate_holes(polygon.inners(), outer_point, vertices, points_);
+        std::cout << "Holes eliminated. New outer point index: " << outer_point << std::endl;
+    }
+
+    ear_clipping_linked(outer_point, indices, points_);
+    std::cout << "Number of triangles: " << indices.size() / 3 << std::endl;
+
+    std::cout << "Indices: ";
+    for (std::size_t idx : indices) {
+        std::cout << idx << " ";
+    }
+    std::cout << std::endl;
+
+    points_.clear();
+}
+
+/// @brief create a Point and optionally link it with the previous one (in a circular doubly linked list)
+std::size_t insert_point(
+    std::size_t i, const Point2d& pt, std::vector<Point>& points_vec, bool clockwise)
 {
-  double sum = 0;
-  const std::size_t len = points.size();
-  EarClipping::Point * last = nullptr;
+    // Create the new point
+    std::size_t p_idx = construct_point(i, pt, points_vec);
 
-  for (size_t i = 0, j = len > 0 ? len - 1 : 0; i < len; j = i++) {
-    const auto & p1 = points[i];
-    const auto & p2 = points[j];
-    const double p10 = p1.x();
-    const double p11 = p1.y();
-    const double p20 = p2.x();
-    const double p21 = p2.y();
-    sum += (p20 - p10) * (p11 + p21);
-  }
+    // Handle linking in the circular doubly linked list
+    if (points_vec.size() == 1) {
+        // Only one point in the list, link it to itself
+        if (clockwise) {
+        points_vec[p_idx].prev_index = p_idx;
+        points_vec[p_idx].next_index = p_idx;
 
-  if (clockwise == (sum > 0)) {
-    for (size_t i = 0; i < len; i++) {
-      last = insert_point(vertices + i, points[i], last);
+        } else {
+        points_vec[p_idx].prev_index = p_idx;
+        points_vec[p_idx].next_index = p_idx;
+
+        }
+    } else {
+        // Adjust indices for circular behavior
+        std::size_t prev_idx = (p_idx - 1 );
+        std::size_t next_idx = (p_idx + 1 );
+
+        // Link according to the direction (clockwise or counterclockwise)
+        if (clockwise) {
+            points_vec[p_idx].prev_index = prev_idx;
+            points_vec[p_idx].next_index = next_idx;
+
+            points_vec[prev_idx].next_index = p_idx;
+            points_vec[next_idx].prev_index = p_idx;
+        } else {
+            points_vec[p_idx].prev_index = next_idx;
+            points_vec[p_idx].next_index = prev_idx;
+
+            points_vec[prev_idx].prev_index = p_idx;
+            points_vec[next_idx].next_index = p_idx;
+        }
     }
-  } else {
-    for (size_t i = len; i-- > 0;) {
-      last = insert_point(vertices + i, points[i], last);
+    return p_idx;
+}
+
+std::size_t linked_list(const LinearRing2d& points, bool clockwise, std::size_t& vertices, std::vector<Point>& points_vec) {
+    double sum = 0;
+    const std::size_t len = points.size();
+    std::size_t last_index = std::numeric_limits<std::size_t>::max();
+
+    // Calculate area to determine clockwise or counterclockwise
+    for (std::size_t i = 0, j = len > 0 ? len - 1 : 0; i < len; j = i++) {
+        const auto& p1 = points[i];
+        const auto& p2 = points[j];
+        sum += (p2.x() - p1.x()) * (p1.y() + p2.y());
     }
-  }
 
-  if (last && equals(last, last->next)) {
-    remove_point(last);
-    last = last->next;
-  }
+    // Determine the correct direction and insert points
+    if (clockwise == (sum > 0)) {
+        for (std::size_t i = 0; i < len; i++) {
+            last_index = insert_point(vertices + i, points[i], points_vec, clockwise == (sum > 0));
+        }
+    } else {
+        for (std::size_t i = 0; i < len; i++) {
+            last_index = insert_point(vertices + i, points[len - 1 - i], points_vec, clockwise == (sum > 0));
+        }
+    }
+    if (clockwise == (sum > 0)) {
+    points_vec[0].prev_index = 1;
+    points_vec[0].next_index = last_index;
+    points_vec[last_index].prev_index = 0;
+    points_vec[last_index].next_index = last_index-1;
 
-  vertices += len;
 
-  return last;
+} else {
+    points_vec[0].prev_index = last_index;
+    points_vec[0].next_index = 1;
+    points_vec[last_index].prev_index = last_index-1;
+    points_vec[last_index].next_index = 0;
+
+    }
+
+
+    for (std::size_t i = 0; i < points_vec.size(); ++i) {
+        std::cout << "Index: " << i
+                  << ", Prev index: " << points_vec[i].prev_index
+                  << ", Next index: " << points_vec[i].next_index
+                  << std::endl;
+    }
+    // Update the number of vertices
+    vertices += len;
+    return last_index;
 }
 
 /// @brief eliminate colinear or duplicate points
-EarClipping::Point * EarClipping::filter_points(
-  EarClipping::Point * start, EarClipping::Point * end)
-{
-  if (!end) end = start;
-
-  EarClipping::Point * p = start;
-  bool again = false;
-  do {
-    again = false;
-
-    if (!p->steiner && (equals(p, p->next) || area(p->prev, p, p->next) == 0)) {
-      remove_point(p);
-      p = end = p->prev;
-
-      if (p == p->next) break;
-      again = true;
-
-    } else {
-      p = p->next;
-    }
-  } while (again || p != end);
-
-  return end;
-}
-
-/// @brief find a bridge between vertices that connects hole with an outer ring and and link it
-EarClipping::Point * EarClipping::eliminate_hole(
-  EarClipping::Point * hole, EarClipping::Point * outer_point)
-{
-  EarClipping::Point * bridge = find_hole_bridge(hole, outer_point);
-  if (!bridge) {
-    return outer_point;
-  }
-  EarClipping::Point * bridge_reverse = split_polygon(bridge, hole);
-
-  // filter collinear points around the cuts
-  filter_points(bridge_reverse, bridge_reverse->next);
-
-  // Check if input node was removed by the filtering
-  return filter_points(bridge, bridge->next);
-}
-
-EarClipping::Point * EarClipping::eliminate_holes(
-  const std::vector<LinearRing2d> & inners, EarClipping::Point * outer_point)
-{
-  const size_t len = inners.size();
-
-  std::vector<Point *> queue;
-  for (size_t i = 0; i < len; i++) {
-    Point * list = linked_list(inners[i], false);
-    if (list) {
-      if (list == list->next) list->steiner = true;
-      queue.push_back(get_leftmost(list));
-    }
-  }
-  std::sort(
-    queue.begin(), queue.end(), [](const Point * a, const Point * b) { return a->x() < b->x(); });
-  for (const auto & q : queue) {
-    outer_point = eliminate_hole(q, outer_point);
-  }
-
-  return outer_point;
-}
-
-// cspell: ignore Eberly
-/// @brief David Eberly's algorithm for finding a bridge between hole and outer polygon
-EarClipping::Point * EarClipping::find_hole_bridge(Point * hole, Point * outer_point)
-{
-  Point * p = outer_point;
-  double hx = hole->x();
-  double hy = hole->y();
-  double qx = -std::numeric_limits<double>::infinity();
-  Point * m = nullptr;
-  do {
-    if (hy <= p->y() && hy >= p->next->y() && p->next->y() != p->y()) {
-      double x = p->x() + (hy - p->y()) * (p->next->x() - p->x()) / (p->next->y() - p->y());
-      if (x <= hx && x > qx) {
-        qx = x;
-        m = p->x() < p->next->x() ? p : p->next;
-        if (x == hx) return m;
-      }
-    }
-    p = p->next;
-  } while (p != outer_point);
-
-  if (!m) return nullptr;
-
-  const Point * stop = m;
-  double tan_min = std::numeric_limits<double>::infinity();
-
-  p = m;
-  double mx = m->x();
-  double my = m->y();
-
-  do {
-    if (
-      hx >= p->x() && p->x() >= mx && hx != p->x() &&
-      point_in_triangle(hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, p->x(), p->y())) {
-      const auto tan_cur = std::abs(hy - p->y()) / (hx - p->x());
-
-      if (
-        locally_inside(p, hole) &&
-        (tan_cur < tan_min ||
-         (tan_cur == tan_min && (p->x() > m->x() || sector_contains_sector(m, p))))) {
-        m = p;
-        tan_min = tan_cur;
-      }
+std::size_t filter_points(std::size_t start_index, std::size_t end_index, std::vector<Point>& points_vec) {
+    if (end_index == std::numeric_limits<std::size_t>::max()) {
+        end_index = start_index;
     }
 
-    p = p->next;
-  } while (p != stop);
+    auto p = start_index;
+    bool again = false;
+    do {
+        again = false;
 
-  return m;
+        // Check if the point should be removed due to collinearity or duplication
+        if (!points_vec[p].steiner &&
+            (equals(p, points_vec[p].next_index, points_vec) ||
+             area(points_vec, points_vec[p].prev_index, p, points_vec[p].next_index) == 0)) {
+            remove_point(p, points_vec);
+            p = points_vec[p].prev_index;
+
+            // Ensure the loop stops if it has traversed the entire ring
+            if (p == points_vec[p].next_index) break;
+            again = true;
+
+        } else {
+            p = points_vec[p].next_index;
+        }
+    } while (again || p != end_index);
+
+    return end_index;
+}
+/// @brief find a bridge between vertices that connects hole with an outer ring and link it
+std::size_t eliminate_hole(std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points_vec) {
+    auto bridge = find_hole_bridge(hole_index, outer_index, points_vec);
+    if (bridge == std::numeric_limits<std::size_t>::max()) {
+        return outer_index;
+    }
+    auto bridge_reverse = split_polygon(bridge, hole_index, points_vec);
+
+    filter_points(bridge_reverse, points_vec[bridge_reverse].next_index, points_vec);
+    return filter_points(bridge, points_vec[bridge].next_index, points_vec);
 }
 
+std::size_t eliminate_holes(const std::vector<LinearRing2d>& inners, std::size_t outer_index, std::size_t& vertices, std::vector<Point> & points_vec) {
+    const std::size_t len = inners.size();
+    std::vector<std::size_t> queue;
+    for (std::size_t i = 0; i < len; i++) {
+        auto list = linked_list(inners[i], false, vertices, points_vec);
+        if (list != std::numeric_limits<std::size_t>::max()) {
+            queue.push_back(get_leftmost(list, points_vec));
+        }
+    }
+    std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {
+        return points_vec[a].x() < points_vec[b].x();
+    });
+    for (const auto& q : queue) {
+        outer_index = eliminate_hole(q, outer_index, points_vec);
+    }
+    return outer_index;
+}
 /// @brief main ear slicing loop which triangulates a polygon using linked list
-void EarClipping::ear_clipping_linked(EarClipping::Point * ear, int pass)
-{
-  if (!ear) return;
+void ear_clipping_linked(std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec, int pass) {
+    if (ear_index == std::numeric_limits<std::size_t>::max()) return;
 
-  EarClipping::Point * stop = ear;
-  EarClipping::Point * next = nullptr;
+    auto stop = ear_index;  // Stopping point for the loop
+    std::size_t next = std::numeric_limits<std::size_t>::max();
 
-  // Iterate through ears, slicing them one by one
-  while (ear->prev != ear->next) {
-    next = ear->next;
+    // Iterate through ears, slicing them one by one
+    while (points_vec[ear_index].prev_index != points_vec[ear_index].next_index) {
+        next = points_vec[ear_index].next_index;
 
-    if (is_ear(ear)) {
-      // Cut off the triangle
-      indices.emplace_back(ear->prev->i);
-      indices.emplace_back(ear->i);
-      indices.emplace_back(next->i);
+        if (is_ear(ear_index, points_vec)) {
+            // Cut off the triangle and store the indices
+            indices.emplace_back(points_vec[ear_index].prev_index);
+            indices.emplace_back(ear_index);
+            indices.emplace_back(next);
 
-      remove_point(ear);
-      ear = next->next;
-      stop = next->next;
+            // Remove the ear and update the ear_index to continue
+            remove_point(ear_index, points_vec);
 
-      continue;
+            // Move to the next ear after removal
+            ear_index = points_vec[next].next_index;
+            stop = points_vec[next].next_index;
+
+            continue;
+        }
+
+        ear_index = next;
+
+        // If we have completed a full loop and haven't found any ears
+        if (ear_index == stop) {
+            if (pass == 0) {
+                // Filter the points and try another pass
+                ear_clipping_linked(filter_points(ear_index, std::numeric_limits<std::size_t>::max(), points_vec), indices, points_vec, 1);
+            } else if (pass == 1) {
+                // Cure local intersections and move to the next pass
+                ear_index = cure_local_intersections(filter_points(ear_index, std::numeric_limits<std::size_t>::max(), points_vec), indices, points_vec);
+                ear_clipping_linked(ear_index, indices, points_vec, 2);
+            } else if (pass == 2) {
+                // Split the remaining polygon
+                split_ear_clipping(points_vec, ear_index, indices);
+            }
+            break;  // End the loop after handling all passes
+        }
     }
 
-    ear = next;
-    if (ear == stop) {
-      if (!pass) {
-        ear_clipping_linked(filter_points(ear), 1);
-      } else if (pass == 1) {
-        ear = cure_local_intersections(filter_points(ear));
-        ear_clipping_linked(ear, 2);
-      } else if (pass == 2) {
-        split_ear_clipping(ear);
-      }
-      break;
+    // Check if we have reduced the polygon to the final triangle
+    if (points_vec[ear_index].prev_index == points_vec[ear_index].next_index) {
+        // The remaining triangle
+        std::size_t prev = points_vec[ear_index].prev_index;
+        indices.emplace_back(prev);
+        indices.emplace_back(ear_index);
+        indices.emplace_back(points_vec[ear_index].next_index);
     }
-  }
 }
-
 /// @brief check whether ear is valid
-bool EarClipping::is_ear(EarClipping::Point * ear)
-{
-  const EarClipping::Point * a = ear->prev;
-  const EarClipping::Point * b = ear;
-  const EarClipping::Point * c = ear->next;
+bool is_ear(std::size_t ear_index, const std::vector<Point>& points_vec) {
+    const auto a = points_vec[ear_index].prev_index;
+    const auto b = ear_index;
+    const auto c = points_vec[ear_index].next_index;
 
-  if (area(a, b, c) >= 0) return false;  // Reflex, can't be an ear
+    // Check if the area is non-negative
+    if (area(points_vec, a, b, c) >= 0) {
+        return false;
+    }
 
-  EarClipping::Point * p = ear->next->next;
+    auto p = points_vec[ear_index].next_index;
+    while (p != points_vec[ear_index].prev_index) {
+        // Check if point p is inside the triangle (a, b, c)
+        if (point_in_triangle(points_vec[a].x(), points_vec[a].y(), points_vec[b].x(), points_vec[b].y(),
+                              points_vec[c].x(), points_vec[c].y(), points_vec[p].x(), points_vec[p].y())) {
+            // Check if p is not collinear with the ear
+            if (area(points_vec, points_vec[p].prev_index, p, points_vec[p].next_index) >= 0) {
+                return false;
+            }
+        }
+        p = points_vec[p].next_index;
+    }
 
-  while (p != ear->prev) {
-    if (
-      point_in_triangle(a->x(), a->y(), b->x(), b->y(), c->x(), c->y(), p->x(), p->y()) &&
-      area(p->prev, p, p->next) >= 0)
-      return false;
-    p = p->next;
-  }
-
-  return true;
+    return true;
 }
 
 /// @brief go through all polygon Points and cure small local self-intersections
-EarClipping::Point * EarClipping::cure_local_intersections(EarClipping::Point * start)
-{
-  EarClipping::Point * p = start;
-  do {
-    EarClipping::Point * a = p->prev;
-    EarClipping::Point * b = p->next->next;
+std::size_t cure_local_intersections(std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec) {
+    auto p = start_index;
+    do {
+        auto a = points_vec[p].prev_index;
+        auto b = points_vec[p].next_index;
 
-    if (
-      !equals(a, b) && intersects(a, p, p->next, b) && locally_inside(a, b) &&
-      locally_inside(b, a)) {
-      indices.emplace_back(a->i);
-      indices.emplace_back(p->i);
-      indices.emplace_back(b->i);
-      remove_point(p);
-      remove_point(p->next);
+        if (!equals(a, b, points_vec) && intersects(a, p, points_vec[p].next_index, b, points_vec) && locally_inside(a, b, points_vec) && locally_inside(b, a, points_vec)) {
+            indices.emplace_back(a);
+            indices.emplace_back(p);
+            indices.emplace_back(b);
+            remove_point(p, points_vec);
+            remove_point(points_vec[p].next_index, points_vec);
 
-      p = start = b;
-    }
-    p = p->next;
-  } while (p != start);
+            p = b;
+        }
+        p = points_vec[p].next_index;
+    } while (p != start_index);
 
-  return filter_points(p);
+    return filter_points(p, std::numeric_limits<std::size_t>::max(), points_vec);
 }
 
-/// @brief splitting polygon into two and triangulate them independently
-void EarClipping::split_ear_clipping(EarClipping::Point * start)
+/// @brief David Eberly's algorithm for finding a bridge between hole and outer polygon using vector indices
+std::size_t find_hole_bridge(std::size_t hole_index, std::size_t outer_point_index, const std::vector<Point>& points)
 {
-  EarClipping::Point * a = start;
-  do {
-    EarClipping::Point * b = a->next->next;
-    while (b != a->prev) {
-      if (a->i != b->i && is_valid_diagonal(a, b)) {
-        EarClipping::Point * c = split_polygon(a, b);
+    std::size_t p = outer_point_index;
+    double hx = points[hole_index].x();
+    double hy = points[hole_index].y();
+    double qx = -std::numeric_limits<double>::infinity();
+    std::size_t bridge_point = std::numeric_limits<std::size_t>::max();  // Null equivalent for index
 
-        a = filter_points(a, a->next);
-        c = filter_points(c, c->next);
+    // Find the best candidate point on the outer polygon
+    do {
+        std::size_t next_index = points[p].next_index;
+        if (hy <= points[p].y() && hy >= points[next_index].y() && points[next_index].y() != points[p].y()) {
+            double x = points[p].x() + (hy - points[p].y()) * (points[next_index].x() - points[p].x()) / (points[next_index].y() - points[p].y());
+            if (x <= hx && x > qx) {
+                qx = x;
+                bridge_point = points[p].x() < points[next_index].x() ? p : next_index;
+                if (x == hx) return bridge_point;
+            }
+        }
+        p = next_index;
+    } while (p != outer_point_index);
 
-        ear_clipping_linked(a);
-        ear_clipping_linked(c);
-        return;
-      }
-      b = b->next;
-    }
-    a = a->next;
-  } while (a != start);
+    if (bridge_point == std::numeric_limits<std::size_t>::max()) return bridge_point;
+
+    const std::size_t stop = bridge_point;
+    double min_tan = std::numeric_limits<double>::infinity();
+
+    p = bridge_point;
+    double mx = points[bridge_point].x();
+    double my = points[bridge_point].y();
+
+    // Refine the best candidate
+    do {
+        if (
+            hx >= points[p].x() && points[p].x() >= mx && hx != points[p].x() &&
+            point_in_triangle(hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, points[p].x(), points[p].y())) {
+
+            double current_tan = std::abs(hy - points[p].y()) / (hx - points[p].x());
+
+            if (
+                locally_inside(p, hole_index, points) &&
+                (current_tan < min_tan ||
+                 (current_tan == min_tan && (points[p].x() > points[bridge_point].x() || sector_contains_sector(bridge_point, p, points))))) {
+                bridge_point = p;
+                min_tan = current_tan;
+            }
+        }
+
+        p = points[p].next_index;
+    } while (p != stop);
+
+    return bridge_point;
 }
 
-/// @brief check whether sector in vertex m contains sector in vertex p in the same coordinates
-bool EarClipping::sector_contains_sector(const EarClipping::Point * m, const EarClipping::Point * p)
+/// @brief Split the polygon using ear clipping
+void split_ear_clipping(std::vector<Point>& points, std::size_t start_idx, std::vector<std::size_t>& indices)
 {
-  return area(m->prev, m, p->prev) < 0 && area(p->next, m, m->next) < 0;
+    std::size_t a_idx = start_idx;
+    do {
+        std::size_t b_idx = points[a_idx].next_index;
+        while (b_idx != points[a_idx].prev_index) {
+            if (points[a_idx].i != points[b_idx].i && is_valid_diagonal(a_idx, b_idx, points)) {
+                std::size_t c_idx = split_polygon(a_idx, b_idx, points);
+
+                a_idx = filter_points(start_idx, points[a_idx].next_index, points);
+                c_idx = filter_points(start_idx, points[c_idx].next_index, points);
+
+                ear_clipping_linked(a_idx, indices, points);
+                ear_clipping_linked(c_idx, indices, points);
+                return;
+            }
+            b_idx = points[b_idx].next_index;
+        }
+        a_idx = points[a_idx].next_index;
+    } while (a_idx != start_idx);
 }
 
-/// @brief find the leftmost Point of a polygon ring
-EarClipping::Point * EarClipping::get_leftmost(EarClipping::Point * start)
+/// @brief Check whether the sector in vertex m contains the sector in vertex p in the same coordinates
+bool sector_contains_sector(std::size_t m_idx, std::size_t p_idx, const std::vector<Point>& points)
 {
-  EarClipping::Point * p = start;
-  EarClipping::Point * leftmost = start;
-  do {
-    if (p->x() < leftmost->x() || (p->x() == leftmost->x() && p->y() < leftmost->y())) leftmost = p;
-    p = p->next;
-  } while (p != start);
+    return area(points, points[m_idx].prev_index, m_idx, p_idx) < 0 &&
+           area(points, p_idx, points[m_idx].next_index, m_idx) < 0;
+}
 
-  return leftmost;
+/// @brief Find the leftmost Point of a polygon ring
+std::size_t get_leftmost(std::size_t start_idx, const std::vector<Point>& points)
+{
+    std::size_t p_idx = start_idx;
+    std::size_t left_most_idx = start_idx;
+    do {
+        if (points[p_idx].x() < points[left_most_idx].x() || 
+           (points[p_idx].x() == points[left_most_idx].x() && points[p_idx].y() < points[left_most_idx].y())) 
+        {
+            left_most_idx = p_idx;
+        }
+        p_idx = points[p_idx].next_index;
+    } while (p_idx != start_idx);
+
+    return left_most_idx;
 }
 
 /// @brief check if a point lies within a convex triangle
-bool EarClipping::point_in_triangle(
-  double ax, double ay, double bx, double by, double cx, double cy, double px, double py)
+bool point_in_triangle(
+    double ax, double ay, double bx, double by, double cx, double cy, double px, double py)
 {
-  return (cx - px) * (ay - py) >= (ax - px) * (cy - py) &&
-         (ax - px) * (by - py) >= (bx - px) * (ay - py) &&
-         (bx - px) * (cy - py) >= (cx - px) * (by - py);
+    return (cx - px) * (ay - py) >= (ax - px) * (cy - py) &&
+           (ax - px) * (by - py) >= (bx - px) * (ay - py) &&
+           (bx - px) * (cy - py) >= (cx - px) * (by - py);
 }
 
 /// @brief check if a diagonal between two polygon Points is valid
-bool EarClipping::is_valid_diagonal(EarClipping::Point * a, EarClipping::Point * b)
+/// @brief Check if a diagonal between two polygon Points is valid
+bool is_valid_diagonal(std::size_t a_idx, std::size_t b_idx, const std::vector<Point>& points)
 {
-  return a->next->i != b->i && a->prev->i != b->i && !intersects_polygon(a, b) &&
-         ((locally_inside(a, b) && locally_inside(b, a) && middle_inside(a, b) &&
-           (area(a->prev, a, b->prev) != 0.0 || area(a, b->prev, b) != 0.0)) ||
-          (equals(a, b) && area(a->prev, a, a->next) > 0 && area(b->prev, b, b->next) > 0));
+    const Point& a = points[a_idx];
+    const Point& b = points[b_idx];
+
+    // Extract indices for the next and previous points
+    std::size_t a_next_idx = a.next_index;
+    std::size_t a_prev_idx = a.prev_index;
+    std::size_t b_next_idx = b.next_index;
+    std::size_t b_prev_idx = b.prev_index;
+
+    // Check if diagonal does not connect adjacent or same points
+    if (points[a_next_idx].i == b.i || points[a_prev_idx].i == b.i || intersects_polygon(points, a_idx, b_idx))
+    {
+        return false;
+    }
+
+    // Check if diagonals are locally inside and not intersecting
+    bool is_locally_inside_ab = locally_inside(a_idx, b_idx, points);
+    bool is_locally_inside_ba = locally_inside(b_idx, a_idx, points);
+    bool is_middle_inside = middle_inside(a_idx, b_idx, points);
+
+    bool is_valid_diagonal = (is_locally_inside_ab && is_locally_inside_ba && is_middle_inside &&
+                            (area(points, a_prev_idx, a_idx, b_prev_idx) != 0.0 ||
+                             area(points, a_idx, b_prev_idx, b_idx) != 0.0)) ||
+                           (equals(a_idx, b_idx, points) &&
+                            area(points, a_prev_idx, a_idx, points[a_next_idx].i) > 0 &&
+                            area(points, b_prev_idx, b_idx, points[b_next_idx].i) > 0);
+
+    return is_valid_diagonal;
 }
 
 /// @brief signed area of a triangle
-double EarClipping::area(
-  const EarClipping::Point * p, const EarClipping::Point * q, const EarClipping::Point * r)
+double area(const std::vector<Point>& points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
 {
-  return (q->y() - p->y()) * (r->x() - q->x()) - (q->x() - p->x()) * (r->y() - q->y());
+    const Point& p = points[p_idx];
+    const Point& q = points[q_idx];
+    const Point& r = points[r_idx];
+    return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
 }
 
 /// @brief check if two points are equal
-bool EarClipping::equals(const EarClipping::Point * p1, const EarClipping::Point * p2)
+bool equals(std::size_t p1_idx, std::size_t p2_idx, const std::vector<Point>& points)
 {
-  return p1->x() == p2->x() && p1->y() == p2->y();
+    return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
 }
 
 /// @brief check if two segments intersect
-bool EarClipping::intersects(
-  const EarClipping::Point * p1, const EarClipping::Point * q1, const EarClipping::Point * p2,
-  const EarClipping::Point * q2)
+bool intersects(std::size_t p1_idx, std::size_t q1_idx, std::size_t p2_idx, std::size_t q2_idx, const std::vector<Point>& points)
 {
-  int o1 = sign(area(p1, q1, p2));
-  int o2 = sign(area(p1, q1, q2));
-  int o3 = sign(area(p2, q2, p1));
-  int o4 = sign(area(p2, q2, q1));
+    int o1 = sign(area(points, p1_idx, q1_idx, p2_idx));
+    int o2 = sign(area(points, p1_idx, q1_idx, q2_idx));
+    int o3 = sign(area(points, p2_idx, q2_idx, p1_idx));
+    int o4 = sign(area(points, p2_idx, q2_idx, q1_idx));
 
-  if (o1 != o2 && o3 != o4) return true;
+    if (o1 != o2 && o3 != o4) return true;
 
-  if (o1 == 0 && on_segment(p1, p2, q1)) return true;
-  if (o2 == 0 && on_segment(p1, q2, q1)) return true;
-  if (o3 == 0 && on_segment(p2, p1, q2)) return true;
-  if (o4 == 0 && on_segment(p2, q1, q2)) return true;
+    if (o1 == 0 && on_segment(points, p1_idx, p2_idx, q1_idx)) return true;
+    if (o2 == 0 && on_segment(points, p1_idx, q2_idx, q1_idx)) return true;
+    if (o3 == 0 && on_segment(points, p2_idx, p1_idx, q2_idx)) return true;
+    if (o4 == 0 && on_segment(points, p2_idx, q1_idx, q2_idx)) return true;
 
-  return false;
+    return false;
 }
 
 /// @brief for collinear points p, q, r, check if point q lies on segment pr
-bool EarClipping::on_segment(
-  const EarClipping::Point * p, const EarClipping::Point * q, const EarClipping::Point * r)
+bool on_segment(const std::vector<Point>& points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
 {
-  return q->x() <= std::max<double>(p->x(), r->x()) && q->x() >= std::min<double>(p->x(), r->x()) &&
-         q->y() <= std::max<double>(p->y(), r->y()) && q->y() >= std::min<double>(p->y(), r->y());
+    const Point& p = points[p_idx];
+    const Point& q = points[q_idx];
+    const Point& r = points[r_idx];
+    return q.x() <= std::max<double>(p.x(), r.x()) && q.x() >= std::min<double>(p.x(), r.x()) &&
+           q.y() <= std::max<double>(p.y(), r.y()) && q.y() >= std::min<double>(p.y(), r.y());
 }
 
 /// @brief Sign function for area calculation
-int EarClipping::sign(double val)
+int sign(double val)
 {
-  return (0.0 < val) - (val < 0.0);
+    return (0.0 < val) - (val < 0.0);
 }
 
 /// @brief Check if a polygon diagonal intersects any polygon segments
-bool EarClipping::intersects_polygon(const EarClipping::Point * a, const EarClipping::Point * b)
+/// @brief Check if a polygon diagonal intersects any polygon segments
+bool intersects_polygon(const std::vector<Point>& points, std::size_t a_idx, std::size_t b_idx)
 {
-  const EarClipping::Point * p = a;
-  do {
-    if (
-      p->i != a->i && p->next->i != a->i && p->i != b->i && p->next->i != b->i &&
-      intersects(p, p->next, a, b))
-      return true;
-    p = p->next;
-  } while (p != a);
+    std::size_t p_idx = a_idx;
+    do {
+        if (points[p_idx].i != points[a_idx].i && points[points[p_idx].next_index].i != points[a_idx].i &&
+            points[p_idx].i != points[b_idx].i && points[points[p_idx].next_index].i != points[b_idx].i &&
+            intersects(p_idx, points[p_idx].next_index, a_idx, b_idx, points))
+        {
+            return true;
+        }
+        p_idx = points[p_idx].next_index;
+    } while (p_idx != a_idx);
 
-  return false;
+    return false;
 }
-
 /// @brief Check if a polygon diagonal is locally inside the polygon
-bool EarClipping::locally_inside(const EarClipping::Point * a, const EarClipping::Point * b)
+bool locally_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point>& points)
 {
-  return area(a->prev, a, a->next) < 0 ? area(a, b, a->next) >= 0 && area(a, a->prev, b) >= 0
-                                       : area(a, b, a->prev) < 0 || area(a, a->next, b) < 0;
+    return area(points, points[a_idx].prev_index, a_idx, points[a_idx].next_index) < 0 ? 
+        area(points, a_idx, b_idx, points[a_idx].next_index) >= 0 && 
+        area(points, a_idx, points[a_idx].prev_index, b_idx) >= 0 
+        : area(points, a_idx, b_idx, points[a_idx].prev_index) < 0 || 
+          area(points, a_idx, points[a_idx].next_index, b_idx) < 0;
 }
 
 /// @brief Check if the middle vertex of a polygon diagonal is inside the polygon
-bool EarClipping::middle_inside(const EarClipping::Point * a, const EarClipping::Point * b)
+bool middle_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point>& points)
 {
-  const EarClipping::Point * p = a;
-  bool inside = false;
-  double px = (a->x() + b->x()) / 2;
-  double py = (a->y() + b->y()) / 2;
-  do {
-    if (
-      ((p->y() > py) != (p->next->y() > py)) && p->next->y() != p->y() &&
-      (px < (p->next->x() - p->x()) * (py - p->y()) / (p->next->y() - p->y()) + p->x()))
-      inside = !inside;
-    p = p->next;
-  } while (p != a);
+    std::size_t p_idx = a_idx;
+    bool inside = false;
+    double px = (points[a_idx].x() + points[b_idx].x()) / 2;
+    double py = (points[a_idx].y() + points[b_idx].y()) / 2;
+    do {
+        if (((points[p_idx].y() > py) != (points[points[p_idx].next_index].y() > py)) && 
+            points[points[p_idx].next_index].y() != points[p_idx].y() &&
+            (px < (points[points[p_idx].next_index].x() - points[p_idx].x()) * (py - points[p_idx].y()) / 
+            (points[points[p_idx].next_index].y() - points[p_idx].y()) + points[p_idx].x()))
+        {
+            inside = !inside;
+        }
+        p_idx = points[p_idx].next_index;
+    } while (p_idx != a_idx);
 
-  return inside;
+    return inside;
 }
 
 /// @brief Link two polygon vertices with a bridge
-EarClipping::Point * EarClipping::split_polygon(EarClipping::Point * a, EarClipping::Point * b)
+std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points)
 {
-  Point2d a_point(a->x(), a->y());
-  Point2d b_point(b->x(), b->y());
+    Point2d a_point(points[a_index].x(), points[a_index].y());
+    Point2d b_point(points[b_index].x(), points[b_index].y());
 
-  // Use construct_point to create new Point objects
-  EarClipping::Point * a2 = construct_point(a->i, a_point);
-  EarClipping::Point * b2 = construct_point(b->i, b_point);
+    // Use construct_point to create new Point objects
+    std::size_t a2_idx = construct_point(points[a_index].i, a_point, points);
+    std::size_t b2_idx = construct_point(points[b_index].i, b_point, points);
 
-  EarClipping::Point * an = a->next;
-  EarClipping::Point * bp = b->prev;
+    std::size_t an_idx = points[a_index].next_index;
+    std::size_t bp_idx = points[b_index].prev_index;
 
-  // Update the linked list connections
-  a->next = b;
-  b->prev = a;
+    // Update the linked list connections
+    points[a_index].next_index = b_index;
+    points[b_index].prev_index = a_index;
 
-  a2->next = an;
-  if (an) {
-    an->prev = a2;
-  }
-
-  b2->next = a2;
-  a2->prev = b2;
-
-  if (bp) {
-    bp->next = b2;
-  }
-  b2->prev = bp;
-
-  return b2;
-}
-
-/// @brief create a Point and optionally link it with the previous one (in a circular doubly linked
-/// list)
-EarClipping::Point * EarClipping::insert_point(
-  std::size_t i, const Point2d & pt, EarClipping::Point * last)
-{
-  EarClipping::Point * p = construct_point(static_cast<std::size_t>(i), pt);
-
-  if (!last) {
-    p->prev = p;
-    p->next = p;
-  } else {
-    assert(last);
-    p->next = last->next;
-    p->prev = last;
-    last->next->prev = p;
-    last->next = p;
-  }
-  return p;
-}
-
-/// @brief remove a Point from the linked list
-void EarClipping::remove_point(EarClipping::Point * p)
-{
-  p->next->prev = p->prev;
-  p->prev->next = p->next;
-}
-
-/// @brief main triangulate function
-std::vector<Polygon2d> triangulate(const Polygon2d & poly)
-{
-  autoware::universe_utils::EarClipping triangulate;
-  triangulate(poly);
-
-  std::vector<Polygon2d> triangles;
-
-  const auto & indices = triangulate.indices;
-  const std::size_t num_indices = indices.size();
-
-  if (num_indices % 3 != 0) {
-    throw std::runtime_error("Indices size should be a multiple of 3");
-  }
-
-  // Gather all vertices from outer and inner rings
-  std::vector<Point2d> all_vertices;
-  const auto & outer_ring = poly.outer();
-  all_vertices.insert(all_vertices.end(), outer_ring.begin(), outer_ring.end());
-
-  for (const auto & inner_ring : poly.inners()) {
-    all_vertices.insert(all_vertices.end(), inner_ring.begin(), inner_ring.end());
-  }
-
-  const std::size_t total_vertices = all_vertices.size();
-
-  for (std::size_t i = 0; i < num_indices; i += 3) {
-    if (
-      indices[i] >= total_vertices || indices[i + 1] >= total_vertices ||
-      indices[i + 2] >= total_vertices) {
-      throw std::runtime_error("Index out of range");
+    points[a2_idx].next_index = an_idx;
+    if (an_idx != a_index) {
+        points[an_idx].prev_index = a2_idx;
     }
 
-    Polygon2d triangle;
-    triangle.outer().push_back(all_vertices[indices[i]]);
-    triangle.outer().push_back(all_vertices[indices[i + 1]]);
-    triangle.outer().push_back(all_vertices[indices[i + 2]]);
-    triangle.outer().push_back(all_vertices[indices[i]]);  // Close the triangle
+    points[b2_idx].next_index = a2_idx;
+    points[a2_idx].prev_index = b2_idx;
 
-    triangles.push_back(triangle);
-  }
+    if (bp_idx != b_index) {
+        points[bp_idx].next_index = b2_idx;
+    }
+    points[b2_idx].prev_index = bp_idx;
 
-  return triangles;
+    return b2_idx;
+}
+
+
+/// @brief remove a Point from the linked list
+void remove_point(std::size_t p_index, std::vector<Point>& points) {
+    std::size_t prev_index = points[p_index].prev_index;
+    std::size_t next_index = points[p_index].next_index;
+
+    points[prev_index].next_index = next_index;
+    points[next_index].prev_index = prev_index;
+}
+
+
+/// @brief main triangulate function
+std::vector<Polygon2d> triangulate(const Polygon2d& poly) {
+    std::vector<std::size_t> indices;
+    perform_triangulation(poly, indices);
+
+    std::vector<Polygon2d> triangles;
+    const std::size_t num_indices = indices.size();
+
+    std::cout << "Number of indices: " << num_indices << std::endl;
+
+    if (num_indices % 3 != 0) {
+        throw std::runtime_error("Indices size should be a multiple of 3");
+    }
+
+    std::vector<Point2d> all_vertices;
+    const auto& outer_ring = poly.outer();
+    all_vertices.insert(all_vertices.end(), outer_ring.begin(), outer_ring.end());
+
+    for (const auto& inner_ring : poly.inners()) {
+        all_vertices.insert(all_vertices.end(), inner_ring.begin(), inner_ring.end());
+    }
+
+    const std::size_t total_vertices = all_vertices.size();
+
+    std::cout << "Total vertices: " << total_vertices << std::endl;
+
+    for (std::size_t i = 0; i < num_indices; i += 3) {
+        if (indices[i] >= total_vertices || indices[i + 1] >= total_vertices || indices[i + 2] >= total_vertices) {
+            std::cerr << "Index out of range: " << indices[i] << ", " << indices[i + 1] << ", " << indices[i + 2] << std::endl;
+            throw std::runtime_error("Index out of range");
+        }
+
+        std::cout << "Creating triangle with indices: " << indices[i] << ", " << indices[i + 1] << ", " << indices[i + 2] << std::endl;
+
+        Polygon2d triangle;
+        triangle.outer().push_back(all_vertices[indices[i]]);
+        triangle.outer().push_back(all_vertices[indices[i + 1]]);
+        triangle.outer().push_back(all_vertices[indices[i + 2]]);
+        triangle.outer().push_back(all_vertices[indices[i]]); // Closing the triangle
+
+        triangles.push_back(triangle);
+    }
+
+    return triangles;
 }
 
 }  // namespace autoware::universe_utils

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -424,13 +424,13 @@ std::size_t eliminate_holes(
   std::vector<std::size_t> queue;
 
   for (std::size_t i = 0; i < len; ++i) {
-    auto points_inner = linked_list(inners[i], false, vertices, points);
+    auto inner_index = linked_list(inners[i], false, vertices, points);
 
-    if (points[points_inner].next_index.value() == points_inner) {
-      points[points_inner].steiner = true;
+    if (points[inner_index].next_index.value() == inner_index) {
+      points[inner_index].steiner = true;
     }
 
-    queue.push_back(get_leftmost(points_inner, points));
+    queue.push_back(get_leftmost(inner_index, points));
   }
 
   std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -17,14 +17,6 @@
 namespace autoware::universe_utils
 {
 
-/// Utils Function
-std::size_t construct_point(
-  const std::size_t index, const Point2d & point, std::vector<LinkedPoint> & points)
-{
-  points.emplace_back(index, point);
-  return index;
-}
-
 void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
   std::size_t prev_index = points[p_index].prev_index.value();
@@ -447,7 +439,6 @@ std::size_t cure_local_intersections(
     } else {
       p = pointsvec[p].next_index.value();
     }
-
   } while (p != start_index && updated);
 
   return filter_points(p, p, pointsvec);

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -14,71 +14,226 @@
 
 #include "autoware/universe_utils/geometry/ear_clipping.hpp"
 
-#ifndef EAR_CUT_IMPL_HPP
-#define EAR_CUT_IMPL_HPP
-
 namespace autoware::universe_utils
 {
 
-std::size_t construct_point(std::size_t index, const Point2d & point, std::vector<Point> & points)
+/// Utils Function
+/// @brief insert a point inside the linked linst on an index
+std::size_t construct_point(
+  const std::size_t index, const Point2d & point, std::vector<LinkedPoint> & points)
 {
   points.emplace_back(index, point);
   return index;
 }
 
-std::vector<Point> perform_triangulation(
-  const Polygon2d & polygon, std::vector<std::size_t> & indices)
+/// @brief remove a Point from the linked list
+void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
-  indices.clear();
-  std::vector<Point> points_;
-  std::size_t vertices = 0;
-  const auto & outer_ring = polygon.outer();
-  std::size_t len = outer_ring.size();
-  points_.reserve(len * 3 / 2);
+  std::size_t prev_index = points[p_index].prev_index.value();
+  std::size_t next_index = points[p_index].next_index.value();
 
-  if (polygon.outer().empty()) return points_;
-
-  indices.reserve(len + outer_ring.size());
-  auto outer_point = linked_list(outer_ring, true, vertices, points_);
-  if (outer_point == points_[outer_point.value()].prev_index.value()) {
-    return points_;
-  }
-
-  if (!polygon.inners().empty()) {
-    outer_point = eliminate_holes(polygon.inners(), outer_point.value(), vertices, points_);
-  }
-
-  ear_clipping_linked(outer_point.value(), indices, points_);
-  return points_;
+  points[prev_index].next_index = next_index;
+  points[next_index].prev_index = prev_index;
 }
 
+/// @brief find the leftmost Point of a polygon ring
+std::size_t get_leftmost(const std::size_t start_idx, const std::vector<LinkedPoint> & points)
+{
+  std::size_t p_idx = start_idx;
+  std::size_t left_most_idx = start_idx;
+  do {
+    if (
+      points[p_idx].x() < points[left_most_idx].x() ||
+      (points[p_idx].x() == points[left_most_idx].x() &&
+       points[p_idx].y() < points[left_most_idx].y())) {
+      left_most_idx = p_idx;
+    }
+    p_idx = points[p_idx].next_index.value();
+  } while (p_idx != start_idx);
+
+  return left_most_idx;
+}
+
+/// @brief check if a point lies within a convex triangle
+bool point_in_triangle(
+  const double ax, const double ay, const double bx, const double by, const double cx,
+  const double cy, const double px, const double py)
+{
+  return (cx - px) * (ay - py) >= (ax - px) * (cy - py) &&
+         (ax - px) * (by - py) >= (bx - px) * (ay - py) &&
+         (bx - px) * (cy - py) >= (cx - px) * (by - py);
+}
+
+/// @brief signed area of a triangle
+double area(
+  const std::vector<LinkedPoint> & points, const std::size_t p_idx, const std::size_t q_idx,
+  const std::size_t r_idx)
+{
+  const LinkedPoint & p = points[p_idx];
+  const LinkedPoint & q = points[q_idx];
+  const LinkedPoint & r = points[r_idx];
+  return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
+}
+
+/// @brief check if the middle vertex of a polygon diagonal is inside the polygon
+bool middle_inside(
+  const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
+{
+  std::size_t p_idx = a_idx;
+  bool inside = false;
+  double px = (points[a_idx].x() + points[b_idx].x()) / 2;
+  double py = (points[a_idx].y() + points[b_idx].y()) / 2;
+  do {
+    if (
+      ((points[p_idx].y() > py) != (points[points[p_idx].next_index.value()].y() > py)) &&
+      points[points[p_idx].next_index.value()].y() != points[p_idx].y() &&
+      (px < (points[points[p_idx].next_index.value()].x() - points[p_idx].x()) *
+                (py - points[p_idx].y()) /
+                (points[points[p_idx].next_index.value()].y() - points[p_idx].y()) +
+              points[p_idx].x())) {
+      inside = !inside;
+    }
+    p_idx = points[p_idx].next_index.value();
+  } while (p_idx != a_idx);
+
+  return inside;
+}
+
+/// @brief check if two points are equal
+bool equals(
+  const std::size_t p1_idx, const std::size_t p2_idx, const std::vector<LinkedPoint> & points)
+{
+  return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
+}
+
+/// @brief sign function for area calculation
+int sign(const double val)
+{
+  return (0.0 < val) - (val < 0.0);
+}
+
+/// @brief for collinear points p, q, r, check if point q lies on segment pr
+bool on_segment(
+  const std::vector<LinkedPoint> & points, const std::size_t p_idx, const std::size_t q_idx,
+  const std::size_t r_idx)
+{
+  const LinkedPoint & p = points[p_idx];
+  const LinkedPoint & q = points[q_idx];
+  const LinkedPoint & r = points[r_idx];
+  return q.x() <= std::max<double>(p.x(), r.x()) && q.x() >= std::min<double>(p.x(), r.x()) &&
+         q.y() <= std::max<double>(p.y(), r.y()) && q.y() >= std::min<double>(p.y(), r.y());
+}
+
+/// @brief check if a polygon diagonal is locally inside the polygon
+bool locally_inside(
+  const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
+{
+  return area(points, points[a_idx].prev_index.value(), a_idx, points[a_idx].next_index.value()) < 0
+           ? area(points, a_idx, b_idx, points[a_idx].next_index.value()) >= 0 &&
+               area(points, a_idx, points[a_idx].prev_index.value(), b_idx) >= 0
+           : area(points, a_idx, b_idx, points[a_idx].prev_index.value()) < 0 ||
+               area(points, a_idx, points[a_idx].next_index.value(), b_idx) < 0;
+}
+
+/// @brief check if two segments intersect
+bool intersects(
+  const std::size_t p1_idx, const std::size_t q1_idx, const std::size_t p2_idx,
+  const std::size_t q2_idx, const std::vector<LinkedPoint> & points)
+{
+  int o1 = sign(area(points, p1_idx, q1_idx, p2_idx));
+  int o2 = sign(area(points, p1_idx, q1_idx, q2_idx));
+  int o3 = sign(area(points, p2_idx, q2_idx, p1_idx));
+  int o4 = sign(area(points, p2_idx, q2_idx, q1_idx));
+
+  if (o1 != o2 && o3 != o4) return true;
+
+  if (o1 == 0 && on_segment(points, p1_idx, p2_idx, q1_idx)) return true;
+  if (o2 == 0 && on_segment(points, p1_idx, q2_idx, q1_idx)) return true;
+  if (o3 == 0 && on_segment(points, p2_idx, p1_idx, q2_idx)) return true;
+  if (o4 == 0 && on_segment(points, p2_idx, q1_idx, q2_idx)) return true;
+
+  return false;
+}
+
+/// @brief check if a polygon diagonal intersects any polygon segments
+bool intersects_polygon(
+  const std::vector<LinkedPoint> & points, const std::size_t a_idx, const std::size_t b_idx)
+{
+  std::size_t p_idx = a_idx;
+  do {
+    std::size_t p_next_idx = points[p_idx].next_index.value();  // Get the next point in the polygon
+
+    if (p_idx != a_idx && p_next_idx != a_idx && p_idx != b_idx && p_next_idx != b_idx) {
+      if (intersects(p_idx, p_next_idx, a_idx, b_idx, points)) {
+        return true;
+      }
+    }
+
+    p_idx = p_next_idx;
+  } while (p_idx != a_idx);
+
+  return false;
+}
+
+/// @brief check if a diagonal between two polygon Points is valid
+bool is_valid_diagonal(
+  const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
+{
+  // Extract indices for the next and previous points
+  std::size_t a_next_idx = points[a_idx].next_index.value();
+  std::size_t a_prev_idx = points[a_idx].prev_index.value();
+  std::size_t b_next_idx = points[b_idx].next_index.value();
+  std::size_t b_prev_idx = points[b_idx].prev_index.value();
+
+  // Check if diagonal does not connect adjacent or same points
+  if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx)) {
+    return false;
+  }
+
+  // Check if diagonals are locally inside and not intersecting
+  bool is_locally_inside_ab = locally_inside(a_idx, b_idx, points);
+  bool is_locally_inside_ba = locally_inside(b_idx, a_idx, points);
+  bool is_middle_inside = middle_inside(a_idx, b_idx, points);
+
+  bool is_valid_diagonal =
+    (is_locally_inside_ab && is_locally_inside_ba && is_middle_inside &&
+     (area(points, a_prev_idx, a_idx, b_prev_idx) != 0.0 ||
+      area(points, a_idx, b_prev_idx, b_idx) != 0.0)) ||
+    (equals(a_idx, b_idx, points) && area(points, a_prev_idx, a_idx, a_next_idx) > 0 &&
+     area(points, b_prev_idx, b_idx, b_next_idx) > 0);
+
+  return is_valid_diagonal;
+}
+
+// Main Earclipping Function
 /// @brief create a Point and optionally link it with the previous one (in a circular doubly linked
 /// list)
 std::size_t insert_point(
-  std::size_t i, const Point2d & pt, std::vector<Point> & points_vec,
-  std::optional<std::size_t> last_index)
+  const std::size_t i, const Point2d & pt, std::vector<LinkedPoint> & pointsvec,
+  const std::optional<std::size_t> last_index)
 {
-  std::size_t p_idx = points_vec.size();
-  points_vec.emplace_back(i, pt);
+  std::size_t p_idx = pointsvec.size();
+  pointsvec.emplace_back(i, pt);
   if (!last_index.has_value()) {
-    points_vec[p_idx].prev_index = p_idx;
-    points_vec[p_idx].next_index = p_idx;
+    pointsvec[p_idx].prev_index = p_idx;
+    pointsvec[p_idx].next_index = p_idx;
   } else {
     std::size_t last = last_index.value();
-    std::size_t next = points_vec[last].next_index.value();
-    points_vec[p_idx].prev_index = last;
-    points_vec[p_idx].next_index = next;
+    std::size_t next = pointsvec[last].next_index.value();
+    pointsvec[p_idx].prev_index = last;
+    pointsvec[p_idx].next_index = next;
 
-    points_vec[last].next_index = p_idx;
-    points_vec[next].prev_index = p_idx;
+    pointsvec[last].next_index = p_idx;
+    pointsvec[next].prev_index = p_idx;
   }
 
   return p_idx;
 }
 
-std::optional<std::size_t> linked_list(
-  const LinearRing2d & points, bool clockwise, std::size_t & vertices,
-  std::vector<Point> & points_vec)
+/// @brief create a circular doubly linked list from polygon points in the specified winding order
+std::size_t linked_list(
+  const LinearRing2d & points, const bool clockwise, std::size_t & vertices,
+  std::vector<LinkedPoint> & pointsvec)
 {
   double sum = 0;
   const std::size_t len = points.size();
@@ -92,214 +247,40 @@ std::optional<std::size_t> linked_list(
 
   if (clockwise == (sum > 0)) {
     for (std::size_t i = 0; i < len; i++) {
-      last_index = insert_point(vertices + i, points[i], points_vec, last_index);
+      last_index = insert_point(vertices + i, points[i], pointsvec, last_index);
     }
   } else {
     for (size_t i = len; i-- > 0;) {
-      last_index = insert_point(vertices + i, points[i], points_vec, last_index);
+      last_index = insert_point(vertices + i, points[i], pointsvec, last_index);
     }
   }
 
   if (
     last_index.has_value() &&
-    equals(last_index.value(), points_vec[last_index.value()].next_index.value(), points_vec)) {
-    std::size_t next_index = points_vec[last_index.value()].next_index.value();
-    remove_point(last_index.value(), points_vec);
+    equals(last_index.value(), pointsvec[last_index.value()].next_index.value(), pointsvec)) {
+    std::size_t next_index = pointsvec[last_index.value()].next_index.value();
+    remove_point(last_index.value(), pointsvec);
     last_index = next_index;
   }
   vertices += len;
-  return last_index;
+  return last_index.value();
 }
 
-/// @brief eliminate colinear or duplicate points
-std::size_t filter_points(
-  std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point> & points_vec)
+/// @brief check whether the sector in vertex m contains the sector in vertex p in the same
+/// coordinates
+bool sector_contains_sector(
+  const std::size_t m_idx, const std::size_t p_idx, const std::vector<LinkedPoint> & points)
 {
-  if (!end_index.has_value()) {
-    end_index = start_index;
-  }
-
-  auto p = start_index;
-  bool again = false;
-  do {
-    again = false;
-    if (
-      !points_vec[p].steiner &&
-      (equals(p, points_vec[p].next_index.value(), points_vec) ||
-       area(points_vec, points_vec[p].prev_index.value(), p, points_vec[p].next_index.value()) ==
-         0)) {
-      remove_point(p, points_vec);
-      p = points_vec[p].prev_index.value();
-
-      if (p == points_vec[p].next_index.value()) break;
-      again = true;
-
-    } else {
-      p = points_vec[p].next_index.value();
-    }
-  } while (again || p != end_index.value());
-
-  return end_index.value();
-}
-
-/// @brief find a bridge between vertices that connects hole with an outer ring and link it
-std::size_t eliminate_hole(
-  std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points_vec)
-{
-  auto bridge = find_hole_bridge(hole_index, outer_index, points_vec);
-  if (!bridge.has_value()) {
-    return outer_index;
-  }
-  auto bridge_reverse = split_polygon(bridge.value(), hole_index, points_vec);
-
-  filter_points(bridge_reverse, points_vec[bridge_reverse].next_index.value(), points_vec);
-  return filter_points(bridge.value(), points_vec[bridge.value()].next_index.value(), points_vec);
-}
-
-std::size_t eliminate_holes(
-  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
-  std::vector<Point> & points_vec)
-{
-  const std::size_t len = inners.size();
-
-  std::vector<std::size_t> queue;
-  for (std::size_t i = 0; i < len; i++) {
-    auto list = linked_list(inners[i], false, vertices, points_vec);
-
-    if (list.has_value()) {
-      if (points_vec[list.value()].next_index == list.value()) {
-        points_vec[list.value()].steiner = true;
-      }
-
-      queue.push_back(get_leftmost(list.value(), points_vec));
-    }
-  }
-
-  std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {
-    return points_vec[a].x() < points_vec[b].x();
-  });
-
-  for (const auto & q : queue) {
-    outer_index = eliminate_hole(q, outer_index, points_vec);
-  }
-
-  return outer_index;
-}
-
-/// @brief triangulate a polygon using linked list
-void ear_clipping_linked(
-  std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices,
-  std::vector<Point> & points_vec, int pass)
-{
-  if (!ear_index.has_value()) {
-    return;
-  }
-
-  auto stop = ear_index;  // Stopping point for the loop
-  std::optional<std::size_t> next = std::nullopt;
-
-  // Iterate through ears, slicing them one by one
-  while (points_vec[ear_index.value()].prev_index.value() !=
-         points_vec[ear_index.value()].next_index.value()) {
-    next = points_vec[ear_index.value()].next_index;
-
-    if (is_ear(ear_index.value(), points_vec)) {
-      // Cut off the triangle and store the indices
-      indices.emplace_back(points_vec[ear_index.value()].prev_index.value());
-      indices.emplace_back(ear_index.value());
-      indices.emplace_back(next.value());
-
-      // Remove the ear and update the ear_index to continue
-      remove_point(ear_index.value(), points_vec);
-
-      // Move to the next ear after removal
-      ear_index = points_vec[next.value()].next_index.value();
-      stop = points_vec[next.value()].next_index.value();
-      continue;
-    }
-
-    ear_index = next.value();
-
-    if (ear_index == stop) {
-      if (pass == 0) {
-        ear_clipping_linked(
-          filter_points(ear_index.value(), std::nullopt, points_vec), indices, points_vec, 1);
-      } else if (pass == 1) {
-        ear_index = cure_local_intersections(
-          filter_points(ear_index.value(), std::nullopt, points_vec), indices, points_vec);
-        ear_clipping_linked(ear_index.value(), indices, points_vec, 2);
-      } else if (pass == 2) {
-        split_ear_clipping(points_vec, ear_index.value(), indices);
-      }
-      break;
-    }
-  }
-}
-
-/// @brief check whether ear is valid
-bool is_ear(std::size_t ear_index, const std::vector<Point> & points_vec)
-{
-  const auto a_index = points_vec[ear_index].prev_index.value();
-  const auto b_index = ear_index;
-  const auto c_index = points_vec[ear_index].next_index.value();
-
-  const auto a = points_vec[a_index];
-  const auto b = points_vec[b_index];
-  const auto c = points_vec[c_index];
-
-  if (area(points_vec, a_index, b_index, c_index) >= 0) return false;  // Reflex, can't be an ear
-
-  auto p_index = points_vec[c_index].next_index.value();
-  while (p_index != a_index) {
-    const auto p = points_vec[p_index];
-    if (
-      point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
-      area(points_vec, p.prev_index.value(), p_index, p.next_index.value()) >= 0) {
-      return false;
-    }
-    p_index = points_vec[p_index].next_index.value();
-  }
-
-  return true;
-}
-
-/// @brief go through all polygon Points and cure small local self-intersections
-std::size_t cure_local_intersections(
-  std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec)
-{
-  auto p = start_index;
-  bool updated = false;
-
-  do {
-    auto a = points_vec[p].prev_index.value();
-    auto b = points_vec[points_vec[p].next_index.value()].next_index.value();
-
-    if (
-      !equals(a, b, points_vec) &&
-      intersects(a, p, points_vec[p].next_index.value(), b, points_vec) &&
-      locally_inside(a, b, points_vec) && locally_inside(b, a, points_vec)) {
-      indices.emplace_back(a);
-      indices.emplace_back(p);
-      indices.emplace_back(b);
-
-      remove_point(p, points_vec);
-      remove_point(points_vec[p].next_index.value(), points_vec);
-
-      p = start_index = b;
-      updated = true;
-    } else {
-      p = points_vec[p].next_index.value();
-    }
-  } while (p != start_index && updated);
-
-  return filter_points(p, std::nullopt, points_vec);
+  return area(points, points[m_idx].prev_index.value(), m_idx, p_idx) < 0 &&
+         area(points, p_idx, points[m_idx].next_index.value(), m_idx) < 0;
 }
 
 // cspell: ignore Eberly
 /// @brief David Eberly's algorithm for finding a bridge between hole and outer polygon using vector
 /// indices
-std::optional<std::size_t> find_hole_bridge(
-  std::size_t hole_index, std::size_t outer_point_index, const std::vector<Point> & points)
+std::size_t find_hole_bridge(
+  const std::size_t hole_index, const std::size_t outer_point_index,
+  const std::vector<LinkedPoint> & points)
 {
   std::size_t p = outer_point_index;
   double hx = points[hole_index].x();
@@ -351,204 +332,12 @@ std::optional<std::size_t> find_hole_bridge(
     p = points[p].next_index.value();
   } while (p != stop);
 
-  return bridge_point;
-}
-
-/// @brief split the polygon using ear clipping
-void split_ear_clipping(
-  std::vector<Point> & points, std::size_t start_idx, std::vector<std::size_t> & indices)
-{
-  std::size_t a_idx = start_idx;
-  do {
-    std::size_t b_idx = points[points[a_idx].next_index.value()].next_index.value();
-    while (b_idx != points[a_idx].prev_index.value()) {
-      if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
-        std::size_t c_idx = split_polygon(a_idx, b_idx, points);
-
-        a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
-        c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
-
-        ear_clipping_linked(a_idx, indices, points);
-        ear_clipping_linked(c_idx, indices, points);
-        return;
-      }
-      b_idx = points[b_idx].next_index.value();
-    }
-    a_idx = points[a_idx].next_index.value();
-  } while (a_idx != start_idx);
-}
-
-/// @brief check whether the sector in vertex m contains the sector in vertex p in the same
-/// coordinates
-bool sector_contains_sector(std::size_t m_idx, std::size_t p_idx, const std::vector<Point> & points)
-{
-  return area(points, points[m_idx].prev_index.value(), m_idx, p_idx) < 0 &&
-         area(points, p_idx, points[m_idx].next_index.value(), m_idx) < 0;
-}
-
-/// @brief find the leftmost Point of a polygon ring
-std::size_t get_leftmost(std::size_t start_idx, const std::vector<Point> & points)
-{
-  std::size_t p_idx = start_idx;
-  std::size_t left_most_idx = start_idx;
-  do {
-    if (
-      points[p_idx].x() < points[left_most_idx].x() ||
-      (points[p_idx].x() == points[left_most_idx].x() &&
-       points[p_idx].y() < points[left_most_idx].y())) {
-      left_most_idx = p_idx;
-    }
-    p_idx = points[p_idx].next_index.value();
-  } while (p_idx != start_idx);
-
-  return left_most_idx;
-}
-
-/// @brief check if a point lies within a convex triangle
-bool point_in_triangle(
-  double ax, double ay, double bx, double by, double cx, double cy, double px, double py)
-{
-  return (cx - px) * (ay - py) >= (ax - px) * (cy - py) &&
-         (ax - px) * (by - py) >= (bx - px) * (ay - py) &&
-         (bx - px) * (cy - py) >= (cx - px) * (by - py);
-}
-
-/// @brief check if a diagonal between two polygon Points is valid
-bool is_valid_diagonal(std::size_t a_idx, std::size_t b_idx, const std::vector<Point> & points)
-{
-  // Extract indices for the next and previous points
-  std::size_t a_next_idx = points[a_idx].next_index.value();
-  std::size_t a_prev_idx = points[a_idx].prev_index.value();
-  std::size_t b_next_idx = points[b_idx].next_index.value();
-  std::size_t b_prev_idx = points[b_idx].prev_index.value();
-
-  // Check if diagonal does not connect adjacent or same points
-  if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx)) {
-    return false;
-  }
-
-  // Check if diagonals are locally inside and not intersecting
-  bool is_locally_inside_ab = locally_inside(a_idx, b_idx, points);
-  bool is_locally_inside_ba = locally_inside(b_idx, a_idx, points);
-  bool is_middle_inside = middle_inside(a_idx, b_idx, points);
-
-  bool is_valid_diagonal =
-    (is_locally_inside_ab && is_locally_inside_ba && is_middle_inside &&
-     (area(points, a_prev_idx, a_idx, b_prev_idx) != 0.0 ||
-      area(points, a_idx, b_prev_idx, b_idx) != 0.0)) ||
-    (equals(a_idx, b_idx, points) && area(points, a_prev_idx, a_idx, a_next_idx) > 0 &&
-     area(points, b_prev_idx, b_idx, b_next_idx) > 0);
-
-  return is_valid_diagonal;
-}
-
-/// @brief signed area of a triangle
-double area(
-  const std::vector<Point> & points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
-{
-  const Point & p = points[p_idx];
-  const Point & q = points[q_idx];
-  const Point & r = points[r_idx];
-  return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
-}
-
-/// @brief check if two points are equal
-bool equals(std::size_t p1_idx, std::size_t p2_idx, const std::vector<Point> & points)
-{
-  return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
-}
-
-/// @brief check if two segments intersect
-bool intersects(
-  std::size_t p1_idx, std::size_t q1_idx, std::size_t p2_idx, std::size_t q2_idx,
-  const std::vector<Point> & points)
-{
-  int o1 = sign(area(points, p1_idx, q1_idx, p2_idx));
-  int o2 = sign(area(points, p1_idx, q1_idx, q2_idx));
-  int o3 = sign(area(points, p2_idx, q2_idx, p1_idx));
-  int o4 = sign(area(points, p2_idx, q2_idx, q1_idx));
-
-  if (o1 != o2 && o3 != o4) return true;
-
-  if (o1 == 0 && on_segment(points, p1_idx, p2_idx, q1_idx)) return true;
-  if (o2 == 0 && on_segment(points, p1_idx, q2_idx, q1_idx)) return true;
-  if (o3 == 0 && on_segment(points, p2_idx, p1_idx, q2_idx)) return true;
-  if (o4 == 0 && on_segment(points, p2_idx, q1_idx, q2_idx)) return true;
-
-  return false;
-}
-
-/// @brief for collinear points p, q, r, check if point q lies on segment pr
-bool on_segment(
-  const std::vector<Point> & points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
-{
-  const Point & p = points[p_idx];
-  const Point & q = points[q_idx];
-  const Point & r = points[r_idx];
-  return q.x() <= std::max<double>(p.x(), r.x()) && q.x() >= std::min<double>(p.x(), r.x()) &&
-         q.y() <= std::max<double>(p.y(), r.y()) && q.y() >= std::min<double>(p.y(), r.y());
-}
-
-/// @brief sign function for area calculation
-int sign(double val)
-{
-  return (0.0 < val) - (val < 0.0);
-}
-
-/// @brief check if a polygon diagonal intersects any polygon segments
-bool intersects_polygon(const std::vector<Point> & points, std::size_t a_idx, std::size_t b_idx)
-{
-  std::size_t p_idx = a_idx;
-  do {
-    std::size_t p_next_idx = points[p_idx].next_index.value();  // Get the next point in the polygon
-
-    if (p_idx != a_idx && p_next_idx != a_idx && p_idx != b_idx && p_next_idx != b_idx) {
-      if (intersects(p_idx, p_next_idx, a_idx, b_idx, points)) {
-        return true;
-      }
-    }
-
-    p_idx = p_next_idx;
-  } while (p_idx != a_idx);
-
-  return false;
-}
-
-/// @brief check if a polygon diagonal is locally inside the polygon
-bool locally_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point> & points)
-{
-  return area(points, points[a_idx].prev_index.value(), a_idx, points[a_idx].next_index.value()) < 0
-           ? area(points, a_idx, b_idx, points[a_idx].next_index.value()) >= 0 &&
-               area(points, a_idx, points[a_idx].prev_index.value(), b_idx) >= 0
-           : area(points, a_idx, b_idx, points[a_idx].prev_index.value()) < 0 ||
-               area(points, a_idx, points[a_idx].next_index.value(), b_idx) < 0;
-}
-
-/// @brief check if the middle vertex of a polygon diagonal is inside the polygon
-bool middle_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point> & points)
-{
-  std::size_t p_idx = a_idx;
-  bool inside = false;
-  double px = (points[a_idx].x() + points[b_idx].x()) / 2;
-  double py = (points[a_idx].y() + points[b_idx].y()) / 2;
-  do {
-    if (
-      ((points[p_idx].y() > py) != (points[points[p_idx].next_index.value()].y() > py)) &&
-      points[points[p_idx].next_index.value()].y() != points[p_idx].y() &&
-      (px < (points[points[p_idx].next_index.value()].x() - points[p_idx].x()) *
-                (py - points[p_idx].y()) /
-                (points[points[p_idx].next_index.value()].y() - points[p_idx].y()) +
-              points[p_idx].x())) {
-      inside = !inside;
-    }
-    p_idx = points[p_idx].next_index.value();
-  } while (p_idx != a_idx);
-
-  return inside;
+  return bridge_point.value();
 }
 
 /// @brief link two polygon vertices with a bridge
-std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points)
+std::size_t split_polygon(
+  const std::size_t a_index, const std::size_t b_index, std::vector<LinkedPoint> & points)
 {
   Point2d a_point(points[a_index].x(), points[a_index].y());
   Point2d b_point(points[b_index].x(), points[b_index].y());
@@ -578,21 +367,232 @@ std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<
   return b2_idx;
 }
 
-/// @brief remove a Point from the linked list
-void remove_point(std::size_t p_index, std::vector<Point> & points)
+/// @brief eliminate colinear or duplicate points
+std::size_t filter_points(
+  const std::size_t start_index, const std::size_t end_index, std::vector<LinkedPoint> & pointsvec)
 {
-  std::size_t prev_index = points[p_index].prev_index.value();
-  std::size_t next_index = points[p_index].next_index.value();
+  auto p = start_index;
+  bool again = false;
+  do {
+    again = false;
+    if (
+      !pointsvec[p].steiner &&
+      (equals(p, pointsvec[p].next_index.value(), pointsvec) ||
+       area(pointsvec, pointsvec[p].prev_index.value(), p, pointsvec[p].next_index.value()) == 0)) {
+      remove_point(p, pointsvec);
+      p = pointsvec[p].prev_index.value();
 
-  points[prev_index].next_index = next_index;
-  points[next_index].prev_index = prev_index;
+      if (p == pointsvec[p].next_index.value()) break;
+      again = true;
+
+    } else {
+      p = pointsvec[p].next_index.value();
+    }
+  } while (again || p != end_index);
+
+  return end_index;
 }
 
+/// @brief find a bridge between vertices that connects hole with an outer ring and link it
+std::size_t eliminate_hole(
+  const std::size_t hole_index, const std::size_t outer_index, std::vector<LinkedPoint> & pointsvec)
+{
+  auto bridge = find_hole_bridge(hole_index, outer_index, pointsvec);
+  auto bridge_reverse = split_polygon(bridge, hole_index, pointsvec);
+
+  filter_points(bridge_reverse, pointsvec[bridge_reverse].next_index.value(), pointsvec);
+  return filter_points(bridge, pointsvec[bridge].next_index.value(), pointsvec);
+}
+
+std::size_t eliminate_holes(
+  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
+  std::vector<LinkedPoint> & pointsvec)
+{
+  const std::size_t len = inners.size();
+
+  std::vector<std::size_t> queue;
+  for (std::size_t i = 0; i < len; i++) {
+    auto list = linked_list(inners[i], false, vertices, pointsvec);
+
+    if (pointsvec[list].next_index == list) {
+      pointsvec[list].steiner = true;
+    }
+
+    queue.push_back(get_leftmost(list, pointsvec));
+  }
+
+  std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {
+    return pointsvec[a].x() < pointsvec[b].x();
+  });
+
+  for (const auto & q : queue) {
+    outer_index = eliminate_hole(q, outer_index, pointsvec);
+  }
+
+  return outer_index;
+}
+
+/// @brief check whether ear is valid
+bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & pointsvec)
+{
+  const auto a_index = pointsvec[ear_index].prev_index.value();
+  const auto b_index = ear_index;
+  const auto c_index = pointsvec[ear_index].next_index.value();
+
+  const auto a = pointsvec[a_index];
+  const auto b = pointsvec[b_index];
+  const auto c = pointsvec[c_index];
+
+  if (area(pointsvec, a_index, b_index, c_index) >= 0) return false;  // Reflex, can't be an ear
+
+  auto p_index = pointsvec[c_index].next_index.value();
+  while (p_index != a_index) {
+    const auto p = pointsvec[p_index];
+    if (
+      point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
+      area(pointsvec, p.prev_index.value(), p_index, p.next_index.value()) >= 0) {
+      return false;
+    }
+    p_index = pointsvec[p_index].next_index.value();
+  }
+
+  return true;
+}
+
+/// @brief go through all polygon Points and cure small local self-intersections
+std::size_t cure_local_intersections(
+  std::size_t start_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & pointsvec)
+{
+  auto p = start_index;
+  bool updated = false;
+
+  do {
+    auto a = pointsvec[p].prev_index.value();
+    auto b = pointsvec[pointsvec[p].next_index.value()].next_index.value();
+
+    if (
+      !equals(a, b, pointsvec) && intersects(a, p, pointsvec[p].next_index.value(), b, pointsvec) &&
+      locally_inside(a, b, pointsvec) && locally_inside(b, a, pointsvec)) {
+      indices.emplace_back(a);
+      indices.emplace_back(p);
+      indices.emplace_back(b);
+
+      remove_point(p, pointsvec);
+      remove_point(pointsvec[p].next_index.value(), pointsvec);
+
+      p = start_index = b;
+      updated = true;
+    } else {
+      p = pointsvec[p].next_index.value();
+    }
+  } while (p != start_index && updated);
+
+  return filter_points(p, p, pointsvec);
+}
+
+/// @brief main ear slicing loop which triangulates a polygon using linked list
+void ear_clipping_linked(
+  std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & pointsvec,
+  const int pass = 0)
+{
+  auto stop = ear_index;  // Stopping point for the loop
+  std::optional<std::size_t> next = std::nullopt;
+
+  // Iterate through ears, slicing them one by one
+  while (pointsvec[ear_index].prev_index.value() != pointsvec[ear_index].next_index.value()) {
+    next = pointsvec[ear_index].next_index;
+
+    if (is_ear(ear_index, pointsvec)) {
+      // Cut off the triangle and store the indices
+      indices.emplace_back(pointsvec[ear_index].prev_index.value());
+      indices.emplace_back(ear_index);
+      indices.emplace_back(next.value());
+
+      // Remove the ear and update the ear_index to continue
+      remove_point(ear_index, pointsvec);
+
+      // Move to the next ear after removal
+      ear_index = pointsvec[next.value()].next_index.value();
+      stop = pointsvec[next.value()].next_index.value();
+      continue;
+    }
+
+    ear_index = next.value();
+
+    if (ear_index == stop) {
+      if (pass == 0) {
+        ear_clipping_linked(filter_points(ear_index, ear_index, pointsvec), indices, pointsvec, 1);
+      } else if (pass == 1) {
+        ear_index = cure_local_intersections(
+          filter_points(ear_index, ear_index, pointsvec), indices, pointsvec);
+        ear_clipping_linked(ear_index, indices, pointsvec, 2);
+      } else if (pass == 2) {
+        split_ear_clipping(pointsvec, ear_index, indices);
+      }
+      break;
+    }
+  }
+}
+
+/// @brief split the polygon using ear clipping
+void split_ear_clipping(
+  std::vector<LinkedPoint> & points, const std::size_t start_idx,
+  std::vector<std::size_t> & indices)
+{
+  std::size_t a_idx = start_idx;
+  do {
+    std::size_t b_idx = points[points[a_idx].next_index.value()].next_index.value();
+    while (b_idx != points[a_idx].prev_index.value()) {
+      if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
+        std::size_t c_idx = split_polygon(a_idx, b_idx, points);
+
+        a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
+        c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
+
+        ear_clipping_linked(a_idx, indices, points);
+        ear_clipping_linked(c_idx, indices, points);
+        return;
+      }
+      b_idx = points[b_idx].next_index.value();
+    }
+    a_idx = points[a_idx].next_index.value();
+  } while (a_idx != start_idx);
+}
+
+std::vector<LinkedPoint> perform_triangulation(
+  const Polygon2d & polygon, std::vector<std::size_t> & indices)
+{
+  indices.clear();
+  std::vector<LinkedPoint> points;
+  std::size_t vertices = 0;
+  const auto & outer_ring = polygon.outer();
+  std::size_t len = outer_ring.size();
+  points.reserve(len * 3 / 2);
+
+  if (polygon.outer().empty()) return points;
+
+  indices.reserve(len + outer_ring.size());
+  auto outer_point_index = linked_list(outer_ring, true, vertices, points);
+  if (
+    !points[outer_point_index].prev_index.has_value() ||
+    outer_point_index == points[outer_point_index].prev_index.value()) {
+    return points;
+  }
+
+  if (!polygon.inners().empty()) {
+    outer_point_index = eliminate_holes(polygon.inners(), outer_point_index, vertices, points);
+  }
+
+  ear_clipping_linked(outer_point_index, indices, points);
+  return points;
+}
+
+// Main Function
 /// @brief main triangulate function
 std::vector<Polygon2d> triangulate(const Polygon2d & poly)
 {
   std::vector<std::size_t> indices;
-  auto list_ = perform_triangulation(poly, indices);
+  auto points = perform_triangulation(poly, indices);
 
   std::vector<Polygon2d> triangles;
   const std::size_t num_indices = indices.size();
@@ -603,17 +603,15 @@ std::vector<Polygon2d> triangulate(const Polygon2d & poly)
 
   for (std::size_t i = 0; i < num_indices; i += 3) {
     Polygon2d triangle;
-    triangle.outer().push_back(list_[indices[i]].pt);
-    triangle.outer().push_back(list_[indices[i + 1]].pt);
-    triangle.outer().push_back(list_[indices[i + 2]].pt);
-    triangle.outer().push_back(list_[indices[i]].pt);
+    triangle.outer().push_back(points[indices[i]].pt);
+    triangle.outer().push_back(points[indices[i + 1]].pt);
+    triangle.outer().push_back(points[indices[i + 2]].pt);
+    triangle.outer().push_back(points[indices[i]].pt);
 
     triangles.push_back(triangle);
   }
-  list_.clear();
+  points.clear();
   return triangles;
 }
 
 }  // namespace autoware::universe_utils
-
-#endif  // EAR_CUT_IMPL_HPP

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include "autoware/universe_utils/geometry/ear_clipping.hpp"
-#include <iostream>
-
 
 #ifndef EAR_CUT_IMPL_HPP
 #define EAR_CUT_IMPL_HPP
@@ -22,585 +20,598 @@
 namespace autoware::universe_utils
 {
 
-std::size_t construct_point(std::size_t index, const Point2d& point, std::vector<Point> & points) {
-    points.emplace_back(index, point);
-    return index;
-}
-
-std::vector<Point> perform_triangulation(const Polygon2d & polygon, std::vector<std::size_t> & indices) {
-    indices.clear();
-    std::vector<Point> points_;
-    std::size_t vertices = 0;
-    const auto & outer_ring = polygon.outer();
-    std::size_t len = outer_ring.size();
-    points_.reserve(len * 3 / 2);
-
-    if (polygon.outer().empty()) return points_;
-
-    indices.reserve(len + outer_ring.size());
-    auto outer_point = linked_list(outer_ring, true, vertices, points_);
-    if (outer_point == points_[outer_point.value()].prev_index.value()) {
-        return points_;
-    }
-
-    if (!polygon.inners().empty()) {
-        outer_point = eliminate_holes(polygon.inners(), outer_point.value(), vertices, points_);
-    }
-
-    ear_clipping_linked(outer_point.value(), indices, points_);
-    return points_;
-}
-
-/// @brief create a Point and optionally link it with the previous one (in a circular doubly linked list)
-std::size_t insert_point(
-    std::size_t i, const Point2d& pt, std::vector<Point>& points_vec, std::optional<std::size_t> last_index)
+std::size_t construct_point(std::size_t index, const Point2d & point, std::vector<Point> & points)
 {
-    std::size_t p_idx = points_vec.size();
-    points_vec.emplace_back(i, pt);
-    if (!last_index.has_value()) {
-        points_vec[p_idx].prev_index = p_idx;
-        points_vec[p_idx].next_index = p_idx;
-    } else {
-        std::size_t last = last_index.value();
-        std::size_t next = points_vec[last].next_index.value(); 
-        points_vec[p_idx].prev_index = last;
-        points_vec[p_idx].next_index = next;
-        
-        points_vec[last].next_index = p_idx;
-        points_vec[next].prev_index = p_idx;
-    }
-
-    return p_idx;
+  points.emplace_back(index, point);
+  return index;
 }
 
-std::optional<std::size_t> linked_list(const LinearRing2d& points, bool clockwise, std::size_t& vertices, std::vector<Point>& points_vec) {
-    double sum = 0;
-    const std::size_t len = points.size();
-    std::optional<std::size_t> last_index = std::nullopt;
+std::vector<Point> perform_triangulation(
+  const Polygon2d & polygon, std::vector<std::size_t> & indices)
+{
+  indices.clear();
+  std::vector<Point> points_;
+  std::size_t vertices = 0;
+  const auto & outer_ring = polygon.outer();
+  std::size_t len = outer_ring.size();
+  points_.reserve(len * 3 / 2);
 
-    // Calculate area to determine clockwise or counterclockwise
-    for (std::size_t i = 0, j = len > 0 ? len - 1 : 0; i < len; j = i++) {
-        const auto& p1 = points[i];
-        const auto& p2 = points[j];
-        sum += (p2.x() - p1.x()) * (p1.y() + p2.y());
+  if (polygon.outer().empty()) return points_;
+
+  indices.reserve(len + outer_ring.size());
+  auto outer_point = linked_list(outer_ring, true, vertices, points_);
+  if (outer_point == points_[outer_point.value()].prev_index.value()) {
+    return points_;
+  }
+
+  if (!polygon.inners().empty()) {
+    outer_point = eliminate_holes(polygon.inners(), outer_point.value(), vertices, points_);
+  }
+
+  ear_clipping_linked(outer_point.value(), indices, points_);
+  return points_;
+}
+
+/// @brief create a Point and optionally link it with the previous one (in a circular doubly linked
+/// list)
+std::size_t insert_point(
+  std::size_t i, const Point2d & pt, std::vector<Point> & points_vec,
+  std::optional<std::size_t> last_index)
+{
+  std::size_t p_idx = points_vec.size();
+  points_vec.emplace_back(i, pt);
+  if (!last_index.has_value()) {
+    points_vec[p_idx].prev_index = p_idx;
+    points_vec[p_idx].next_index = p_idx;
+  } else {
+    std::size_t last = last_index.value();
+    std::size_t next = points_vec[last].next_index.value();
+    points_vec[p_idx].prev_index = last;
+    points_vec[p_idx].next_index = next;
+
+    points_vec[last].next_index = p_idx;
+    points_vec[next].prev_index = p_idx;
+  }
+
+  return p_idx;
+}
+
+std::optional<std::size_t> linked_list(
+  const LinearRing2d & points, bool clockwise, std::size_t & vertices,
+  std::vector<Point> & points_vec)
+{
+  double sum = 0;
+  const std::size_t len = points.size();
+  std::optional<std::size_t> last_index = std::nullopt;
+
+  for (std::size_t i = 0, j = len > 0 ? len - 1 : 0; i < len; j = i++) {
+    const auto & p1 = points[i];
+    const auto & p2 = points[j];
+    sum += (p2.x() - p1.x()) * (p1.y() + p2.y());
+  }
+
+  if (clockwise == (sum > 0)) {
+    for (std::size_t i = 0; i < len; i++) {
+      last_index = insert_point(vertices + i, points[i], points_vec, last_index);
     }
-
-    // Determine the correct direction and insert points
-    if (clockwise == (sum > 0)) {
-        for (std::size_t i = 0; i < len; i++) {
-            last_index = insert_point(vertices + i, points[i], points_vec, last_index);
-        }
-    } else {
-        for (size_t i = len; i-- > 0;) {
-            last_index = insert_point(vertices + i, points[i], points_vec, last_index);
-        }
+  } else {
+    for (size_t i = len; i-- > 0;) {
+      last_index = insert_point(vertices + i, points[i], points_vec, last_index);
     }
+  }
 
-    
-    if (last_index.has_value() && equals(last_index.value(), points_vec[last_index.value()].next_index.value(), points_vec)) {
-        std::size_t next_index = points_vec[last_index.value()].next_index.value();
-        remove_point(last_index.value(), points_vec);
-        last_index = next_index;
-    }
-
-    // Update the number of vertices
-    vertices += len;
-    return last_index;
+  if (
+    last_index.has_value() &&
+    equals(last_index.value(), points_vec[last_index.value()].next_index.value(), points_vec)) {
+    std::size_t next_index = points_vec[last_index.value()].next_index.value();
+    remove_point(last_index.value(), points_vec);
+    last_index = next_index;
+  }
+  vertices += len;
+  return last_index;
 }
 
 /// @brief eliminate colinear or duplicate points
-std::size_t filter_points(std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point>& points_vec) {
-    if (!end_index.has_value()) {
-        end_index = start_index;
+std::size_t filter_points(
+  std::size_t start_index, std::optional<std::size_t> end_index, std::vector<Point> & points_vec)
+{
+  if (!end_index.has_value()) {
+    end_index = start_index;
+  }
+
+  auto p = start_index;
+  bool again = false;
+  do {
+    again = false;
+    if (
+      !points_vec[p].steiner &&
+      (equals(p, points_vec[p].next_index.value(), points_vec) ||
+       area(points_vec, points_vec[p].prev_index.value(), p, points_vec[p].next_index.value()) ==
+         0)) {
+      remove_point(p, points_vec);
+      p = points_vec[p].prev_index.value();
+
+      if (p == points_vec[p].next_index.value()) break;
+      again = true;
+
+    } else {
+      p = points_vec[p].next_index.value();
     }
+  } while (again || p != end_index.value());
 
-    auto p = start_index;
-    bool again = false;
-    do {
-        again = false;
-
-        // Check if the point should be removed due to collinearity or duplication
-        if (!points_vec[p].steiner &&
-            (equals(p, points_vec[p].next_index.value(), points_vec) ||
-             area(points_vec, points_vec[p].prev_index.value(), p, points_vec[p].next_index.value()) == 0)) {
-            remove_point(p, points_vec);
-            p = points_vec[p].prev_index.value();
-
-            // Ensure the loop stops if it has traversed the entire ring
-            if (p == points_vec[p].next_index.value()) break;
-            again = true;
-
-        } else {
-            p = points_vec[p].next_index.value();
-        }
-    } while (again || p != end_index.value());
-
-    return end_index.value();
+  return end_index.value();
 }
-/// @brief find a bridge between vertices that connects hole with an outer ring and link it
-std::size_t eliminate_hole(std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points_vec) {
-    auto bridge = find_hole_bridge(hole_index, outer_index, points_vec);
-    if (!bridge.has_value()) {
-        return outer_index;
-    }
-    auto bridge_reverse = split_polygon(bridge.value(), hole_index, points_vec);
 
-    filter_points(bridge_reverse, points_vec[bridge_reverse].next_index.value(), points_vec);
-    return filter_points(bridge.value(), points_vec[bridge.value()].next_index.value(), points_vec);
+/// @brief find a bridge between vertices that connects hole with an outer ring and link it
+std::size_t eliminate_hole(
+  std::size_t hole_index, std::size_t outer_index, std::vector<Point> & points_vec)
+{
+  auto bridge = find_hole_bridge(hole_index, outer_index, points_vec);
+  if (!bridge.has_value()) {
+    return outer_index;
+  }
+  auto bridge_reverse = split_polygon(bridge.value(), hole_index, points_vec);
+
+  filter_points(bridge_reverse, points_vec[bridge_reverse].next_index.value(), points_vec);
+  return filter_points(bridge.value(), points_vec[bridge.value()].next_index.value(), points_vec);
 }
 
 std::size_t eliminate_holes(
-    const std::vector<LinearRing2d>& inners, std::size_t outer_index, std::size_t& vertices, std::vector<Point>& points_vec)
+  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
+  std::vector<Point> & points_vec)
 {
-    const std::size_t len = inners.size();
+  const std::size_t len = inners.size();
 
-    std::vector<std::size_t> queue;
-    for (std::size_t i = 0; i < len; i++) {
-        // Get the linked list starting point (first point in the inner ring)
-        auto list = linked_list(inners[i], false, vertices, points_vec);
+  std::vector<std::size_t> queue;
+  for (std::size_t i = 0; i < len; i++) {
+    auto list = linked_list(inners[i], false, vertices, points_vec);
 
-        if (list.has_value()) {
-            // If the list is a single-point loop, mark it as Steiner
-            if (points_vec[list.value()].next_index == list.value()) {
-                points_vec[list.value()].steiner = true;
-            }
+    if (list.has_value()) {
+      if (points_vec[list.value()].next_index == list.value()) {
+        points_vec[list.value()].steiner = true;
+      }
 
-            // Add the leftmost point of the list to the queue
-            queue.push_back(get_leftmost(list.value(), points_vec));
-        }
+      queue.push_back(get_leftmost(list.value(), points_vec));
     }
+  }
 
-    // Sort the queue based on the x-coordinate of the points
-    std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {
-        return points_vec[a].x() < points_vec[b].x();
-    });
+  std::sort(queue.begin(), queue.end(), [&](std::size_t a, std::size_t b) {
+    return points_vec[a].x() < points_vec[b].x();
+  });
 
-    // Eliminate each hole by merging with the outer polygon
-    for (const auto& q : queue) {
-        outer_index = eliminate_hole(q, outer_index, points_vec);
-    }
+  for (const auto & q : queue) {
+    outer_index = eliminate_hole(q, outer_index, points_vec);
+  }
 
-    return outer_index;
+  return outer_index;
 }
-/// @brief main ear slicing loop which triangulates a polygon using linked list
-void ear_clipping_linked(std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec, int pass) {
-    if (!ear_index.has_value()) {
-        return;
+
+/// @brief triangulate a polygon using linked list
+void ear_clipping_linked(
+  std::optional<std::size_t> ear_index, std::vector<std::size_t> & indices,
+  std::vector<Point> & points_vec, int pass)
+{
+  if (!ear_index.has_value()) {
+    return;
+  }
+
+  auto stop = ear_index;  // Stopping point for the loop
+  std::optional<std::size_t> next = std::nullopt;
+
+  // Iterate through ears, slicing them one by one
+  while (points_vec[ear_index.value()].prev_index.value() !=
+         points_vec[ear_index.value()].next_index.value()) {
+    next = points_vec[ear_index.value()].next_index;
+
+    if (is_ear(ear_index.value(), points_vec)) {
+      // Cut off the triangle and store the indices
+      indices.emplace_back(points_vec[ear_index.value()].prev_index.value());
+      indices.emplace_back(ear_index.value());
+      indices.emplace_back(next.value());
+
+      // Remove the ear and update the ear_index to continue
+      remove_point(ear_index.value(), points_vec);
+
+      // Move to the next ear after removal
+      ear_index = points_vec[next.value()].next_index.value();
+      stop = points_vec[next.value()].next_index.value();
+      continue;
     }
 
-    auto stop = ear_index;  // Stopping point for the loop
-    std::optional<std::size_t> next = std::nullopt;
+    ear_index = next.value();
 
-    // Iterate through ears, slicing them one by one
-    while (points_vec[ear_index.value()].prev_index.value() != points_vec[ear_index.value()].next_index.value()) {
-        next = points_vec[ear_index.value()].next_index;
-
-
-        if (is_ear(ear_index.value(), points_vec)) {
-
-            // Cut off the triangle and store the indices
-            indices.emplace_back(points_vec[ear_index.value()].prev_index.value());
-            indices.emplace_back(ear_index.value());
-            indices.emplace_back(next.value());
-
-
-            // Remove the ear and update the ear_index to continue
-            remove_point(ear_index.value(), points_vec);
-
-            // Move to the next ear after removal
-            ear_index = points_vec[next.value()].next_index.value();
-            stop = points_vec[next.value()].next_index.value();
-            continue;
-        }
-
-        ear_index = next.value();
-
-        // If we have completed a full loop and haven't found any ears
-        if (ear_index == stop) {
-            if (pass == 0) {
-                ear_clipping_linked(filter_points(ear_index.value(), std::nullopt, points_vec), indices, points_vec, 1);
-            } else if (pass == 1) {
-                ear_index = cure_local_intersections(filter_points(ear_index.value(), std::nullopt, points_vec), indices, points_vec);
-                ear_clipping_linked(ear_index.value(), indices, points_vec, 2);
-            } else if (pass == 2) {
-                split_ear_clipping(points_vec, ear_index.value(), indices);
-            }
-            break;  // End the loop after handling all passes
-        }
+    if (ear_index == stop) {
+      if (pass == 0) {
+        ear_clipping_linked(
+          filter_points(ear_index.value(), std::nullopt, points_vec), indices, points_vec, 1);
+      } else if (pass == 1) {
+        ear_index = cure_local_intersections(
+          filter_points(ear_index.value(), std::nullopt, points_vec), indices, points_vec);
+        ear_clipping_linked(ear_index.value(), indices, points_vec, 2);
+      } else if (pass == 2) {
+        split_ear_clipping(points_vec, ear_index.value(), indices);
+      }
+      break;
     }
+  }
 }
 
 /// @brief check whether ear is valid
-bool is_ear(std::size_t ear_index, const std::vector<Point>& points_vec)
+bool is_ear(std::size_t ear_index, const std::vector<Point> & points_vec)
 {
-    const auto a_index = points_vec[ear_index].prev_index.value();
-    const auto b_index = ear_index;
-    const auto c_index = points_vec[ear_index].next_index.value();
+  const auto a_index = points_vec[ear_index].prev_index.value();
+  const auto b_index = ear_index;
+  const auto c_index = points_vec[ear_index].next_index.value();
 
-    const auto a = points_vec[a_index];
-    const auto b = points_vec[b_index];
-    const auto c = points_vec[c_index];
+  const auto a = points_vec[a_index];
+  const auto b = points_vec[b_index];
+  const auto c = points_vec[c_index];
 
-    if (area(points_vec, a_index, b_index, c_index) >= 0) return false;  // Reflex, can't be an ear
+  if (area(points_vec, a_index, b_index, c_index) >= 0) return false;  // Reflex, can't be an ear
 
-    auto p_index = points_vec[c_index].next_index.value();
-    while (p_index != a_index) {
-        const auto p = points_vec[p_index];
-        if (
-          point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
-          area(points_vec, p.prev_index.value(), p_index, p.next_index.value()) >= 0
-        ) {
-            return false;
-        }
-        p_index = points_vec[p_index].next_index.value();
+  auto p_index = points_vec[c_index].next_index.value();
+  while (p_index != a_index) {
+    const auto p = points_vec[p_index];
+    if (
+      point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
+      area(points_vec, p.prev_index.value(), p_index, p.next_index.value()) >= 0) {
+      return false;
     }
+    p_index = points_vec[p_index].next_index.value();
+  }
 
-    return true;
+  return true;
 }
 
 /// @brief go through all polygon Points and cure small local self-intersections
-std::size_t cure_local_intersections(std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec) {
-    auto p = start_index;
-    bool updated = false;
+std::size_t cure_local_intersections(
+  std::size_t start_index, std::vector<std::size_t> & indices, std::vector<Point> & points_vec)
+{
+  auto p = start_index;
+  bool updated = false;
 
-    do {
-        auto a = points_vec[p].prev_index.value();
-        auto b = points_vec[points_vec[p].next_index.value()].next_index.value(); // b is next->next
+  do {
+    auto a = points_vec[p].prev_index.value();
+    auto b = points_vec[points_vec[p].next_index.value()].next_index.value();
 
-        if (!equals(a, b, points_vec) &&
-            intersects(a, p, points_vec[p].next_index.value(), b, points_vec) &&
-            locally_inside(a, b, points_vec) &&
-            locally_inside(b, a, points_vec)) {
+    if (
+      !equals(a, b, points_vec) &&
+      intersects(a, p, points_vec[p].next_index.value(), b, points_vec) &&
+      locally_inside(a, b, points_vec) && locally_inside(b, a, points_vec)) {
+      indices.emplace_back(a);
+      indices.emplace_back(p);
+      indices.emplace_back(b);
 
-            indices.emplace_back(a);
-            indices.emplace_back(p);
-            indices.emplace_back(b);
+      remove_point(p, points_vec);
+      remove_point(points_vec[p].next_index.value(), points_vec);
 
-            remove_point(p, points_vec);
-            remove_point(points_vec[p].next_index.value(), points_vec); // Removing next point
+      p = start_index = b;
+      updated = true;
+    } else {
+      p = points_vec[p].next_index.value();
+    }
+  } while (p != start_index && updated);
 
-            p = start_index = b;
-            updated = true;
-        } else {
-            p = points_vec[p].next_index.value();
-        }
-
-    } while (p != start_index && updated); // Continue if `p` has not looped back to `start_index` and there was an update
-
-    return filter_points(p, std::nullopt, points_vec);
+  return filter_points(p, std::nullopt, points_vec);
 }
 
-
-/// @brief David Eberly's algorithm for finding a bridge between hole and outer polygon using vector indices
-std::optional<std::size_t> find_hole_bridge(std::size_t hole_index, std::size_t outer_point_index, const std::vector<Point>& points)
+// cspell: ignore Eberly
+/// @brief David Eberly's algorithm for finding a bridge between hole and outer polygon using vector
+/// indices
+std::optional<std::size_t> find_hole_bridge(
+  std::size_t hole_index, std::size_t outer_point_index, const std::vector<Point> & points)
 {
-    std::size_t p = outer_point_index;
-    double hx = points[hole_index].x();
-    double hy = points[hole_index].y();
-    double qx = -std::numeric_limits<double>::infinity();
-    std::optional<std::size_t> bridge_point = std::nullopt;  // Null equivalent for index
+  std::size_t p = outer_point_index;
+  double hx = points[hole_index].x();
+  double hy = points[hole_index].y();
+  double qx = -std::numeric_limits<double>::infinity();
+  std::optional<std::size_t> bridge_point = std::nullopt;
+  do {
+    std::size_t next_index = points[p].next_index.value();
+    if (
+      hy <= points[p].y() && hy >= points[next_index].y() &&
+      points[next_index].y() != points[p].y()) {
+      double x = points[p].x() + (hy - points[p].y()) * (points[next_index].x() - points[p].x()) /
+                                   (points[next_index].y() - points[p].y());
+      if (x <= hx && x > qx) {
+        qx = x;
+        bridge_point = points[p].x() < points[next_index].x() ? p : next_index;
+        if (x == hx) return bridge_point.value();
+      }
+    }
+    p = next_index;
+  } while (p != outer_point_index);
 
-    // Find the best candidate point on the outer polygon
-    do {
-        std::size_t next_index = points[p].next_index.value();
-        if (hy <= points[p].y() && hy >= points[next_index].y() && points[next_index].y() != points[p].y()) {
-            double x = points[p].x() + (hy - points[p].y()) * (points[next_index].x() - points[p].x()) / (points[next_index].y() - points[p].y());
-            if (x <= hx && x > qx) {
-                qx = x;
-                bridge_point = points[p].x() < points[next_index].x() ? p : next_index;
-                if (x == hx) return bridge_point.value();
-            }
-        }
-        p = next_index;
-    } while (p != outer_point_index);
+  if (!bridge_point.has_value()) return bridge_point.value();
 
-    if (!bridge_point.has_value()) return bridge_point.value();
+  const std::size_t stop = bridge_point.value();
+  double min_tan = std::numeric_limits<double>::infinity();
 
-    const std::size_t stop = bridge_point.value();
-    double min_tan = std::numeric_limits<double>::infinity();
+  p = bridge_point.value();
+  double mx = points[bridge_point.value()].x();
+  double my = points[bridge_point.value()].y();
 
-    p = bridge_point.value();
-    double mx = points[bridge_point.value()].x();
-    double my = points[bridge_point.value()].y();
+  do {
+    if (
+      hx >= points[p].x() && points[p].x() >= mx && hx != points[p].x() &&
+      point_in_triangle(
+        hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, points[p].x(), points[p].y())) {
+      double current_tan = std::abs(hy - points[p].y()) / (hx - points[p].x());
 
-    // Refine the best candidate
-    do {
-        if (
-            hx >= points[p].x() && points[p].x() >= mx && hx != points[p].x() &&
-            point_in_triangle(hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, points[p].x(), points[p].y())) {
+      if (
+        locally_inside(p, hole_index, points) &&
+        (current_tan < min_tan ||
+         (current_tan == min_tan && (points[p].x() > points[bridge_point.value()].x() ||
+                                     sector_contains_sector(bridge_point.value(), p, points))))) {
+        bridge_point = p;
+        min_tan = current_tan;
+      }
+    }
 
-            double current_tan = std::abs(hy - points[p].y()) / (hx - points[p].x());
+    p = points[p].next_index.value();
+  } while (p != stop);
 
-            if (
-                locally_inside(p, hole_index, points) &&
-                (current_tan < min_tan ||
-                 (current_tan == min_tan && (points[p].x() > points[bridge_point.value()].x() || sector_contains_sector(bridge_point.value(), p, points))))) {
-                bridge_point = p;
-                min_tan = current_tan;
-            }
-        }
-
-        p = points[p].next_index.value();
-    } while (p != stop);
-
-    return bridge_point;
+  return bridge_point;
 }
 
-/// @brief Split the polygon using ear clipping
-void split_ear_clipping(std::vector<Point>& points, std::size_t start_idx, std::vector<std::size_t>& indices)
+/// @brief split the polygon using ear clipping
+void split_ear_clipping(
+  std::vector<Point> & points, std::size_t start_idx, std::vector<std::size_t> & indices)
 {
-    std::size_t a_idx = start_idx;
-    do {
-        std::size_t b_idx = points[points[a_idx].next_index.value()].next_index.value();
-        while (b_idx != points[a_idx].prev_index.value()) {
-            if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
-                std::size_t c_idx = split_polygon(a_idx, b_idx, points);
+  std::size_t a_idx = start_idx;
+  do {
+    std::size_t b_idx = points[points[a_idx].next_index.value()].next_index.value();
+    while (b_idx != points[a_idx].prev_index.value()) {
+      if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
+        std::size_t c_idx = split_polygon(a_idx, b_idx, points);
 
-                a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
-                c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
+        a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
+        c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
 
-                ear_clipping_linked(a_idx, indices, points);
-                ear_clipping_linked(c_idx, indices, points);
-                return;
-            }
-            b_idx = points[b_idx].next_index.value();
-        }
-        a_idx = points[a_idx].next_index.value();
-    } while (a_idx != start_idx);
+        ear_clipping_linked(a_idx, indices, points);
+        ear_clipping_linked(c_idx, indices, points);
+        return;
+      }
+      b_idx = points[b_idx].next_index.value();
+    }
+    a_idx = points[a_idx].next_index.value();
+  } while (a_idx != start_idx);
 }
 
-/// @brief Check whether the sector in vertex m contains the sector in vertex p in the same coordinates
-bool sector_contains_sector(std::size_t m_idx, std::size_t p_idx, const std::vector<Point>& points)
+/// @brief check whether the sector in vertex m contains the sector in vertex p in the same
+/// coordinates
+bool sector_contains_sector(std::size_t m_idx, std::size_t p_idx, const std::vector<Point> & points)
 {
-    return area(points, points[m_idx].prev_index.value(), m_idx, p_idx) < 0 &&
-           area(points, p_idx, points[m_idx].next_index.value(), m_idx) < 0;
+  return area(points, points[m_idx].prev_index.value(), m_idx, p_idx) < 0 &&
+         area(points, p_idx, points[m_idx].next_index.value(), m_idx) < 0;
 }
 
-/// @brief Find the leftmost Point of a polygon ring
-std::size_t get_leftmost(std::size_t start_idx, const std::vector<Point>& points)
+/// @brief find the leftmost Point of a polygon ring
+std::size_t get_leftmost(std::size_t start_idx, const std::vector<Point> & points)
 {
-    std::size_t p_idx = start_idx;
-    std::size_t left_most_idx = start_idx;
-    do {
-        if (points[p_idx].x() < points[left_most_idx].x() || 
-           (points[p_idx].x() == points[left_most_idx].x() && points[p_idx].y() < points[left_most_idx].y())) 
-        {
-            left_most_idx = p_idx;
-        }
-        p_idx = points[p_idx].next_index.value();
-    } while (p_idx != start_idx);
+  std::size_t p_idx = start_idx;
+  std::size_t left_most_idx = start_idx;
+  do {
+    if (
+      points[p_idx].x() < points[left_most_idx].x() ||
+      (points[p_idx].x() == points[left_most_idx].x() &&
+       points[p_idx].y() < points[left_most_idx].y())) {
+      left_most_idx = p_idx;
+    }
+    p_idx = points[p_idx].next_index.value();
+  } while (p_idx != start_idx);
 
-    return left_most_idx;
+  return left_most_idx;
 }
 
 /// @brief check if a point lies within a convex triangle
 bool point_in_triangle(
-    double ax, double ay, double bx, double by, double cx, double cy, double px, double py)
+  double ax, double ay, double bx, double by, double cx, double cy, double px, double py)
 {
-    return (cx - px) * (ay - py) >= (ax - px) * (cy - py) &&
-           (ax - px) * (by - py) >= (bx - px) * (ay - py) &&
-           (bx - px) * (cy - py) >= (cx - px) * (by - py);
+  return (cx - px) * (ay - py) >= (ax - px) * (cy - py) &&
+         (ax - px) * (by - py) >= (bx - px) * (ay - py) &&
+         (bx - px) * (cy - py) >= (cx - px) * (by - py);
 }
 
 /// @brief check if a diagonal between two polygon Points is valid
-/// @brief Check if a diagonal between two polygon Points is valid
-bool is_valid_diagonal(std::size_t a_idx, std::size_t b_idx, const std::vector<Point>& points)
+bool is_valid_diagonal(std::size_t a_idx, std::size_t b_idx, const std::vector<Point> & points)
 {
-    // Extract indices for the next and previous points
-    std::size_t a_next_idx = points[a_idx].next_index.value();
-    std::size_t a_prev_idx = points[a_idx].prev_index.value();
-    std::size_t b_next_idx = points[b_idx].next_index.value();
-    std::size_t b_prev_idx = points[b_idx].prev_index.value();
+  // Extract indices for the next and previous points
+  std::size_t a_next_idx = points[a_idx].next_index.value();
+  std::size_t a_prev_idx = points[a_idx].prev_index.value();
+  std::size_t b_next_idx = points[b_idx].next_index.value();
+  std::size_t b_prev_idx = points[b_idx].prev_index.value();
 
-    // Check if diagonal does not connect adjacent or same points
-    if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx))
-    {
-        return false;
-    }
+  // Check if diagonal does not connect adjacent or same points
+  if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx)) {
+    return false;
+  }
 
-    // Check if diagonals are locally inside and not intersecting
-    bool is_locally_inside_ab = locally_inside(a_idx, b_idx, points);
-    bool is_locally_inside_ba = locally_inside(b_idx, a_idx, points);
-    bool is_middle_inside = middle_inside(a_idx, b_idx, points);
+  // Check if diagonals are locally inside and not intersecting
+  bool is_locally_inside_ab = locally_inside(a_idx, b_idx, points);
+  bool is_locally_inside_ba = locally_inside(b_idx, a_idx, points);
+  bool is_middle_inside = middle_inside(a_idx, b_idx, points);
 
-    bool is_valid_diagonal = (is_locally_inside_ab && is_locally_inside_ba && is_middle_inside &&
-                            (area(points, a_prev_idx, a_idx, b_prev_idx) != 0.0 ||
-                             area(points, a_idx, b_prev_idx, b_idx) != 0.0)) ||
-                           (equals(a_idx, b_idx, points) &&
-                            area(points, a_prev_idx, a_idx, a_next_idx) > 0 &&
-                            area(points, b_prev_idx, b_idx, b_next_idx) > 0);
+  bool is_valid_diagonal =
+    (is_locally_inside_ab && is_locally_inside_ba && is_middle_inside &&
+     (area(points, a_prev_idx, a_idx, b_prev_idx) != 0.0 ||
+      area(points, a_idx, b_prev_idx, b_idx) != 0.0)) ||
+    (equals(a_idx, b_idx, points) && area(points, a_prev_idx, a_idx, a_next_idx) > 0 &&
+     area(points, b_prev_idx, b_idx, b_next_idx) > 0);
 
-    return is_valid_diagonal;
+  return is_valid_diagonal;
 }
 
 /// @brief signed area of a triangle
-double area(const std::vector<Point>& points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
+double area(
+  const std::vector<Point> & points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
 {
-    const Point& p = points[p_idx];
-    const Point& q = points[q_idx];
-    const Point& r = points[r_idx];
-    return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
+  const Point & p = points[p_idx];
+  const Point & q = points[q_idx];
+  const Point & r = points[r_idx];
+  return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
 }
 
 /// @brief check if two points are equal
-bool equals(std::size_t p1_idx, std::size_t p2_idx, const std::vector<Point>& points)
+bool equals(std::size_t p1_idx, std::size_t p2_idx, const std::vector<Point> & points)
 {
-    return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
+  return points[p1_idx].x() == points[p2_idx].x() && points[p1_idx].y() == points[p2_idx].y();
 }
 
 /// @brief check if two segments intersect
-bool intersects(std::size_t p1_idx, std::size_t q1_idx, std::size_t p2_idx, std::size_t q2_idx, const std::vector<Point>& points)
+bool intersects(
+  std::size_t p1_idx, std::size_t q1_idx, std::size_t p2_idx, std::size_t q2_idx,
+  const std::vector<Point> & points)
 {
-    int o1 = sign(area(points, p1_idx, q1_idx, p2_idx));
-    int o2 = sign(area(points, p1_idx, q1_idx, q2_idx));
-    int o3 = sign(area(points, p2_idx, q2_idx, p1_idx));
-    int o4 = sign(area(points, p2_idx, q2_idx, q1_idx));
+  int o1 = sign(area(points, p1_idx, q1_idx, p2_idx));
+  int o2 = sign(area(points, p1_idx, q1_idx, q2_idx));
+  int o3 = sign(area(points, p2_idx, q2_idx, p1_idx));
+  int o4 = sign(area(points, p2_idx, q2_idx, q1_idx));
 
-    if (o1 != o2 && o3 != o4) return true;
+  if (o1 != o2 && o3 != o4) return true;
 
-    if (o1 == 0 && on_segment(points, p1_idx, p2_idx, q1_idx)) return true;
-    if (o2 == 0 && on_segment(points, p1_idx, q2_idx, q1_idx)) return true;
-    if (o3 == 0 && on_segment(points, p2_idx, p1_idx, q2_idx)) return true;
-    if (o4 == 0 && on_segment(points, p2_idx, q1_idx, q2_idx)) return true;
+  if (o1 == 0 && on_segment(points, p1_idx, p2_idx, q1_idx)) return true;
+  if (o2 == 0 && on_segment(points, p1_idx, q2_idx, q1_idx)) return true;
+  if (o3 == 0 && on_segment(points, p2_idx, p1_idx, q2_idx)) return true;
+  if (o4 == 0 && on_segment(points, p2_idx, q1_idx, q2_idx)) return true;
 
-    return false;
+  return false;
 }
 
 /// @brief for collinear points p, q, r, check if point q lies on segment pr
-bool on_segment(const std::vector<Point>& points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
+bool on_segment(
+  const std::vector<Point> & points, std::size_t p_idx, std::size_t q_idx, std::size_t r_idx)
 {
-    const Point& p = points[p_idx];
-    const Point& q = points[q_idx];
-    const Point& r = points[r_idx];
-    return q.x() <= std::max<double>(p.x(), r.x()) && q.x() >= std::min<double>(p.x(), r.x()) &&
-           q.y() <= std::max<double>(p.y(), r.y()) && q.y() >= std::min<double>(p.y(), r.y());
+  const Point & p = points[p_idx];
+  const Point & q = points[q_idx];
+  const Point & r = points[r_idx];
+  return q.x() <= std::max<double>(p.x(), r.x()) && q.x() >= std::min<double>(p.x(), r.x()) &&
+         q.y() <= std::max<double>(p.y(), r.y()) && q.y() >= std::min<double>(p.y(), r.y());
 }
 
-/// @brief Sign function for area calculation
+/// @brief sign function for area calculation
 int sign(double val)
 {
-    return (0.0 < val) - (val < 0.0);
+  return (0.0 < val) - (val < 0.0);
 }
 
-/// @brief Check if a polygon diagonal intersects any polygon segments
-bool intersects_polygon(const std::vector<Point>& points, std::size_t a_idx, std::size_t b_idx) {
-    std::size_t p_idx = a_idx;
-    do {
-        std::size_t p_next_idx = points[p_idx].next_index.value();  // Get the next point in the polygon
-
-        // Ensure we are not comparing the same segment as `a-b`
-        if (p_idx != a_idx && p_next_idx != a_idx && p_idx != b_idx && p_next_idx != b_idx) {
-            if (intersects(p_idx, p_next_idx, a_idx, b_idx, points)) {
-                return true;
-            }
-        }
-
-        p_idx = p_next_idx;  // Move to the next point in the polygon
-    } while (p_idx != a_idx);  // Loop until we come back to the starting point
-
-    return false;
-}
-
-/// @brief Check if a polygon diagonal is locally inside the polygon
-bool locally_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point>& points)
+/// @brief check if a polygon diagonal intersects any polygon segments
+bool intersects_polygon(const std::vector<Point> & points, std::size_t a_idx, std::size_t b_idx)
 {
-    return area(points, points[a_idx].prev_index.value(), a_idx, points[a_idx].next_index.value()) < 0 ? 
-        area(points, a_idx, b_idx, points[a_idx].next_index.value()) >= 0 && 
-        area(points, a_idx, points[a_idx].prev_index.value(), b_idx) >= 0 
-        : area(points, a_idx, b_idx, points[a_idx].prev_index.value()) < 0 || 
-          area(points, a_idx, points[a_idx].next_index.value(), b_idx) < 0;
+  std::size_t p_idx = a_idx;
+  do {
+    std::size_t p_next_idx = points[p_idx].next_index.value();  // Get the next point in the polygon
+
+    if (p_idx != a_idx && p_next_idx != a_idx && p_idx != b_idx && p_next_idx != b_idx) {
+      if (intersects(p_idx, p_next_idx, a_idx, b_idx, points)) {
+        return true;
+      }
+    }
+
+    p_idx = p_next_idx;
+  } while (p_idx != a_idx);
+
+  return false;
 }
 
-/// @brief Check if the middle vertex of a polygon diagonal is inside the polygon
-bool middle_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point>& points)
+/// @brief check if a polygon diagonal is locally inside the polygon
+bool locally_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point> & points)
 {
-    std::size_t p_idx = a_idx;
-    bool inside = false;
-    double px = (points[a_idx].x() + points[b_idx].x()) / 2;
-    double py = (points[a_idx].y() + points[b_idx].y()) / 2;
-    do {
-        if (((points[p_idx].y() > py) != (points[points[p_idx].next_index.value()].y() > py)) && 
-            points[points[p_idx].next_index.value()].y() != points[p_idx].y() &&
-            (px < (points[points[p_idx].next_index.value()].x() - points[p_idx].x()) * (py - points[p_idx].y()) / 
-            (points[points[p_idx].next_index.value()].y() - points[p_idx].y()) + points[p_idx].x()))
-        {
-            inside = !inside;
-        }
-        p_idx = points[p_idx].next_index.value();
-    } while (p_idx != a_idx);
-
-    return inside;
+  return area(points, points[a_idx].prev_index.value(), a_idx, points[a_idx].next_index.value()) < 0
+           ? area(points, a_idx, b_idx, points[a_idx].next_index.value()) >= 0 &&
+               area(points, a_idx, points[a_idx].prev_index.value(), b_idx) >= 0
+           : area(points, a_idx, b_idx, points[a_idx].prev_index.value()) < 0 ||
+               area(points, a_idx, points[a_idx].next_index.value(), b_idx) < 0;
 }
 
-/// @brief Link two polygon vertices with a bridge
+/// @brief check if the middle vertex of a polygon diagonal is inside the polygon
+bool middle_inside(std::size_t a_idx, std::size_t b_idx, const std::vector<Point> & points)
+{
+  std::size_t p_idx = a_idx;
+  bool inside = false;
+  double px = (points[a_idx].x() + points[b_idx].x()) / 2;
+  double py = (points[a_idx].y() + points[b_idx].y()) / 2;
+  do {
+    if (
+      ((points[p_idx].y() > py) != (points[points[p_idx].next_index.value()].y() > py)) &&
+      points[points[p_idx].next_index.value()].y() != points[p_idx].y() &&
+      (px < (points[points[p_idx].next_index.value()].x() - points[p_idx].x()) *
+                (py - points[p_idx].y()) /
+                (points[points[p_idx].next_index.value()].y() - points[p_idx].y()) +
+              points[p_idx].x())) {
+      inside = !inside;
+    }
+    p_idx = points[p_idx].next_index.value();
+  } while (p_idx != a_idx);
+
+  return inside;
+}
+
+/// @brief link two polygon vertices with a bridge
 std::size_t split_polygon(std::size_t a_index, std::size_t b_index, std::vector<Point> & points)
 {
-    Point2d a_point(points[a_index].x(), points[a_index].y());
-    Point2d b_point(points[b_index].x(), points[b_index].y());
+  Point2d a_point(points[a_index].x(), points[a_index].y());
+  Point2d b_point(points[b_index].x(), points[b_index].y());
 
-    // Use construct_point to create new Point objects
-    std::size_t a2_idx = construct_point(a_index, a_point, points);
-    std::size_t b2_idx = construct_point(b_index, b_point, points);
+  std::size_t a2_idx = construct_point(a_index, a_point, points);
+  std::size_t b2_idx = construct_point(b_index, b_point, points);
 
-    std::size_t an_idx = points[a_index].next_index.value();
-    std::size_t bp_idx = points[b_index].prev_index.value();
+  std::size_t an_idx = points[a_index].next_index.value();
+  std::size_t bp_idx = points[b_index].prev_index.value();
 
-    // Update the linked list connections
-    points[a_index].next_index = b_index;
-    points[b_index].prev_index = a_index;
+  points[a_index].next_index = b_index;
+  points[b_index].prev_index = a_index;
 
-    points[a2_idx].next_index = an_idx;
-    if (an_idx != a_index) {
-        points[an_idx].prev_index = a2_idx;
-    }
+  points[a2_idx].next_index = an_idx;
+  if (an_idx != a_index) {
+    points[an_idx].prev_index = a2_idx;
+  }
 
-    points[b2_idx].next_index = a2_idx;
-    points[a2_idx].prev_index = b2_idx;
+  points[b2_idx].next_index = a2_idx;
+  points[a2_idx].prev_index = b2_idx;
 
-    if (bp_idx != b_index) {
-        points[bp_idx].next_index = b2_idx;
-    }
-    points[b2_idx].prev_index = bp_idx;
+  if (bp_idx != b_index) {
+    points[bp_idx].next_index = b2_idx;
+  }
+  points[b2_idx].prev_index = bp_idx;
 
-    return b2_idx;
+  return b2_idx;
 }
-
 
 /// @brief remove a Point from the linked list
-void remove_point(std::size_t p_index, std::vector<Point>& points) {
-    std::size_t prev_index = points[p_index].prev_index.value();
-    std::size_t next_index = points[p_index].next_index.value();
+void remove_point(std::size_t p_index, std::vector<Point> & points)
+{
+  std::size_t prev_index = points[p_index].prev_index.value();
+  std::size_t next_index = points[p_index].next_index.value();
 
-    points[prev_index].next_index = next_index;
-    points[next_index].prev_index = prev_index;
+  points[prev_index].next_index = next_index;
+  points[next_index].prev_index = prev_index;
 }
 
-
 /// @brief main triangulate function
-std::vector<Polygon2d> triangulate(const Polygon2d& poly) {
-    std::vector<std::size_t> indices;
-    auto list_ = perform_triangulation(poly, indices);
+std::vector<Polygon2d> triangulate(const Polygon2d & poly)
+{
+  std::vector<std::size_t> indices;
+  auto list_ = perform_triangulation(poly, indices);
 
-    std::vector<Polygon2d> triangles;
-    const std::size_t num_indices = indices.size();
+  std::vector<Polygon2d> triangles;
+  const std::size_t num_indices = indices.size();
 
+  if (num_indices % 3 != 0) {
+    throw std::runtime_error("Indices size should be a multiple of 3");
+  }
 
-    if (num_indices % 3 != 0) {
-        throw std::runtime_error("Indices size should be a multiple of 3");
-    }
+  for (std::size_t i = 0; i < num_indices; i += 3) {
+    Polygon2d triangle;
+    triangle.outer().push_back(list_[indices[i]].pt);
+    triangle.outer().push_back(list_[indices[i + 1]].pt);
+    triangle.outer().push_back(list_[indices[i + 2]].pt);
+    triangle.outer().push_back(list_[indices[i]].pt);
 
-    for (std::size_t i = 0; i < num_indices; i += 3) {
-
-        Polygon2d triangle;
-        triangle.outer().push_back(list_[indices[i]].pt);
-        triangle.outer().push_back(list_[indices[i + 1]].pt);
-        triangle.outer().push_back(list_[indices[i + 2]].pt);
-        triangle.outer().push_back(list_[indices[i]].pt); // Closing the triangle
-
-        triangles.push_back(triangle);
-    }
-    list_.clear();
-    return triangles;
+    triangles.push_back(triangle);
+  }
+  list_.clear();
+  return triangles;
 }
 
 }  // namespace autoware::universe_utils


### PR DESCRIPTION
## Description
Refactor the triangulation function to use `std::vector` instead of raw pointer.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Random and Unit tested.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
