### PR TITLE
fix(tier4_state_rviz_plugin): fix unmatchedSuppression

### DIFF
--- a/common/tier4_state_rviz_plugin/src/custom_button.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_button.cpp
@@ -63,7 +63,6 @@ QSize CustomElevatedButton::minimumSizeHint() const
   return sizeHint();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomElevatedButton::updateStyle(
   const QString & text, const QColor & bgColor, const QColor & textColor, const QColor & hoverColor,
   const QColor & pressedColor, const QColor & checkedColor, const QColor & disabledBgColor,

--- a/common/tier4_state_rviz_plugin/src/custom_container.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_container.cpp
@@ -26,7 +26,6 @@ CustomContainer::CustomContainer(QWidget * parent) : QFrame(parent), cornerRadiu
   setLayout(layout);
 }
 
-// cppcheck-suppress unusedFunction
 QGridLayout * CustomContainer::getLayout() const
 {
   return layout;  // Provide access to the layout

--- a/common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp
@@ -40,7 +40,6 @@ CustomSegmentedButtonItem * CustomSegmentedButton::addButton(const QString & tex
   return button;
 }
 
-// cppcheck-suppress unusedFunction
 QButtonGroup * CustomSegmentedButton::getButtonGroup() const
 {
   return buttonGroup;

--- a/common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp
+++ b/common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp
@@ -44,14 +44,12 @@ CustomSegmentedButtonItem::CustomSegmentedButtonItem(const QString & text, QWidg
 //   setFixedSize(width, height);
 // }
 
-// cppcheck-suppress unusedFunction
 void CustomSegmentedButtonItem::setHovered(bool hovered)
 {
   isHovered = hovered;
   updateCheckableState();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomSegmentedButtonItem::setCheckableButton(bool checkable)
 {
   setCheckable(checkable);
@@ -66,14 +64,12 @@ void CustomSegmentedButtonItem::updateCheckableState()
   update();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomSegmentedButtonItem::setDisabledButton(bool disabled)
 {
   isDisabled = disabled;
   updateCheckableState();
 }
 
-// cppcheck-suppress unusedFunction
 void CustomSegmentedButtonItem::setActivated(bool activated)
 {
   isActivated = activated;


### PR DESCRIPTION
## Description
This is a fix based on cppcheck unmatchedSuppression warnings.
Due to a modification to cppcheck's CI, comment suppression is no longer required for items that previously generated warnings.

```
common/tier4_state_rviz_plugin/src/custom_button.cpp:67:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomElevatedButton::updateStyle(
^
common/tier4_state_rviz_plugin/src/custom_container.cpp:30:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
QGridLayout * CustomContainer::getLayout() const
^
common/tier4_state_rviz_plugin/src/custom_segmented_button.cpp:44:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
QButtonGroup * CustomSegmentedButton::getButtonGroup() const
^
common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp:48:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSegmentedButtonItem::setHovered(bool hovered)
^
common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp:55:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSegmentedButtonItem::setCheckableButton(bool checkable)
^
common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp:70:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSegmentedButtonItem::setDisabledButton(bool disabled)
^
common/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp:77:0: information: Unmatched suppression: unusedFunction [unmatchedSuppression]
void CustomSegmentedButtonItem::setActivated(bool activated)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
