### PR TITLE
fix(universe_utils): avoid test timeout

### DIFF
--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -723,7 +723,7 @@ TEST(alt_geometry, within)
 TEST(alt_geometry, areaRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -763,7 +763,7 @@ TEST(alt_geometry, areaRand)
 TEST(alt_geometry, convexHullRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -811,7 +811,7 @@ TEST(alt_geometry, convexHullRand)
 TEST(alt_geometry, coveredByRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -878,7 +878,7 @@ TEST(alt_geometry, coveredByRand)
 TEST(alt_geometry, disjointRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -944,7 +944,7 @@ TEST(alt_geometry, disjointRand)
 TEST(alt_geometry, intersectsRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -1010,7 +1010,7 @@ TEST(alt_geometry, intersectsRand)
 TEST(alt_geometry, touchesRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -1077,7 +1077,7 @@ TEST(alt_geometry, touchesRand)
 TEST(alt_geometry, withinPolygonRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 

--- a/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
@@ -1937,7 +1937,7 @@ TEST(
 TEST(geometry, intersectPolygonRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 
@@ -2227,7 +2227,7 @@ TEST(geometry, intersectConcavePolygonRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
   std::vector<std::vector<autoware::universe_utils::Polygon2d>> triangulations;
-  constexpr auto polygons_nb = 500;
+  constexpr auto polygons_nb = 100;
   constexpr auto max_vertices = 10;
   constexpr auto max_values = 1000;
 


### PR DESCRIPTION
## Description

This PR avoids tests of `autoware_universe_utils` package from timing out.

## How was this PR tested?

```
colcon test --packages-select autoware_universe_utils --event-handlers console_cohesion+
```

Before:

```
Label Time Summary:
copyright     =   3.87 sec*proc (1 test)
cppcheck      =   0.16 sec*proc (1 test)
gtest         =  48.97 sec*proc (1 test)
lint_cmake    =   0.15 sec*proc (1 test)
linter        =   5.05 sec*proc (4 tests)
xmllint       =   0.87 sec*proc (1 test)

Total Test time (real) =  54.03 sec
```

After:

```
Label Time Summary:
copyright     =   3.56 sec*proc (1 test)
cppcheck      =   0.14 sec*proc (1 test)
gtest         =  14.69 sec*proc (1 test)
lint_cmake    =   0.14 sec*proc (1 test)
linter        =   4.90 sec*proc (4 tests)
xmllint       =   1.06 sec*proc (1 test)

Total Test time (real) =  19.60 sec
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
