### PR TITLE
feat(tier4_planning_rviz_plugin): set path colors from rviz and add fade_out feature

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -36,6 +36,7 @@
 #include <OgreSceneNode.h>
 
 #include <deque>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -71,10 +71,10 @@ std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
 
   std::unique_ptr<Ogre::ColourValue> color_ptr(new Ogre::ColourValue());
   if (vel_min < cmd_vel_abs && cmd_vel_abs <= (vel_max / 2.0)) {
-    double ratio = (cmd_vel_abs) / (vel_max / 2.0);
+    double ratio = (cmd_vel_abs - vel_min) / (vel_max / 2.0 - vel_min);
     color_ptr = gradation(color_min.getColor(), color_mid.getColor(), ratio);
   } else if ((vel_max / 2.0) < cmd_vel_abs && cmd_vel_abs <= vel_max) {
-    double ratio = (cmd_vel_abs - vel_max / 2.0) / (vel_max / 2.0);
+    double ratio = (cmd_vel_abs - vel_max / 2.0) / (vel_max - vel_max / 2.0);
     color_ptr = gradation(color_mid.getColor(), color_max.getColor(), ratio);
   } else if (vel_max < cmd_vel_abs) {
     // Use max color when velocity exceeds max

--- a/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -651,11 +651,11 @@ protected:
   rviz_common::properties::BoolProperty property_path_width_view_;
   rviz_common::properties::FloatProperty property_path_width_;
   rviz_common::properties::FloatProperty property_path_alpha_;
-  // Properties for customizable colors
+  // Gradient points for velocity color
   rviz_common::properties::ColorProperty property_min_color_;
   rviz_common::properties::ColorProperty property_mid_color_;
   rviz_common::properties::ColorProperty property_max_color_;
-  // Property for fading out the path
+  // Last x meters of the path will fade out to transparent
   rviz_common::properties::FloatProperty property_fade_out_distance_;
 
   rviz_common::properties::FloatProperty property_vel_max_;

--- a/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -75,7 +75,6 @@ std::unique_ptr<Ogre::ColourValue> setColorDependsOnVelocity(
     color_ptr = gradation(color_min.getColor(), color_mid.getColor(), ratio);
   } else if ((vel_max / 2.0) < cmd_vel_abs && cmd_vel_abs <= vel_max) {
     double ratio = (cmd_vel_abs - vel_max / 2.0) / (vel_max / 2.0);
-
     color_ptr = gradation(color_mid.getColor(), color_max.getColor(), ratio);
   } else if (vel_max < cmd_vel_abs) {
     // Use max color when velocity exceeds max

--- a/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -54,8 +54,7 @@ std::unique_ptr<Ogre::ColourValue> gradation(
   color_ptr->g =
     static_cast<float>(color_max.greenF() * ratio + color_min.greenF() * (1.0 - ratio));
   color_ptr->r = static_cast<float>(color_max.redF() * ratio + color_min.redF() * (1.0 - ratio));
-  color_ptr->b =
-    static_cast<float>(color_max.blueF() * ratio + color_min.blueF() * (1.0 - ratio));
+  color_ptr->b = static_cast<float>(color_max.blueF() * ratio + color_min.blueF() * (1.0 - ratio));
 
   return color_ptr;
 }


### PR DESCRIPTION
## Description
Updating the style of the path/trajectory display plugin

## Related links

### Videos

- https://www.youtube.com/playlist?list=PL97OXOB9UA-gSyZWr3VVn4dNnBtt0lqTp


## How was this PR tested?

Just run the planning sim demo.

## Notes for reviewers

We don't need to modify autoware_launch rviz config file because the defaults are set in the plugin.

## Interface changes

New parameters are added:

- property_min_color_("Min Velocity Color", QColor("`#3F2EE3`"), "", &property_path_view_)
- property_mid_color_("Mid Velocity Color", QColor("`#208AAE`"), "", &property_path_view_)
- property_max_color_("Max Velocity Color", QColor("`#00E678`"), "", &property_path_view_)
- property_fade_out_distance_{"Fade Out Distance", 0.0, "[m]", &property_path_view_}

## Effects on system behavior

None.
