### PR TITLE
feat(autoware_multi_object_tracker): set maximum reverse velocity to bicycle and crtv motion models

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -58,12 +58,13 @@ private:
       2.7416e-5;  // [rad^2/s^2] uncertain slip angle change rate, 0.3 deg/s
     double q_cov_slip_rate_max = 0.03046;  // [rad^2/s^2] uncertain slip angle change rate, 10 deg/s
     double q_max_slip_angle = 0.5236;      // [rad] max slip angle, 30deg
-    double lf_ratio = 0.3;     // [-] ratio of the distance from the center to the front wheel
-    double lr_ratio = 0.25;    // [-] ratio of the distance from the center to the rear wheel
-    double lf_min = 1.0;       // [m] minimum distance from the center to the front wheel
-    double lr_min = 1.0;       // [m] minimum distance from the center to the rear wheel
-    double max_vel = 27.8;     // [m/s] maximum velocity, 100km/h
-    double max_slip = 0.5236;  // [rad] maximum slip angle, 30deg
+    double lf_ratio = 0.3;           // [-] ratio of the distance from the center to the front wheel
+    double lr_ratio = 0.25;          // [-] ratio of the distance from the center to the rear wheel
+    double lf_min = 1.0;             // [m] minimum distance from the center to the front wheel
+    double lr_min = 1.0;             // [m] minimum distance from the center to the rear wheel
+    double max_vel = 27.8;           // [m/s] maximum velocity, 100km/h
+    double max_slip = 0.5236;        // [rad] maximum slip angle, 30deg
+    double max_reverse_vel = -1.38;  // [m/s] maximum reverse velocity, -5km/h
   } motion_params_;
 
 public:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -58,13 +58,14 @@ private:
       2.7416e-5;  // [rad^2/s^2] uncertain slip angle change rate, 0.3 deg/s
     double q_cov_slip_rate_max = 0.03046;  // [rad^2/s^2] uncertain slip angle change rate, 10 deg/s
     double q_max_slip_angle = 0.5236;      // [rad] max slip angle, 30deg
-    double lf_ratio = 0.3;           // [-] ratio of the distance from the center to the front wheel
-    double lr_ratio = 0.25;          // [-] ratio of the distance from the center to the rear wheel
-    double lf_min = 1.0;             // [m] minimum distance from the center to the front wheel
-    double lr_min = 1.0;             // [m] minimum distance from the center to the rear wheel
-    double max_vel = 27.8;           // [m/s] maximum velocity, 100km/h
-    double max_slip = 0.5236;        // [rad] maximum slip angle, 30deg
-    double max_reverse_vel = -1.38;  // [m/s] maximum reverse velocity, -5km/h
+    double lf_ratio = 0.3;     // [-] ratio of the distance from the center to the front wheel
+    double lr_ratio = 0.25;    // [-] ratio of the distance from the center to the rear wheel
+    double lf_min = 1.0;       // [m] minimum distance from the center to the front wheel
+    double lr_min = 1.0;       // [m] minimum distance from the center to the rear wheel
+    double max_vel = 27.8;     // [m/s] maximum velocity, 100km/h
+    double max_slip = 0.5236;  // [rad] maximum slip angle, 30deg
+    double max_reverse_vel =
+      -1.389;  // [m/s] maximum reverse velocity, -5km/h. The value is expected to be negative
   } motion_params_;
 
 public:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
@@ -45,13 +45,14 @@ private:
   // motion parameters: process noise and motion limits
   struct MotionParams
   {
-    double q_cov_x = 0.025;     // [m^2/s^2] uncertain position in x, 0.5m/s
-    double q_cov_y = 0.025;     // [m^2/s^2] uncertain position in y, 0.5m/s
-    double q_cov_yaw = 0.1218;  // [rad^2/s^2] uncertain yaw angle, 20deg/s
-    double q_cov_vel = 8.6436;  // [m^2/s^4] uncertain velocity, 0.3G m/s^2
-    double q_cov_wz = 0.5236;   // [rad^2/s^4] uncertain yaw rate, 30deg/s^2
-    double max_vel = 2.78;      // [m/s] maximum velocity
-    double max_wz = 0.5236;     // [rad/s] maximum yaw rate, 30deg/s
+    double q_cov_x = 0.025;          // [m^2/s^2] uncertain position in x, 0.5m/s
+    double q_cov_y = 0.025;          // [m^2/s^2] uncertain position in y, 0.5m/s
+    double q_cov_yaw = 0.1218;       // [rad^2/s^2] uncertain yaw angle, 20deg/s
+    double q_cov_vel = 8.6436;       // [m^2/s^4] uncertain velocity, 0.3G m/s^2
+    double q_cov_wz = 0.5236;        // [rad^2/s^4] uncertain yaw rate, 30deg/s^2
+    double max_vel = 2.78;           // [m/s] maximum velocity
+    double max_wz = 0.5236;          // [rad/s] maximum yaw rate, 30deg/s
+    double max_reverse_vel = -1.38;  // [m/s] maximum reverse velocity, -5km/h
   } motion_params_;
 
 public:

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -41,6 +41,10 @@ BicycleMotionModel::BicycleMotionModel() : logger_(rclcpp::get_logger("BicycleMo
   // set prediction parameters
   constexpr double dt_max = 0.11;  // [s] maximum time interval for prediction
   setMaxDeltaTime(dt_max);
+
+  if (motion_params_.max_reverse_vel > 0) {
+    RCLCPP_WARN(logger_, "BicycleMotionModel: maximum reverse velocity should be less than 0.");
+  }
 }
 
 void BicycleMotionModel::setMotionParams(
@@ -228,7 +232,7 @@ bool BicycleMotionModel::limitStates()
   ekf_.getP(P_t);
 
   // maximum reverse velocity
-  if (X_t(IDX::VEL) < 0 && X_t(IDX::VEL) < motion_params_.max_reverse_vel) {
+  if (motion_params_.max_reverse_vel < 0 && X_t(IDX::VEL) < motion_params_.max_reverse_vel) {
     // rotate the object orientation by 180 degrees
     X_t(IDX::VEL) = -X_t(IDX::VEL);
     X_t(IDX::YAW) = X_t(IDX::YAW) + M_PI;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -226,15 +226,26 @@ bool BicycleMotionModel::limitStates()
   Eigen::MatrixXd P_t(DIM, DIM);
   ekf_.getX(X_t);
   ekf_.getP(P_t);
-  X_t(IDX::YAW) = autoware::universe_utils::normalizeRadian(X_t(IDX::YAW));
+
+  // maximum reverse velocity
+  if (X_t(IDX::VEL) < 0 && X_t(IDX::VEL) < motion_params_.max_reverse_vel) {
+    // rotate the object orientation by 180 degrees
+    X_t(IDX::VEL) = -X_t(IDX::VEL);
+    X_t(IDX::YAW) = X_t(IDX::YAW) + M_PI;
+  }
+  // maximum velocity
   if (!(-motion_params_.max_vel <= X_t(IDX::VEL) && X_t(IDX::VEL) <= motion_params_.max_vel)) {
     X_t(IDX::VEL) = X_t(IDX::VEL) < 0 ? -motion_params_.max_vel : motion_params_.max_vel;
   }
+  // maximum slip angle
   if (!(-motion_params_.max_slip <= X_t(IDX::SLIP) && X_t(IDX::SLIP) <= motion_params_.max_slip)) {
     X_t(IDX::SLIP) = X_t(IDX::SLIP) < 0 ? -motion_params_.max_slip : motion_params_.max_slip;
   }
-  ekf_.init(X_t, P_t);
+  // normalize yaw
+  X_t(IDX::YAW) = autoware::universe_utils::normalizeRadian(X_t(IDX::YAW));
 
+  // overwrite state
+  ekf_.init(X_t, P_t);
   return true;
 }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -41,10 +41,6 @@ BicycleMotionModel::BicycleMotionModel() : logger_(rclcpp::get_logger("BicycleMo
   // set prediction parameters
   constexpr double dt_max = 0.11;  // [s] maximum time interval for prediction
   setMaxDeltaTime(dt_max);
-
-  if (motion_params_.max_reverse_vel > 0) {
-    RCLCPP_WARN(logger_, "BicycleMotionModel: maximum reverse velocity should be less than 0.");
-  }
 }
 
 void BicycleMotionModel::setMotionParams(

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
@@ -203,15 +203,26 @@ bool CTRVMotionModel::limitStates()
   Eigen::MatrixXd P_t(DIM, DIM);
   ekf_.getX(X_t);
   ekf_.getP(P_t);
-  X_t(IDX::YAW) = autoware::universe_utils::normalizeRadian(X_t(IDX::YAW));
+
+  // maximum reverse velocity
+  if (X_t(IDX::VEL) < 0 && X_t(IDX::VEL) < motion_params_.max_reverse_vel) {
+    // rotate the object orientation by 180 degrees
+    X_t(IDX::VEL) = -X_t(IDX::VEL);
+    X_t(IDX::YAW) = X_t(IDX::YAW) + M_PI;
+  }
+  // maximum velocity
   if (!(-motion_params_.max_vel <= X_t(IDX::VEL) && X_t(IDX::VEL) <= motion_params_.max_vel)) {
     X_t(IDX::VEL) = X_t(IDX::VEL) < 0 ? -motion_params_.max_vel : motion_params_.max_vel;
   }
+  // maximum yaw rate
   if (!(-motion_params_.max_wz <= X_t(IDX::WZ) && X_t(IDX::WZ) <= motion_params_.max_wz)) {
     X_t(IDX::WZ) = X_t(IDX::WZ) < 0 ? -motion_params_.max_wz : motion_params_.max_wz;
   }
-  ekf_.init(X_t, P_t);
+  // normalize yaw
+  X_t(IDX::YAW) = autoware::universe_utils::normalizeRadian(X_t(IDX::YAW));
 
+  // overwrite state
+  ekf_.init(X_t, P_t);
   return true;
 }
 


### PR DESCRIPTION
## Description

Revert the tracker orientation when the velocity exceed the maximum reverse velocity

The tracking object orientation is determined by the initial object orientation.
If the initial object yaw was reversed (180 deg rotated), and the object moves forward, the object is tracked as reversed direction.
This mismatch can cause yaw instability in case of the bicycle motion model.

- Before

![Screenshot from 2024-10-03 18-38-10](https://github.com/user-attachments/assets/e701c1e5-50e4-45a0-a608-ced12b05cb01)

The screenshot shows trackedObjects. Triangles of the bounding box corners indicates front of the object. 
The right object heads left upper side but its velocity is right bottom side. This shows the object is reversed motion. 
If the detector has high confidence of its headings, this situation can be trusted. But, the current lidar-based detection has high error rate on its headings.

Considering the current Autoware implementation (the map_based_prediction fixes the object to head its velocity direction anyway), fixing the orientation with a certain threshold is feasible. 


- After

![Screenshot from 2024-10-03 18-47-57](https://github.com/user-attachments/assets/1af091a4-9581-47ec-82fd-14a97d2d5947)

If the object is reversed and it reaches a threshold ( -5 kmph by default), the tracked object will be flipped and heads forward to its velocity vector. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
