### PR TITLE
fix(static_obstacle_avoidance): remove redundant calculation

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1822,6 +1822,9 @@ void updateRoadShoulderDistance(
       clip_objects.push_back(object);
     }
   });
+
+  if (clip_objects.empty()) return;
+
   for (auto & o : clip_objects) {
     const auto & vehicle_width = planner_data->parameters.vehicle_width;
     const auto object_type = utils::getHighestProbLabel(o.object.classification);
@@ -1886,6 +1889,7 @@ void filterTargetObjects(
         data.other_objects.push_back(o);
         continue;
       }
+      o.avoid_margin = filtering_utils::getAvoidMargin(o, planner_data, parameters);
     } else if (filtering_utils::isVehicleTypeObject(o)) {
       // TARGET: CAR, TRUCK, BUS, TRAILER, MOTORCYCLE
 


### PR DESCRIPTION
## Description
Inside `fillAvoidanceTargetObjects` function, `filterTargetObjects` and `updateRoadShoulderDistance` are called sequentially.
Both function calls `getRoadShoulderDistance` function, which is relatively time consuming (refer to figure).
The `updateRoadShoulderDistance` function updates the target object's distance to road shoulder (`to_road_shoulder_distance`) and avoidance margin (`avoid_margin`) according to the clip object information.
However, this calculation would be redundant if there is no clip objects.
This PR will resolve the above problem. 

![image](https://github.com/user-attachments/assets/759ad8cc-1aa2-48d7-8c1f-a62678f62541)


## Related links

## How was this PR tested?
- [x] [TIER IV internal evauator](https://evaluation.tier4.jp/evaluation/reports/7d522c74-6e21-5285-8f7f-a64099582682?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
