### PR TITLE
fix(tier4_camera_view_rviz_plugin): fix unmatchedSuppression

### DIFF
--- a/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp
+++ b/common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp
@@ -99,7 +99,6 @@ void BirdEyeViewController::reset()
   y_property_->setFloat(0);
 }
 
-// cppcheck-suppress unusedFunction
 void BirdEyeViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
 {
   if (event.shift()) {


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unmatchedSuppression warnings.
Due to a modification to cppcheck's CI, comment suppression is no longer required for items that previously generated warnings.

```
common/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp:103:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void BirdEyeViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
