### PR TITLE
refactor(lane_change): add TransientData to store commonly used lane change-related variables.

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -124,7 +124,7 @@ bool AvoidanceByLaneChange::specialRequiredCheck() const
 
   const auto & nearest_object = data.target_objects.front();
   const auto minimum_avoid_length = calcMinAvoidanceLength(nearest_object);
-  const auto minimum_lane_change_length = calcMinimumLaneChangeLength();
+  const auto minimum_lane_change_length = calc_minimum_dist_buffer();
 
   lane_change_debug_.execution_area = create_execution_area(
     getCommonParam().vehicle_info, getEgoPose(),
@@ -315,16 +315,11 @@ double AvoidanceByLaneChange::calcMinAvoidanceLength(const ObjectData & nearest_
   return avoidance_helper_->getMinAvoidanceDistance(shift_length);
 }
 
-double AvoidanceByLaneChange::calcMinimumLaneChangeLength() const
+double AvoidanceByLaneChange::calc_minimum_dist_buffer() const
 {
-  const auto current_lanes = get_current_lanes();
-  if (current_lanes.empty()) {
-    RCLCPP_DEBUG(logger_, "no empty lanes");
-    return std::numeric_limits<double>::infinity();
-  }
-
-  return utils::lane_change::calculation::calc_minimum_lane_change_length(
-    getRouteHandler(), current_lanes.back(), *lane_change_parameters_, direction_);
+  const auto [_, dist_buffer] = utils::lane_change::calculation::calc_lc_length_and_dist_buffer(
+    common_data_ptr_, get_current_lanes());
+  return dist_buffer.min;
 }
 
 double AvoidanceByLaneChange::calcLateralOffset() const

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.hpp
@@ -63,7 +63,7 @@ private:
   void fillAvoidanceTargetObjects(AvoidancePlanningData & data, AvoidanceDebugData & debug) const;
 
   double calcMinAvoidanceLength(const ObjectData & nearest_object) const;
-  double calcMinimumLaneChangeLength() const;
+  double calc_minimum_dist_buffer() const;
   double calcLateralOffset() const;
 };
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -54,6 +54,8 @@ public:
 
   void update_lanes(const bool is_approved) final;
 
+  void update_transient_data() final;
+
   void update_filtered_objects() final;
 
   void updateLaneChangeStatus() override;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/base_class.hpp
@@ -67,6 +67,8 @@ public:
 
   virtual void update_lanes(const bool is_approved) = 0;
 
+  virtual void update_transient_data() = 0;
+
   virtual void update_filtered_objects() = 0;
 
   virtual void updateLaneChangeStatus() = 0;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -144,28 +144,31 @@ std::vector<PhaseMetrics> calc_shift_phase_metrics(
   const double max_length_threshold = std::numeric_limits<double>::max());
 
 /**
- * @brief Calculates the minimum and maximum lane change lengths, and corresponding distance buffers.
+ * @brief Calculates the minimum and maximum lane changing lengths, along with the corresponding
+ * distance buffers.
  *
- * This function computes both the minimum and maximum lane change lengths based on shift intervals
- * and vehicle parameters, and calculates the corresponding distance buffers for the lane change process.
- * The calculated values provide an estimation of the space required to perform a lane change, without
- * considering safety aspects.
+ * This function computes the minimum and maximum lane change lengths based on shift intervals and
+ * vehicle parameters. It only accounts for the lane changing phase itself, excluding the prepare
+ * distance, which should be handled separately during path generation.
  *
- * If the lane information or necessary data is unavailable, the function returns default values of
- * `std::numeric_limits<double>::max()` to prevent lane change execution.
+ * Additionally, the function calculates the distance buffer to ensure that the ego vehicle has
+ * enough space to complete the lane change, including cases where multiple lane changes may be
+ * necessary.
  *
  * @param common_data_ptr Shared pointer to a CommonData structure, which includes:
- *  - `lc_param_ptr`: Parameters related to lane changing, such as velocity, lateral acceleration, and jerk.
+ *  - `lc_param_ptr`: Parameters related to lane changing, such as velocity, lateral acceleration,
+ * and jerk.
  *  - `route_handler_ptr`: Pointer to the route handler for managing routes.
  *  - `direction`: Lane change direction (e.g., left or right).
  *  - `transient_data.acc.max`: Maximum acceleration of the vehicle.
- *  - Other relevant data for ego vehicle's dynamics and state.
+ *  - Other relevant data for the ego vehicle's dynamics and state.
  * @param lanes The set of lanelets representing the lanes for the lane change.
  *
  * @return A pair of `MinMaxValue` structures where:
- *  - The first element contains the minimum and maximum lane change lengths in meters.
+ *  - The first element contains the minimum and maximum lane changing lengths in meters.
  *  - The second element contains the minimum and maximum distance buffers in meters.
- * If the lanes or necessary data are unavailable, returns `std::numeric_limits<double>::max()` for both values.
+ * If the lanes or necessary data are unavailable, returns `std::numeric_limits<double>::max()` for
+ * both values.
  */
 std::pair<MinMaxValue, MinMaxValue> calc_lc_length_and_dist_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -24,24 +24,8 @@ using autoware::route_handler::Direction;
 using autoware::route_handler::RouteHandler;
 using behavior_path_planner::lane_change::CommonDataPtr;
 using behavior_path_planner::lane_change::LCParamPtr;
+using behavior_path_planner::lane_change::MinMaxValue;
 using behavior_path_planner::lane_change::PhaseMetrics;
-
-/**
- * @brief Calculates the distance from the ego vehicle to the terminal point.
- *
- * This function computes the distance from the current position of the ego vehicle
- * to either the goal pose or the end of the current lane, depending on whether
- * the vehicle's current lane is within the goal section.
- *
- * @param common_data_ptr Shared pointer to a CommonData structure, which should include:
- *  - Non null `lanes_ptr` that points to the current lanes data.
- *  - Non null `self_odometry_ptr` that contains the current pose of the ego vehicle.
- *  - Non null `route_handler_ptr` that contains the goal pose of the route.
- *
- * @return The distance to the terminal point (either the goal pose or the end of the current lane)
- * in meters.
- */
-double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr);
 
 double calc_dist_from_pose_to_terminal_end(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
@@ -119,21 +103,6 @@ double calc_ego_dist_to_lanes_start(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
-double calc_minimum_lane_change_length(
-  const LaneChangeParameters & lane_change_parameters, const std::vector<double> & shift_intervals);
-
-double calc_minimum_lane_change_length(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lane,
-  const LaneChangeParameters & lane_change_parameters, Direction direction);
-
-double calc_maximum_lane_change_length(
-  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
-  const std::vector<double> & shift_intervals, const double max_acc);
-
-double calc_maximum_lane_change_length(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
-  const double max_acc);
-
 /**
  * @brief Calculates the distance required during a lane change operation.
  *
@@ -165,6 +134,9 @@ std::vector<PhaseMetrics> calc_shift_phase_metrics(
   const CommonDataPtr & common_data_ptr, const double shift_length, const double initial_velocity,
   const double max_velocity, const double lon_accel,
   const double max_length_threshold = std::numeric_limits<double>::max());
+
+std::pair<MinMaxValue, MinMaxValue> calc_lc_length_and_dist_buffer(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__CALCULATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -103,6 +103,18 @@ double calc_ego_dist_to_lanes_start(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
+double calc_maximum_lane_change_length(
+  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
+  const std::vector<double> & shift_intervals, const double max_acc);
+
+double calc_maximum_lane_change_length(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
+  const double max_acc);
+
+double calc_lane_changing_acceleration(
+  const double initial_lane_changing_velocity, const double max_path_velocity,
+  const double lane_changing_time, const double prepare_longitudinal_acc);
+
 /**
  * @brief Calculates the distance required during a lane change operation.
  *
@@ -120,18 +132,6 @@ double calc_phase_length(
   const double velocity, const double maximum_velocity, const double acceleration,
   const double duration);
 
-double calc_maximum_lane_change_length(
-  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
-  const std::vector<double> & shift_intervals, const double max_acc);
-
-double calc_maximum_lane_change_length(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
-  const double max_acc);
-
-double calc_lane_changing_acceleration(
-  const double initial_lane_changing_velocity, const double max_path_velocity,
-  const double lane_changing_time, const double prepare_longitudinal_acc);
-
 std::vector<PhaseMetrics> calc_prepare_phase_metrics(
   const CommonDataPtr & common_data_ptr, const std::vector<double> & prepare_durations,
   const std::vector<double> & lon_accel_values, const double current_velocity,
@@ -143,6 +143,30 @@ std::vector<PhaseMetrics> calc_shift_phase_metrics(
   const double max_velocity, const double lon_accel,
   const double max_length_threshold = std::numeric_limits<double>::max());
 
+/**
+ * @brief Calculates the minimum and maximum lane change lengths, and corresponding distance buffers.
+ *
+ * This function computes both the minimum and maximum lane change lengths based on shift intervals
+ * and vehicle parameters, and calculates the corresponding distance buffers for the lane change process.
+ * The calculated values provide an estimation of the space required to perform a lane change, without
+ * considering safety aspects.
+ *
+ * If the lane information or necessary data is unavailable, the function returns default values of
+ * `std::numeric_limits<double>::max()` to prevent lane change execution.
+ *
+ * @param common_data_ptr Shared pointer to a CommonData structure, which includes:
+ *  - `lc_param_ptr`: Parameters related to lane changing, such as velocity, lateral acceleration, and jerk.
+ *  - `route_handler_ptr`: Pointer to the route handler for managing routes.
+ *  - `direction`: Lane change direction (e.g., left or right).
+ *  - `transient_data.acc.max`: Maximum acceleration of the vehicle.
+ *  - Other relevant data for ego vehicle's dynamics and state.
+ * @param lanes The set of lanelets representing the lanes for the lane change.
+ *
+ * @return A pair of `MinMaxValue` structures where:
+ *  - The first element contains the minimum and maximum lane change lengths in meters.
+ *  - The second element contains the minimum and maximum distance buffers in meters.
+ * If the lanes or necessary data are unavailable, returns `std::numeric_limits<double>::max()` for both values.
+ */
 std::pair<MinMaxValue, MinMaxValue> calc_lc_length_and_dist_buffer(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes);
 }  // namespace autoware::behavior_path_planner::utils::lane_change::calculation

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -120,6 +120,14 @@ double calc_phase_length(
   const double velocity, const double maximum_velocity, const double acceleration,
   const double duration);
 
+double calc_maximum_lane_change_length(
+  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
+  const std::vector<double> & shift_intervals, const double max_acc);
+
+double calc_maximum_lane_change_length(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
+  const double max_acc);
+
 double calc_lane_changing_acceleration(
   const double initial_lane_changing_velocity, const double max_path_velocity,
   const double lane_changing_time, const double prepare_longitudinal_acc);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -323,13 +323,20 @@ struct MinMaxValue
 
 struct TransientData
 {
-  MinMaxValue acc;
-  MinMaxValue lane_changing_length;
-  MinMaxValue current_dist_buffer;
-  MinMaxValue next_dist_buffer;
-  double dist_from_ego_to_current_terminal_end{std::numeric_limits<double>::min()};
-  double dist_from_ego_to_current_terminal_start{std::numeric_limits<double>::min()};
-  double maximum_prepare_length{std::numeric_limits<double>::max()};
+  MinMaxValue acc;                   // acceleration profile for accelerating lane change path
+  MinMaxValue lane_changing_length;  // lane changing length for a single lane change
+  MinMaxValue
+    current_dist_buffer;  // distance buffer computed backward from current lanes' terminal end
+  MinMaxValue
+    next_dist_buffer;  // distance buffer computed backward  from target lanes' terminal end
+  double dist_to_terminal_end{
+    std::numeric_limits<double>::min()};  // distance from ego base link to the current lanes'
+                                          // terminal end
+  double dist_to_terminal_start{
+    std::numeric_limits<double>::min()};  // distance from ego base link to the current lanes'
+                                          // terminal start
+  double max_prepare_length{
+    std::numeric_limits<double>::max()};  // maximum prepare length, starting from ego's base link
 
   bool is_ego_near_current_terminal_start{false};
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -122,9 +122,7 @@ std::vector<DrivableLanes> generateDrivableLanes(
 double getLateralShift(const LaneChangePath & path);
 
 bool hasEnoughLengthToLaneChangeAfterAbort(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelets & current_lanes,
-  const Pose & curent_pose, const double abort_return_dist,
-  const LaneChangeParameters & lane_change_parameters, const Direction direction);
+  const CommonDataPtr & common_data_ptr, const double abort_return_dist);
 
 CandidateOutput assignToCandidate(
   const LaneChangePath & lane_change_path, const Point & ego_position);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -76,6 +76,7 @@ void LaneChangeInterface::updateData()
   universe_utils::ScopedTimeTrack st(__func__, *getTimeKeeper());
   module_type_->setPreviousModuleOutput(getPreviousModuleOutput());
   module_type_->update_lanes(getCurrentStatus() == ModuleStatus::RUNNING);
+  module_type_->update_transient_data();
   module_type_->update_filtered_objects();
   module_type_->updateSpecialData();
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -86,16 +86,75 @@ void NormalLaneChange::update_lanes(const bool is_approved)
   common_data_ptr_->lanes_ptr->target = target_lanes;
 
   const auto & route_handler_ptr = common_data_ptr_->route_handler_ptr;
+  common_data_ptr_->current_lanes_path =
+    route_handler_ptr->getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
+
   common_data_ptr_->lanes_ptr->target_neighbor = utils::lane_change::getTargetNeighborLanes(
     *route_handler_ptr, current_lanes, common_data_ptr_->lc_type);
 
   common_data_ptr_->lanes_ptr->current_lane_in_goal_section =
     route_handler_ptr->isInGoalRouteSection(current_lanes.back());
+  common_data_ptr_->lanes_ptr->target_lane_in_goal_section =
+    route_handler_ptr->isInGoalRouteSection(target_lanes.back());
+
   common_data_ptr_->lanes_ptr->preceding_target = utils::getPrecedingLanelets(
     *route_handler_ptr, get_target_lanes(), common_data_ptr_->get_ego_pose(),
     common_data_ptr_->lc_param_ptr->backward_lane_length);
 
   *common_data_ptr_->lanes_polygon_ptr = create_lanes_polygon(common_data_ptr_);
+}
+
+void NormalLaneChange::update_transient_data()
+{
+  if (
+    !common_data_ptr_ || !common_data_ptr_->is_data_available() ||
+    !common_data_ptr_->is_lanes_available()) {
+    return;
+  }
+
+  auto & transient_data = common_data_ptr_->transient_data;
+  std::tie(transient_data.acc.min, transient_data.acc.max) = calcCurrentMinMaxAcceleration();
+
+  std::tie(transient_data.lane_changing_length, transient_data.current_dist_buffer) =
+    calculation::calc_lc_length_and_dist_buffer(common_data_ptr_, get_current_lanes());
+
+  transient_data.next_dist_buffer.min =
+    transient_data.current_dist_buffer.min - transient_data.lane_changing_length.min -
+    common_data_ptr_->lc_param_ptr->lane_change_finish_judge_buffer;
+
+  transient_data.dist_from_ego_to_current_terminal_end =
+    calculation::calc_dist_from_pose_to_terminal_end(
+      common_data_ptr_, common_data_ptr_->lanes_ptr->current, common_data_ptr_->get_ego_pose());
+  transient_data.dist_from_ego_to_current_terminal_start =
+    transient_data.dist_from_ego_to_current_terminal_end - transient_data.current_dist_buffer.min;
+
+  transient_data.maximum_prepare_length =
+    calculation::calc_maximum_prepare_length(common_data_ptr_);
+
+  transient_data.is_ego_near_current_terminal_start =
+    transient_data.dist_from_ego_to_current_terminal_start < transient_data.maximum_prepare_length;
+
+  RCLCPP_DEBUG(
+    logger_, "acc - min: %.4f, max: %.4f", transient_data.acc.min, transient_data.acc.max);
+  RCLCPP_DEBUG(
+    logger_, "lane_changing_length - min: %.4f, max: %.4f", transient_data.lane_changing_length.min,
+    transient_data.lane_changing_length.max);
+  RCLCPP_DEBUG(
+    logger_, "current_dist_buffer - min: %.4f, max: %.4f", transient_data.current_dist_buffer.min,
+    transient_data.current_dist_buffer.max);
+  RCLCPP_DEBUG(
+    logger_, "next_dist_buffer - min: %.4f, max: %.4f", transient_data.next_dist_buffer.min,
+    transient_data.next_dist_buffer.max);
+  RCLCPP_DEBUG(
+    logger_, "dist_from_ego_to_current_terminal_start: %.4f",
+    transient_data.dist_from_ego_to_current_terminal_start);
+  RCLCPP_DEBUG(
+    logger_, "dist_from_ego_to_current_terminal_end: %.4f",
+    transient_data.dist_from_ego_to_current_terminal_end);
+  RCLCPP_DEBUG(logger_, "maximum_prepare_length: %.4f", transient_data.maximum_prepare_length);
+  RCLCPP_DEBUG(
+    logger_, "is_ego_near_current_terminal_start: %s",
+    (transient_data.is_ego_near_current_terminal_start ? "true" : "false"));
 }
 
 void NormalLaneChange::update_filtered_objects()
@@ -151,18 +210,14 @@ bool NormalLaneChange::isLaneChangeRequired()
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const auto current_lanes =
-    utils::getCurrentLanesFromPath(prev_module_output_.path, planner_data_);
-
-  if (current_lanes.empty()) {
+  if (
+    !common_data_ptr_ || !common_data_ptr_->is_data_available() ||
+    !common_data_ptr_->is_lanes_available()) {
     return false;
   }
 
-  const auto target_lanes = getLaneChangeLanes(current_lanes, direction_);
-
-  if (target_lanes.empty()) {
-    return false;
-  }
+  const auto & current_lanes = common_data_ptr_->lanes_ptr->current;
+  const auto & target_lanes = common_data_ptr_->lanes_ptr->target;
 
   const auto ego_dist_to_target_start =
     calculation::calc_ego_dist_to_lanes_start(common_data_ptr_, current_lanes, target_lanes);
@@ -182,21 +237,11 @@ bool NormalLaneChange::isLaneChangeRequired()
 
 bool NormalLaneChange::is_near_regulatory_element() const
 {
-  const auto & current_lanes = get_current_lanes();
+  if (!common_data_ptr_ || !common_data_ptr_->is_data_available()) return false;
 
-  if (current_lanes.empty()) return false;
-
-  const auto shift_intervals =
-    getRouteHandler()->getLateralIntervalsToPreferredLane(current_lanes.back());
-
-  if (shift_intervals.empty()) return false;
-
-  const auto & lc_params = *common_data_ptr_->lc_param_ptr;
   const auto max_prepare_length = calculation::calc_maximum_prepare_length(common_data_ptr_);
-  const auto min_lc_length =
-    calculation::calc_minimum_lane_change_length(lc_params, shift_intervals);
   const auto dist_to_terminal_start =
-    calculation::calc_ego_dist_to_terminal_end(common_data_ptr_) - min_lc_length;
+    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start;
 
   if (dist_to_terminal_start <= max_prepare_length) return false;
 
@@ -249,14 +294,9 @@ TurnSignalInfo NormalLaneChange::get_terminal_turn_signal_info() const
 
   const auto original_turn_signal_info = prev_module_output_.turn_signal_info;
 
-  const auto shift_intervals =
-    getRouteHandler()->getLateralIntervalsToPreferredLane(get_current_lanes().back());
-  const double next_lane_change_buffer =
-    calculation::calc_minimum_lane_change_length(lane_change_param, shift_intervals);
-
-  const double buffer = next_lane_change_buffer +
-                        lane_change_param.min_length_for_turn_signal_activation +
-                        common_param.base_link2front;
+  const auto buffer = common_data_ptr_->transient_data.current_dist_buffer.min +
+                      lane_change_param.min_length_for_turn_signal_activation +
+                      common_param.base_link2front;
   const double path_length = autoware::motion_utils::calcArcLength(path.points);
   const auto start_pose = autoware::motion_utils::calcLongitudinalOffsetPose(
     path.points, 0, std::max(path_length - buffer, 0.0));
@@ -405,9 +445,8 @@ void NormalLaneChange::insertStopPoint(
     return;
   }
 
-  const auto shift_intervals = route_handler->getLateralIntervalsToPreferredLane(lanelets.back());
-  const auto lane_change_buffer =
-    calculation::calc_minimum_lane_change_length(*lane_change_parameters_, shift_intervals);
+  const auto [_, lanes_dist_buffer] =
+    calculation::calc_lc_length_and_dist_buffer(common_data_ptr_, lanelets);
 
   const auto getDistanceAlongLanelet = [&](const geometry_msgs::msg::Pose & target) {
     return utils::getSignedDistance(path.points.front().point.pose, target, lanelets);
@@ -425,7 +464,7 @@ void NormalLaneChange::insertStopPoint(
 
   const double stop_point_buffer = lane_change_parameters_->backward_length_buffer_for_end_of_lane;
   const auto target_objects = filterObjects();
-  double stopping_distance = distance_to_terminal - lane_change_buffer - stop_point_buffer;
+  double stopping_distance = distance_to_terminal - lanes_dist_buffer.min - stop_point_buffer;
 
   const auto & curr_lanes_poly = common_data_ptr_->lanes_polygon_ptr->current.value();
   if (utils::isEgoWithinOriginalLane(curr_lanes_poly, getEgoPose(), planner_data_->parameters)) {
@@ -486,11 +525,9 @@ void NormalLaneChange::insertStopPoint(
     const auto rss_dist = calcRssDistance(
       0.0, lane_change_parameters_->minimum_lane_changing_velocity,
       lane_change_parameters_->rss_params);
-    const double lane_change_buffer_for_blocking_object =
-      calculation::calc_minimum_lane_change_length(*lane_change_parameters_, shift_intervals);
 
     const auto stopping_distance_for_obj =
-      distance_to_ego_lane_obj - lane_change_buffer_for_blocking_object -
+      distance_to_ego_lane_obj - lanes_dist_buffer.min -
       lane_change_parameters_->backward_length_buffer_for_blocking_object - rss_dist -
       getCommonParam().base_link2front;
 
@@ -704,9 +741,8 @@ bool NormalLaneChange::isNearEndOfCurrentLanes(
 
   const auto & route_handler = getRouteHandler();
   const auto & current_pose = getEgoPose();
-  const auto lane_change_buffer = calculation::calc_minimum_lane_change_length(
-    route_handler, current_lanes.back(), *lane_change_parameters_, Direction::NONE);
 
+  // TODO(Azu) fully change to transient data
   const auto distance_to_lane_change_end = std::invoke([&]() {
     auto distance_to_end = utils::getDistanceToEndOfLane(current_pose, current_lanes);
 
@@ -716,7 +752,8 @@ bool NormalLaneChange::isNearEndOfCurrentLanes(
         utils::getSignedDistance(current_pose, route_handler->getGoalPose(), current_lanes));
     }
 
-    return std::max(0.0, distance_to_end) - lane_change_buffer;
+    return std::max(0.0, distance_to_end) -
+           common_data_ptr_->transient_data.current_dist_buffer.min;
   });
 
   lane_change_debug_.distance_to_end_of_current_lane = distance_to_lane_change_end;
@@ -811,27 +848,20 @@ bool NormalLaneChange::isAbleToReturnCurrentLane() const
 
 bool NormalLaneChange::is_near_terminal() const
 {
-  const auto & current_lanes = common_data_ptr_->lanes_ptr->current;
-
-  if (current_lanes.empty()) {
+  if (!common_data_ptr_ || !common_data_ptr_->is_data_available()) {
     return true;
   }
 
-  const auto & current_lanes_terminal = current_lanes.back();
+  // TODO(Azu) fully change to transient data
   const auto & lc_param_ptr = common_data_ptr_->lc_param_ptr;
-  const auto direction = common_data_ptr_->direction;
-  const auto & route_handler_ptr = common_data_ptr_->route_handler_ptr;
-  const auto min_lane_changing_distance = calculation::calc_minimum_lane_change_length(
-    route_handler_ptr, current_lanes_terminal, *lc_param_ptr, direction);
-
   const auto backward_buffer = calculation::calc_stopping_distance(lc_param_ptr);
 
+  const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
   const auto min_lc_dist_with_buffer =
-    backward_buffer + min_lane_changing_distance + lc_param_ptr->lane_change_finish_judge_buffer;
-  const auto dist_from_ego_to_terminal_end =
-    calculation::calc_ego_dist_to_terminal_end(common_data_ptr_);
+    backward_buffer + current_min_dist_buffer + lc_param_ptr->lane_change_finish_judge_buffer;
 
-  return dist_from_ego_to_terminal_end < min_lc_dist_with_buffer;
+  return common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end <
+         min_lc_dist_with_buffer;
 }
 
 bool NormalLaneChange::isEgoOnPreparePhase() const
@@ -954,10 +984,9 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
   }
 
   // calculate maximum lane change length
-  const double max_lane_change_length =
-    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes.back(), max_acc);
+  const auto current_max_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.max;
 
-  if (max_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
+  if (current_max_dist_buffer > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     RCLCPP_DEBUG(
       logger_, "No enough distance to the end of lane. Normal sampling for acc: [%f ~ %f]", min_acc,
       max_acc);
@@ -979,12 +1008,12 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
   // sample max acc
   if (route_handler.isInGoalRouteSection(target_lanes.back())) {
     const auto goal_pose = route_handler.getGoalPose();
-    if (max_lane_change_length < utils::getSignedDistance(current_pose, goal_pose, target_lanes)) {
+    if (current_max_dist_buffer < utils::getSignedDistance(current_pose, goal_pose, target_lanes)) {
       RCLCPP_DEBUG(
         logger_, "Distance to goal has enough distance. Sample only max_acc: %f", max_acc);
       return {max_acc};
     }
-  } else if (max_lane_change_length < utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
+  } else if (current_max_dist_buffer < utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
     RCLCPP_DEBUG(
       logger_, "Distance to end of lane has enough distance. Sample only max_acc: %f", max_acc);
     return {max_acc};
@@ -1313,7 +1342,7 @@ PathWithLaneId NormalLaneChange::getTargetSegment(
 
 bool NormalLaneChange::hasEnoughLength(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes, const Direction direction) const
+  const lanelet::ConstLanelets & target_lanes, [[maybe_unused]] const Direction direction) const
 {
   if (target_lanes.empty()) {
     return false;
@@ -1323,8 +1352,7 @@ bool NormalLaneChange::hasEnoughLength(
   const auto & route_handler = getRouteHandler();
   const auto overall_graphs_ptr = route_handler->getOverallGraphPtr();
   const auto minimum_lane_change_length_to_preferred_lane =
-    calculation::calc_minimum_lane_change_length(
-      route_handler, target_lanes.back(), *lane_change_parameters_, direction);
+    common_data_ptr_->transient_data.next_dist_buffer.min;
 
   const double lane_change_length = path.info.length.sum();
   if (lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
@@ -1381,19 +1409,17 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
   const auto longitudinal_acc_sampling_values =
     sampleLongitudinalAccValues(current_lanes, target_lanes);
 
-  const auto is_goal_in_route = route_handler.isInGoalRouteSection(target_lanes.back());
+  const auto is_goal_in_route = common_data_ptr_->lanes_ptr->target_lane_in_goal_section;
 
-  const double lane_change_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()));
-  const double next_lane_change_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(target_lanes.back()));
+  const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
+  const auto next_min_dist_buffer = common_data_ptr_->transient_data.next_dist_buffer.min;
 
-  const auto dist_to_terminal_end = calculation::calc_ego_dist_to_terminal_end(common_data_ptr_);
   const auto dist_to_target_start =
     calculation::calc_ego_dist_to_lanes_start(common_data_ptr_, current_lanes, target_lanes);
-  const auto dist_to_terminal_start = dist_to_terminal_end - lane_change_buffer;
+  const auto dist_to_terminal_end =
+    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end;
+  const auto dist_to_terminal_start =
+    common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_start;
 
   const auto target_lane_length = lanelet::utils::getLaneletLength2d(target_lanes);
 
@@ -1431,9 +1457,7 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
       if (!check_lc) return false;
 
       const auto lc_diff = std::abs(candidate_paths.back().info.length.lane_changing - lc_length);
-      if (lc_diff > lane_change_parameters_->skip_process_lon_diff_th_lane_changing) return true;
-
-      return false;
+      return lc_diff > lane_change_parameters_->skip_process_lon_diff_th_lane_changing;
     };
 
   for (const auto & prep_metric : prepare_phase_metrics) {
@@ -1489,7 +1513,7 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
           ? std::min(dist_to_terminal_end, dist_to_next_regulatory_element) - prep_metric.length
           : dist_to_terminal_end - prep_metric.length;
       auto target_lane_buffer =
-        lane_change_parameters_->lane_change_finish_judge_buffer + next_lane_change_buffer;
+        lane_change_parameters_->lane_change_finish_judge_buffer + next_min_dist_buffer;
       if (std::abs(route_handler.getNumLaneToPreferredLane(target_lanes.back(), direction_)) > 0) {
         target_lane_buffer += lane_change_parameters_->backward_length_buffer_for_end_of_lane;
       }
@@ -1520,7 +1544,7 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
       try {
         candidate_path = get_candidate_path(
           prep_metric, lc_metric, prepare_segment, sorted_lane_ids, lane_changing_start_pose,
-          target_lane_length, shift_length, next_lane_change_buffer, is_goal_in_route);
+          target_lane_length, shift_length, next_min_dist_buffer, is_goal_in_route);
       } catch (const std::exception & e) {
         debug_print_lat(std::string("Reject: ") + e.what());
         continue;
@@ -1530,8 +1554,8 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
 
       bool is_safe = false;
       try {
-        is_safe =
-          check_candidate_path_safety(candidate_path, target_objects, lane_change_buffer, is_stuck);
+        is_safe = check_candidate_path_safety(
+          candidate_path, target_objects, current_min_dist_buffer, is_stuck);
       } catch (const std::exception & e) {
         debug_print_lat(std::string("Reject: ") + e.what());
         return false;
@@ -1662,12 +1686,8 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
 
   const auto is_goal_in_route = route_handler.isInGoalRouteSection(target_lanes.back());
 
-  const double lane_change_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()));
-  const double next_lane_change_buffer = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    route_handler.getLateralIntervalsToPreferredLane(target_lanes.back()));
+  const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
+  const auto next_min_dist_buffer = common_data_ptr_->transient_data.next_dist_buffer.min;
 
   const auto target_lane_length = lanelet::utils::getLaneletLength2d(target_lanes);
 
@@ -1686,7 +1706,7 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
 
   const auto lane_changing_start_pose = autoware::motion_utils::calcLongitudinalOffsetPose(
     prev_module_output_.path.points, current_lane_terminal_point,
-    -(lane_change_buffer + next_lane_change_buffer + distance_to_terminal_from_goal));
+    -(current_min_dist_buffer + next_min_dist_buffer + distance_to_terminal_from_goal));
 
   if (!lane_changing_start_pose) {
     RCLCPP_DEBUG(logger_, "Reject: lane changing start pose not found!!!");
@@ -1712,8 +1732,8 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
     shift_length, lane_change_parameters_->lane_changing_lateral_jerk, max_lateral_acc);
 
   const auto target_segment = getTargetSegment(
-    target_lanes, lane_changing_start_pose.value(), target_lane_length, lane_change_buffer,
-    minimum_lane_changing_velocity, next_lane_change_buffer);
+    target_lanes, lane_changing_start_pose.value(), target_lane_length, current_min_dist_buffer,
+    minimum_lane_changing_velocity, next_min_dist_buffer);
 
   if (target_segment.points.empty()) {
     RCLCPP_DEBUG(logger_, "Reject: target segment is empty!! something wrong...");
@@ -1725,7 +1745,7 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
   lane_change_info.duration = LaneChangePhaseInfo{0.0, lane_changing_time};
   lane_change_info.velocity =
     LaneChangePhaseInfo{minimum_lane_changing_velocity, minimum_lane_changing_velocity};
-  lane_change_info.length = LaneChangePhaseInfo{0.0, lane_change_buffer};
+  lane_change_info.length = LaneChangePhaseInfo{0.0, current_min_dist_buffer};
   lane_change_info.lane_changing_start = lane_changing_start_pose.value();
   lane_change_info.lane_changing_end = target_segment.points.front().point.pose;
   lane_change_info.lateral_acceleration = max_lateral_acc;
@@ -1740,11 +1760,11 @@ std::optional<LaneChangePath> NormalLaneChange::calcTerminalLaneChangePath(
   }
 
   const auto resample_interval = utils::lane_change::calcLaneChangeResampleInterval(
-    lane_change_buffer, minimum_lane_changing_velocity);
+    current_min_dist_buffer, minimum_lane_changing_velocity);
   const auto target_lane_reference_path = utils::lane_change::getReferencePathFromTargetLane(
     route_handler, target_lanes, lane_changing_start_pose.value(), target_lane_length,
-    lane_change_buffer, forward_path_length, resample_interval, is_goal_in_route,
-    next_lane_change_buffer);
+    current_min_dist_buffer, forward_path_length, resample_interval, is_goal_in_route,
+    next_min_dist_buffer);
 
   if (target_lane_reference_path.points.empty()) {
     RCLCPP_DEBUG(logger_, "Reject: target_lane_reference_path is empty!!");
@@ -1785,12 +1805,11 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 
   CollisionCheckDebugMap debug_data;
 
-  const auto min_lc_length = calculation::calc_minimum_lane_change_length(
-    *lane_change_parameters_,
-    common_data_ptr_->route_handler_ptr->getLateralIntervalsToPreferredLane(current_lanes.back()));
+  const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
 
   const auto has_passed_parked_objects = utils::lane_change::passed_parked_objects(
-    common_data_ptr_, path, filtered_objects_.target_lane_leading, min_lc_length, debug_data);
+    common_data_ptr_, path, filtered_objects_.target_lane_leading, current_min_dist_buffer,
+    debug_data);
 
   if (!has_passed_parked_objects) {
     RCLCPP_DEBUG(logger_, "Lane change has been delayed.");
@@ -1906,16 +1925,14 @@ bool NormalLaneChange::calcAbortPath()
   const auto ego_nearest_dist_threshold = common_param.ego_nearest_dist_threshold;
   const auto ego_nearest_yaw_threshold = common_param.ego_nearest_yaw_threshold;
 
-  const auto direction = getDirection();
-  const auto minimum_lane_change_length = calculation::calc_minimum_lane_change_length(
-    route_handler, get_current_lanes().back(), *lane_change_parameters_, direction);
+  const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
 
   const auto & lane_changing_path = selected_path.path;
   const auto & reference_lanelets = get_current_lanes();
   const auto lane_changing_end_pose_idx = std::invoke([&]() {
     constexpr double s_start = 0.0;
     const double s_end = std::max(
-      lanelet::utils::getLaneletLength2d(reference_lanelets) - minimum_lane_change_length, 0.0);
+      lanelet::utils::getLaneletLength2d(reference_lanelets) - current_min_dist_buffer, 0.0);
 
     const auto ref = route_handler->getCenterLinePath(reference_lanelets, s_start, s_end);
     return autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
@@ -1956,8 +1973,7 @@ bool NormalLaneChange::calcAbortPath()
   }
 
   if (!utils::lane_change::hasEnoughLengthToLaneChangeAfterAbort(
-        route_handler, reference_lanelets, current_pose, abort_return_dist,
-        *lane_change_parameters_, direction)) {
+        common_data_ptr_, abort_return_dist)) {
     RCLCPP_ERROR(logger_, "insufficient distance to abort.");
     return false;
   }
@@ -2227,10 +2243,9 @@ bool NormalLaneChange::isVehicleStuck(
     route_handler->isInGoalRouteSection(current_lanes.back())
       ? utils::getSignedDistance(getEgoPose(), route_handler->getGoalPose(), current_lanes)
       : utils::getDistanceToEndOfLane(getEgoPose(), current_lanes);
-  const auto lane_change_buffer = calculation::calc_minimum_lane_change_length(
-    route_handler, current_lanes.back(), *lane_change_parameters_, Direction::NONE);
+  const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
   const double stop_point_buffer = lane_change_parameters_->backward_length_buffer_for_end_of_lane;
-  const double terminal_judge_buffer = lane_change_buffer + stop_point_buffer + 1.0;
+  const double terminal_judge_buffer = current_min_dist_buffer + stop_point_buffer + 1.0;
   if (distance_to_terminal < terminal_judge_buffer) {
     return true;
   }
@@ -2264,8 +2279,7 @@ bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lan
   }
 
   const auto [min_acc, max_acc] = calcCurrentMinMaxAcceleration();
-  const auto max_lane_change_length =
-    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes.back(), max_acc);
+  const auto current_max_dist_buffer = common_data_ptr_->transient_data.next_dist_buffer.max;
   const auto rss_dist = calcRssDistance(
     0.0, lane_change_parameters_->minimum_lane_changing_velocity,
     lane_change_parameters_->rss_params);
@@ -2276,9 +2290,10 @@ bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lan
   // stopped at a traffic light. Essentially, the calculation should be based on the information of
   // the stop reason, but this is outside the scope of one module. I keep it as a TODO.
   constexpr double DETECTION_DISTANCE_MARGIN = 10.0;
-  const auto detection_distance = max_lane_change_length + rss_dist +
+  const auto detection_distance = current_max_dist_buffer + rss_dist +
                                   getCommonParam().base_link2front + DETECTION_DISTANCE_MARGIN;
-  RCLCPP_DEBUG(logger_, "max_lane_change_length: %f, max_acc: %f", max_lane_change_length, max_acc);
+  RCLCPP_DEBUG(
+    logger_, "current_max_dist_buffer: %f, max_acc: %f", current_max_dist_buffer, max_acc);
 
   auto is_vehicle_stuck = isVehicleStuck(current_lanes, detection_distance);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -857,8 +857,7 @@ bool NormalLaneChange::is_near_terminal() const
   const auto backward_buffer = calculation::calc_stopping_distance(lc_param_ptr);
 
   const auto current_min_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.min;
-  const auto min_lc_dist_with_buffer =
-    backward_buffer + current_min_dist_buffer + lc_param_ptr->lane_change_finish_judge_buffer;
+  const auto min_lc_dist_with_buffer = backward_buffer + current_min_dist_buffer;
 
   return common_data_ptr_->transient_data.dist_from_ego_to_current_terminal_end <
          min_lc_dist_with_buffer;
@@ -984,7 +983,9 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
   }
 
   // calculate maximum lane change length
-  const auto current_max_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.max;
+  // TODO(Azu) Double check why it's failing with transient data
+  const auto current_max_dist_buffer =
+    calculation::calc_maximum_lane_change_length(common_data_ptr_, current_lanes.back(), max_acc);
 
   if (current_max_dist_buffer > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     RCLCPP_DEBUG(
@@ -2279,7 +2280,7 @@ bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lan
   }
 
   const auto [min_acc, max_acc] = calcCurrentMinMaxAcceleration();
-  const auto current_max_dist_buffer = common_data_ptr_->transient_data.next_dist_buffer.max;
+  const auto current_max_dist_buffer = common_data_ptr_->transient_data.current_dist_buffer.max;
   const auto rss_dist = calcRssDistance(
     0.0, lane_change_parameters_->minimum_lane_changing_velocity,
     lane_change_parameters_->rss_params);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -28,15 +28,6 @@ rclcpp::Logger get_logger()
   return logger;
 }
 
-double calc_ego_dist_to_terminal_end(const CommonDataPtr & common_data_ptr)
-{
-  const auto & lanes_ptr = common_data_ptr->lanes_ptr;
-  const auto & current_lanes = lanes_ptr->current;
-  const auto & current_pose = common_data_ptr->get_ego_pose();
-
-  return calc_dist_from_pose_to_terminal_end(common_data_ptr, current_lanes, current_pose);
-}
-
 double calc_dist_from_pose_to_terminal_end(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes,
   const Pose & src_pose)
@@ -45,10 +36,10 @@ double calc_dist_from_pose_to_terminal_end(
     return 0.0;
   }
 
-  const auto & lanes_ptr = common_data_ptr->lanes_ptr;
-  const auto & goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
-
-  if (lanes_ptr->current_lane_in_goal_section) {
+  const auto in_goal_route_section =
+    common_data_ptr->route_handler_ptr->isInGoalRouteSection(lanes.back());
+  if (in_goal_route_section) {
+    const auto & goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
     return utils::getSignedDistance(src_pose, goal_pose, lanes);
   }
   return utils::getDistanceToEndOfLane(src_pose, lanes);
@@ -137,8 +128,7 @@ double calc_ego_dist_to_lanes_start(
     return std::numeric_limits<double>::max();
   }
 
-  const auto path =
-    route_handler_ptr->getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto & path = common_data_ptr->current_lanes_path;
 
   if (path.points.empty()) {
     return std::numeric_limits<double>::max();
@@ -150,94 +140,126 @@ double calc_ego_dist_to_lanes_start(
   return motion_utils::calcSignedArcLength(path.points, ego_position, target_front_pt);
 }
 
-double calc_minimum_lane_change_length(
-  const LaneChangeParameters & lane_change_parameters, const std::vector<double> & shift_intervals)
+std::vector<double> calc_all_min_lc_lengths(
+  const LCParamPtr & lc_param_ptr, const std::vector<double> & shift_intervals)
 {
   if (shift_intervals.empty()) {
-    return 0.0;
+    return {};
   }
 
-  const auto min_vel = lane_change_parameters.minimum_lane_changing_velocity;
-  const auto min_max_lat_acc = lane_change_parameters.lane_change_lat_acc_map.find(min_vel);
-  // const auto min_lat_acc = std::get<0>(min_max_lat_acc);
+  const auto min_vel = lc_param_ptr->minimum_lane_changing_velocity;
+  const auto min_max_lat_acc = lc_param_ptr->lane_change_lat_acc_map.find(min_vel);
   const auto max_lat_acc = std::get<1>(min_max_lat_acc);
-  const auto lat_jerk = lane_change_parameters.lane_changing_lateral_jerk;
-  const auto finish_judge_buffer = lane_change_parameters.lane_change_finish_judge_buffer;
+  const auto lat_jerk = lc_param_ptr->lane_changing_lateral_jerk;
 
-  const auto calc_sum = [&](double sum, double shift_interval) {
+  std::vector<double> min_lc_lengths{};
+  min_lc_lengths.reserve(shift_intervals.size());
+
+  const auto min_lc_length = [&](const auto shift_interval) {
     const auto t = PathShifter::calcShiftTimeFromJerk(shift_interval, lat_jerk, max_lat_acc);
-    return sum + (min_vel * t + finish_judge_buffer);
+    return min_vel * t;
   };
 
-  const auto total_length =
-    std::accumulate(shift_intervals.begin(), shift_intervals.end(), 0.0, calc_sum);
+  std::transform(
+    shift_intervals.cbegin(), shift_intervals.cend(), std::back_inserter(min_lc_lengths),
+    min_lc_length);
 
-  const auto backward_buffer = lane_change_parameters.backward_length_buffer_for_end_of_lane;
-  return total_length + backward_buffer * (static_cast<double>(shift_intervals.size()) - 1.0);
+  return min_lc_lengths;
 }
 
-double calc_minimum_lane_change_length(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lane,
-  const LaneChangeParameters & lane_change_parameters, Direction direction)
-{
-  if (!route_handler) {
-    return std::numeric_limits<double>::max();
-  }
-
-  const auto shift_intervals = route_handler->getLateralIntervalsToPreferredLane(lane, direction);
-  return calc_minimum_lane_change_length(lane_change_parameters, shift_intervals);
-}
-
-double calc_maximum_lane_change_length(
-  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
-  const std::vector<double> & shift_intervals, const double max_acc)
+std::vector<double> calc_all_max_lc_lengths(
+  const CommonDataPtr & common_data_ptr, const std::vector<double> & shift_intervals)
 {
   if (shift_intervals.empty()) {
-    return 0.0;
+    return {};
   }
 
-  const auto finish_judge_buffer = lane_change_parameters.lane_change_finish_judge_buffer;
-  const auto lat_jerk = lane_change_parameters.lane_changing_lateral_jerk;
-  const auto t_prepare = lane_change_parameters.lane_change_prepare_duration;
+  const auto & lc_param_ptr = common_data_ptr->lc_param_ptr;
+  const auto lat_jerk = lc_param_ptr->lane_changing_lateral_jerk;
+  const auto t_prepare = lc_param_ptr->lane_change_prepare_duration;
+  const auto max_acc = common_data_ptr->transient_data.acc.max;
 
-  auto vel = current_velocity;
+  const auto limit_vel = [&](const auto vel) {
+    const auto max_global_vel = common_data_ptr->bpp_param_ptr->max_vel;
+    return std::clamp(vel, lc_param_ptr->minimum_lane_changing_velocity, max_global_vel);
+  };
 
-  const auto calc_sum = [&](double sum, double shift_interval) {
+  auto vel = limit_vel(common_data_ptr->get_ego_speed());
+
+  std::vector<double> max_lc_lengths{};
+
+  const auto max_lc_length = [&](const auto shift_interval) {
     // prepare section
     const auto prepare_length = vel * t_prepare + 0.5 * max_acc * t_prepare * t_prepare;
-    vel = vel + max_acc * t_prepare;
+    vel = limit_vel(vel + max_acc * t_prepare);
 
     // lane changing section
-    const auto [min_lat_acc, max_lat_acc] =
-      lane_change_parameters.lane_change_lat_acc_map.find(vel);
+    const auto [min_lat_acc, max_lat_acc] = lc_param_ptr->lane_change_lat_acc_map.find(vel);
     const auto t_lane_changing =
       PathShifter::calcShiftTimeFromJerk(shift_interval, lat_jerk, max_lat_acc);
     const auto lane_changing_length =
       vel * t_lane_changing + 0.5 * max_acc * t_lane_changing * t_lane_changing;
 
-    vel = vel + max_acc * t_lane_changing;
-    return sum + (prepare_length + lane_changing_length + finish_judge_buffer);
+    vel = limit_vel(vel + max_acc * t_lane_changing);
+    return prepare_length + lane_changing_length;
   };
 
-  const auto total_length =
-    std::accumulate(shift_intervals.begin(), shift_intervals.end(), 0.0, calc_sum);
-
-  const auto backward_buffer = lane_change_parameters.backward_length_buffer_for_end_of_lane;
-  return total_length + backward_buffer * (static_cast<double>(shift_intervals.size()) - 1.0);
+  std::transform(
+    shift_intervals.cbegin(), shift_intervals.cend(), std::back_inserter(max_lc_lengths),
+    max_lc_length);
+  return max_lc_lengths;
 }
 
-double calc_maximum_lane_change_length(
-  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
-  const double max_acc)
+double calc_distance_buffer(
+  const LCParamPtr & lc_param_ptr, const std::vector<double> & min_lc_lengths)
 {
-  const auto shift_intervals =
-    common_data_ptr->route_handler_ptr->getLateralIntervalsToPreferredLane(
-      current_terminal_lanelet);
-  const auto vel = std::max(
-    common_data_ptr->get_ego_speed(),
-    common_data_ptr->lc_param_ptr->minimum_lane_changing_velocity);
-  return calc_maximum_lane_change_length(
-    vel, *common_data_ptr->lc_param_ptr, shift_intervals, max_acc);
+  if (min_lc_lengths.empty()) {
+    return std::numeric_limits<double>::max();
+  }
+
+  const auto finish_judge_buffer = lc_param_ptr->lane_change_finish_judge_buffer;
+  const auto backward_buffer = calc_stopping_distance(lc_param_ptr);
+  const auto lengths_sum = std::accumulate(min_lc_lengths.begin(), min_lc_lengths.end(), 0.0);
+  const auto num_of_lane_changes = static_cast<double>(min_lc_lengths.size());
+  return lengths_sum + (num_of_lane_changes * finish_judge_buffer) +
+         ((num_of_lane_changes - 1.0) * backward_buffer);
+}
+
+std::vector<double> calc_shift_intervals(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes)
+{
+  if (!common_data_ptr || !common_data_ptr->is_data_available() || lanes.empty()) {
+    return {};
+  }
+
+  const auto & route_handler_ptr = common_data_ptr->route_handler_ptr;
+  const auto direction = common_data_ptr->direction;
+
+  return route_handler_ptr->getLateralIntervalsToPreferredLane(lanes.back(), direction);
+}
+
+std::pair<MinMaxValue, MinMaxValue> calc_lc_length_and_dist_buffer(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & lanes)
+{
+  if (!common_data_ptr || !common_data_ptr->is_data_available() || lanes.empty()) {
+    return {};
+  }
+  const auto shift_intervals = calculation::calc_shift_intervals(common_data_ptr, lanes);
+  const auto all_min_lc_lengths =
+    calculation::calc_all_min_lc_lengths(common_data_ptr->lc_param_ptr, shift_intervals);
+  const auto min_lc_length =
+    !all_min_lc_lengths.empty() ? all_min_lc_lengths.front() : std::numeric_limits<double>::max();
+  const auto min_dist_buffer =
+    calculation::calc_distance_buffer(common_data_ptr->lc_param_ptr, all_min_lc_lengths);
+
+  const auto all_max_lc_lengths =
+    calculation::calc_all_max_lc_lengths(common_data_ptr, shift_intervals);
+  const auto max_lc_length =
+    !all_max_lc_lengths.empty() ? all_max_lc_lengths.front() : std::numeric_limits<double>::max();
+  const auto max_dist_buffer =
+    calculation::calc_distance_buffer(common_data_ptr->lc_param_ptr, all_max_lc_lengths);
+
+  return {{min_lc_length, max_lc_length}, {min_dist_buffer, max_dist_buffer}};
 }
 
 double calc_phase_length(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -140,6 +140,58 @@ double calc_ego_dist_to_lanes_start(
   return motion_utils::calcSignedArcLength(path.points, ego_position, target_front_pt);
 }
 
+double calc_maximum_lane_change_length(
+  const double current_velocity, const LaneChangeParameters & lane_change_parameters,
+  const std::vector<double> & shift_intervals, const double max_acc)
+{
+  if (shift_intervals.empty()) {
+    return 0.0;
+  }
+
+  const auto finish_judge_buffer = lane_change_parameters.lane_change_finish_judge_buffer;
+  const auto lat_jerk = lane_change_parameters.lane_changing_lateral_jerk;
+  const auto t_prepare = lane_change_parameters.lane_change_prepare_duration;
+
+  auto vel = current_velocity;
+
+  const auto calc_sum = [&](double sum, double shift_interval) {
+    // prepare section
+    const auto prepare_length = vel * t_prepare + 0.5 * max_acc * t_prepare * t_prepare;
+    vel = vel + max_acc * t_prepare;
+
+    // lane changing section
+    const auto [min_lat_acc, max_lat_acc] =
+      lane_change_parameters.lane_change_lat_acc_map.find(vel);
+    const auto t_lane_changing =
+      PathShifter::calcShiftTimeFromJerk(shift_interval, lat_jerk, max_lat_acc);
+    const auto lane_changing_length =
+      vel * t_lane_changing + 0.5 * max_acc * t_lane_changing * t_lane_changing;
+
+    vel = vel + max_acc * t_lane_changing;
+    return sum + (prepare_length + lane_changing_length + finish_judge_buffer);
+  };
+
+  const auto total_length =
+    std::accumulate(shift_intervals.begin(), shift_intervals.end(), 0.0, calc_sum);
+
+  const auto backward_buffer = lane_change_parameters.backward_length_buffer_for_end_of_lane;
+  return total_length + backward_buffer * (static_cast<double>(shift_intervals.size()) - 1.0);
+}
+
+double calc_maximum_lane_change_length(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelet & current_terminal_lanelet,
+  const double max_acc)
+{
+  const auto shift_intervals =
+    common_data_ptr->route_handler_ptr->getLateralIntervalsToPreferredLane(
+      current_terminal_lanelet);
+  const auto vel = std::max(
+    common_data_ptr->get_ego_speed(),
+    common_data_ptr->lc_param_ptr->minimum_lane_changing_velocity);
+  return calc_maximum_lane_change_length(
+    vel, *common_data_ptr->lc_param_ptr, shift_intervals, max_acc);
+}
+
 std::vector<double> calc_all_min_lc_lengths(
   const LCParamPtr & lc_param_ptr, const std::vector<double> & shift_intervals)
 {
@@ -190,8 +242,8 @@ std::vector<double> calc_all_max_lc_lengths(
 
   const auto max_lc_length = [&](const auto shift_interval) {
     // prepare section
-    const auto prepare_length = vel * t_prepare + 0.5 * max_acc * t_prepare * t_prepare;
     vel = limit_vel(vel + max_acc * t_prepare);
+    const auto prepare_length = vel * t_prepare + 0.5 * max_acc * t_prepare * t_prepare;
 
     // lane changing section
     const auto [min_lat_acc, max_lat_acc] = lc_param_ptr->lane_change_lat_acc_map.find(vel);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -549,28 +549,23 @@ double getLateralShift(const LaneChangePath & path)
 }
 
 bool hasEnoughLengthToLaneChangeAfterAbort(
-  const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelets & current_lanes,
-  const Pose & current_pose, const double abort_return_dist,
-  const LaneChangeParameters & lane_change_parameters, const Direction direction)
+  const CommonDataPtr & common_data_ptr, const double abort_return_dist)
 {
+  const auto & current_lanes = common_data_ptr->lanes_ptr->current;
   if (current_lanes.empty()) {
     return false;
   }
 
-  const auto minimum_lane_change_length = calculation::calc_minimum_lane_change_length(
-    route_handler, current_lanes.back(), lane_change_parameters, direction);
-  const auto abort_plus_lane_change_length = abort_return_dist + minimum_lane_change_length;
+  const auto & current_pose = common_data_ptr->get_ego_pose();
+  const auto abort_plus_lane_change_length =
+    abort_return_dist + common_data_ptr->transient_data.current_dist_buffer.min;
   if (abort_plus_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     return false;
   }
 
-  if (
-    abort_plus_lane_change_length >
-    utils::getSignedDistance(current_pose, route_handler->getGoalPose(), current_lanes)) {
-    return false;
-  }
-
-  return true;
+  const auto goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
+  return abort_plus_lane_change_length <=
+         utils::getSignedDistance(current_pose, goal_pose, current_lanes);
 }
 
 std::vector<std::vector<int64_t>> getSortedLaneIds(
@@ -851,9 +846,7 @@ bool passed_parked_objects(
     lane_change_parameters.object_check_min_road_shoulder_width;
   const auto & object_shiftable_ratio_threshold =
     lane_change_parameters.object_shiftable_ratio_threshold;
-  const auto & current_lanes = common_data_ptr->lanes_ptr->current;
-  const auto current_lane_path =
-    route_handler.getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto & current_lane_path = common_data_ptr->current_lanes_path;
 
   if (objects.empty() || lane_change_path.path.points.empty() || current_lane_path.points.empty()) {
     return true;


### PR DESCRIPTION
## Description

This PR adds TransientData to standardize commonly used values in the lane change module, such as the current lanes' buffer and the distance to the terminal start and end. The goal is to ensure consistency when calculating limits and lengths.

## Related links

- https://github.com/autowarefoundation/autoware.universe/pull/8849 → 8849 has caused some degradation in the Evaluator, so it has been set to draft for the time being. 8954 is a subset of 8849 and has no scenario failures.

## How was this PR tested?

- PSIM
- Evaluator: [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/b1ac9431-b48b-5c7d-b6c7-a1ea6f8854e1?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
