### PR TITLE
fix(static_obstacle_avoidance): update UUID when candidate shift is empty

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -162,16 +162,26 @@ private:
    */
   void removeCandidateRTCStatus()
   {
+    bool candidate_registered = false;
+
     if (rtc_interface_ptr_map_.at("left")->isRegistered(candidate_uuid_)) {
       rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
         candidate_uuid_, true, State::FAILED, std::numeric_limits<double>::lowest(),
         std::numeric_limits<double>::lowest(), clock_->now());
+      candidate_registered = true;
     }
 
     if (rtc_interface_ptr_map_.at("right")->isRegistered(candidate_uuid_)) {
       rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
         candidate_uuid_, true, State::FAILED, std::numeric_limits<double>::lowest(),
         std::numeric_limits<double>::lowest(), clock_->now());
+      candidate_registered = true;
+    }
+
+    if (candidate_registered) {
+      uuid_map_.at("left") = generateUUID();
+      uuid_map_.at("right") = generateUUID();
+      candidate_uuid_ = generateUUID();
     }
   }
 


### PR DESCRIPTION
## Description
Fix rtc state transition error for static_obstacle_avoidance module.
There was a problem that the same UUID was used for candidates shift line, although the cooperateStatus has been changed to FAILED.
```
[WARN] [1726619093.498740895] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.RTCInterface[static_obstacle_avoidance_left]]: [updateCooperateStatus] uuid : 8c50d0b80d2539be7fc496c00e153d7a cannot transit from FAILED to WAITING_FOR_EXECUTION
```
This happens when `removeCandidateRTCStatus` function is once called, and the candidate is re-registered in the next period.
This PR generates a new UUID once the `removeCandidateRTCStatus` function is called.

## Related links
- https://github.com/autowarefoundation/autoware.universe/pull/8883
- https://github.com/autowarefoundation/autoware.universe/pull/8855

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/c811d9a6-592a-5872-8ba6-166a3a484d90?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
