### PR TITLE
fix(autoware_lidar_centerpoint): fix twist covariance orientation

### DIFF
--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/ros_utils.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/ros_utils.hpp
@@ -35,7 +35,7 @@ uint8_t getSemanticType(const std::string & class_name);
 
 std::array<double, 36> convertPoseCovarianceMatrix(const Box3D & box3d);
 
-std::array<double, 36> convertTwistCovarianceMatrix(const Box3D & box3d);
+std::array<double, 36> convertTwistCovarianceMatrix(const Box3D & box3d, const float yaw);
 
 bool isCarLikeVehicleLabel(const uint8_t label);
 

--- a/perception/autoware_lidar_centerpoint/test/test_ros_utils.cpp
+++ b/perception/autoware_lidar_centerpoint/test/test_ros_utils.cpp
@@ -125,13 +125,14 @@ TEST(TestSuite, convertPoseCovarianceMatrix)
 TEST(TestSuite, convertTwistCovarianceMatrix)
 {
   autoware::lidar_centerpoint::Box3D box3d;
-  box3d.vel_x_variance = 0.1;
+  box3d.vel_x_variance = 0.5;
   box3d.vel_y_variance = 0.2;
+  float yaw = 0;
 
   std::array<double, 36> twist_covariance =
-    autoware::lidar_centerpoint::convertTwistCovarianceMatrix(box3d);
+    autoware::lidar_centerpoint::convertTwistCovarianceMatrix(box3d, yaw);
 
-  EXPECT_FLOAT_EQ(twist_covariance[0], 0.1);
+  EXPECT_FLOAT_EQ(twist_covariance[0], 0.5);
   EXPECT_FLOAT_EQ(twist_covariance[7], 0.2);
 }
 


### PR DESCRIPTION
## Description

Fix the twist covariance converter considering the twist covariance matrix is based on the object coordinate.

Before

![Screenshot from 2024-10-01 16-29-22](https://github.com/user-attachments/assets/3398aa3c-d65f-4b03-a321-f9cdb161d598)

The twist (velocity) estimation of the centerpoint is based on the base_link frame. The covariance is also the same.
In the shown case, a vehicle in front has velocity negative Y direction to the ego vehicle, and the covariance of the velocity is large in Y direction.
However, the twist covariance is directly inserted to Y coordinate of the object message, and it showed large twist covariance in lateral object velocity.

After

![Screenshot from 2024-10-01 16-35-32](https://github.com/user-attachments/assets/010a6cd7-c656-4dc8-95df-d05c45a3ee28)

The twist covariance is translated to the object coordinate, which is by its definition. 
As result, the twist covariance is oriented in Y direction to the ego vehicle, as expected.


NOTE: There is not inference of covariance of XY and YX. The covariance eclipse always oriented in the same direction to the base_link frame. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
