### PR TITLE
refactor(mission_planner): move anonymous functions to utils and add namespace

### DIFF
--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -41,96 +41,6 @@
 #include <limits>
 #include <vector>
 
-namespace
-{
-using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
-
-bool is_in_lane(const lanelet::ConstLanelet & lanelet, const lanelet::ConstPoint3d & point)
-{
-  // check if goal is on a lane at appropriate angle
-  const auto distance = boost::geometry::distance(
-    lanelet.polygon2d().basicPolygon(), lanelet::utils::to2D(point).basicPoint());
-  constexpr double th_distance = std::numeric_limits<double>::epsilon();
-  return distance < th_distance;
-}
-
-bool is_in_parking_space(
-  const lanelet::ConstLineStrings3d & parking_spaces, const lanelet::ConstPoint3d & point)
-{
-  for (const auto & parking_space : parking_spaces) {
-    lanelet::ConstPolygon3d parking_space_polygon;
-    if (!lanelet::utils::lineStringWithWidthToPolygon(parking_space, &parking_space_polygon)) {
-      continue;
-    }
-
-    const double distance = boost::geometry::distance(
-      lanelet::utils::to2D(parking_space_polygon).basicPolygon(),
-      lanelet::utils::to2D(point).basicPoint());
-    constexpr double th_distance = std::numeric_limits<double>::epsilon();
-    if (distance < th_distance) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool is_in_parking_lot(
-  const lanelet::ConstPolygons3d & parking_lots, const lanelet::ConstPoint3d & point)
-{
-  for (const auto & parking_lot : parking_lots) {
-    const double distance = boost::geometry::distance(
-      lanelet::utils::to2D(parking_lot).basicPolygon(), lanelet::utils::to2D(point).basicPoint());
-    constexpr double th_distance = std::numeric_limits<double>::epsilon();
-    if (distance < th_distance) {
-      return true;
-    }
-  }
-  return false;
-}
-
-double project_goal_to_map(
-  const lanelet::ConstLanelet & lanelet_component, const lanelet::ConstPoint3d & goal_point)
-{
-  const lanelet::ConstLineString3d center_line =
-    lanelet::utils::generateFineCenterline(lanelet_component);
-  lanelet::BasicPoint3d project = lanelet::geometry::project(center_line, goal_point.basicPoint());
-  return project.z();
-}
-
-geometry_msgs::msg::Pose get_closest_centerline_pose(
-  const lanelet::ConstLanelets & road_lanelets, const geometry_msgs::msg::Pose & point,
-  autoware::vehicle_info_utils::VehicleInfo vehicle_info)
-{
-  lanelet::Lanelet closest_lanelet;
-  if (!lanelet::utils::query::getClosestLaneletWithConstrains(
-        road_lanelets, point, &closest_lanelet, 0.0)) {
-    // point is not on any lanelet.
-    return point;
-  }
-
-  const auto refined_center_line = lanelet::utils::generateFineCenterline(closest_lanelet, 1.0);
-  closest_lanelet.setCenterline(refined_center_line);
-
-  const double lane_yaw = lanelet::utils::getLaneletAngle(closest_lanelet, point.position);
-
-  const auto nearest_idx = autoware::motion_utils::findNearestIndex(
-    convertCenterlineToPoints(closest_lanelet), point.position);
-  const auto nearest_point = closest_lanelet.centerline()[nearest_idx];
-
-  // shift nearest point on its local y axis so that vehicle's right and left edges
-  // would have approx the same clearance from road border
-  const auto shift_length = (vehicle_info.right_overhang_m - vehicle_info.left_overhang_m) / 2.0;
-  const auto delta_x = -shift_length * std::sin(lane_yaw);
-  const auto delta_y = shift_length * std::cos(lane_yaw);
-
-  lanelet::BasicPoint3d refined_point(
-    nearest_point.x() + delta_x, nearest_point.y() + delta_y, nearest_point.z());
-
-  return convertBasicPoint3dToPose(refined_point, lane_yaw);
-}
-
-}  // anonymous namespace
-
 namespace autoware::mission_planner::lanelet2
 {
 
@@ -395,8 +305,7 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
 
   std::stringstream log_ss;
   for (const auto & point : points) {
-    log_ss << "x: " << point.position.x << " "
-           << "y: " << point.position.y << std::endl;
+    log_ss << "x: " << point.position.x << " " << "y: " << point.position.y << std::endl;
   }
   RCLCPP_DEBUG_STREAM(
     logger, "start planning route with check points: " << std::endl

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -14,10 +14,18 @@
 
 #include "utility_functions.hpp"
 
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+
 #include <boost/geometry.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
 
+#include <limits>
+
+namespace autoware::mission_planner::lanelet2
+{
 autoware::universe_utils::Polygon2d convert_linear_ring_to_polygon(
   autoware::universe_utils::LinearRing2d footprint)
 {
@@ -64,3 +72,89 @@ geometry_msgs::msg::Pose convertBasicPoint3dToPose(
 
   return pose;
 }
+
+bool is_in_lane(const lanelet::ConstLanelet & lanelet, const lanelet::ConstPoint3d & point)
+{
+  // check if goal is on a lane at appropriate angle
+  const auto distance = boost::geometry::distance(
+    lanelet.polygon2d().basicPolygon(), lanelet::utils::to2D(point).basicPoint());
+  constexpr double th_distance = std::numeric_limits<double>::epsilon();
+  return distance < th_distance;
+}
+
+bool is_in_parking_space(
+  const lanelet::ConstLineStrings3d & parking_spaces, const lanelet::ConstPoint3d & point)
+{
+  for (const auto & parking_space : parking_spaces) {
+    lanelet::ConstPolygon3d parking_space_polygon;
+    if (!lanelet::utils::lineStringWithWidthToPolygon(parking_space, &parking_space_polygon)) {
+      continue;
+    }
+
+    const double distance = boost::geometry::distance(
+      lanelet::utils::to2D(parking_space_polygon).basicPolygon(),
+      lanelet::utils::to2D(point).basicPoint());
+    constexpr double th_distance = std::numeric_limits<double>::epsilon();
+    if (distance < th_distance) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool is_in_parking_lot(
+  const lanelet::ConstPolygons3d & parking_lots, const lanelet::ConstPoint3d & point)
+{
+  for (const auto & parking_lot : parking_lots) {
+    const double distance = boost::geometry::distance(
+      lanelet::utils::to2D(parking_lot).basicPolygon(), lanelet::utils::to2D(point).basicPoint());
+    constexpr double th_distance = std::numeric_limits<double>::epsilon();
+    if (distance < th_distance) {
+      return true;
+    }
+  }
+  return false;
+}
+
+double project_goal_to_map(
+  const lanelet::ConstLanelet & lanelet_component, const lanelet::ConstPoint3d & goal_point)
+{
+  const lanelet::ConstLineString3d center_line =
+    lanelet::utils::generateFineCenterline(lanelet_component);
+  lanelet::BasicPoint3d project = lanelet::geometry::project(center_line, goal_point.basicPoint());
+  return project.z();
+}
+
+geometry_msgs::msg::Pose get_closest_centerline_pose(
+  const lanelet::ConstLanelets & road_lanelets, const geometry_msgs::msg::Pose & point,
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info)
+{
+  lanelet::Lanelet closest_lanelet;
+  if (!lanelet::utils::query::getClosestLaneletWithConstrains(
+        road_lanelets, point, &closest_lanelet, 0.0)) {
+    // point is not on any lanelet.
+    return point;
+  }
+
+  const auto refined_center_line = lanelet::utils::generateFineCenterline(closest_lanelet, 1.0);
+  closest_lanelet.setCenterline(refined_center_line);
+
+  const double lane_yaw = lanelet::utils::getLaneletAngle(closest_lanelet, point.position);
+
+  const auto nearest_idx = autoware::motion_utils::findNearestIndex(
+    convertCenterlineToPoints(closest_lanelet), point.position);
+  const auto nearest_point = closest_lanelet.centerline()[nearest_idx];
+
+  // shift nearest point on its local y axis so that vehicle's right and left edges
+  // would have approx the same clearance from road border
+  const auto shift_length = (vehicle_info.right_overhang_m - vehicle_info.left_overhang_m) / 2.0;
+  const auto delta_x = -shift_length * std::sin(lane_yaw);
+  const auto delta_y = shift_length * std::cos(lane_yaw);
+
+  lanelet::BasicPoint3d refined_point(
+    nearest_point.x() + delta_x, nearest_point.y() + delta_y, nearest_point.z());
+
+  return convertBasicPoint3dToPose(refined_point, lane_yaw);
+}
+
+}  // namespace autoware::mission_planner::lanelet2

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -29,6 +29,10 @@
 
 #include <vector>
 
+namespace autoware::mission_planner::lanelet2
+{
+using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
+
 template <typename T>
 bool exists(const std::vector<T> & vectors, const T & item)
 {
@@ -48,4 +52,17 @@ void insert_marker_array(
 std::vector<geometry_msgs::msg::Point> convertCenterlineToPoints(const lanelet::Lanelet & lanelet);
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
   const lanelet::BasicPoint3d & point, const double lane_yaw);
+
+bool is_in_lane(const lanelet::ConstLanelet & lanelet, const lanelet::ConstPoint3d & point);
+bool is_in_parking_space(
+  const lanelet::ConstLineStrings3d & parking_spaces, const lanelet::ConstPoint3d & point);
+bool is_in_parking_lot(
+  const lanelet::ConstPolygons3d & parking_lots, const lanelet::ConstPoint3d & point);
+double project_goal_to_map(
+  const lanelet::ConstLanelet & lanelet_component, const lanelet::ConstPoint3d & goal_point);
+geometry_msgs::msg::Pose get_closest_centerline_pose(
+  const lanelet::ConstLanelets & road_lanelets, const geometry_msgs::msg::Pose & point,
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info);
+
+}  // namespace autoware::mission_planner::lanelet2
 #endif  // LANELET2_PLUGINS__UTILITY_FUNCTIONS_HPP_


### PR DESCRIPTION
## Description

move anonymous functions to utility  for unit test:  https://github.com/autowarefoundation/autoware.universe/pull/9011


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
