### PR TITLE
fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -2162,7 +2162,7 @@ static std::vector<utils::path_safety_checker::ExtendedPredictedObject> filterOb
   const auto & target_object_types = params->object_types_to_check;
 
   PredictedObjects filtered_objects = utils::path_safety_checker::filterObjectsByVelocity(
-    *objects, ignore_object_velocity_threshold, false);
+    *objects, ignore_object_velocity_threshold, true);
 
   utils::path_safety_checker::filterObjectsByClass(filtered_objects, target_object_types);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
@@ -113,7 +113,7 @@ PredictedObjects filterObjects(
  */
 PredictedObjects filterObjectsByVelocity(
   const PredictedObjects & objects, const double velocity_threshold,
-  const bool remove_above_threshold = true);
+  const bool remove_above_threshold = false);
 
 /**
  * @brief Helper function to filter objects based on their velocity.

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -118,7 +118,7 @@ PredictedObjects filterObjects(
   const ObjectTypesToCheck & target_object_types = params->object_types_to_check;
 
   PredictedObjects filtered_objects =
-    filterObjectsByVelocity(*objects, ignore_object_velocity_threshold, false);
+    filterObjectsByVelocity(*objects, ignore_object_velocity_threshold, true);
 
   filterObjectsByClass(filtered_objects, target_object_types);
 
@@ -136,7 +136,7 @@ PredictedObjects filterObjectsByVelocity(
   const PredictedObjects & objects, const double velocity_threshold,
   const bool remove_above_threshold)
 {
-  if (remove_above_threshold) {
+  if (!remove_above_threshold) {
     return filterObjectsByVelocity(objects, -velocity_threshold, velocity_threshold);
   }
   return filterObjectsByVelocity(objects, velocity_threshold, std::numeric_limits<double>::max());

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -329,7 +329,7 @@ bool StartPlannerModule::noMovingObjectsAround() const
   utils::path_safety_checker::filterObjectsByClass(
     dynamic_objects, parameters_->surround_moving_obstacles_type_to_check);
   const auto filtered_objects = utils::path_safety_checker::filterObjectsByVelocity(
-    dynamic_objects, parameters_->th_moving_obstacle_velocity, false);
+    dynamic_objects, parameters_->th_moving_obstacle_velocity, true);
   if (!filtered_objects.objects.empty()) {
     DEBUG_PRINT("Moving objects exist in the safety check area");
   }


### PR DESCRIPTION
## Description
Function `filterObjectsByVelocity` has an argument `remove_above_threshold` which is used to ignore the upper limit or not.
The upper velocity limit would be ignored when the value is `false` and it might lead to misunderstanding.
This PR swaps the condition, by ignoring the upper velocity limit when `remove_above_threshold` is `true`.

## Related links
None

## How was this PR tested?

- [ ] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/088ffc46-79ad-56f5-8ad0-ea1a988ea4fc?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
