### PR TITLE
fix(intersection): set RTC enable

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
@@ -441,6 +441,7 @@ void IntersectionModuleManager::setActivation()
     scene_module->setActivation(rtc_interface_.isActivated(getUUID(scene_module->getModuleId())));
     intersection_module->setOcclusionActivation(
       occlusion_rtc_interface_.isActivated(occlusion_uuid));
+    scene_module->setRTCEnabled(rtc_interface_.isRTCEnabled(getUUID(scene_module->getModuleId())));
   }
 }
 


### PR DESCRIPTION
## Description
In the intersection module, member variable `rtc_enabled_` was not set appropriately. 
This functions sets the `rtc_enabled_` according to the RTC interface.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/5697

## How was this PR tested?

- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/67989f9a-7770-539a-9cf8-bc9db08a5714?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
