### PR TITLE
fix(lane_change): set initail rtc state properly

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -125,16 +125,21 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   } else {
     const auto path =
       assignToCandidate(module_type_->getLaneChangePath(), module_type_->getEgoPosition());
-    const auto force_activated = std::any_of(
+    const auto is_registered = std::any_of(
       rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(),
-      [&](const auto & rtc) { return rtc.second->isForceActivated(uuid_map_.at(rtc.first)); });
-    if (!force_activated) {
+      [&](const auto & rtc) { return rtc.second->isRegistered(uuid_map_.at(rtc.first)); });
+
+    if (!is_registered) {
       updateRTCStatus(
         path.start_distance_to_path_change, path.finish_distance_to_path_change, true,
-        State::RUNNING);
+        State::WAITING_FOR_EXECUTION);
     } else {
+      const auto force_activated = std::any_of(
+        rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(),
+        [&](const auto & rtc) { return rtc.second->isForceActivated(uuid_map_.at(rtc.first)); });
+      const bool safe = force_activated ? false : true;
       updateRTCStatus(
-        path.start_distance_to_path_change, path.finish_distance_to_path_change, false,
+        path.start_distance_to_path_change, path.finish_distance_to_path_change, safe,
         State::RUNNING);
     }
   }


### PR DESCRIPTION
## Description
The following WARNING appears when the lane change module `plan()' function is called at it's first time.
```
[WARN] [1726626143.864958038] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.RTCInterface[lane_change_right]]: [isForceActivated] uuid : cad0dcbfaf3c176c142900e225f85ae5 is not found
[WARN] [1726626143.864981280] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.RTCInterface[lane_change_right]]: [updateCooperateStatus]  Cannot register RUNNING as initial state
```
This PR solves the warnings by checking whether the uuid is registered or not.
If the uuid is not registered the cooperateStatus state is set to WAITING_FOR_EXECUTION and the force activation is not checked.

## Related links
- https://github.com/autowarefoundation/autoware.universe/pull/8883
- https://github.com/autowarefoundation/autoware.universe/pull/8855

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/e808ce6f-45b1-57a5-83c2-24a1d3c70625?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
