### PR TITLE
fix(autoware_lidar_centerpoint): convert object's velocity to follow its definition

### DIFF
--- a/perception/autoware_lidar_centerpoint/lib/ros_utils.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/ros_utils.cpp
@@ -68,10 +68,8 @@ void box3DToDetectedObject(
     float vel_x = box3d.vel_x;
     float vel_y = box3d.vel_y;
     geometry_msgs::msg::Twist twist;
-    const float vel_norm = std::sqrt(vel_x * vel_x + vel_y * vel_y);
-    const float angle_diff = std::atan2(vel_y, vel_x) - yaw;
-    twist.linear.x = vel_norm * std::cos(angle_diff);
-    twist.linear.y = vel_norm * std::sin(angle_diff);
+    twist.linear.x = std::cos(yaw) * vel_x + std::sin(yaw) * vel_y;
+    twist.linear.y = -std::sin(yaw) * vel_x + std::cos(yaw) * vel_y;
     twist.angular.z = 0;  // angular velocity is not supported
 
     obj.kinematics.twist_with_covariance.twist = twist;

--- a/perception/autoware_lidar_centerpoint/lib/ros_utils.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/ros_utils.cpp
@@ -68,8 +68,12 @@ void box3DToDetectedObject(
     float vel_x = box3d.vel_x;
     float vel_y = box3d.vel_y;
     geometry_msgs::msg::Twist twist;
-    twist.linear.x = std::sqrt(std::pow(vel_x, 2) + std::pow(vel_y, 2));
-    twist.angular.z = 2 * (std::atan2(vel_y, vel_x) - yaw);
+    const float vel_norm = std::sqrt(vel_x * vel_x + vel_y * vel_y);
+    const float angle_diff = std::atan2(vel_y, vel_x) - yaw;
+    twist.linear.x = vel_norm * std::cos(angle_diff);
+    twist.linear.y = vel_norm * std::sin(angle_diff);
+    twist.angular.z = 0;  // angular velocity is not supported
+
     obj.kinematics.twist_with_covariance.twist = twist;
     obj.kinematics.has_twist = has_twist;
     if (has_variance) {


### PR DESCRIPTION
## Description

The centerpoint velocity is in the world_frame_id. The object message velocity is based on its object's pose. 
This PR is fixing the implementation of the velocity conversion to follow those definition.

The yaw rate (rotation speed) is not obtained, so set it as zero.


Before

![Screenshot from 2024-09-27 18-25-31](https://github.com/user-attachments/assets/bc27a18f-904d-4c09-a722-fb4ccfd51853)

Yaw rate (Red circle) are shown as a large or none.
Velocity(Red stick) heads to its bounding box (Blue box) orientation, which is not always true.

After

![Screenshot from 2024-09-27 18-23-29](https://github.com/user-attachments/assets/f2b9e159-fc2a-48a4-9925-543d872294f7)

The bounding box orientation and the velocity vector is not always the same direction, but it is as the inference result.
Yaw rates are zero.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
