### PR TITLE
feat(autonomous_emergency_braking): make hull markers 3d

### DIFF
--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -65,6 +65,7 @@ using sensor_msgs::msg::Imu;
 using sensor_msgs::msg::PointCloud2;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 using autoware::universe_utils::Polygon2d;
+using autoware::universe_utils::Polygon3d;
 using autoware::vehicle_info_utils::VehicleInfo;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
@@ -496,7 +497,7 @@ public:
    * @param debug_markers Marker array for debugging
    */
   void addClusterHullMarkers(
-    const rclcpp::Time & current_time, const std::vector<Polygon2d> & hulls,
+    const rclcpp::Time & current_time, const std::vector<Polygon3d> & hulls,
     const colorTuple & debug_colors, const std::string & ns, MarkerArray & debug_markers);
 
   /**

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -42,6 +42,7 @@
 namespace autoware::motion::control::autonomous_emergency_braking::utils
 {
 using autoware::universe_utils::Polygon2d;
+using autoware::universe_utils::Polygon3d;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using geometry_msgs::msg::Point;
@@ -105,6 +106,14 @@ std::optional<geometry_msgs::msg::TransformStamped> getTransform(
  */
 void fillMarkerFromPolygon(
   const std::vector<Polygon2d> & polygons, visualization_msgs::msg::Marker & polygon_marker);
+
+/**
+ * @brief Get the predicted object's shape as a geometry polygon
+ * @param polygons vector of Polygon3d
+ * @param polygon_marker marker to be filled with polygon points
+ */
+void fillMarkerFromPolygon(
+  const std::vector<Polygon3d> & polygons, visualization_msgs::msg::Marker & polygon_marker);
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils
 
 #endif  // AUTOWARE__AUTONOMOUS_EMERGENCY_BRAKING__UTILS_HPP_

--- a/control/autoware_autonomous_emergency_braking/src/utils.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/utils.cpp
@@ -186,4 +186,21 @@ void fillMarkerFromPolygon(
   }
 }
 
+void fillMarkerFromPolygon(
+  const std::vector<Polygon3d> & polygons, visualization_msgs::msg::Marker & polygon_marker)
+{
+  for (const auto & poly : polygons) {
+    for (size_t dp_idx = 0; dp_idx < poly.outer().size(); ++dp_idx) {
+      const auto & boost_cp = poly.outer().at(dp_idx);
+      const auto & boost_np = poly.outer().at((dp_idx + 1) % poly.outer().size());
+      const auto curr_point =
+        autoware::universe_utils::createPoint(boost_cp.x(), boost_cp.y(), boost_cp.z());
+      const auto next_point =
+        autoware::universe_utils::createPoint(boost_np.x(), boost_np.y(), boost_np.z());
+      polygon_marker.points.push_back(curr_point);
+      polygon_marker.points.push_back(next_point);
+    }
+  }
+}
+
 }  // namespace autoware::motion::control::autonomous_emergency_braking::utils


### PR DESCRIPTION
## Description
This PR makes the convex hull markers 3D to facilitate PC clustering parameter tuning
![cap- 2024-09-20-18-21-48](https://github.com/user-attachments/assets/e13eeba2-e303-47fb-b140-03f9253fd702)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
