### PR TITLE
feat(autoware_behavior_path_planner_common): disable feature of turning off blinker at low velocity

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -138,11 +138,11 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
   const size_t current_seg_idx, const RouteHandler & route_handler,
   const double nearest_dist_threshold, const double nearest_yaw_threshold)
 {
-  const auto requires_turn_signal = [&](const auto & lane_attribute) {
+  const auto requires_turn_signal = [&](const auto & turn_direction, const bool is_in_turn_lane) {
     constexpr double stop_velocity_threshold = 0.1;
     return (
-      lane_attribute == "right" || lane_attribute == "left" ||
-      (lane_attribute == "straight" && current_vel < stop_velocity_threshold));
+      turn_direction == "right" || turn_direction == "left" ||
+      (turn_direction == "straight" && current_vel < stop_velocity_threshold && !is_in_turn_lane));
   };
   // base search distance
   const double base_search_distance =
@@ -160,6 +160,19 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
     }
   }
 
+  bool is_in_turn_lane = false;
+  for (const auto & lane_id : unique_lane_ids) {
+    const auto lanelet = route_handler.getLaneletsFromId(lane_id);
+    const std::string turn_direction = lanelet.attributeOr("turn_direction", "none");
+    if (turn_direction == "left" || turn_direction == "right") {
+      const auto & position = current_pose.position;
+      const lanelet::BasicPoint2d point(position.x, position.y);
+      if (lanelet::geometry::inside(lanelet, point)) {
+        is_in_turn_lane = true;
+        break;
+      }
+    }
+  }
   // combine consecutive lanes of the same turn direction
   // stores lanes that have already been combine
   std::set<int> processed_lanes;
@@ -175,7 +188,7 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
     // Get the lane and its attribute
     const std::string lane_attribute =
       current_lane.attributeOr("turn_direction", std::string("none"));
-    if (!requires_turn_signal(lane_attribute)) continue;
+    if (!requires_turn_signal(lane_attribute, is_in_turn_lane)) continue;
 
     do {
       processed_lanes.insert(current_lane.id());
@@ -256,7 +269,7 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
     } else if (search_distance <= dist_to_front_point) {
       continue;
     }
-    if (requires_turn_signal(lane_attribute)) {
+    if (requires_turn_signal(lane_attribute, is_in_turn_lane)) {
       // update map if necessary
       if (desired_start_point_map_.find(lane_id) == desired_start_point_map_.end()) {
         desired_start_point_map_.emplace(lane_id, current_pose);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -138,7 +138,8 @@ std::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo(
   const size_t current_seg_idx, const RouteHandler & route_handler,
   const double nearest_dist_threshold, const double nearest_yaw_threshold)
 {
-  const auto requires_turn_signal = [&](const auto & turn_direction, const bool is_in_turn_lane) {
+  const auto requires_turn_signal = [&current_vel](
+                                      const auto & turn_direction, const bool is_in_turn_lane) {
     constexpr double stop_velocity_threshold = 0.1;
     return (
       turn_direction == "right" || turn_direction == "left" ||


### PR DESCRIPTION
## Description

When ego vehicle stops in the lane with turn_direction right or left, blinker turns off because of the following implementation.
```
  const auto requires_turn_signal = [&](const auto & lane_attribute) {
    constexpr double stop_velocity_threshold = 0.1;
    return (
      lane_attribute == "right" || lane_attribute == "left" ||
      (lane_attribute == "straight" && current_vel < stop_velocity_threshold));
  };
```
![image](https://github.com/user-attachments/assets/e72d2f9d-2ac3-428f-a221-7d3a05b82b43)

The expected behavior for the scene is the keep turning on when the ego vehicle is on the lane with turn_direction is right or left.

So changed so that keep turning on blinker in this PR.


## Related links

**Parent Issue:**

- [TIERIV INTERNAL TICKET LINK](https://tier4.atlassian.net/browse/RT0-33633)
<!-- ⬇️🟢
**Private Links:**

- [TIERIV INTERNAL TICKETS LINK]()
⬆️🟢 -->

## How was this PR tested?

- [x] tested with psim
- [ ] passed [TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/ff1dbf4c-19e2-5392-b1fe-dbeee2af253a?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
