### PR TITLE
fix(autoware_utils): Address self-intersecting polygons in random_concave_generator and handle empty inners() during triangulation

### DIFF
--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -582,7 +582,12 @@ std::vector<LinkedPoint> perform_triangulation(
   }
 
   if (!polygon.inners().empty()) {
-    outer_point_index = eliminate_holes(polygon.inners(), outer_point_index, vertices, points);
+    const auto & inner_rings = polygon.inners();
+    bool has_non_empty_holes = std::any_of(
+      inner_rings.begin(), inner_rings.end(), [](const auto & ring) { return !ring.empty(); });
+    if (has_non_empty_holes) {
+      outer_point_index = eliminate_holes(inner_rings, outer_point_index, vertices, points);
+    }
   }
 
   ear_clipping_linked(outer_point_index, indices, points);

--- a/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp
+++ b/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp
@@ -140,24 +140,17 @@ bool intersecting(const Edge & e, const Polygon2d & polygon)
 /// @brief checks if an edge is valid for a given polygon and set of points
 bool is_valid(const Edge & e, const Polygon2d & P, const std::vector<Point2d> & Q)
 {
-  bool valid = false;
-  size_t i = 0;
-
-  while (!valid && i < Q.size()) {
-    const Point2d & q = Q[i];
+  for (const Point2d & q : Q) {
     Edge e1 = {e.first, q};
     Edge e2 = {q, e.second};
     bool intersects_e1 = intersecting(e1, P);
     bool intersects_e2 = intersecting(e2, P);
-
-    if (!intersects_e1 && !intersects_e2) {
-      valid = true;
+    if (intersects_e1 || intersects_e2) {
+      return false;
     }
-
-    ++i;
   }
 
-  return valid;
+  return true;
 }
 
 /// @brief finds the nearest node from a set of points to an edge


### PR DESCRIPTION
## Description

This fix two issues in autoware_utils:

- Self-intersecting polygons in random_concave_generator: fix is_valid function to properly validate inserted edges.

- Handling empty inners() during triangulation: ensures that empty inners() are properly handled in the triangulation process.

## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- Unit test on self- intersecting polygon and polygon with empty inners().

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
