### PR TITLE
fix(crosswalk): change exceptional handling

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -332,7 +332,7 @@ std::optional<StopFactor> CrosswalkModule::checkStopForCrosswalkUsers(
   const double dist_default_stop =
     default_stop_pose_opt.has_value()
       ? calcSignedArcLength(ego_path.points, ego_pos, default_stop_pose_opt->position)
-      : std::numeric_limits<double>::max();
+      : 0.0;
   updateObjectState(
     dist_default_stop, sparse_resample_path, crosswalk_attention_range, attention_area);
 


### PR DESCRIPTION
## Description
Currently, after the backward path go over the default stop line, the crosswalk module do not treat as ego is yielding, 
This PR change this behavior with the assumption that default stop pose is null only if the ego has passed the default stop pose.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/8853

<!-- ⬇️🟢
**Private Links:**

⬆️🟢 -->

## How was this PR tested?
tier4 internal tests

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
