### PR TITLE
refactor(osqp_interface): added autoware prefix to osqp_interface

### DIFF
--- a/common/autoware_osqp_interface/CMakeLists.txt
+++ b/common/autoware_osqp_interface/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(osqp_interface)
+project(autoware_osqp_interface)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
@@ -17,9 +17,9 @@ set(OSQP_INTERFACE_LIB_SRC
 )
 
 set(OSQP_INTERFACE_LIB_HEADERS
-  include/osqp_interface/csc_matrix_conv.hpp
-  include/osqp_interface/osqp_interface.hpp
-  include/osqp_interface/visibility_control.hpp
+  include/autoware/osqp_interface/csc_matrix_conv.hpp
+  include/autoware/osqp_interface/osqp_interface.hpp
+  include/autoware/osqp_interface/visibility_control.hpp
 )
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -28,18 +28,18 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-error=old-style-cast -Wno-error=useless-cast)
 
-target_include_directories(osqp_interface
+target_include_directories(${PROJECT_NAME}
   SYSTEM PUBLIC
     "${OSQP_INCLUDE_DIR}"
     "${EIGEN3_INCLUDE_DIR}"
 )
 
-ament_target_dependencies(osqp_interface
+ament_target_dependencies(${PROJECT_NAME}
   Eigen3
   osqp_vendor
 )
 
-# crucial so downstream package builds because osqp_interface exposes osqp.hpp
+# crucial so downstream package builds because autoware_osqp_interface exposes osqp.hpp
 ament_export_include_directories("${OSQP_INCLUDE_DIR}")
 # crucial so the linking order is correct in a downstream package: libosqp_interface.a should come before libosqp.a
 ament_export_libraries(osqp::osqp)

--- a/common/autoware_osqp_interface/design/osqp_interface-design.md
+++ b/common/autoware_osqp_interface/design/osqp_interface-design.md
@@ -1,6 +1,6 @@
 # Interface for the OSQP library
 
-This is the design document for the `osqp_interface` package.
+This is the design document for the `autoware_osqp_interface` package.
 
 ## Purpose / Use cases
 

--- a/common/autoware_osqp_interface/include/autoware/osqp_interface/csc_matrix_conv.hpp
+++ b/common/autoware_osqp_interface/include/autoware/osqp_interface/csc_matrix_conv.hpp
@@ -12,21 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
-#define OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
+#ifndef AUTOWARE__OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
+#define AUTOWARE__OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
 
+#include "autoware/osqp_interface/visibility_control.hpp"
 #include "osqp/glob_opts.h"  // for 'c_int' type ('long' or 'long long')
-#include "osqp_interface/visibility_control.hpp"
 
 #include <Eigen/Core>
 
 #include <vector>
 
-namespace autoware
-{
-namespace common
-{
-namespace osqp
+namespace autoware::osqp_interface
 {
 /// \brief Compressed-Column-Sparse Matrix
 struct OSQP_INTERFACE_PUBLIC CSC_Matrix
@@ -46,8 +42,6 @@ OSQP_INTERFACE_PUBLIC CSC_Matrix calCSCMatrixTrapezoidal(const Eigen::MatrixXd &
 /// \brief Print the given CSC matrix to the standard output
 OSQP_INTERFACE_PUBLIC void printCSCMatrix(const CSC_Matrix & csc_mat);
 
-}  // namespace osqp
-}  // namespace common
-}  // namespace autoware
+}  // namespace autoware::osqp_interface
 
-#endif  // OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
+#endif  // AUTOWARE__OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_

--- a/common/autoware_osqp_interface/include/autoware/osqp_interface/osqp_interface.hpp
+++ b/common/autoware_osqp_interface/include/autoware/osqp_interface/osqp_interface.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OSQP_INTERFACE__OSQP_INTERFACE_HPP_
-#define OSQP_INTERFACE__OSQP_INTERFACE_HPP_
+#ifndef AUTOWARE__OSQP_INTERFACE__OSQP_INTERFACE_HPP_
+#define AUTOWARE__OSQP_INTERFACE__OSQP_INTERFACE_HPP_
 
+#include "autoware/osqp_interface/csc_matrix_conv.hpp"
+#include "autoware/osqp_interface/visibility_control.hpp"
 #include "osqp/osqp.h"
-#include "osqp_interface/csc_matrix_conv.hpp"
-#include "osqp_interface/visibility_control.hpp"
 
 #include <Eigen/Core>
 #include <rclcpp/rclcpp.hpp>
@@ -28,11 +28,7 @@
 #include <tuple>
 #include <vector>
 
-namespace autoware
-{
-namespace common
-{
-namespace osqp
+namespace autoware::osqp_interface
 {
 constexpr c_float INF = 1e30;
 
@@ -193,8 +189,6 @@ public:
   void logUnsolvedStatus(const std::string & prefix_message = "") const;
 };
 
-}  // namespace osqp
-}  // namespace common
-}  // namespace autoware
+}  // namespace autoware::osqp_interface
 
-#endif  // OSQP_INTERFACE__OSQP_INTERFACE_HPP_
+#endif  // AUTOWARE__OSQP_INTERFACE__OSQP_INTERFACE_HPP_

--- a/common/autoware_osqp_interface/include/autoware/osqp_interface/visibility_control.hpp
+++ b/common/autoware_osqp_interface/include/autoware/osqp_interface/visibility_control.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OSQP_INTERFACE__VISIBILITY_CONTROL_HPP_
-#define OSQP_INTERFACE__VISIBILITY_CONTROL_HPP_
+#ifndef AUTOWARE__OSQP_INTERFACE__VISIBILITY_CONTROL_HPP_
+#define AUTOWARE__OSQP_INTERFACE__VISIBILITY_CONTROL_HPP_
 
 ////////////////////////////////////////////////////////////////////////////////
 #if defined(__WIN32)
@@ -34,4 +34,4 @@
 #error "Unsupported Build Configuration"
 #endif
 
-#endif  // OSQP_INTERFACE__VISIBILITY_CONTROL_HPP_
+#endif  // AUTOWARE__OSQP_INTERFACE__VISIBILITY_CONTROL_HPP_

--- a/common/autoware_osqp_interface/package.xml
+++ b/common/autoware_osqp_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>osqp_interface</name>
+  <name>autoware_osqp_interface</name>
   <version>1.0.0</version>
   <description>Interface for the OSQP solver</description>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/common/autoware_osqp_interface/src/csc_matrix_conv.cpp
+++ b/common/autoware_osqp_interface/src/csc_matrix_conv.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "osqp_interface/csc_matrix_conv.hpp"
+#include "autoware/osqp_interface/csc_matrix_conv.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
@@ -21,11 +21,7 @@
 #include <iostream>
 #include <vector>
 
-namespace autoware
-{
-namespace common
-{
-namespace osqp
+namespace autoware::osqp_interface
 {
 CSC_Matrix calCSCMatrix(const Eigen::MatrixXd & mat)
 {
@@ -136,6 +132,4 @@ void printCSCMatrix(const CSC_Matrix & csc_mat)
   std::cout << "]\n";
 }
 
-}  // namespace osqp
-}  // namespace common
-}  // namespace autoware
+}  // namespace autoware::osqp_interface

--- a/common/autoware_osqp_interface/src/osqp_interface.cpp
+++ b/common/autoware_osqp_interface/src/osqp_interface.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "osqp_interface/osqp_interface.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 
+#include "autoware/osqp_interface/csc_matrix_conv.hpp"
 #include "osqp/osqp.h"
-#include "osqp_interface/csc_matrix_conv.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -25,11 +25,7 @@
 #include <tuple>
 #include <vector>
 
-namespace autoware
-{
-namespace common
-{
-namespace osqp
+namespace autoware::osqp_interface
 {
 OSQPInterface::OSQPInterface(const c_float eps_abs, const bool polish)
 : m_work{nullptr, OSQPWorkspaceDeleter}
@@ -436,6 +432,4 @@ void OSQPInterface::logUnsolvedStatus(const std::string & prefix_message) const
   // log with warning
   RCLCPP_WARN(rclcpp::get_logger("osqp_interface"), output_message.c_str());
 }
-}  // namespace osqp
-}  // namespace common
-}  // namespace autoware
+}  // namespace autoware::osqp_interface

--- a/common/autoware_osqp_interface/test/test_csc_matrix_conv.cpp
+++ b/common/autoware_osqp_interface/test/test_csc_matrix_conv.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/osqp_interface/csc_matrix_conv.hpp"
 #include "gtest/gtest.h"
-#include "osqp_interface/csc_matrix_conv.hpp"
 
 #include <Eigen/Core>
 
@@ -23,8 +23,8 @@
 
 TEST(TestCscMatrixConv, Nominal)
 {
-  using autoware::common::osqp::calCSCMatrix;
-  using autoware::common::osqp::CSC_Matrix;
+  using autoware::osqp_interface::calCSCMatrix;
+  using autoware::osqp_interface::CSC_Matrix;
 
   Eigen::MatrixXd rect1(1, 2);
   rect1 << 0.0, 1.0;
@@ -117,8 +117,8 @@ TEST(TestCscMatrixConv, Nominal)
 }
 TEST(TestCscMatrixConv, Trapezoidal)
 {
-  using autoware::common::osqp::calCSCMatrixTrapezoidal;
-  using autoware::common::osqp::CSC_Matrix;
+  using autoware::osqp_interface::calCSCMatrixTrapezoidal;
+  using autoware::osqp_interface::CSC_Matrix;
 
   Eigen::MatrixXd square1(2, 2);
   Eigen::MatrixXd square2(3, 3);
@@ -166,10 +166,10 @@ TEST(TestCscMatrixConv, Trapezoidal)
 }
 TEST(TestCscMatrixConv, Print)
 {
-  using autoware::common::osqp::calCSCMatrix;
-  using autoware::common::osqp::calCSCMatrixTrapezoidal;
-  using autoware::common::osqp::CSC_Matrix;
-  using autoware::common::osqp::printCSCMatrix;
+  using autoware::osqp_interface::calCSCMatrix;
+  using autoware::osqp_interface::calCSCMatrixTrapezoidal;
+  using autoware::osqp_interface::CSC_Matrix;
+  using autoware::osqp_interface::printCSCMatrix;
   Eigen::MatrixXd square1(2, 2);
   Eigen::MatrixXd rect1(1, 2);
   square1 << 1.0, 2.0, 2.0, 4.0;

--- a/common/autoware_osqp_interface/test/test_osqp_interface.cpp
+++ b/common/autoware_osqp_interface/test/test_osqp_interface.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "gtest/gtest.h"
-#include "osqp_interface/osqp_interface.hpp"
 
 #include <Eigen/Core>
 
@@ -39,9 +39,9 @@ namespace
 
 TEST(TestOsqpInterface, BasicQp)
 {
-  using autoware::common::osqp::calCSCMatrix;
-  using autoware::common::osqp::calCSCMatrixTrapezoidal;
-  using autoware::common::osqp::CSC_Matrix;
+  using autoware::osqp_interface::calCSCMatrix;
+  using autoware::osqp_interface::calCSCMatrixTrapezoidal;
+  using autoware::osqp_interface::CSC_Matrix;
 
   auto check_result =
     [](const std::tuple<std::vector<double>, std::vector<double>, int, int, int> & result) {
@@ -66,12 +66,12 @@ TEST(TestOsqpInterface, BasicQp)
   const Eigen::MatrixXd P = (Eigen::MatrixXd(2, 2) << 4, 1, 1, 2).finished();
   const Eigen::MatrixXd A = (Eigen::MatrixXd(4, 2) << 1, 1, 1, 0, 0, 1, 0, 1).finished();
   const std::vector<double> q = {1.0, 1.0};
-  const std::vector<double> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
-  const std::vector<double> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
+  const std::vector<double> l = {1.0, 0.0, 0.0, -autoware::osqp_interface::INF};
+  const std::vector<double> u = {1.0, 0.7, 0.7, autoware::osqp_interface::INF};
 
   {
     // Define problem during optimization
-    autoware::common::osqp::OSQPInterface osqp;
+    autoware::osqp_interface::OSQPInterface osqp;
     std::tuple<std::vector<double>, std::vector<double>, int, int, int> result =
       osqp.optimize(P, A, q, l, u);
     check_result(result);
@@ -79,7 +79,7 @@ TEST(TestOsqpInterface, BasicQp)
 
   {
     // Define problem during initialization
-    autoware::common::osqp::OSQPInterface osqp(P, A, q, l, u, 1e-6);
+    autoware::osqp_interface::OSQPInterface osqp(P, A, q, l, u, 1e-6);
     std::tuple<std::vector<double>, std::vector<double>, int, int, int> result = osqp.optimize();
     check_result(result);
   }
@@ -92,7 +92,7 @@ TEST(TestOsqpInterface, BasicQp)
     std::vector<double> q_ini(2, 0.0);
     std::vector<double> l_ini(4, 0.0);
     std::vector<double> u_ini(4, 0.0);
-    autoware::common::osqp::OSQPInterface osqp(P_ini, A_ini, q_ini, l_ini, u_ini, 1e-6);
+    autoware::osqp_interface::OSQPInterface osqp(P_ini, A_ini, q_ini, l_ini, u_ini, 1e-6);
     osqp.optimize();
 
     // Redefine problem before optimization
@@ -105,7 +105,7 @@ TEST(TestOsqpInterface, BasicQp)
     // Define problem during initialization with csc matrix
     CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
     CSC_Matrix A_csc = calCSCMatrix(A);
-    autoware::common::osqp::OSQPInterface osqp(P_csc, A_csc, q, l, u, 1e-6);
+    autoware::osqp_interface::OSQPInterface osqp(P_csc, A_csc, q, l, u, 1e-6);
     std::tuple<std::vector<double>, std::vector<double>, int, int, int> result = osqp.optimize();
     check_result(result);
   }
@@ -118,7 +118,7 @@ TEST(TestOsqpInterface, BasicQp)
     std::vector<double> q_ini(2, 0.0);
     std::vector<double> l_ini(4, 0.0);
     std::vector<double> u_ini(4, 0.0);
-    autoware::common::osqp::OSQPInterface osqp(P_ini_csc, A_ini_csc, q_ini, l_ini, u_ini, 1e-6);
+    autoware::osqp_interface::OSQPInterface osqp(P_ini_csc, A_ini_csc, q_ini, l_ini, u_ini, 1e-6);
     osqp.optimize();
 
     // Redefine problem before optimization
@@ -138,7 +138,7 @@ TEST(TestOsqpInterface, BasicQp)
     std::vector<double> q_ini(2, 0.0);
     std::vector<double> l_ini(4, 0.0);
     std::vector<double> u_ini(4, 0.0);
-    autoware::common::osqp::OSQPInterface osqp(P_ini_csc, A_ini_csc, q_ini, l_ini, u_ini, 1e-6);
+    autoware::osqp_interface::OSQPInterface osqp(P_ini_csc, A_ini_csc, q_ini, l_ini, u_ini, 1e-6);
     osqp.optimize();
 
     // Redefine problem before optimization

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/qp_solver/qp_solver_osqp.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/qp_solver/qp_solver_osqp.hpp
@@ -16,7 +16,7 @@
 #define AUTOWARE__MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 
 #include "autoware/mpc_lateral_controller/qp_solver/qp_solver_interface.hpp"
-#include "osqp_interface/osqp_interface.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller
@@ -58,7 +58,7 @@ public:
   double getObjVal() const override { return osqpsolver_.getObjVal(); }
 
 private:
-  autoware::common::osqp::OSQPInterface osqpsolver_;
+  autoware::osqp_interface::OSQPInterface osqpsolver_;
   rclcpp::Logger logger_;
 };
 }  // namespace autoware::motion::control::mpc_lateral_controller

--- a/control/autoware_mpc_lateral_controller/package.xml
+++ b/control/autoware_mpc_lateral_controller/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_control_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_trajectory_follower_base</depend>
   <depend>autoware_universe_utils</depend>
@@ -29,7 +30,6 @@
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>osqp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/control/autoware_trajectory_follower_base/package.xml
+++ b/control/autoware_trajectory_follower_base/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_control_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
@@ -31,7 +32,6 @@
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>osqp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/optimization_based_planner/velocity_optimizer.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/optimization_based_planner/velocity_optimizer.hpp
@@ -15,7 +15,7 @@
 #define AUTOWARE__OBSTACLE_CRUISE_PLANNER__OPTIMIZATION_BASED_PLANNER__VELOCITY_OPTIMIZER_HPP_
 
 #include "autoware/obstacle_cruise_planner/optimization_based_planner/s_boundary.hpp"
-#include "osqp_interface/osqp_interface.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 
 #include <vector>
 
@@ -69,7 +69,7 @@ private:
   double over_j_weight_;
 
   // QPSolver
-  autoware::common::osqp::OSQPInterface qp_solver_;
+  autoware::osqp_interface::OSQPInterface qp_solver_;
 };
 
 #endif  // AUTOWARE__OBSTACLE_CRUISE_PLANNER__OPTIMIZATION_BASED_PLANNER__VELOCITY_OPTIMIZER_HPP_

--- a/planning/autoware_obstacle_cruise_planner/package.xml
+++ b/planning/autoware_obstacle_cruise_planner/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
@@ -30,7 +31,6 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>object_recognition_utils</depend>
-  <depend>osqp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/mpt_optimizer.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/mpt_optimizer.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/interpolation/spline_interpolation_points_2d.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "autoware/path_optimizer/common_structs.hpp"
 #include "autoware/path_optimizer/state_equation_generator.hpp"
 #include "autoware/path_optimizer/type_alias.hpp"
@@ -24,7 +25,6 @@
 #include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "gtest/gtest.h"
-#include "osqp_interface/osqp_interface.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>
@@ -228,7 +228,7 @@ private:
   MPTParam mpt_param_;
 
   StateEquationGenerator state_equation_generator_;
-  std::unique_ptr<autoware::common::osqp::OSQPInterface> osqp_solver_ptr_;
+  std::unique_ptr<autoware::osqp_interface::OSQPInterface> osqp_solver_ptr_;
 
   const double osqp_epsilon_ = 1.0e-3;
 

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -16,13 +16,13 @@
 
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>osqp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -414,7 +414,7 @@ MPTOptimizer::MPTOptimizer(
     StateEquationGenerator(vehicle_info_.wheel_base_m, mpt_param_.max_steer_rad, time_keeper_);
 
   // osqp solver
-  osqp_solver_ptr_ = std::make_unique<autoware::common::osqp::OSQPInterface>(osqp_epsilon_);
+  osqp_solver_ptr_ = std::make_unique<autoware::osqp_interface::OSQPInterface>(osqp_epsilon_);
 
   // publisher
   debug_fixed_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_fixed_traj", 1);
@@ -1330,8 +1330,8 @@ MPTOptimizer::ConstraintMatrix MPTOptimizer::calcConstraintMatrix(
 
   // NOTE: The following takes 1 [ms]
   Eigen::MatrixXd A = Eigen::MatrixXd::Zero(A_rows, N_v);
-  Eigen::VectorXd lb = Eigen::VectorXd::Constant(A_rows, -autoware::common::osqp::INF);
-  Eigen::VectorXd ub = Eigen::VectorXd::Constant(A_rows, autoware::common::osqp::INF);
+  Eigen::VectorXd lb = Eigen::VectorXd::Constant(A_rows, -autoware::osqp_interface::INF);
+  Eigen::VectorXd ub = Eigen::VectorXd::Constant(A_rows, autoware::osqp_interface::INF);
   size_t A_rows_end = 0;
 
   // 1. State equation
@@ -1502,9 +1502,9 @@ std::optional<Eigen::VectorXd> MPTOptimizer::calcOptimizedSteerAngles(
   // initialize or update solver according to warm start
   time_keeper_->start_track("initOsqp");
 
-  const autoware::common::osqp::CSC_Matrix P_csc =
-    autoware::common::osqp::calCSCMatrixTrapezoidal(H);
-  const autoware::common::osqp::CSC_Matrix A_csc = autoware::common::osqp::calCSCMatrix(A);
+  const autoware::osqp_interface::CSC_Matrix P_csc =
+    autoware::osqp_interface::calCSCMatrixTrapezoidal(H);
+  const autoware::osqp_interface::CSC_Matrix A_csc = autoware::osqp_interface::calCSCMatrix(A);
   if (
     prev_solution_status_ == 1 && mpt_param_.enable_warm_start && prev_mat_n_ == H.rows() &&
     prev_mat_m_ == A.rows()) {
@@ -1515,7 +1515,7 @@ std::optional<Eigen::VectorXd> MPTOptimizer::calcOptimizedSteerAngles(
     osqp_solver_ptr_->updateBounds(lower_bound, upper_bound);
   } else {
     RCLCPP_INFO_EXPRESSION(logger_, enable_debug_info_, "no warm start");
-    osqp_solver_ptr_ = std::make_unique<autoware::common::osqp::OSQPInterface>(
+    osqp_solver_ptr_ = std::make_unique<autoware::osqp_interface::OSQPInterface>(
       P_csc, A_csc, f, lower_bound, upper_bound, osqp_epsilon_);
   }
   prev_mat_n_ = H.rows();

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band.hpp
@@ -15,9 +15,9 @@
 #ifndef AUTOWARE__PATH_SMOOTHER__ELASTIC_BAND_HPP_
 #define AUTOWARE__PATH_SMOOTHER__ELASTIC_BAND_HPP_
 
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "autoware/path_smoother/common_structs.hpp"
 #include "autoware/path_smoother/type_alias.hpp"
-#include "osqp_interface/osqp_interface.hpp"
 
 #include <Eigen/Core>
 
@@ -109,7 +109,7 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_traj_pub_;
   rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_fixed_traj_pub_;
 
-  std::unique_ptr<autoware::common::osqp::OSQPInterface> osqp_solver_ptr_;
+  std::unique_ptr<autoware::osqp_interface::OSQPInterface> osqp_solver_ptr_;
   std::shared_ptr<std::vector<TrajectoryPoint>> prev_eb_traj_points_ptr_{nullptr};
 
   std::vector<TrajectoryPoint> insertFixedPoint(

--- a/planning/autoware_path_smoother/package.xml
+++ b/planning/autoware_path_smoother/package.xml
@@ -16,12 +16,12 @@
 
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_universe_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>osqp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -381,7 +381,7 @@ void EBPathSmoother::updateConstraint(
     osqp_solver_ptr_->updateBounds(lower_bound, upper_bound);
     osqp_solver_ptr_->updateEpsRel(p.qp_param.eps_rel);
   } else {
-    osqp_solver_ptr_ = std::make_unique<autoware::common::osqp::OSQPInterface>(
+    osqp_solver_ptr_ = std::make_unique<autoware::osqp_interface::OSQPInterface>(
       P, A, q, lower_bound, upper_bound, p.qp_param.eps_abs);
     osqp_solver_ptr_->updateEpsRel(p.qp_param.eps_rel);
     osqp_solver_ptr_->updateEpsAbs(p.qp_param.eps_abs);

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_map_projection_loader</depend>
   <depend>autoware_mission_planner</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_path_optimizer</depend>
   <depend>autoware_path_smoother</depend>
   <depend>autoware_perception_msgs</depend>
@@ -33,7 +34,6 @@
   <depend>geometry_msgs</depend>
   <depend>global_parameter_loader</depend>
   <depend>map_loader</depend>
-  <depend>osqp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_map_msgs</depend>

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/math/unit_conversion.hpp"
 #include "autoware/universe_utils/ros/logger_level_configure.hpp"
@@ -31,7 +32,6 @@
 #include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
-#include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_ros/transform_listener.h"

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -16,10 +16,10 @@
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__L2_PSEUDO_JERK_SMOOTHER_HPP_
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
-#include "osqp_interface/osqp_interface.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
@@ -57,7 +57,7 @@ public:
 
 private:
   Param smoother_param_;
-  autoware::common::osqp::OSQPInterface qp_solver_;
+  autoware::osqp_interface::OSQPInterface qp_solver_;
   rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("l2_pseudo_jerk_smoother")};
 };
 }  // namespace autoware::velocity_smoother

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -16,10 +16,10 @@
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__LINF_PSEUDO_JERK_SMOOTHER_HPP_
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/osqp_interface/osqp_interface.hpp"
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
-#include "osqp_interface/osqp_interface.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
@@ -57,7 +57,7 @@ public:
 
 private:
   Param smoother_param_;
-  autoware::common::osqp::OSQPInterface qp_solver_;
+  autoware::osqp_interface::OSQPInterface qp_solver_;
   rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("linf_pseudo_jerk_smoother")};
 };
 }  // namespace autoware::velocity_smoother

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -23,13 +23,13 @@
 
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_osqp_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>osqp_interface</depend>
   <depend>qp_interface</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
## Description

Added `autoware` prefix to `osqp_interface`

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5077
- https://github.com/autowarefoundation/autoware/issues/4569

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
