### PR TITLE
fix(pose_initializer): switch direct init with gnss cov check

### DIFF
--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -70,6 +70,7 @@ private:
     const Initialize::Service::Request::SharedPtr req,
     const Initialize::Service::Response::SharedPtr res);
   PoseWithCovarianceStamped get_gnss_pose();
+  bool is_covariance_zero(const std::array<double, 36> & covariance);
 };
 }  // namespace autoware::pose_initializer
 


### PR DESCRIPTION
## Description
Adding switch direct initialization with checking GNSS poses covariance values. This PR checks GNSS covariance values, If your GNSS covariance values are completely Zero, it uses DIRECT initialization method.  
## Related links

**Parent Issue:**
- https://github.com/autowarefoundation/autoware.universe/issues/8940

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
