### PR TITLE
fix(pose_initializer): add topic subscription to direct initialization

### DIFF
--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -115,6 +115,11 @@ method: 1
 
 The initial position is set directly by the input position without going through localization algorithm.
 
+> [!NOTE]
+> If you want to activate the direct initialization feature with GNSS poses, you must change the parameters. </br>
+> You need to update [config/default_adapi.param.yaml](../../system/autoware_default_adapi/config/default_adapi.param.yaml) </br> 
+> `initialization_method` should be set to 1 for direct initialization. </br>
+
 ### Via ros2 topic pub
 
 ```bash

--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -117,8 +117,7 @@ The initial position is set directly by the input position without going through
 
 > [!NOTE]
 > If you want to activate the direct initialization feature with GNSS poses, you must change the parameters. </br>
-> You need to update [config/default_adapi.param.yaml](../../system/autoware_default_adapi/config/default_adapi.param.yaml) </br> 
-> `initialization_method` should be set to 1 for direct initialization. </br>
+> You need to update [config/default_adapi.param.yaml](../../system/autoware_default_adapi/config/default_adapi.param.yaml) </br> > `initialization_method` should be set to 1 for direct initialization. </br>
 
 ### Via ros2 topic pub
 

--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -116,8 +116,9 @@ method: 1
 The initial position is set directly by the input position without going through localization algorithm.
 
 > [!NOTE]
-> If you want to activate the direct initialization feature with GNSS poses, you must change the parameters. </br>
-> You need to update [config/default_adapi.param.yaml](../../system/autoware_default_adapi/config/default_adapi.param.yaml) </br> > `initialization_method` should be set to 1 for direct initialization. </br>
+> To enable the direct initialization feature using GNSS poses, the parameters must be adjusted accordingly.
+> 1. Open the [config/default_adapi.param.yaml](../../system/autoware_default_adapi/config/default_adapi.param.yaml) file.
+> 2. Set the `initialization_method` parameter to 1 to activate direct initialization.
 
 ### Via ros2 topic pub
 

--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -117,6 +117,7 @@ The initial position is set directly by the input position without going through
 
 > [!NOTE]
 > To enable the direct initialization feature using GNSS poses, the parameters must be adjusted accordingly.
+>
 > 1. Open the [config/default_adapi.param.yaml](../../system/autoware_default_adapi/config/default_adapi.param.yaml) file.
 > 2. Set the `initialization_method` parameter to 1 to activate direct initialization.
 

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -185,7 +185,7 @@ void PoseInitializer::on_initialize(
       change_state(State::Message::INITIALIZED);
 
     } else if (req->method == Initialize::Service::Request::DIRECT) {
-      if (req->pose_with_covariance.empty()) {
+      if (req->pose_with_covariance.empty() && !gnss_) {
         std::stringstream message;
         message << "No input pose_with_covariance. If you want to use DIRECT method, please input "
                    "pose_with_covariance.";
@@ -193,7 +193,10 @@ void PoseInitializer::on_initialize(
         throw ServiceException(
           autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR, message.str());
       }
-      auto pose = req->pose_with_covariance.front().pose.pose;
+
+      auto pose = req->pose_with_covariance.empty() ? get_gnss_pose().pose.pose
+                                                    : req->pose_with_covariance.front().pose.pose;
+
       set_user_defined_initial_pose(pose, false);
       res->status.success = true;
 

--- a/system/autoware_default_adapi/config/default_adapi.param.yaml
+++ b/system/autoware_default_adapi/config/default_adapi.param.yaml
@@ -9,4 +9,4 @@
 
 /adapi/node/localization:
   ros__parameters:
-    initialization_method: 1  # 0: AUTO, 1: DIRECT
+    initialization_method: 0  # 0: AUTO, 1: DIRECT

--- a/system/autoware_default_adapi/config/default_adapi.param.yaml
+++ b/system/autoware_default_adapi/config/default_adapi.param.yaml
@@ -6,3 +6,7 @@
   ros__parameters:
     require_accept_start: false
     stop_check_duration: 1.0
+
+/adapi/node/localization:
+  ros__parameters:
+    initialization_method: 1  # 0: AUTO, 1: DIRECT

--- a/system/autoware_default_adapi/src/localization.cpp
+++ b/system/autoware_default_adapi/src/localization.cpp
@@ -27,13 +27,15 @@ LocalizationNode::LocalizationNode(const rclcpp::NodeOptions & options)
   adaptor.relay_message(pub_state_, sub_state_);
   adaptor.init_cli(cli_initialize_);
   adaptor.init_srv(srv_initialize_, this, &LocalizationNode::on_initialize, group_cli_);
+
+  initialization_method_ = declare_parameter<int>("initialization_method");
 }
 
 void LocalizationNode::on_initialize(
   const autoware_ad_api::localization::Initialize::Service::Request::SharedPtr req,
   const autoware_ad_api::localization::Initialize::Service::Response::SharedPtr res)
 {
-  res->status = localization_conversion::convert_call(cli_initialize_, req);
+  res->status = localization_conversion::convert_call(cli_initialize_, req, initialization_method_);
 }
 
 }  // namespace autoware::default_adapi

--- a/system/autoware_default_adapi/src/localization.hpp
+++ b/system/autoware_default_adapi/src/localization.hpp
@@ -36,6 +36,7 @@ private:
   Pub<autoware_ad_api::localization::InitializationState> pub_state_;
   Cli<localization_interface::Initialize> cli_initialize_;
   Sub<localization_interface::InitializationState> sub_state_;
+  int initialization_method_;
 
   void on_initialize(
     const autoware_ad_api::localization::Initialize::Service::Request::SharedPtr req,

--- a/system/autoware_default_adapi/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.cpp
@@ -29,6 +29,8 @@ InternalInitializeRequest convert_request(
     internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::AUTO;
   else if (initialization_method == 1)
     internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::DIRECT;
+  else
+    throw std::invalid_argument("Invalid initialization_method. initialization_method must be 0 (AUTO) or 1 (DIRECT)");
 
   return internal;
 }

--- a/system/autoware_default_adapi/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.cpp
@@ -19,11 +19,17 @@
 namespace autoware::default_adapi::localization_conversion
 {
 
-InternalInitializeRequest convert_request(const ExternalInitializeRequest & external)
+InternalInitializeRequest convert_request(
+  const ExternalInitializeRequest & external, int initialization_method)
 {
   auto internal = std::make_shared<InternalInitializeRequest::element_type>();
   internal->pose_with_covariance = external->pose;
-  internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::AUTO;
+
+  if (initialization_method == 0)
+    internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::AUTO;
+  else if (initialization_method == 1)
+    internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::DIRECT;
+
   return internal;
 }
 

--- a/system/autoware_default_adapi/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.cpp
@@ -30,7 +30,8 @@ InternalInitializeRequest convert_request(
   else if (initialization_method == 1)
     internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::DIRECT;
   else
-    throw std::invalid_argument("Invalid initialization_method. initialization_method must be 0 (AUTO) or 1 (DIRECT)");
+    throw std::invalid_argument(
+      "Invalid initialization_method. initialization_method must be 0 (AUTO) or 1 (DIRECT)");
 
   return internal;
 }

--- a/system/autoware_default_adapi/src/utils/localization_conversion.hpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.hpp
@@ -27,16 +27,17 @@ using ExternalInitializeRequest =
   autoware_adapi_v1_msgs::srv::InitializeLocalization::Request::SharedPtr;
 using InternalInitializeRequest =
   tier4_localization_msgs::srv::InitializeLocalization::Request::SharedPtr;
-InternalInitializeRequest convert_request(const ExternalInitializeRequest & external);
+InternalInitializeRequest convert_request(
+  const ExternalInitializeRequest & external, int initialization_method);
 
 using ExternalResponse = autoware_adapi_v1_msgs::msg::ResponseStatus;
 using InternalResponse = autoware_common_msgs::msg::ResponseStatus;
 ExternalResponse convert_response(const InternalResponse & internal);
 
 template <class ClientT, class RequestT>
-ExternalResponse convert_call(ClientT & client, RequestT & req)
+ExternalResponse convert_call(ClientT & client, RequestT & req, int initialization_method)
 {
-  return convert_response(client->call(convert_request(req))->status);
+  return convert_response(client->call(convert_request(req, initialization_method))->status);
 }
 
 }  // namespace autoware::default_adapi::localization_conversion


### PR DESCRIPTION
## Description
You need to call service to initialize directly now. [Documentation](https://github.com/autowarefoundation/autoware.universe/tree/main/localization/autoware_pose_initializer#direct-initial-position-set)
However, if you trust the GNSS pose, you may want to initialize directly with the GNSS pose. For example, we think that the pose coming from GNSS for the simulation environment can be used for initialization directly. We think that the feature of using GNSS poses should be added to activate the direct initialization feature for such cases.


This PR allows you to directly initialize the position from GNSS poses with a parameter change.
## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware.universe/issues/8940
- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Test Steps:
### 1. Checkout autoware.universe
```bash
cd ~/autoware/src/universe/autoware.universe/
git remote add autoware.universe https://github.com/meliketanrikulu/autoware.universe.git
git remote update
git checkout fix/add_topic_subscription_to_direct_initialization
```
### 2. Compile updated packages:
```bash
cd ~/autoware
colcon build --symlink-install --packages-select autoware_pose_initializer autoware_default_adapi
```
### 3. Update Parameters
To enable the direct initialization feature using GNSS poses, the parameters must be adjusted accordingly.

> 1. Open the [config/default_adapi.param.yaml](https://github.com/meliketanrikulu/autoware.universe/blob/1f161fa21decb59e9296842113434622953bbd31/system/autoware_default_adapi/config/default_adapi.param.yaml#L12) file.
> 2. Set the `initialization_method` parameter to 1 to activate direct initialization.

### 4. Run autoware
```bash
source ~/autoware/install/setup.bash
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```

### 4. Run bag file
```bash
source ~/autoware/install/setup.bash
ros2 bag play ~/autoware_map/sample-rosbag/ -r 0.2 -s sqlite3
```
Instead, you can test PR in any sensor model or simulation environment and observe it with the GNSS pose to see the results.

## Notes for reviewers
What do we expect to see?
If we set initialization method as 1 (DIRECT Initialization method), we expect to see the vehicle initialize at exactly the same point and with the same orientation as the GNSS pose.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
