### PR TITLE
refactor: update to use autoware_ndt_omp as a dependency

### DIFF
--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -5,13 +5,13 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 # Compile flags for SIMD instructions
-# Be careful to change these options, especially when `ndt_omp` implementation is used.
-# All packages linked to `ndt_omp` should use the same SIMD instruction set.
+# Be careful to change these options, especially when `autoware_ndt_omp` implementation is used.
+# All packages linked to `autoware_ndt_omp` should use the same SIMD instruction set.
 # In case mismatched instruction set are used, program causes a crash at its initialization
 # because of a misaligned access to the `Eigen` libraries' data structure.
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   # For x86_64 architecture, SIMD instruction set is fixed below versions,
-  # because the `ndt_omp` is optimized to these versions.
+  # because the `autoware_ndt_omp` is optimized to these versions.
   add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 else()
   # For other architecture, like arm64, compile flags are generally prepared by compiler

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/hyper_parameters.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/hyper_parameters.hpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <multigrid_pclomp/multigrid_ndt_omp.h>
+#include <autoware/ndt_omp/multigrid_pclomp/multigrid_ndt_omp.h>
 
 #include <algorithm>
 #include <sstream>
@@ -54,7 +54,7 @@ struct HyperParameters
     double required_distance{};
   } sensor_points{};
 
-  pclomp::NdtParams ndt{};
+  autoware::ndt_omp::pclomp::NdtParams ndt{};
   bool ndt_regularization_enable{};
 
   struct InitialPoseEstimation

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
@@ -30,7 +30,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <fmt/format.h>
-#include <multigrid_pclomp/multigrid_ndt_omp.h>
+#include <autoware/ndt_omp/multigrid_pclomp/multigrid_ndt_omp.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <map>
@@ -47,7 +47,7 @@ class MapUpdateModule
 {
   using PointSource = pcl::PointXYZ;
   using PointTarget = pcl::PointXYZ;
-  using NdtType = pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
+  using NdtType = autoware::ndt_omp::pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
   using NdtPtrType = std::shared_ptr<NdtType>;
 
 public:

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/map_update_module.hpp
@@ -29,8 +29,8 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <fmt/format.h>
 #include <autoware/ndt_omp/multigrid_pclomp/multigrid_ndt_omp.h>
+#include <fmt/format.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <map>
@@ -47,7 +47,8 @@ class MapUpdateModule
 {
   using PointSource = pcl::PointXYZ;
   using PointTarget = pcl::PointXYZ;
-  using NdtType = autoware::ndt_omp::pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
+  using NdtType =
+    autoware::ndt_omp::pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
   using NdtPtrType = std::shared_ptr<NdtType>;
 
 public:

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -38,7 +38,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <fmt/format.h>
-#include <multigrid_pclomp/multigrid_ndt_omp.h>
+#include <autoware/ndt_omp/multigrid_pclomp/multigrid_ndt_omp.h>
 #include <pcl/point_types.h>
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
@@ -77,7 +77,7 @@ class NDTScanMatcher : public rclcpp::Node
   using PointSource = pcl::PointXYZ;
   using PointTarget = pcl::PointXYZ;
   using NormalDistributionsTransform =
-    pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
+    autoware::ndt_omp::pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
 
 public:
   explicit NDTScanMatcher(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
@@ -142,7 +142,7 @@ private:
   static int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array);
 
   Eigen::Matrix2d estimate_covariance(
-    const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
+    const autoware::ndt_omp::pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
     const rclcpp::Time & sensor_ros_time);
 
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr visualize_point_score(

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -37,8 +37,8 @@
 #include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <fmt/format.h>
 #include <autoware/ndt_omp/multigrid_pclomp/multigrid_ndt_omp.h>
+#include <fmt/format.h>
 #include <pcl/point_types.h>
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
@@ -142,8 +142,8 @@ private:
   static int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array);
 
   Eigen::Matrix2d estimate_covariance(
-    const autoware::ndt_omp::pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
-    const rclcpp::Time & sensor_ros_time);
+    const autoware::ndt_omp::pclomp::NdtResult & ndt_result,
+    const Eigen::Matrix4f & initial_pose_matrix, const rclcpp::Time & sensor_ros_time);
 
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr visualize_point_score(
     const pcl::shared_ptr<pcl::PointCloud<PointSource>> & sensor_points_in_map_ptr,

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_map_msgs</depend>
+  <depend>autoware_ndt_omp</depend>
   <depend>autoware_universe_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>
@@ -25,7 +26,6 @@
   <depend>libpcl-all-dev</depend>
   <depend>localization_util</depend>
   <depend>nav_msgs</depend>
-  <depend>ndt_omp</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
## Description

This PR updates the `ndt_omp` dependency with the `autoware_` prefix. To be merged after https://github.com/tier4/ndt_omp/pull/68

## Related links

**Parent Issue:**

- Link

https://github.com/tier4/ndt_omp/pull/68

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
