### PR TITLE
refactor(start_planner,raw_vechile_cmd_converter): align parameter with autoware_launch's parameter

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -69,10 +69,11 @@
         search_configs:
           theta_size: 120
           angle_goal_range: 6.0
-          curve_weight: 0.5
-          reverse_weight: 1.0
           lateral_goal_range: 0.5
           longitudinal_goal_range: 2.0
+          curve_weight: 0.5
+          reverse_weight: 1.0
+          direction_change_weight: 1.5
         # costmap configs
         costmap_configs:
           obstacle_threshold: 30
@@ -81,7 +82,13 @@
           search_method: "forward"  # options: forward, backward
           only_behind_solutions: false
           use_back: true
+          adapt_expansion_distance: true
+          expansion_distance: 0.5
+          near_goal_distance: 3.0
           distance_heuristic_weight: 2.0
+          smoothness_weight: 0.5
+          obstacle_distance_weight: 1.75
+          goal_lat_distance_weight: 5.0
         # -- RRT* search Configurations --
         rrtstar:
           enable_update: true

--- a/vehicle/autoware_raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
@@ -5,7 +5,7 @@
     csv_path_steer_map: $(find-pkg-share autoware_raw_vehicle_cmd_converter)/data/default/steer_map.csv
     convert_accel_cmd: true
     convert_brake_cmd: true
-    convert_steer_cmd: true
+    convert_steer_cmd: false
     use_steer_ff: true
     use_steer_fb: true
     is_debugging: false


### PR DESCRIPTION
## Description

align parameter in the yaml file to the [autoware_launch](https://github.com/autowarefoundation/autoware_launch)


## How was this PR tested?

No testing.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### ROS Parameter Changes


#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
