### PR TITLE
fix(simple_planning_simulator, raw_vehicle_cmd_converter): swap row index and column index for csv loader 

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp
@@ -41,8 +41,8 @@ public:
     }
 
     vehicle_name_ = table[0][0];
-    vel_index_ = CSVLoader::getRowIndex(table);
-    acc_index_ = CSVLoader::getColumnIndex(table);
+    vel_index_ = CSVLoader::getColumnIndex(table);
+    acc_index_ = CSVLoader::getRowIndex(table);
     acceleration_map_ = CSVLoader::getMap(table);
 
     std::cout << "[SimModelDelaySteerMapAccGeared]: success to read acceleration map from "

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/utils/csv_loader.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/utils/csv_loader.cpp
@@ -119,7 +119,7 @@ Map CSVLoader::getMap(const Table & table)
   return map;
 }
 
-std::vector<double> CSVLoader::getRowIndex(const Table & table)
+std::vector<double> CSVLoader::getColumnIndex(const Table & table)
 {
   // NOTE: table[0][i] represents the element in the 0-th row and i-th column
   // This means that we are getting the index of each column in the 0-th row
@@ -130,7 +130,7 @@ std::vector<double> CSVLoader::getRowIndex(const Table & table)
   return index;
 }
 
-std::vector<double> CSVLoader::getColumnIndex(const Table & table)
+std::vector<double> CSVLoader::getRowIndex(const Table & table)
 {
   // NOTE: table[i][0] represents the element in the i-th row and 0-th column
   // This means that we are getting the index of each row in the 0-th column

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.cpp
@@ -27,13 +27,10 @@ bool ActuationMap::readActuationMapFromCSV(const std::string & csv_path, const b
     return false;
   }
 
-  state_index_ = CSVLoader::getRowIndex(table);
-  actuation_index_ = CSVLoader::getColumnIndex(table);
+  state_index_ = CSVLoader::getColumnIndex(table);
+  actuation_index_ = CSVLoader::getRowIndex(table);
   actuation_map_ = CSVLoader::getMap(table);
-  if (validation && !CSVLoader::validateMap(actuation_map_, true)) {
-    return false;
-  }
-  return true;
+  return !validation || CSVLoader::validateMap(actuation_map_, true);
 }
 
 double ActuationMap::getControlCommand(const double actuation, const double state) const
@@ -41,7 +38,8 @@ double ActuationMap::getControlCommand(const double actuation, const double stat
   std::vector<double> interpolated_control_vec{};
   const double clamped_state = CSVLoader::clampValue(state, state_index_);
 
-  for (std::vector<double> control_command_values : actuation_map_) {
+  interpolated_control_vec.reserve(actuation_map_.size());
+  for (const std::vector<double> & control_command_values : actuation_map_) {
     interpolated_control_vec.push_back(
       autoware::interpolation::lerp(state_index_, control_command_values, clamped_state));
   }
@@ -61,7 +59,8 @@ std::optional<double> AccelMap::getThrottle(const double acc, double vel) const
   const double clamped_vel = CSVLoader::clampValue(vel, vel_indices);
 
   // (throttle, vel, acc) map => (throttle, acc) map by fixing vel
-  for (std::vector<double> accelerations : accel_map) {
+  interpolated_acc_vec.reserve(accel_map.size());
+  for (const std::vector<double> & accelerations : accel_map) {
     interpolated_acc_vec.push_back(
       autoware::interpolation::lerp(vel_indices, accelerations, clamped_vel));
   }
@@ -71,7 +70,8 @@ std::optional<double> AccelMap::getThrottle(const double acc, double vel) const
   // When the desired acceleration is greater than the throttle area, return max throttle
   if (acc < interpolated_acc_vec.front()) {
     return std::nullopt;
-  } else if (interpolated_acc_vec.back() < acc) {
+  }
+  if (interpolated_acc_vec.back() < acc) {
     return throttle_indices.back();
   }
 
@@ -88,7 +88,8 @@ double BrakeMap::getBrake(const double acc, double vel) const
   const double clamped_vel = CSVLoader::clampValue(vel, vel_indices);
 
   // (brake, vel, acc) map => (brake, acc) map by fixing vel
-  for (std::vector<double> accelerations : brake_map) {
+  interpolated_acc_vec.reserve(brake_map.size());
+  for (const std::vector<double> & accelerations : brake_map) {
     interpolated_acc_vec.push_back(
       autoware::interpolation::lerp(vel_indices, accelerations, clamped_vel));
   }
@@ -98,7 +99,8 @@ double BrakeMap::getBrake(const double acc, double vel) const
   // When the desired acceleration is greater than the brake area, return min brake on the map
   if (acc < interpolated_acc_vec.back()) {
     return brake_indices.back();
-  } else if (interpolated_acc_vec.front() < acc) {
+  }
+  if (interpolated_acc_vec.front() < acc) {
     return brake_indices.front();
   }
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/accel_map.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/accel_map.cpp
@@ -31,8 +31,8 @@ bool AccelMap::readAccelMapFromCSV(const std::string & csv_path, const bool vali
   }
 
   vehicle_name_ = table[0][0];
-  vel_index_ = CSVLoader::getRowIndex(table);
-  throttle_index_ = CSVLoader::getColumnIndex(table);
+  vel_index_ = CSVLoader::getColumnIndex(table);
+  throttle_index_ = CSVLoader::getRowIndex(table);
   accel_map_ = CSVLoader::getMap(table);
   return !validation || CSVLoader::validateMap(accel_map_, true);
 }

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/brake_map.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/brake_map.cpp
@@ -32,8 +32,8 @@ bool BrakeMap::readBrakeMapFromCSV(const std::string & csv_path, const bool vali
   }
 
   vehicle_name_ = table[0][0];
-  vel_index_ = CSVLoader::getRowIndex(table);
-  brake_index_ = CSVLoader::getColumnIndex(table);
+  vel_index_ = CSVLoader::getColumnIndex(table);
+  brake_index_ = CSVLoader::getRowIndex(table);
   brake_map_ = CSVLoader::getMap(table);
   brake_index_rev_ = brake_index_;
   if (validation && !CSVLoader::validateMap(brake_map_, false)) {

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/csv_loader.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/csv_loader.cpp
@@ -115,7 +115,7 @@ Map CSVLoader::getMap(const Table & table)
   return map;
 }
 
-std::vector<double> CSVLoader::getRowIndex(const Table & table)
+std::vector<double> CSVLoader::getColumnIndex(const Table & table)
 {
   std::vector<double> index = {};
   for (size_t i = 1; i < table[0].size(); i++) {
@@ -124,7 +124,7 @@ std::vector<double> CSVLoader::getRowIndex(const Table & table)
   return index;
 }
 
-std::vector<double> CSVLoader::getColumnIndex(const Table & table)
+std::vector<double> CSVLoader::getRowIndex(const Table & table)
 {
   std::vector<double> index = {};
   for (size_t i = 1; i < table.size(); i++) {

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/steer_map.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/steer_map.cpp
@@ -32,8 +32,8 @@ bool SteerMap::readSteerMapFromCSV(const std::string & csv_path, const bool vali
   }
 
   vehicle_name_ = table[0][0];
-  steer_index_ = CSVLoader::getRowIndex(table);
-  output_index_ = CSVLoader::getColumnIndex(table);
+  steer_index_ = CSVLoader::getColumnIndex(table);
+  output_index_ = CSVLoader::getRowIndex(table);
   steer_map_ = CSVLoader::getMap(table);
   return !validation || CSVLoader::validateMap(steer_map_, true);
 }


### PR DESCRIPTION
## Description
Both the `simple_planning_simulator` and `autoware_raw_vehicle_cmd_converter` package has a CSV loader class.
As a member function they have `getRowIndex` and `getColumnIndex`.
However, the `getRowIndex` seems to read index for columns, and the `getColumnIndex` seems to read index for rows.
These functions have been swapped in this PR.

Furthermore, some refactoring was made based on clang tidy.

## Related links
None

## How was this PR tested?
Was able to drive autonomously in PSim.
![Screenshot from 2024-09-26 13-38-17](https://github.com/user-attachments/assets/628005a3-b6d7-4be1-a682-4692244fc764)

Parameters were changed as below:
`simulator_model.param.yaml`
```
/**:
  ros__parameters:
    simulated_frame_id: "base_link"
    origin_frame_id: "map"
    vehicle_model_type: "ACTUATION_CMD"
    initialize_source: "INITIAL_POSE_TOPIC"
    timer_sampling_time_ms: 25
    add_measurement_noise: False
    enable_road_slope_simulation: True
    vel_lim: 50.0
    vel_rate_lim: 7.0
    steer_lim: 1.0
    steer_rate_lim: 5.0
    acc_time_delay: 0.1
    acc_time_constant: 0.1
    steer_time_delay: 0.24
    steer_time_constant: 0.27
    steer_dead_band: 0.0012
    x_stddev: 0.0001 # x standard deviation for dummy covariance in map coordinate
    y_stddev: 0.0001 # y standard deviation for dummy covariance in map coordinate

    accel_time_delay: 0.1
    accel_time_constant: 0.1
    brake_time_delay: 0.1
    brake_time_constant: 0.1
    accel_map_path: $(find-pkg-share simple_planning_simulator)/data/actuation_cmd_map/accel_map.csv
    brake_map_path: $(find-pkg-share simple_planning_simulator)/data/actuation_cmd_map/brake_map.csv
    steer_map_path: $(find-pkg-share simple_planning_simulator)/data/actuation_cmd_map/steer_map.csv
    convert_accel_cmd: true
    convert_brake_cmd: true
    convert_steer_cmd: true

    convert_steer_cmd_method: "vgr"
    vgr_coef_a: 15.713
    vgr_coef_b: 0.053
    vgr_coef_c: 0.042
    enable_pub_steer: true
```
`raw_vehicle_cmd_converter.param.yaml`
```
/**:
  ros__parameters:
    csv_path_accel_map: $(find-pkg-share autoware_raw_vehicle_cmd_converter)/data/default/accel_map.csv
    csv_path_brake_map: $(find-pkg-share autoware_raw_vehicle_cmd_converter)/data/default/brake_map.csv
    csv_path_steer_map: $(find-pkg-share autoware_raw_vehicle_cmd_converter)/data/default/steer_map.csv
    convert_accel_cmd: true
    convert_brake_cmd: true
    convert_steer_cmd: true
    use_steer_ff: true
    use_steer_fb: true
    is_debugging: false
    max_throttle: 0.4
    max_brake: 0.8
    max_steer: 10.0
    min_steer: -10.0
    steer_pid:
      kp: 150.0
      ki: 15.0
      kd: 0.0
      max: 8.0
      min: -8.0
      max_p: 8.0
      min_p: -8.0
      max_i: 8.0
      min_i: -8.0
      max_d: 0.0
      min_d: 0.0
      invalid_integration_decay: 0.97
    convert_steer_cmd_method: "vgr"  # "vgr" or "steer_map"
    vgr_coef_a: 15.713
    vgr_coef_b: 0.053
    vgr_coef_c: 0.042
    convert_actuation_to_steering_status: false
```

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
