### PR TITLE
fix(compare_map_segmentation): throw runtime error when using non-split map pointcloud for DynamicMapLoader

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/filter/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/filter/pointcloud_map_filter.launch.py
@@ -39,6 +39,7 @@ class PointcloudMapFilterPipeline:
         self.downsize_ratio_z_axis = self.pointcloud_map_filter_param["downsize_ratio_z_axis"]
         self.timer_interval_ms = self.pointcloud_map_filter_param["timer_interval_ms"]
         self.use_dynamic_map_loading = self.pointcloud_map_filter_param["use_dynamic_map_loading"]
+        self.max_map_grid_size = self.pointcloud_map_filter_param["max_map_grid_size"]
         self.map_update_distance_threshold = self.pointcloud_map_filter_param[
             "map_update_distance_threshold"
         ]
@@ -124,6 +125,7 @@ class PointcloudMapFilterPipeline:
                         "map_update_distance_threshold": self.map_update_distance_threshold,
                         "map_loader_radius": self.map_loader_radius,
                         "publish_debug_pcd": self.publish_debug_pcd,
+                        "max_map_grid_size": self.max_map_grid_size,
                         "input_frame": "map",
                     }
                 ],

--- a/perception/autoware_compare_map_segmentation/config/distance_based_compare_map_filter.param.yaml
+++ b/perception/autoware_compare_map_segmentation/config/distance_based_compare_map_filter.param.yaml
@@ -6,3 +6,4 @@
     map_update_distance_threshold: 10.0
     map_loader_radius: 150.0
     publish_debug_pcd: False
+    max_map_grid_size: 100.0

--- a/perception/autoware_compare_map_segmentation/config/voxel_based_approximate_compare_map_filter.param.yaml
+++ b/perception/autoware_compare_map_segmentation/config/voxel_based_approximate_compare_map_filter.param.yaml
@@ -7,3 +7,4 @@
     map_update_distance_threshold: 10.0
     map_loader_radius: 150.0
     publish_debug_pcd: False
+    max_map_grid_size: 100.0

--- a/perception/autoware_compare_map_segmentation/config/voxel_based_compare_map_filter.param.yaml
+++ b/perception/autoware_compare_map_segmentation/config/voxel_based_compare_map_filter.param.yaml
@@ -7,3 +7,4 @@
     map_update_distance_threshold: 10.0
     map_loader_radius: 150.0
     publish_debug_pcd: False
+    max_map_grid_size: 100.0

--- a/perception/autoware_compare_map_segmentation/config/voxel_distance_based_compare_map_filter.param.yaml
+++ b/perception/autoware_compare_map_segmentation/config/voxel_distance_based_compare_map_filter.param.yaml
@@ -7,3 +7,4 @@
     map_update_distance_threshold: 10.0
     map_loader_radius: 150.0
     publish_debug_pcd: False
+    max_map_grid_size: 100.0

--- a/perception/autoware_compare_map_segmentation/schema/distance_based_compare_map_filter.schema.json
+++ b/perception/autoware_compare_map_segmentation/schema/distance_based_compare_map_filter.schema.json
@@ -35,6 +35,11 @@
           "type": "boolean",
           "default": "false",
           "description": "Publish a downsampled map pointcloud for debugging"
+        },
+        "max_map_grid_size": {
+          "type": "number",
+          "default": "100.0",
+          "description": "Threshold of grid size to split map pointcloud"
         }
       },
       "required": [
@@ -43,7 +48,8 @@
         "timer_interval_ms",
         "map_update_distance_threshold",
         "map_loader_radius",
-        "publish_debug_pcd"
+        "publish_debug_pcd",
+        "max_map_grid_size"
       ],
       "additionalProperties": false
     }

--- a/perception/autoware_compare_map_segmentation/schema/voxel_based_approximate_compare_map_filter.schema.json
+++ b/perception/autoware_compare_map_segmentation/schema/voxel_based_approximate_compare_map_filter.schema.json
@@ -40,6 +40,11 @@
           "type": "boolean",
           "default": "false",
           "description": "Publish a downsampled map pointcloud for debugging"
+        },
+        "max_map_grid_size": {
+          "type": "number",
+          "default": "100.0",
+          "description": "Threshold of grid size to split map pointcloud"
         }
       },
       "required": [
@@ -49,7 +54,8 @@
         "timer_interval_ms",
         "map_update_distance_threshold",
         "map_loader_radius",
-        "publish_debug_pcd"
+        "publish_debug_pcd",
+        "max_map_grid_size"
       ],
       "additionalProperties": false
     }

--- a/perception/autoware_compare_map_segmentation/schema/voxel_based_compare_map_filter.schema.json
+++ b/perception/autoware_compare_map_segmentation/schema/voxel_based_compare_map_filter.schema.json
@@ -40,6 +40,11 @@
           "type": "boolean",
           "default": "false",
           "description": "Publish a downsampled map pointcloud for debugging"
+        },
+        "max_map_grid_size": {
+          "type": "number",
+          "default": "100.0",
+          "description": "Threshold of grid size to split map pointcloud"
         }
       },
       "required": [
@@ -49,7 +54,8 @@
         "timer_interval_ms",
         "map_update_distance_threshold",
         "map_loader_radius",
-        "publish_debug_pcd"
+        "publish_debug_pcd",
+        "max_map_grid_size"
       ],
       "additionalProperties": false
     }

--- a/perception/autoware_compare_map_segmentation/schema/voxel_distance_based_compare_map_filter.schema.json
+++ b/perception/autoware_compare_map_segmentation/schema/voxel_distance_based_compare_map_filter.schema.json
@@ -40,6 +40,11 @@
           "type": "boolean",
           "default": "false",
           "description": "Publish a downsampled map pointcloud for debugging"
+        },
+        "max_map_grid_size": {
+          "type": "number",
+          "default": "100.0",
+          "description": "Threshold of grid size to split map pointcloud"
         }
       },
       "required": [
@@ -49,7 +54,8 @@
         "timer_interval_ms",
         "map_update_distance_threshold",
         "map_loader_radius",
-        "publish_debug_pcd"
+        "publish_debug_pcd",
+        "max_map_grid_size"
       ],
       "additionalProperties": false
     }

--- a/perception/autoware_compare_map_segmentation/schema/voxel_distance_based_compare_map_filter.schema.json
+++ b/perception/autoware_compare_map_segmentation/schema/voxel_distance_based_compare_map_filter.schema.json
@@ -44,7 +44,7 @@
         "max_map_grid_size": {
           "type": "number",
           "default": "100.0",
-          "description": "Threshold of grid size to split map pointcloud"
+          "description": "Maximum size of the pcd map with dynamic map loading."
         }
       },
       "required": [

--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.cpp
@@ -293,6 +293,7 @@ VoxelGridDynamicMapLoader::VoxelGridDynamicMapLoader(
   auto timer_interval_ms = node->declare_parameter<int>("timer_interval_ms");
   map_update_distance_threshold_ = node->declare_parameter<double>("map_update_distance_threshold");
   map_loader_radius_ = node->declare_parameter<double>("map_loader_radius");
+  max_map_grid_size_ = node->declare_parameter<double>("max_map_grid_size");
   auto main_sub_opt = rclcpp::SubscriptionOptions();
   main_sub_opt.callback_group = main_callback_group;
   sub_kinematic_state_ = node->create_subscription<nav_msgs::msg::Odometry>(

--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
@@ -274,7 +274,6 @@ public:
     if (map_grid_size_x_ > max_map_grid_size_ || map_grid_size_y_ > max_map_grid_size_) {
       throw std::runtime_error(
         "Map was not split or split map grid size is too large. Split map with smaller grid.");
-      return;
     }
 
     origin_x_remainder_ = std::remainder(map_cell_to_add.metadata.min_x, map_grid_size_x_);

--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
@@ -272,8 +272,11 @@ public:
     map_grid_size_x_ = map_cell_to_add.metadata.max_x - map_cell_to_add.metadata.min_x;
     map_grid_size_y_ = map_cell_to_add.metadata.max_y - map_cell_to_add.metadata.min_y;
     if (map_grid_size_x_ > max_map_grid_size_ || map_grid_size_y_ > max_map_grid_size_) {
-      throw std::runtime_error(
-        "Map was not split or split map grid size is too large. Split map with smaller grid.");
+      RCLCPP_ERROR(
+        logger_,
+        "Map was not split or split map grid size is too large. Split map with grid size smaller "
+        "than %f",
+        max_map_grid_size_);
     }
 
     origin_x_remainder_ = std::remainder(map_cell_to_add.metadata.min_x, map_grid_size_x_);

--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
@@ -152,6 +152,7 @@ protected:
   rclcpp::TimerBase::SharedPtr map_update_timer_;
   double map_update_distance_threshold_;
   double map_loader_radius_;
+  double max_map_grid_size_;
   rclcpp::Client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>::SharedPtr
     map_update_client_;
   rclcpp::CallbackGroup::SharedPtr client_callback_group_;
@@ -270,6 +271,11 @@ public:
   {
     map_grid_size_x_ = map_cell_to_add.metadata.max_x - map_cell_to_add.metadata.min_x;
     map_grid_size_y_ = map_cell_to_add.metadata.max_y - map_cell_to_add.metadata.min_y;
+    if (map_grid_size_x_ > max_map_grid_size_ || map_grid_size_y_ > max_map_grid_size_) {
+      throw std::runtime_error(
+        "Map was not split or split map grid size is too large. Split map with smaller grid.");
+      return;
+    }
 
     origin_x_remainder_ = std::remainder(map_cell_to_add.metadata.min_x, map_grid_size_x_);
     origin_y_remainder_ = std::remainder(map_cell_to_add.metadata.min_y, map_grid_size_y_);


### PR DESCRIPTION
## Description
- This PR will limit autoware to use split map pointcloud for `dynamic_map_loader` in `compare_map_segmentation`. Otherwise, ERROR message will be output as below
```
[component_container_mt-1] [ERROR] [1728371768.729818629] [perception.object_recognition.detection.voxel_based_compare_map_filter]: Map was not split or split map grid size is too large. Split map with grid size smaller than 100.000000

```

- This PR should be merged after PR: https://github.com/autowarefoundation/autoware_launch/pull/1184
## Related links

- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-4938)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
