### PR TITLE
fix(goal_planner): fix freespace planning chattering

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1329,9 +1329,12 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsOutput(
     return getPreviousModuleOutput();
   }
 
+  const bool is_freespace =
+    thread_safe_data_.getPullOverPlannerType() == PullOverPlannerType::FREESPACE;
   if (
     path_decision_controller_.get_current_state().state ==
       PathDecisionState::DecisionKind::NOT_DECIDED &&
+    !is_freespace &&
     needPathUpdate(
       planner_data_->self_odometry->pose.pose, 1.0 /*path_update_duration*/, *parameters_)) {
     // if the final path is not decided and enough time has passed since last path update,
@@ -1370,9 +1373,7 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsOutput(
   setOutput(context_data, output);
 
   // return to lane parking if it is possible
-  if (
-    thread_safe_data_.getPullOverPlannerType() == PullOverPlannerType::FREESPACE &&
-    canReturnToLaneParking(context_data)) {
+  if (is_freespace && canReturnToLaneParking(context_data)) {
     thread_safe_data_.set_pull_over_path(thread_safe_data_.get_lane_parking_pull_over_path());
   }
 


### PR DESCRIPTION
## Description

updating path during not decided status caseus freespace planning cancel.
In this PR, when freespace planning stop lane parking path update.

before

https://github.com/user-attachments/assets/d5e08d99-db33-471a-a74c-d13a2f1f51ad

after

https://github.com/user-attachments/assets/a23e4f29-acb1-433a-a553-820d2013322d




## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

2024/09/27 https://evaluation.tier4.jp/evaluation/reports/6b782f80-be1a-5495-84f2-92f4314a972f/?project_id=prd_jt

2024/09/27 https://evaluation.tier4.jp/evaluation/reports/1c24e789-e846-58a4-8a75-7ab696289e7c/?project_id=prd_jt


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
