### PR TITLE
fix(autoware_behavior_path_lane_change_module): fix unusedFunction

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -91,10 +91,6 @@ bool isPathInLanelets(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
-bool pathFootprintExceedsTargetLaneBound(
-  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info,
-  const double margin = 0.1);
-
 std::optional<LaneChangePath> construct_candidate_path(
   const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_lane_reference_path,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -211,8 +211,6 @@ rclcpp::Logger getLogger(const std::string & type);
  */
 Polygon2d getEgoCurrentFootprint(const Pose & ego_pose, const VehicleInfo & ego_info);
 
-Point getEgoFrontVertex(const Pose & ego_pose, const VehicleInfo & ego_info, bool left);
-
 /**
  * @brief Checks if the given polygon is within an intersection area.
  *

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -91,6 +91,10 @@ bool isPathInLanelets(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
+bool pathFootprintExceedsTargetLaneBound(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info,
+  const double margin = 0.1);
+
 std::optional<LaneChangePath> construct_candidate_path(
   const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_lane_reference_path,
@@ -210,6 +214,8 @@ rclcpp::Logger getLogger(const std::string & type);
  * @return Polygon2d A polygon representing the current 2D footprint of the ego vehicle.
  */
 Polygon2d getEgoCurrentFootprint(const Pose & ego_pose, const VehicleInfo & ego_info);
+
+Point getEgoFrontVertex(const Pose & ego_pose, const VehicleInfo & ego_info, bool left);
 
 /**
  * @brief Checks if the given polygon is within an intersection area.

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -200,7 +200,6 @@ bool isPathInLanelets(
   return true;
 }
 
-// TODO:remove this suppression after implementation
 // cppcheck-suppress unusedFunction
 bool pathFootprintExceedsTargetLaneBound(
   const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1024,14 +1024,6 @@ Polygon2d getEgoCurrentFootprint(
   return autoware::universe_utils::toFootprint(ego_pose, base_to_front, base_to_rear, width);
 }
 
-Point getEgoFrontVertex(
-  const Pose & ego_pose, const autoware::vehicle_info_utils::VehicleInfo & ego_info, bool left)
-{
-  const double lon_offset = ego_info.wheel_base_m + ego_info.front_overhang_m;
-  const double lat_offset = 0.5 * (left ? ego_info.vehicle_width_m : -ego_info.vehicle_width_m);
-  return autoware::universe_utils::calcOffsetPose(ego_pose, lon_offset, lat_offset, 0.0).position;
-}
-
 bool isWithinIntersection(
   const std::shared_ptr<RouteHandler> & route_handler, const lanelet::ConstLanelet & lanelet,
   const Polygon2d & polygon)

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -200,36 +200,6 @@ bool isPathInLanelets(
   return true;
 }
 
-bool pathFootprintExceedsTargetLaneBound(
-  const CommonDataPtr & common_data_ptr, const PathWithLaneId & path, const VehicleInfo & ego_info,
-  const double margin)
-{
-  if (common_data_ptr->direction == Direction::NONE || path.points.empty()) {
-    return false;
-  }
-
-  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
-  const bool is_left = common_data_ptr->direction == Direction::LEFT;
-
-  const auto combined_target_lane = lanelet::utils::combineLaneletsShape(target_lanes);
-
-  for (const auto & path_point : path.points) {
-    const auto & pose = path_point.point.pose;
-    const auto front_vertex = getEgoFrontVertex(pose, ego_info, is_left);
-
-    const auto sign = is_left ? -1.0 : 1.0;
-    const auto dist_to_boundary =
-      sign * utils::getSignedDistanceFromLaneBoundary(combined_target_lane, front_vertex, is_left);
-
-    if (dist_to_boundary < margin) {
-      RCLCPP_DEBUG(get_logger(), "Path footprint exceeds target lane boundary");
-      return true;
-    }
-  }
-
-  return false;
-}
-
 std::optional<LaneChangePath> construct_candidate_path(
   const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_lane_reference_path,


### PR DESCRIPTION
## Description

This is a fix based on cppcheck unusedFunction warnings.

```
planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp:203:0: style: The function 'pathFootprintExceedsTargetLaneBound' is never used. [unusedFunction]
bool pathFootprintExceedsTargetLaneBound(
^

planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp:1027:0: style: The function 'getEgoFrontVertex' is never used. [unusedFunction]
Point getEgoFrontVertex(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
