### PR TITLE
fix: removed access to unused ROS_VERSION environment variable.

### DIFF
--- a/simulator/autoware_carla_interface/CMakeLists.txt
+++ b/simulator/autoware_carla_interface/CMakeLists.txt
@@ -14,10 +14,6 @@ endif()
 
 ament_export_dependencies(rclpy)
 
-find_package(ros_environment REQUIRED)
-set(ROS_VERSION $ENV{ROS_VERSION})
-
-
 # Install launch files.
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
 

--- a/simulator/autoware_carla_interface/setup.py
+++ b/simulator/autoware_carla_interface/setup.py
@@ -3,8 +3,6 @@ import os
 
 from setuptools import setup
 
-ROS_VERSION = int(os.environ["ROS_VERSION"])
-
 package_name = "autoware_carla_interface"
 
 setup(


### PR DESCRIPTION
## Description

`carla_interface` attempts to access the `ROS_VERSION` environment variable, but it is not available at build time

This PR removes code that accesses `ROS_VERSION` as it's not being currently used anywhere.

## Related links

**Parent Issue:**

- Link

https://github.com/autowarefoundation/autoware-deb-packages/issues/97

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
