### PR TITLE
refactor(autoware_multi_object_tracker): separate detected object covariance modeling

### DIFF
--- a/perception/autoware_multi_object_tracker/CMakeLists.txt
+++ b/perception/autoware_multi_object_tracker/CMakeLists.txt
@@ -44,6 +44,7 @@ set(${PROJECT_NAME}_lib
   lib/tracker/model/pedestrian_and_bicycle_tracker.cpp
   lib/tracker/model/unknown_tracker.cpp
   lib/tracker/model/pass_through_tracker.cpp
+  lib/uncertainty/uncertainty_processor.cpp
 )
 ament_auto_add_library(${PROJECT_NAME} SHARED
   ${${PROJECT_NAME}_src}

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -16,8 +16,8 @@
 // Author: v1.0 Taekjin Lee
 //
 
-#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__OBJECT_MODEL__OBJECT_MODEL_HPP_
-#define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__OBJECT_MODEL__OBJECT_MODEL_HPP_
+#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__OBJECT_MODEL_HPP_
+#define AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__OBJECT_MODEL_HPP_
 
 #include <cmath>
 
@@ -53,9 +53,6 @@ namespace object_model
 {
 
 enum class ObjectModelType { NormalVehicle, BigVehicle, Bicycle, Pedestrian, Unknown };
-
-
-
 
 struct ObjectSize
 {
@@ -291,7 +288,16 @@ public:
         measurement_covariance.pos_x = sq(0.4);
         measurement_covariance.pos_y = sq(0.4);
         measurement_covariance.yaw = sq(deg2rad(30.0));
+        measurement_covariance.vel_long = sq(kmph2mps(5.0));
+        break;
 
+      case ObjectModelType::Unknown:
+        // measurement noise model
+        measurement_covariance.pos_x = sq(1.0);
+        measurement_covariance.pos_y = sq(1.0);
+        measurement_covariance.yaw = sq(deg2rad(360.0));
+        measurement_covariance.vel_long = sq(kmph2mps(10.0));
+        measurement_covariance.vel_lat = sq(kmph2mps(10.0));
         break;
 
       default:
@@ -306,8 +312,9 @@ static const ObjectModel normal_vehicle(ObjectModelType::NormalVehicle);
 static const ObjectModel big_vehicle(ObjectModelType::BigVehicle);
 static const ObjectModel bicycle(ObjectModelType::Bicycle);
 static const ObjectModel pedestrian(ObjectModelType::Pedestrian);
+static const ObjectModel unknown(ObjectModelType::Unknown);
 
 }  // namespace object_model
 }  // namespace autoware::multi_object_tracker
 
-#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__OBJECT_MODEL__OBJECT_MODEL_HPP_
+#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__OBJECT_MODEL_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -144,6 +144,7 @@ public:
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
         process_limit.vel_long_max = kmph2mps(140.0);
+        process_limit.yaw_rate_max = deg2rad(15.0);
 
         // initial covariance
         initial_covariance.pos_x = sq(1.0);
@@ -188,6 +189,7 @@ public:
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
         process_limit.vel_long_max = kmph2mps(140.0);
+        process_limit.yaw_rate_max = deg2rad(15.0);
 
         // initial covariance
         initial_covariance.pos_x = sq(1.5);
@@ -232,6 +234,7 @@ public:
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
         process_limit.vel_long_max = kmph2mps(120.0);
+        process_limit.yaw_rate_max = deg2rad(15.0);
 
         // initial covariance
         initial_covariance.pos_x = sq(0.8);

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -144,7 +144,6 @@ public:
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
         process_limit.vel_long_max = kmph2mps(140.0);
-        process_limit.yaw_rate_max = deg2rad(15.0);
 
         // initial covariance
         initial_covariance.pos_x = sq(1.0);
@@ -189,7 +188,6 @@ public:
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
         process_limit.vel_long_max = kmph2mps(140.0);
-        process_limit.yaw_rate_max = deg2rad(15.0);
 
         // initial covariance
         initial_covariance.pos_x = sq(1.5);
@@ -234,7 +232,6 @@ public:
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
         process_limit.vel_long_max = kmph2mps(120.0);
-        process_limit.yaw_rate_max = deg2rad(15.0);
 
         // initial covariance
         initial_covariance.pos_x = sq(0.8);

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -53,6 +53,10 @@ namespace object_model
 {
 
 enum class ObjectModelType { NormalVehicle, BigVehicle, Bicycle, Pedestrian, Unknown };
+
+
+
+
 struct ObjectSize
 {
   double length{0.0};  // [m]

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/bicycle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/bicycle_tracker.hpp
@@ -20,9 +20,9 @@
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__MODEL__BICYCLE_TRACKER_HPP_
 
 #include "autoware/kalman_filter/kalman_filter.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
-#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/bicycle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/bicycle_tracker.hpp
@@ -22,7 +22,7 @@
 #include "autoware/kalman_filter/kalman_filter.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
-#include "autoware/multi_object_tracker/tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
@@ -22,7 +22,7 @@
 #include "autoware/kalman_filter/kalman_filter.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
-#include "autoware/multi_object_tracker/tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
@@ -20,9 +20,9 @@
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__MODEL__BIG_VEHICLE_TRACKER_HPP_
 
 #include "autoware/kalman_filter/kalman_filter.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
-#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
@@ -22,7 +22,7 @@
 #include "autoware/kalman_filter/kalman_filter.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
-#include "autoware/multi_object_tracker/tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
@@ -20,9 +20,9 @@
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__MODEL__NORMAL_VEHICLE_TRACKER_HPP_
 
 #include "autoware/kalman_filter/kalman_filter.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
-#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
@@ -22,7 +22,7 @@
 #include "autoware/kalman_filter/kalman_filter.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp"
-#include "autoware/multi_object_tracker/tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
@@ -20,9 +20,9 @@
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__MODEL__PEDESTRIAN_TRACKER_HPP_
 
 #include "autoware/kalman_filter/kalman_filter.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/model/tracker_base.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp"
-#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -45,7 +45,7 @@ private:
   double lf_;
   double lr_;
 
-  // motion parameters
+  // motion parameters: process noise and motion limits
   struct MotionParams
   {
     double q_stddev_acc_long = 3.43;         // [m/s^2] uncertain longitudinal acceleration, 0.35G

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -48,21 +48,22 @@ private:
   // motion parameters
   struct MotionParams
   {
-    double q_stddev_acc_long;
-    double q_stddev_acc_lat;
-    double q_cov_acc_long;
-    double q_cov_acc_lat;
-    double q_stddev_yaw_rate_min;
-    double q_stddev_yaw_rate_max;
-    double q_cov_slip_rate_min;
-    double q_cov_slip_rate_max;
-    double q_max_slip_angle;
-    double lf_ratio;
-    double lr_ratio;
-    double lf_min;
-    double lr_min;
-    double max_vel;
-    double max_slip;
+    double q_stddev_acc_long = 3.43;         // [m/s^2] uncertain longitudinal acceleration, 0.35G
+    double q_stddev_acc_lat = 1.47;          // [m/s^2] uncertain longitudinal acceleration, 0.15G
+    double q_cov_acc_long = 11.8;            // [m/s^2] uncertain longitudinal acceleration, 0.35G
+    double q_cov_acc_lat = 2.16;             // [m/s^2] uncertain lateral acceleration, 0.15G
+    double q_stddev_yaw_rate_min = 0.02618;  // [rad/s] uncertain yaw change rate, 1.5deg/s
+    double q_stddev_yaw_rate_max = 0.2618;   // [rad/s] uncertain yaw change rate, 15deg/s
+    double q_cov_slip_rate_min =
+      2.7416e-5;  // [rad^2/s^2] uncertain slip angle change rate, 0.3 deg/s
+    double q_cov_slip_rate_max = 0.03046;  // [rad^2/s^2] uncertain slip angle change rate, 10 deg/s
+    double q_max_slip_angle = 0.5236;      // [rad] max slip angle, 30deg
+    double lf_ratio = 0.3;     // [-] ratio of the distance from the center to the front wheel
+    double lr_ratio = 0.25;    // [-] ratio of the distance from the center to the rear wheel
+    double lf_min = 1.0;       // [m] minimum distance from the center to the front wheel
+    double lr_min = 1.0;       // [m] minimum distance from the center to the rear wheel
+    double max_vel = 27.8;     // [m/s] maximum velocity, 100km/h
+    double max_slip = 0.5236;  // [rad] maximum slip angle, 30deg
   } motion_params_;
 
 public:
@@ -75,8 +76,6 @@ public:
     const rclcpp::Time & time, const double & x, const double & y, const double & yaw,
     const std::array<double, 36> & pose_cov, const double & vel, const double & vel_cov,
     const double & slip, const double & slip_cov, const double & length);
-
-  void setDefaultParams();
 
   void setMotionParams(
     const double & q_stddev_acc_long, const double & q_stddev_acc_lat,

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
@@ -45,13 +45,13 @@ private:
   // motion parameters
   struct MotionParams
   {
-    double q_cov_x;
-    double q_cov_y;
-    double q_cov_yaw;
-    double q_cov_vel;
-    double q_cov_wz;
-    double max_vel;
-    double max_wz;
+    double q_cov_x = 0.025;     // [m^2/s^2] uncertain position in x, 0.5m/s
+    double q_cov_y = 0.025;     // [m^2/s^2] uncertain position in y, 0.5m/s
+    double q_cov_yaw = 0.1218;  // [rad^2/s^2] uncertain yaw angle, 20deg/s
+    double q_cov_vel = 8.6436;  // [m^2/s^4] uncertain velocity, 0.3G m/s^2
+    double q_cov_wz = 0.5236;   // [rad^2/s^4] uncertain yaw rate, 30deg/s^2
+    double max_vel = 2.78;      // [m/s] maximum velocity
+    double max_wz = 0.5236;     // [rad/s] maximum yaw rate, 30deg/s
   } motion_params_;
 
 public:
@@ -64,8 +64,6 @@ public:
     const rclcpp::Time & time, const double & x, const double & y, const double & yaw,
     const std::array<double, 36> & pose_cov, const double & vel, const double & vel_cov,
     const double & wz, const double & wz_cov);
-
-  void setDefaultParams();
 
   void setMotionParams(
     const double & q_stddev_x, const double & q_stddev_y, const double & q_stddev_yaw,

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
@@ -42,7 +42,7 @@ private:
   // attributes
   rclcpp::Logger logger_;
 
-  // motion parameters
+  // motion parameters: process noise and motion limits
   struct MotionParams
   {
     double q_cov_x = 0.025;     // [m^2/s^2] uncertain position in x, 0.5m/s

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/cv_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/cv_motion_model.hpp
@@ -41,7 +41,7 @@ private:
   // attributes
   rclcpp::Logger logger_;
 
-  // motion parameters
+  // motion parameters: process noise and motion limits
   struct MotionParams
   {
     double q_cov_x = 0.025;    // [m^2/s^2] uncertain position in x, 0.5m/s

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/cv_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/cv_motion_model.hpp
@@ -44,12 +44,12 @@ private:
   // motion parameters
   struct MotionParams
   {
-    double q_cov_x;
-    double q_cov_y;
-    double q_cov_vx;
-    double q_cov_vy;
-    double max_vx;
-    double max_vy;
+    double q_cov_x = 0.025;    // [m^2/s^2] uncertain position in x, 0.5m/s
+    double q_cov_y = 0.025;    // [m^2/s^2] uncertain position in y, 0.5m/s
+    double q_cov_vx = 8.6436;  // [m^2/s^4] uncertain velocity, 0.3G m/s^2
+    double q_cov_vy = 8.6436;  // [m^2/s^4] uncertain velocity, 0.3G m/s^2
+    double max_vx = 16.67;     // [m/s] maximum velocity, 60km/h
+    double max_vy = 16.67;     // [m/s] maximum velocity, 60km/h
   } motion_params_;
 
 public:
@@ -62,8 +62,6 @@ public:
     const rclcpp::Time & time, const double & x, const double & y,
     const std::array<double, 36> & pose_cov, const double & vx, const double & vy,
     const std::array<double, 36> & twist_cov);
-
-  void setDefaultParams();
 
   void setMotionParams(
     const double & q_stddev_x, const double & q_stddev_y, const double & q_stddev_vx,

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Tier IV, Inc.
+// Copyright 2024 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp
@@ -1,0 +1,51 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Author: v1.0 Taekjin Lee
+
+#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__UNCERTAINTY__UNCERTAINTY_PROCESSOR_HPP_
+#define AUTOWARE__MULTI_OBJECT_TRACKER__UNCERTAINTY__UNCERTAINTY_PROCESSOR_HPP_
+
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
+
+#include <object_recognition_utils/object_recognition_utils.hpp>
+
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+
+namespace autoware::multi_object_tracker
+{
+
+namespace uncertainty
+{
+
+using autoware::multi_object_tracker::object_model::ObjectModel;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+
+ObjectModel decodeObjectModel(const ObjectClassification & object_class);
+
+DetectedObjects modelUncertainty(const DetectedObjects & detected_objects);
+
+DetectedObject modelUncertaintyByClass(
+  const DetectedObject & detected_object, const ObjectClassification & object_class);
+
+void normalizeUncertainty(DetectedObjects & detected_objects);
+
+}  // namespace uncertainty
+
+}  // namespace autoware::multi_object_tracker
+
+#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__UNCERTAINTY__UNCERTAINTY_PROCESSOR_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp
@@ -39,7 +39,7 @@ ObjectModel decodeObjectModel(const ObjectClassification & object_class);
 
 DetectedObjects modelUncertainty(const DetectedObjects & detected_objects);
 
-DetectedObject modelUncertaintyByClass(
+object_model::StateCovariance covarianceFromObjectClass(
   const DetectedObject & detected_object, const ObjectClassification & object_class);
 
 void normalizeUncertainty(DetectedObjects & detected_objects);

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
@@ -162,42 +162,6 @@ autoware_perception_msgs::msg::DetectedObject BicycleTracker::getUpdatingObject(
     }
   }
 
-  // UNCERTAINTY MODEL
-  if (!object.kinematics.has_position_covariance) {
-    // measurement noise covariance
-    auto r_cov_x = object_model_.measurement_covariance.pos_x;
-    auto r_cov_y = object_model_.measurement_covariance.pos_y;
-
-    // yaw angle fix
-    const double pose_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-    const bool is_yaw_available =
-      object.kinematics.orientation_availability !=
-      autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
-
-    // fill covariance matrix
-    using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-    auto & pose_cov = updating_object.kinematics.pose_with_covariance.covariance;
-    const double cos_yaw = std::cos(pose_yaw);
-    const double sin_yaw = std::sin(pose_yaw);
-    const double sin_2yaw = std::sin(2.0 * pose_yaw);
-    pose_cov[XYZRPY_COV_IDX::X_X] =
-      r_cov_x * cos_yaw * cos_yaw + r_cov_y * sin_yaw * sin_yaw;           // x - x
-    pose_cov[XYZRPY_COV_IDX::X_Y] = 0.5 * (r_cov_x - r_cov_y) * sin_2yaw;  // x - y
-    pose_cov[XYZRPY_COV_IDX::Y_Y] =
-      r_cov_x * sin_yaw * sin_yaw + r_cov_y * cos_yaw * cos_yaw;                   // y - y
-    pose_cov[XYZRPY_COV_IDX::Y_X] = pose_cov[XYZRPY_COV_IDX::X_Y];                 // y - x
-    pose_cov[XYZRPY_COV_IDX::X_YAW] = 0.0;                                         // x - yaw
-    pose_cov[XYZRPY_COV_IDX::Y_YAW] = 0.0;                                         // y - yaw
-    pose_cov[XYZRPY_COV_IDX::YAW_X] = 0.0;                                         // yaw - x
-    pose_cov[XYZRPY_COV_IDX::YAW_Y] = 0.0;                                         // yaw - y
-    pose_cov[XYZRPY_COV_IDX::YAW_YAW] = object_model_.measurement_covariance.yaw;  // yaw - yaw
-    if (!is_yaw_available) {
-      pose_cov[XYZRPY_COV_IDX::YAW_YAW] *= 1e3;  // yaw is not available, multiply large value
-    }
-    auto & twist_cov = updating_object.kinematics.twist_with_covariance.covariance;
-    twist_cov[XYZRPY_COV_IDX::X_X] = object_model_.measurement_covariance.vel_long;  // vel - vel
-  }
-
   return updating_object;
 }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
@@ -97,7 +97,7 @@ BicycleTracker::BicycleTracker(
   // Set motion limits
   {
     const double max_vel = object_model_.process_limit.vel_long_max;
-    const double max_slip = object_model_.bicycle_state.slip_angle_max;
+    const double max_slip = object_model_.process_limit.yaw_rate_max;
     motion_model_.setMotionLimits(max_vel, max_slip);  // maximum velocity and slip angle
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
@@ -97,7 +97,7 @@ BicycleTracker::BicycleTracker(
   // Set motion limits
   {
     const double max_vel = object_model_.process_limit.vel_long_max;
-    const double max_slip = object_model_.process_limit.yaw_rate_max;
+    const double max_slip = object_model_.bicycle_state.slip_angle_max;
     motion_model_.setMotionLimits(max_vel, max_slip);  // maximum velocity and slip angle
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/big_vehicle_tracker.cpp
@@ -112,7 +112,7 @@ BigVehicleTracker::BigVehicleTracker(
   // Set motion limits
   {
     const double max_vel = object_model_.process_limit.vel_long_max;
-    const double max_slip = object_model_.bicycle_state.slip_angle_max;
+    const double max_slip = object_model_.process_limit.yaw_rate_max;
     motion_model_.setMotionLimits(max_vel, max_slip);  // maximum velocity and slip angle
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/big_vehicle_tracker.cpp
@@ -112,7 +112,7 @@ BigVehicleTracker::BigVehicleTracker(
   // Set motion limits
   {
     const double max_vel = object_model_.process_limit.vel_long_max;
-    const double max_slip = object_model_.process_limit.yaw_rate_max;
+    const double max_slip = object_model_.bicycle_state.slip_angle_max;
     motion_model_.setMotionLimits(max_vel, max_slip);  // maximum velocity and slip angle
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/normal_vehicle_tracker.cpp
@@ -195,50 +195,6 @@ autoware_perception_msgs::msg::DetectedObject NormalVehicleTracker::getUpdatingO
     bounding_box_.width, bounding_box_.length, nearest_corner_index, bbox_object, tracked_yaw,
     updating_object, tracking_offset_);
 
-  // UNCERTAINTY MODEL
-  if (!object.kinematics.has_position_covariance) {
-    // measurement noise covariance
-    auto r_cov_x = object_model_.measurement_covariance.pos_x;
-    auto r_cov_y = object_model_.measurement_covariance.pos_y;
-    const uint8_t label = object_recognition_utils::getHighestProbLabel(object.classification);
-    if (utils::isLargeVehicleLabel(label)) {
-      // if label is changed, enlarge the measurement noise covariance
-      constexpr float r_stddev_x = 2.0;  // [m]
-      constexpr float r_stddev_y = 2.0;  // [m]
-      r_cov_x = r_stddev_x * r_stddev_x;
-      r_cov_y = r_stddev_y * r_stddev_y;
-    }
-
-    // yaw angle fix
-    const double pose_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-    const bool is_yaw_available =
-      object.kinematics.orientation_availability !=
-      autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
-
-    // fill covariance matrix
-    using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-    auto & pose_cov = updating_object.kinematics.pose_with_covariance.covariance;
-    const double cos_yaw = std::cos(pose_yaw);
-    const double sin_yaw = std::sin(pose_yaw);
-    const double sin_2yaw = std::sin(2.0 * pose_yaw);
-    pose_cov[XYZRPY_COV_IDX::X_X] =
-      r_cov_x * cos_yaw * cos_yaw + r_cov_y * sin_yaw * sin_yaw;           // x - x
-    pose_cov[XYZRPY_COV_IDX::X_Y] = 0.5 * (r_cov_x - r_cov_y) * sin_2yaw;  // x - y
-    pose_cov[XYZRPY_COV_IDX::Y_Y] =
-      r_cov_x * sin_yaw * sin_yaw + r_cov_y * cos_yaw * cos_yaw;                   // y - y
-    pose_cov[XYZRPY_COV_IDX::Y_X] = pose_cov[XYZRPY_COV_IDX::X_Y];                 // y - x
-    pose_cov[XYZRPY_COV_IDX::X_YAW] = 0.0;                                         // x - yaw
-    pose_cov[XYZRPY_COV_IDX::Y_YAW] = 0.0;                                         // y - yaw
-    pose_cov[XYZRPY_COV_IDX::YAW_X] = 0.0;                                         // yaw - x
-    pose_cov[XYZRPY_COV_IDX::YAW_Y] = 0.0;                                         // yaw - y
-    pose_cov[XYZRPY_COV_IDX::YAW_YAW] = object_model_.measurement_covariance.yaw;  // yaw - yaw
-    if (!is_yaw_available) {
-      pose_cov[XYZRPY_COV_IDX::YAW_YAW] *= 1e3;  // yaw is not available, multiply large value
-    }
-    auto & twist_cov = updating_object.kinematics.twist_with_covariance.covariance;
-    twist_cov[XYZRPY_COV_IDX::X_X] = object_model_.measurement_covariance.vel_long;  // vel - vel
-  }
-
   return updating_object;
 }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/normal_vehicle_tracker.cpp
@@ -114,7 +114,7 @@ NormalVehicleTracker::NormalVehicleTracker(
   // Set motion limits
   {
     const double max_vel = object_model_.process_limit.vel_long_max;
-    const double max_slip = object_model_.bicycle_state.slip_angle_max;
+    const double max_slip = object_model_.process_limit.yaw_rate_max;
     motion_model_.setMotionLimits(max_vel, max_slip);  // maximum velocity and slip angle
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/normal_vehicle_tracker.cpp
@@ -114,7 +114,7 @@ NormalVehicleTracker::NormalVehicleTracker(
   // Set motion limits
   {
     const double max_vel = object_model_.process_limit.vel_long_max;
-    const double max_slip = object_model_.process_limit.yaw_rate_max;
+    const double max_slip = object_model_.bicycle_state.slip_angle_max;
     motion_model_.setMotionLimits(max_vel, max_slip);  // maximum velocity and slip angle
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/pedestrian_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/pedestrian_tracker.cpp
@@ -154,42 +154,6 @@ autoware_perception_msgs::msg::DetectedObject PedestrianTracker::getUpdatingObje
 {
   autoware_perception_msgs::msg::DetectedObject updating_object = object;
 
-  // UNCERTAINTY MODEL
-  if (!object.kinematics.has_position_covariance) {
-    // measurement noise covariance
-    auto r_cov_x = object_model_.measurement_covariance.pos_x;
-    auto r_cov_y = object_model_.measurement_covariance.pos_y;
-
-    // yaw angle fix
-    const double pose_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-    const bool is_yaw_available =
-      object.kinematics.orientation_availability !=
-      autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
-
-    // fill covariance matrix
-    using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-    auto & pose_cov = updating_object.kinematics.pose_with_covariance.covariance;
-    const double cos_yaw = std::cos(pose_yaw);
-    const double sin_yaw = std::sin(pose_yaw);
-    const double sin_2yaw = std::sin(2.0 * pose_yaw);
-    pose_cov[XYZRPY_COV_IDX::X_X] =
-      r_cov_x * cos_yaw * cos_yaw + r_cov_y * sin_yaw * sin_yaw;           // x - x
-    pose_cov[XYZRPY_COV_IDX::X_Y] = 0.5 * (r_cov_x - r_cov_y) * sin_2yaw;  // x - y
-    pose_cov[XYZRPY_COV_IDX::Y_Y] =
-      r_cov_x * sin_yaw * sin_yaw + r_cov_y * cos_yaw * cos_yaw;                   // y - y
-    pose_cov[XYZRPY_COV_IDX::Y_X] = pose_cov[XYZRPY_COV_IDX::X_Y];                 // y - x
-    pose_cov[XYZRPY_COV_IDX::X_YAW] = 0.0;                                         // x - yaw
-    pose_cov[XYZRPY_COV_IDX::Y_YAW] = 0.0;                                         // y - yaw
-    pose_cov[XYZRPY_COV_IDX::YAW_X] = 0.0;                                         // yaw - x
-    pose_cov[XYZRPY_COV_IDX::YAW_Y] = 0.0;                                         // yaw - y
-    pose_cov[XYZRPY_COV_IDX::YAW_YAW] = object_model_.measurement_covariance.yaw;  // yaw - yaw
-    if (!is_yaw_available) {
-      pose_cov[XYZRPY_COV_IDX::YAW_YAW] *= 1e3;  // yaw is not available, multiply large value
-    }
-    auto & twist_cov = updating_object.kinematics.twist_with_covariance.covariance;
-    twist_cov[XYZRPY_COV_IDX::X_X] = object_model_.measurement_covariance.vel_long;  // vel - vel
-  }
-
   return updating_object;
 }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -38,40 +38,6 @@ using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 
 BicycleMotionModel::BicycleMotionModel() : logger_(rclcpp::get_logger("BicycleMotionModel"))
 {
-  // Initialize motion parameters
-  setDefaultParams();
-}
-
-void BicycleMotionModel::setDefaultParams()
-{
-  // set default motion parameters
-  constexpr double q_stddev_acc_long = 9.8 * 0.35;  // [m/(s*s)] uncertain longitudinal acceleration
-  constexpr double q_stddev_acc_lat = 9.8 * 0.15;   // [m/(s*s)] uncertain lateral acceleration
-  constexpr double q_stddev_yaw_rate_min =
-    autoware::universe_utils::deg2rad(1.5);  // [rad/s] uncertain yaw change rate
-  constexpr double q_stddev_yaw_rate_max =
-    autoware::universe_utils::deg2rad(15.0);  // [rad/s] uncertain yaw change rate
-  constexpr double q_stddev_slip_rate_min =
-    autoware::universe_utils::deg2rad(0.3);  // [rad/s] uncertain slip angle change rate
-  constexpr double q_stddev_slip_rate_max =
-    autoware::universe_utils::deg2rad(10.0);  // [rad/s] uncertain slip angle change rate
-  constexpr double q_max_slip_angle =
-    autoware::universe_utils::deg2rad(30.0);  // [rad] max slip angle
-  // extended state parameters
-  constexpr double lf_ratio = 0.3;   // 30% front from the center
-  constexpr double lf_min = 1.0;     // minimum of 1.0m
-  constexpr double lr_ratio = 0.25;  // 25% rear from the center
-  constexpr double lr_min = 1.0;     // minimum of 1.0m
-  setMotionParams(
-    q_stddev_acc_long, q_stddev_acc_lat, q_stddev_yaw_rate_min, q_stddev_yaw_rate_max,
-    q_stddev_slip_rate_min, q_stddev_slip_rate_max, q_max_slip_angle, lf_ratio, lf_min, lr_ratio,
-    lr_min);
-
-  // set motion limitations
-  constexpr double max_vel = autoware::universe_utils::kmph2mps(100);  // [m/s] maximum velocity
-  constexpr double max_slip = 30.0;                                    // [deg] maximum slip angle
-  setMotionLimits(max_vel, max_slip);
-
   // set prediction parameters
   constexpr double dt_max = 0.11;  // [s] maximum time interval for prediction
   setMaxDeltaTime(dt_max);
@@ -101,8 +67,8 @@ void BicycleMotionModel::setMotionParams(
       logger_,
       "BicycleMotionModel::setMotionParams: minimum wheel position should be greater than 0.01m.");
   }
-  motion_params_.lf_min = (lf_min < minimum_wheel_pos) ? minimum_wheel_pos : lf_min;
-  motion_params_.lr_min = (lr_min < minimum_wheel_pos) ? minimum_wheel_pos : lr_min;
+  motion_params_.lf_min = std::max(minimum_wheel_pos, lf_min);
+  motion_params_.lr_min = std::max(minimum_wheel_pos, lr_min);
   motion_params_.lf_ratio = lf_ratio;
   motion_params_.lr_ratio = lr_ratio;
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
@@ -36,26 +36,6 @@ using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 
 CTRVMotionModel::CTRVMotionModel() : logger_(rclcpp::get_logger("CTRVMotionModel"))
 {
-  // Initialize motion parameters
-  setDefaultParams();
-}
-
-void CTRVMotionModel::setDefaultParams()
-{
-  // process noise covariance
-  constexpr double q_stddev_x = 0.5;                                      // [m/s]
-  constexpr double q_stddev_y = 0.5;                                      // [m/s]
-  constexpr double q_stddev_yaw = autoware::universe_utils::deg2rad(20);  // [rad/s]
-  constexpr double q_stddev_vel = 9.8 * 0.3;                              // [m/(s*s)]
-  constexpr double q_stddev_wz = autoware::universe_utils::deg2rad(30);   // [rad/(s*s)]
-
-  setMotionParams(q_stddev_x, q_stddev_y, q_stddev_yaw, q_stddev_vel, q_stddev_wz);
-
-  // set motion limitations
-  constexpr double max_vel = autoware::universe_utils::kmph2mps(10);  // [m/s] maximum velocity
-  constexpr double max_wz = 30.0;                                     // [deg] maximum yaw rate
-  setMotionLimits(max_vel, max_wz);
-
   // set prediction parameters
   constexpr double dt_max = 0.11;  // [s] maximum time interval for prediction
   setMaxDeltaTime(dt_max);
@@ -77,7 +57,7 @@ void CTRVMotionModel::setMotionLimits(const double & max_vel, const double & max
 {
   // set motion limitations
   motion_params_.max_vel = max_vel;
-  motion_params_.max_wz = autoware::universe_utils::deg2rad(max_wz);
+  motion_params_.max_wz = max_wz;
 }
 
 bool CTRVMotionModel::initialize(

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/cv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/cv_motion_model.cpp
@@ -38,24 +38,6 @@ using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 
 CVMotionModel::CVMotionModel() : logger_(rclcpp::get_logger("CVMotionModel"))
 {
-  // Initialize motion parameters
-  setDefaultParams();
-}
-
-void CVMotionModel::setDefaultParams()
-{
-  // process noise covariance
-  constexpr double q_stddev_x = 0.5;         // [m/s] standard deviation of x
-  constexpr double q_stddev_y = 0.5;         // [m/s] standard deviation of y
-  constexpr double q_stddev_vx = 9.8 * 0.3;  // [m/(s*s)] standard deviation of vx
-  constexpr double q_stddev_vy = 9.8 * 0.3;  // [m/(s*s)] standard deviation of vy
-  setMotionParams(q_stddev_x, q_stddev_y, q_stddev_vx, q_stddev_vy);
-
-  // set motion limitations
-  constexpr double max_vx = autoware::universe_utils::kmph2mps(60);  // [m/s] maximum x velocity
-  constexpr double max_vy = autoware::universe_utils::kmph2mps(60);  // [m/s] maximum y velocity
-  setMotionLimits(max_vx, max_vy);
-
   // set prediction parameters
   constexpr double dt_max = 0.11;  // [s] maximum time interval for prediction
   setMaxDeltaTime(dt_max);

--- a/perception/autoware_multi_object_tracker/lib/uncertainty/uncertainty_processor.cpp
+++ b/perception/autoware_multi_object_tracker/lib/uncertainty/uncertainty_processor.cpp
@@ -1,0 +1,138 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Author: v1.0 Taekjin Lee
+
+#include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
+
+namespace autoware::multi_object_tracker
+{
+namespace uncertainty
+{
+using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+ObjectModel decodeObjectModel(const ObjectClassification & object_class)
+{
+  const auto & label = object_class.label;
+  ObjectModel obj_class_model(object_model::ObjectModelType::Unknown);
+  switch (label) {
+    case ObjectClassification::CAR:
+      obj_class_model = object_model::normal_vehicle;
+      break;
+    case ObjectClassification::BUS:
+    case ObjectClassification::TRUCK:
+    case ObjectClassification::TRAILER:
+      obj_class_model = object_model::big_vehicle;
+      break;
+    case ObjectClassification::BICYCLE:
+    case ObjectClassification::MOTORCYCLE:
+      obj_class_model = object_model::bicycle;
+      break;
+    case ObjectClassification::PEDESTRIAN:
+      obj_class_model = object_model::pedestrian;
+      break;
+    default:
+      obj_class_model = object_model::normal_vehicle;
+      break;
+  }
+  return obj_class_model;
+}
+
+DetectedObject modelUncertaintyByClass(
+  const DetectedObject & object, const ObjectClassification & object_class)
+{
+  DetectedObject updating_object = object;
+
+  // measurement noise covariance
+  ObjectModel obj_class_model = decodeObjectModel(object_class);
+
+  auto r_cov_x = obj_class_model.measurement_covariance.pos_x;
+  auto r_cov_y = obj_class_model.measurement_covariance.pos_y;
+
+  // yaw angle
+  const double pose_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+
+  // fill position covariance matrix
+  auto & pose_cov = updating_object.kinematics.pose_with_covariance.covariance;
+  const double cos_yaw = std::cos(pose_yaw);
+  const double sin_yaw = std::sin(pose_yaw);
+  const double sin_2yaw = std::sin(2.0 * pose_yaw);
+  pose_cov[XYZRPY_COV_IDX::X_X] =
+    r_cov_x * cos_yaw * cos_yaw + r_cov_y * sin_yaw * sin_yaw;           // x - x
+  pose_cov[XYZRPY_COV_IDX::X_Y] = 0.5 * (r_cov_x - r_cov_y) * sin_2yaw;  // x - y
+  pose_cov[XYZRPY_COV_IDX::Y_Y] =
+    r_cov_x * sin_yaw * sin_yaw + r_cov_y * cos_yaw * cos_yaw;                     // y - y
+  pose_cov[XYZRPY_COV_IDX::Y_X] = pose_cov[XYZRPY_COV_IDX::X_Y];                   // y - x
+  pose_cov[XYZRPY_COV_IDX::X_YAW] = 0.0;                                           // x - yaw
+  pose_cov[XYZRPY_COV_IDX::Y_YAW] = 0.0;                                           // y - yaw
+  pose_cov[XYZRPY_COV_IDX::YAW_X] = 0.0;                                           // yaw - x
+  pose_cov[XYZRPY_COV_IDX::YAW_Y] = 0.0;                                           // yaw - y
+  pose_cov[XYZRPY_COV_IDX::YAW_YAW] = obj_class_model.measurement_covariance.yaw;  // yaw - yaw
+  const bool is_yaw_available =
+    object.kinematics.orientation_availability !=
+    autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
+  if (!is_yaw_available) {
+    pose_cov[XYZRPY_COV_IDX::YAW_YAW] *= 1e3;  // yaw is not available, multiply large value
+  }
+
+  // fill twist covariance matrix
+  auto & twist_cov = updating_object.kinematics.twist_with_covariance.covariance;
+  twist_cov[XYZRPY_COV_IDX::X_X] = obj_class_model.measurement_covariance.vel_long;
+  twist_cov[XYZRPY_COV_IDX::X_Y] = 0.0;
+  twist_cov[XYZRPY_COV_IDX::Y_X] = 0.0;
+  twist_cov[XYZRPY_COV_IDX::Y_Y] = obj_class_model.measurement_covariance.vel_lat;
+
+  return updating_object;
+}
+
+DetectedObjects modelUncertainty(const DetectedObjects & detected_objects)
+{
+  DetectedObjects updating_objects;
+  updating_objects.header = detected_objects.header;
+  for (const auto & object : detected_objects.objects) {
+    if (object.kinematics.has_position_covariance) {
+      updating_objects.objects.push_back(object);
+      continue;
+    }
+    const ObjectClassification & object_class =
+      object_recognition_utils::getHighestProbClassification(object.classification);
+    updating_objects.objects.push_back(modelUncertaintyByClass(object, object_class));
+  }
+  return updating_objects;
+}
+
+void normalizeUncertainty(DetectedObjects & detected_objects)
+{
+  constexpr double min_cov_dist = 1e-4;
+  constexpr double min_cov_rad = 1e-6;
+  constexpr double min_cov_vel = 1e-4;
+
+  for (auto & object : detected_objects.objects) {
+    // normalize position covariance
+    auto & pose_cov = object.kinematics.pose_with_covariance.covariance;
+    pose_cov[XYZRPY_COV_IDX::X_X] = std::max(pose_cov[XYZRPY_COV_IDX::X_X], min_cov_dist);
+    pose_cov[XYZRPY_COV_IDX::Y_Y] = std::max(pose_cov[XYZRPY_COV_IDX::Y_Y], min_cov_dist);
+    pose_cov[XYZRPY_COV_IDX::Z_Z] = std::max(pose_cov[XYZRPY_COV_IDX::Z_Z], min_cov_dist);
+    pose_cov[XYZRPY_COV_IDX::YAW_YAW] = std::max(pose_cov[XYZRPY_COV_IDX::YAW_YAW], min_cov_rad);
+
+    // normalize twist covariance
+    auto & twist_cov = object.kinematics.twist_with_covariance.covariance;
+    twist_cov[XYZRPY_COV_IDX::X_X] = std::max(twist_cov[XYZRPY_COV_IDX::X_X], min_cov_vel);
+    twist_cov[XYZRPY_COV_IDX::Y_Y] = std::max(twist_cov[XYZRPY_COV_IDX::Y_Y], min_cov_vel);
+  }
+}
+
+}  // namespace uncertainty
+}  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -17,6 +17,7 @@
 
 #include "multi_object_tracker_node.hpp"
 
+#include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
 #include "autoware/multi_object_tracker/utils/utils.hpp"
 
 #include <Eigen/Core>
@@ -260,11 +261,11 @@ void MultiObjectTracker::onMessage(const ObjectsList & objects_list)
 }
 
 void MultiObjectTracker::runProcess(
-  const DetectedObjects & input_objects_msg, const uint & channel_index)
+  const DetectedObjects & input_objects, const uint & channel_index)
 {
   // Get the time of the measurement
   const rclcpp::Time measurement_time =
-    rclcpp::Time(input_objects_msg.header.stamp, this->now().get_clock_type());
+    rclcpp::Time(input_objects.header.stamp, this->now().get_clock_type());
 
   // Get the transform of the self frame
   const auto self_transform =
@@ -273,10 +274,18 @@ void MultiObjectTracker::runProcess(
     return;
   }
 
+  // Model the object uncertainty if it is empty
+  DetectedObjects input_objects_with_uncertainty = uncertainty::modelUncertainty(input_objects);
+
+  // Normalize the object uncertainty
+  uncertainty::normalizeUncertainty(input_objects_with_uncertainty);
+
+  // Add the odometry uncertainty to the object uncertainty
+
   // Transform the objects to the world frame
   DetectedObjects transformed_objects;
   if (!object_recognition_utils::transformObjects(
-        input_objects_msg, world_frame_id_, tf_buffer_, transformed_objects)) {
+        input_objects_with_uncertainty, world_frame_id_, tf_buffer_, transformed_objects)) {
     return;
   }
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -280,8 +280,6 @@ void MultiObjectTracker::runProcess(
   // Normalize the object uncertainty
   uncertainty::normalizeUncertainty(input_objects_with_uncertainty);
 
-  // Add the odometry uncertainty to the object uncertainty
-
   // Transform the objects to the world frame
   DetectedObjects transformed_objects;
   if (!object_recognition_utils::transformObjects(

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -100,7 +100,7 @@ private:
   void onMessage(const ObjectsList & objects_list);
 
   // publish processes
-  void runProcess(const DetectedObjects & input_objects_msg, const uint & channel_index);
+  void runProcess(const DetectedObjects & input_objects, const uint & channel_index);
   void checkAndPublish(const rclcpp::Time & time);
   void publish(const rclcpp::Time & time) const;
   inline bool shouldTrackerPublish(const std::shared_ptr<const Tracker> tracker) const;


### PR DESCRIPTION
## Description

1. The detected object covariance matrix is modeled if the incoming detectedObject does not have one.
This PR separates the covariance matrix modeling part out from the trackers.

2. Initial values of the tracker was defined by a initialization function, which is inefficient. The initial values were defined from the initializer.

This PR does not have behavioral change.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested in the [TIER IV CLOUD](https://evaluation.tier4.jp/evaluation/reports/a2aab07d-0743-5e7f-b710-3966356b8761?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
