### PR TITLE
fix(static_obstacle_avoidance, avoidance_by_lane_change): remove unused variable

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/config/avoidance_by_lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/config/avoidance_by_lane_change.param.yaml
@@ -7,7 +7,6 @@
       # avoidance is performed for the object type with true
       target_object:
         car:
-          execute_num: 2                               # [-]
           th_moving_speed: 1.0                         # [m/s]
           th_moving_time: 1.0                          # [s]
           max_expand_ratio: 0.0                        # [-]
@@ -17,7 +16,6 @@
             hard_margin: 0.0                           # [m]
             hard_margin_for_parked_vehicle: 0.0        # [m]
         truck:
-          execute_num: 2
           th_moving_speed: 1.0                         # 3.6km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0
@@ -27,7 +25,6 @@
             hard_margin: 0.0                           # [m]
             hard_margin_for_parked_vehicle: 0.0        # [m]
         bus:
-          execute_num: 2
           th_moving_speed: 1.0                         # 3.6km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0
@@ -37,7 +34,6 @@
             hard_margin: 0.0                           # [m]
             hard_margin_for_parked_vehicle: 0.0        # [m]
         trailer:
-          execute_num: 2
           th_moving_speed: 1.0                         # 3.6km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0
@@ -47,7 +43,6 @@
             hard_margin: 0.0                           # [m]
             hard_margin_for_parked_vehicle: 0.0        # [m]
         unknown:
-          execute_num: 1
           th_moving_speed: 0.28                        # 1.0km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0
@@ -57,7 +52,6 @@
             hard_margin: 0.0                           # [m]
             hard_margin_for_parked_vehicle: 0.0        # [m]
         bicycle:
-          execute_num: 2
           th_moving_speed: 0.28                        # 1.0km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0
@@ -67,7 +61,6 @@
             hard_margin: 1.0                           # [m]
             hard_margin_for_parked_vehicle: 1.0        # [m]
         motorcycle:
-          execute_num: 2
           th_moving_speed: 1.0                         # 3.6km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0
@@ -77,7 +70,6 @@
             hard_margin: 1.0                           # [m]
             hard_margin_for_parked_vehicle: 1.0        # [m]
         pedestrian:
-          execute_num: 2
           th_moving_speed: 0.28                        # 1.0km/h
           th_moving_time: 1.0
           max_expand_ratio: 0.0

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/manager.cpp
@@ -66,7 +66,6 @@ void AvoidanceByLaneChangeModuleManager::init(rclcpp::Node * node)
   {
     const auto get_object_param = [&](std::string && ns) {
       ObjectParameter param{};
-      param.execute_num = getOrDeclareParameter<int>(*node, ns + "execute_num");
       param.moving_speed_threshold = getOrDeclareParameter<double>(*node, ns + "th_moving_speed");
       param.moving_time_threshold = getOrDeclareParameter<double>(*node, ns + "th_moving_time");
       param.max_expand_ratio = getOrDeclareParameter<double>(*node, ns + "max_expand_ratio");

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -73,8 +73,6 @@ struct ObjectParameter
 
   bool is_safety_check_target{false};
 
-  size_t execute_num{1};
-
   double moving_speed_threshold{0.0};
 
   double moving_time_threshold{1.0};

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -256,8 +256,6 @@ bool isWithinIntersection(
     return false;
   }
 
-  const auto object_polygon = autoware::universe_utils::toPolygon2d(object.object);
-
   const auto polygon =
     route_handler->getLaneletMapPtr()->polygonLayer.get(std::atoi(area_id.c_str()));
 


### PR DESCRIPTION
## Description
Removes unused variables in static_obstacle_avoidance module and avoidance_by_lane_change moduel.

## Related links
https://github.com/autowarefoundation/autoware_launch/pull/1176

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/fdb29bf8-d697-5459-a286-e626969253cb?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
### ROS Parameter Changes
#### Additions and removals

| Change type   | Parameter Name | 
|:--------------|:---------------|
| Removed | `car.execute_num`   |
| Removed | `truck.execute_num`   |
| Removed | `bus.execute_num`   |
| Removed | `trailer.execute_num`   |
| Removed | `unknown.execute_num`   | 
| Removed | `bicycle.execute_num`   | 
| Removed | `motorcycle.execute_num`   | 
| Removed | `pedestrian.execute_num`   | 

## Effects on system behavior
None.
