### PR TITLE
docs(coverage): display component wise coverage matrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Autoware Universe
 
-[![codecov](https://codecov.io/github/autowarefoundation/autoware.universe/graph/badge.svg?token=KQP68YQ65D)](https://codecov.io/github/autowarefoundation/autoware.universe)
-
 ## Welcome to Autoware Universe
 
 Autoware Universe serves as a foundational pillar within the Autoware ecosystem, playing a critical role in enhancing the core functionalities of autonomous driving technologies.
@@ -16,3 +14,30 @@ To dive into the vast world of Autoware and understand how Autoware Universe fit
 ### Explore Autoware Universe documentation
 
 For those looking to explore the specifics of Autoware Universe components, the [Autoware Universe Documentation](https://autowarefoundation.github.io/autoware.universe/), deployed with MKDocs, offers detailed insights.
+
+## Code Coverage Metrics
+
+Below table shows the coverage rate of entire Autoware Universe and sub-components respectively. "Total" denotes the whole component coverage, and "TIER IV Maintained" denotes the coverage of packages mainly developed/tested by TIER IV.
+
+### Entire Project Coverage
+
+[![codecov](https://codecov.io/github/autowarefoundation/autoware.universe/graph/badge.svg?token=KQP68YQ65D)](https://codecov.io/github/autowarefoundation/autoware.universe)
+
+### Component-wise Coverage
+
+You can check more details by clicking the badge and navigating the codecov website.
+
+| Component    | Total Coverage | TIER IV Maintained Package Coverage                                                                                                                                                                                                                                                                                                                                                        |
+| ------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Common       | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Control      | TBD            | [![codecov](https://img.shields.io/badge/dynamic/json?url=https://codecov.io/api/v2/github/autowarefoundation/repos/autoware.universe/components&label=Control_TIER_IV_Maintained_Packages&query=$.%5B1%5D.coverage&color=brightgreen)](https://app.codecov.io/gh/autowarefoundation/autoware.universe/tree/main/control?components%5B0%5D=Control%20TIER%20IV%20Maintained%20Packages)    |
+| Evaluator    | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Launch       | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Localization | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Map          | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Perception   | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Planning     | TBD            | [![codecov](https://img.shields.io/badge/dynamic/json?url=https://codecov.io/api/v2/github/autowarefoundation/repos/autoware.universe/components&label=Planning_TIER_IV_Maintained_Packages&query=$.%5B0%5D.coverage&color=brightgreen)](https://app.codecov.io/gh/autowarefoundation/autoware.universe/tree/main/planning?components%5B0%5D=Planning%20TIER%20IV%20Maintained%20Packages) |
+| Sensing      | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Simulator    | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| System       | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |
+| Vehicle      | TBD            | TBD                                                                                                                                                                                                                                                                                                                                                                                        |


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/b112c75e-3e0e-4af0-96c4-00118dd0ef98)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
