### PR TITLE
fix(behavior_path_planner): fix rtc state update logic

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -501,7 +501,9 @@ protected:
   {
     for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
       if (ptr) {
-        const auto state = !ptr->isRegistered(uuid_map_.at(module_name)) || isWaitingApproval() ? State::WAITING_FOR_EXECUTION : State::RUNNING;
+        const auto state = !ptr->isRegistered(uuid_map_.at(module_name)) || isWaitingApproval()
+                             ? State::WAITING_FOR_EXECUTION
+                             : State::RUNNING;
         ptr->updateCooperateStatus(
           uuid_map_.at(module_name), isExecutionReady(), state, start_distance, finish_distance,
           clock_->now());

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -501,7 +501,7 @@ protected:
   {
     for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
       if (ptr) {
-        const auto state = isWaitingApproval() ? State::WAITING_FOR_EXECUTION : State::RUNNING;
+        const auto state = !ptr->isRegistered(uuid_map_.at(module_name)) || isWaitingApproval() ? State::WAITING_FOR_EXECUTION : State::RUNNING;
         ptr->updateCooperateStatus(
           uuid_map_.at(module_name), isExecutionReady(), state, start_distance, finish_distance,
           clock_->now());


### PR DESCRIPTION
## Description
Fix rtc state transition error for behavior_path_planner modules.
Specifically, the following warning would be fixed.

```
[component_container_mt-33] [WARN] [1726603502.777678240] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.RTCInterface[goal_planner]]: [updateCooperateStatus]  Cannot register RUNNING as initial state
```

## Related links
- https://github.com/autowarefoundation/autoware.universe/pull/8883
- https://github.com/autowarefoundation/autoware.universe/pull/8855

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/af7e4e4b-44ed-5c81-8f3a-c841ff1e4054?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
