### PR TITLE
refactor(universe_utils): eliminate dependence on Boost.Geometry

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/alt_geometry.hpp
@@ -112,6 +112,8 @@ public:
 
   std::vector<PointList2d> & inners() noexcept { return inners_; }
 
+  autoware::universe_utils::Polygon2d to_boost() const;
+
 protected:
   Polygon2d(const PointList2d & outer, const std::vector<PointList2d> & inners)
   : outer_(outer), inners_(inners)

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -15,26 +15,21 @@
 #ifndef AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_
 #define AUTOWARE__UNIVERSE_UTILS__GEOMETRY__EAR_CLIPPING_HPP_
 
-#include "autoware/universe_utils/geometry/boost_geometry.hpp"
+#include "autoware/universe_utils/geometry/alt_geometry.hpp"
 
 #include <optional>
 #include <vector>
 
 namespace autoware::universe_utils
 {
-
-using Polygon2d = autoware::universe_utils::Polygon2d;
-using Point2d = autoware::universe_utils::Point2d;
-using LinearRing2d = autoware::universe_utils::LinearRing2d;
-
 struct LinkedPoint
 {
-  explicit LinkedPoint(const Point2d & point)
+  explicit LinkedPoint(const alt::Point2d & point)
   : pt(point), steiner(false), prev_index(std::nullopt), next_index(std::nullopt)
   {
   }
 
-  Point2d pt;
+  alt::Point2d pt;
   bool steiner;
   std::optional<std::size_t> prev_index;
   std::optional<std::size_t> next_index;
@@ -59,7 +54,7 @@ void split_ear_clipping(
  * @return the last index of the created linked list
  */
 std::size_t linked_list(
-  const LinearRing2d & ring, const bool clockwise, std::size_t & vertices,
+  const alt::PointList2d & ring, const bool clockwise, std::size_t & vertices,
   std::vector<LinkedPoint> & points);
 
 /**
@@ -85,7 +80,7 @@ std::size_t eliminate_hole(
  * @return the updated outer_index after all holes are eliminated
  */
 std::size_t eliminate_holes(
-  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
+  const std::vector<alt::PointList2d> & inners, std::size_t outer_index, std::size_t & vertices,
   std::vector<LinkedPoint> & points);
 
 /**
@@ -97,6 +92,12 @@ std::size_t eliminate_holes(
  * - `hole_points`: Number of points in all inner polygons.
  * - `2 * n_holes`: Additional points for bridging holes, where `n_holes` is the number of holes.
  * the final size of `points` vector is: `outer_points + hole_points + 2 * n_holes`.
+ * @return A vector of convex triangles representing the triangulated polygon.
+ */
+std::vector<alt::ConvexPolygon2d> triangulate(const alt::Polygon2d & polygon);
+
+/**
+ * @brief Boost.Geometry version of triangulate()
  * @return A vector of convex triangles representing the triangulated polygon.
  */
 std::vector<Polygon2d> triangulate(const Polygon2d & polygon);

--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -77,6 +77,25 @@ std::optional<Polygon2d> Polygon2d::create(
   return Polygon2d::create(outer, inners);
 }
 
+autoware::universe_utils::Polygon2d Polygon2d::to_boost() const
+{
+  autoware::universe_utils::Polygon2d polygon;
+
+  for (const auto & point : outer_) {
+    polygon.outer().emplace_back(point.x(), point.y());
+  }
+
+  for (const auto & inner : inners_) {
+    autoware::universe_utils::LinearRing2d _inner;
+    for (const auto & point : inner) {
+      _inner.emplace_back(point.x(), point.y());
+    }
+    polygon.inners().push_back(_inner);
+  }
+
+  return polygon;
+}
+
 std::optional<ConvexPolygon2d> ConvexPolygon2d::create(const PointList2d & vertices) noexcept
 {
   ConvexPolygon2d poly(vertices);

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -211,7 +211,7 @@ bool is_valid_diagonal(
 }
 
 std::size_t insert_point(
-  const Point2d & pt, std::vector<LinkedPoint> & points,
+  const alt::Point2d & pt, std::vector<LinkedPoint> & points,
   const std::optional<std::size_t> last_index)
 {
   std::size_t p_idx = points.size();
@@ -236,20 +236,13 @@ std::size_t insert_point(
 }
 
 std::size_t linked_list(
-  const LinearRing2d & ring, const bool clockwise, std::size_t & vertices,
+  const alt::PointList2d & ring, const bool clockwise, std::size_t & vertices,
   std::vector<LinkedPoint> & points)
 {
-  double sum = 0;
   const std::size_t len = ring.size();
   std::optional<std::size_t> last_index = std::nullopt;
 
-  for (std::size_t i = 0, j = len > 0 ? len - 1 : 0; i < len; j = i++) {
-    const auto & p1 = ring[i];
-    const auto & p2 = ring[j];
-    sum += (p2.x() - p1.x()) * (p1.y() + p2.y());
-  }
-
-  if (clockwise == (sum > 0)) {
+  if (clockwise == is_clockwise(ring)) {
     for (const auto & point : ring) {
       last_index = insert_point(point, points, last_index);
     }
@@ -417,7 +410,7 @@ std::size_t eliminate_hole(
 }
 
 std::size_t eliminate_holes(
-  const std::vector<LinearRing2d> & inners, std::size_t outer_index, std::size_t & vertices,
+  const std::vector<alt::PointList2d> & inners, std::size_t outer_index, std::size_t & vertices,
   std::vector<LinkedPoint> & points)
 {
   std::vector<std::size_t> queue;
@@ -565,7 +558,7 @@ void ear_clipping_linked(
 }
 
 std::vector<LinkedPoint> perform_triangulation(
-  const Polygon2d & polygon, std::vector<std::size_t> & indices)
+  const alt::Polygon2d & polygon, std::vector<std::size_t> & indices)
 {
   indices.clear();
   std::vector<LinkedPoint> points;
@@ -592,12 +585,12 @@ std::vector<LinkedPoint> perform_triangulation(
   return points;
 }
 
-std::vector<Polygon2d> triangulate(const Polygon2d & poly)
+std::vector<alt::ConvexPolygon2d> triangulate(const alt::Polygon2d & poly)
 {
   std::vector<std::size_t> indices;
   auto points = perform_triangulation(poly, indices);
 
-  std::vector<Polygon2d> triangles;
+  std::vector<alt::ConvexPolygon2d> triangles;
   const std::size_t num_indices = indices.size();
 
   if (num_indices % 3 != 0) {
@@ -605,16 +598,30 @@ std::vector<Polygon2d> triangulate(const Polygon2d & poly)
   }
 
   for (std::size_t i = 0; i < num_indices; i += 3) {
-    Polygon2d triangle;
-    triangle.outer().push_back(points[indices[i]].pt);
-    triangle.outer().push_back(points[indices[i + 1]].pt);
-    triangle.outer().push_back(points[indices[i + 2]].pt);
-    triangle.outer().push_back(points[indices[i]].pt);
+    alt::PointList2d vertices;
+    vertices.push_back(points[indices[i]].pt);
+    vertices.push_back(points[indices[i + 1]].pt);
+    vertices.push_back(points[indices[i + 2]].pt);
+    vertices.push_back(points[indices[i]].pt);
 
-    triangles.push_back(triangle);
+    triangles.push_back(alt::ConvexPolygon2d::create(vertices).value());
   }
   points.clear();
   return triangles;
 }
 
+std::vector<Polygon2d> triangulate(const Polygon2d & poly)
+{
+  const auto alt_poly = alt::Polygon2d::create(poly);
+  if (!alt_poly.has_value()) {
+    return {};
+  }
+
+  const auto alt_triangles = triangulate(alt_poly.value());
+  std::vector<Polygon2d> triangles;
+  for (const auto & alt_triangle : alt_triangles) {
+    triangles.push_back(alt_triangle.to_boost());
+  }
+  return triangles;
+}
 }  // namespace autoware::universe_utils

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -416,7 +416,7 @@ std::size_t eliminate_holes(
   std::vector<std::size_t> queue;
 
   for (const auto & ring : inners) {
-    auto inner_index = linked_list(ring, false, vertices, points);
+    auto inner_index = linked_list(ring, true, vertices, points);
 
     if (points[inner_index].next_index.value() == inner_index) {
       points[inner_index].steiner = true;
@@ -570,7 +570,7 @@ std::vector<LinkedPoint> perform_triangulation(
   if (polygon.outer().empty()) return points;
 
   indices.reserve(len + outer_ring.size());
-  auto outer_point_index = linked_list(outer_ring, true, vertices, points);
+  auto outer_point_index = linked_list(outer_ring, false, vertices, points);
   if (
     !points[outer_point_index].prev_index.has_value() ||
     outer_point_index == points[outer_point_index].prev_index.value()) {

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -236,15 +236,19 @@ std::size_t insert_point(
 }
 
 std::size_t linked_list(
-  const alt::PointList2d & ring, const bool clockwise, std::size_t & vertices,
+  const alt::PointList2d & ring, const bool forward, std::size_t & vertices,
   std::vector<LinkedPoint> & points)
 {
   const std::size_t len = ring.size();
   std::optional<std::size_t> last_index = std::nullopt;
 
-  if (clockwise == is_clockwise(ring)) {
-    for (const auto & point : ring) {
-      last_index = insert_point(point, points, last_index);
+  // create forward linked list if forward is true and ring is counter-clockwise, or
+  //                               forward is false and ring is clockwise
+  // create reverse linked list if forward is true and ring is clockwise, or
+  //                               forward is false and ring is counter-clockwise
+  if (forward == !is_clockwise(ring)) {
+    for (auto it = ring.begin(); it != ring.end(); ++it) {
+      last_index = insert_point(*it, points, last_index);
     }
   } else {
     for (auto it = ring.rbegin(); it != ring.rend(); ++it) {
@@ -416,7 +420,7 @@ std::size_t eliminate_holes(
   std::vector<std::size_t> queue;
 
   for (const auto & ring : inners) {
-    auto inner_index = linked_list(ring, true, vertices, points);
+    auto inner_index = linked_list(ring, false, vertices, points);
 
     if (points[inner_index].next_index.value() == inner_index) {
       points[inner_index].steiner = true;
@@ -570,7 +574,7 @@ std::vector<LinkedPoint> perform_triangulation(
   if (polygon.outer().empty()) return points;
 
   indices.reserve(len + outer_ring.size());
-  auto outer_point_index = linked_list(outer_ring, false, vertices, points);
+  auto outer_point_index = linked_list(outer_ring, true, vertices, points);
   if (
     !points[outer_point_index].prev_index.has_value() ||
     outer_point_index == points[outer_point_index].prev_index.value()) {

--- a/common/autoware_universe_utils/src/ros/marker_helper.cpp
+++ b/common/autoware_universe_utils/src/ros/marker_helper.cpp
@@ -16,7 +16,7 @@
 
 namespace autoware::universe_utils
 {
-
+// cppcheck-suppress unusedFunction
 visualization_msgs::msg::Marker createDefaultMarker(
   const std::string & frame_id, const rclcpp::Time & now, const std::string & ns, const int32_t id,
   const int32_t type, const geometry_msgs::msg::Vector3 & scale,
@@ -41,6 +41,7 @@ visualization_msgs::msg::Marker createDefaultMarker(
   return marker;
 }
 
+// cppcheck-suppress unusedFunction
 visualization_msgs::msg::Marker createDeletedDefaultMarker(
   const rclcpp::Time & now, const std::string & ns, const int32_t id)
 {
@@ -54,6 +55,7 @@ visualization_msgs::msg::Marker createDeletedDefaultMarker(
   return marker;
 }
 
+// cppcheck-suppress unusedFunction
 void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
   visualization_msgs::msg::MarkerArray * marker_array,


### PR DESCRIPTION
## Description

This PR eliminates `autoware::universe_utils::triangulate()`'s dependence on Boost.Geometry.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/8128

## How was this PR tested?

```
colcon test --packages-select autoware_universe_utils --event-handlers console_cohesion+
```

gives the following result:

```
1: [ RUN      ] geometry.intersectPolygonWithHoles
1: [       OK ] geometry.intersectPolygonWithHoles (0 ms)
1: [ RUN      ] geometry.intersectConcavePolygonRand
1: polygons_nb = 500, vertices = 4, 236652 / 250000 pairs with intersects
1: 	Intersect:
1: 		Boost::geometry = 175.75 ms
1: 		GJK = 40.57 ms
1: 		SAT = 52.92 ms
1: 	No Intersect:
1: 		Boost::geometry = 17.93 ms
1: 		GJK = 4.80 ms
1: 		SAT = 3.44 ms
1: 	Total:
1: 		Triangulation = 0.63 ms
1: polygons_nb = 500, vertices = 5, 242428 / 250000 pairs with intersects
1: 	Intersect:
1: 		Boost::geometry = 203.25 ms
1: 		GJK = 46.07 ms
1: 		SAT = 56.45 ms
1: 	No Intersect:
1: 		Boost::geometry = 11.52 ms
1: 		GJK = 4.92 ms
1: 		SAT = 3.49 ms
1: 	Total:
1: 		Triangulation = 0.87 ms
1: polygons_nb = 500, vertices = 6, 245274 / 250000 pairs with intersects
1: 	Intersect:
1: 		Boost::geometry = 225.67 ms
1: 		GJK = 53.28 ms
1: 		SAT = 60.98 ms
1: 	No Intersect:
1: 		Boost::geometry = 9.43 ms
1: 		GJK = 4.71 ms
1: 		SAT = 3.46 ms
1: 	Total:
1: 		Triangulation = 1.15 ms
1: polygons_nb = 500, vertices = 7, 246004 / 250000 pairs with intersects
1: 	Intersect:
1: 		Boost::geometry = 241.27 ms
1: 		GJK = 57.20 ms
1: 		SAT = 63.14 ms
1: 	No Intersect:
1: 		Boost::geometry = 7.36 ms
1: 		GJK = 6.18 ms
1: 		SAT = 4.36 ms
1: 	Total:
1: 		Triangulation = 1.44 ms
1: polygons_nb = 500, vertices = 8, 248090 / 250000 pairs with intersects
1: 	Intersect:
1: 		Boost::geometry = 260.09 ms
1: 		GJK = 62.58 ms
1: 		SAT = 66.66 ms
1: 	No Intersect:
1: 		Boost::geometry = 3.89 ms
1: 		GJK = 3.96 ms
1: 		SAT = 2.74 ms
1: 	Total:
1: 		Triangulation = 1.67 ms
1: polygons_nb = 500, vertices = 9, 247808 / 250000 pairs with intersects
1: 	Intersect:
1: 		Boost::geometry = 272.88 ms
1: 		GJK = 66.60 ms
1: 		SAT = 68.53 ms
1: 	No Intersect:
1: 		Boost::geometry = 4.79 ms
1: 		GJK = 5.61 ms
1: 		SAT = 3.88 ms
1: 	Total:
1: 		Triangulation = 1.92 ms
1: [       OK ] geometry.intersectConcavePolygonRand (2392 ms)
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
