### PR TITLE
fix(goal_planner): fix parking_path curvature and DecidingState transition

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
@@ -43,7 +43,7 @@ public:
 class PathDecisionStateController
 {
 public:
-  PathDecisionStateController() = default;
+  explicit PathDecisionStateController(rclcpp::Logger logger) : logger_(logger) {}
 
   /**
    * @brief update current state and save old current state to prev state
@@ -65,6 +65,8 @@ public:
   PathDecisionState get_prev_state() const { return prev_state_; }
 
 private:
+  rclcpp::Logger logger_;
+
   PathDecisionState current_state_{};
   PathDecisionState prev_state_{};
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
@@ -35,7 +35,7 @@ public:
   };
 
   DecisionKind state{DecisionKind::NOT_DECIDED};
-  rclcpp::Time stamp{};
+  std::optional<rclcpp::Time> deciding_start_time{std::nullopt};
   bool is_stable_safe{false};
   std::optional<rclcpp::Time> safe_start_time{std::nullopt};
 };
@@ -62,13 +62,10 @@ public:
 
   PathDecisionState get_current_state() const { return current_state_; }
 
-  PathDecisionState get_prev_state() const { return prev_state_; }
-
 private:
   rclcpp::Logger logger_;
 
   PathDecisionState current_state_{};
-  PathDecisionState prev_state_{};
 
   /**
    * @brief update current state and save old current state to prev state

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -321,7 +321,7 @@ private:
   // context_data_ is initialized in updateData(), used in plan() and refreshed in postProcess()
   std::optional<PullOverContextData> context_data_{std::nullopt};
   // path_decision_controller is updated in updateData(), and used in plan()
-  PathDecisionStateController path_decision_controller_{};
+  PathDecisionStateController path_decision_controller_{getLogger()};
   std::unique_ptr<LastApprovalData> last_approval_data_{nullptr};
 
   // approximate distance from the start point to the end point of pull_over.

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/pull_over_planner_base.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/pull_over_planner_base.cpp
@@ -73,7 +73,7 @@ std::optional<PullOverPath> PullOverPath::create(
   double parking_path_max_curvature{};
   std::tie(full_path_curvatures, full_path_max_curvature) = calculateCurvaturesAndMax(full_path);
   std::tie(parking_path_curvatures, parking_path_max_curvature) =
-    calculateCurvaturesAndMax(full_path);
+    calculateCurvaturesAndMax(parking_path);
 
   return PullOverPath(
     type, goal_id, id, start_pose, end_pose, partial_paths, full_path, parking_path,


### PR DESCRIPTION
## Description

- due to a mistake, the curvature of parking_path was calculated from full_path, which caused massive "[WARN 1727950663.638648154] [goal_planner_util]: path.points.size() != curvatures.size() in checkObjectsCollision(). judge as non collision" error
- the time DecidingState started was not properly updated
- transition from NOT_DECIDED to DECIDING was inactivated by mistake

## Related links

**Parent Issue:**

- 
<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/58a47f88-1f99-50dd-acdf-910a2227a75f?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/51a8cf14-f91a-5b30-876f-663435e9a095?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
