### PR TITLE
fix(lane_change): fix abort distance enough check

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -121,9 +121,6 @@ std::vector<DrivableLanes> generateDrivableLanes(
 
 double getLateralShift(const LaneChangePath & path);
 
-bool hasEnoughLengthToLaneChangeAfterAbort(
-  const CommonDataPtr & common_data_ptr, const double abort_return_dist);
-
 CandidateOutput assignToCandidate(
   const LaneChangePath & lane_change_path, const Point & ego_position);
 std::optional<lanelet::ConstLanelet> getLaneChangeTargetLane(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1963,8 +1963,12 @@ bool NormalLaneChange::calcAbortPath()
     return false;
   }
 
-  if (!utils::lane_change::hasEnoughLengthToLaneChangeAfterAbort(
-        common_data_ptr_, abort_return_dist)) {
+  const auto enough_abort_dist =
+    abort_start_dist + abort_return_dist +
+      calculation::calc_stopping_distance(common_data_ptr_->lc_param_ptr) <=
+    common_data_ptr_->transient_data.dist_to_terminal_start;
+
+  if (!enough_abort_dist) {
     RCLCPP_ERROR(logger_, "insufficient distance to abort.");
     return false;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -548,26 +548,6 @@ double getLateralShift(const LaneChangePath & path)
   return path.shifted_path.shift_length.at(end_idx) - path.shifted_path.shift_length.at(start_idx);
 }
 
-bool hasEnoughLengthToLaneChangeAfterAbort(
-  const CommonDataPtr & common_data_ptr, const double abort_return_dist)
-{
-  const auto & current_lanes = common_data_ptr->lanes_ptr->current;
-  if (current_lanes.empty()) {
-    return false;
-  }
-
-  const auto & current_pose = common_data_ptr->get_ego_pose();
-  const auto abort_plus_lane_change_length =
-    abort_return_dist + common_data_ptr->transient_data.current_dist_buffer.min;
-  if (abort_plus_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
-    return false;
-  }
-
-  const auto goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
-  return abort_plus_lane_change_length <=
-         utils::getSignedDistance(current_pose, goal_pose, current_lanes);
-}
-
 std::vector<std::vector<int64_t>> getSortedLaneIds(
   const RouteHandler & route_handler, const Pose & current_pose,
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes)


### PR DESCRIPTION
## Description

Before abort path is computed, lane change module check if the remaining distance is sufficient to re-attempt lane change.

Using the following  image as example

![image](https://github.com/user-attachments/assets/9791e834-d134-49bc-bc02-bbf4ba534b0d)

The total remaining distance should be
```
abort start distance + abort distance + min stopping dist + min dist buffer <= dist to terminal
```

The current computation only

```
abort distance + min dist buffer <= dist to terminal
```
which is incorrect.

This PR aims to fix the incorrect  computation.

## Related links

- [TIER IV internal link](https://star4.slack.com/archives/C04HK9T2E0N/p1727415580962899?thread_ts=1727381189.356109&cid=C04HK9T2E0N)
- [TIER IV Internal link](https://tier4.atlassian.net/browse/RT1-7991)
- [Evaluator](https://evaluation.tier4.jp/evaluation/reports/bf054099-496a-52e7-8291-955797e8b13c?project_id=prd_jt)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
