### PR TITLE
fix(autoware_mpc_lateral_controller): fix calculation method of predicted trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -94,8 +94,8 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
 
   // update state in the world coordinate
   const auto updateState = [&](
-                             const Eigen::VectorXd & state_w, const double & input,
-                             const double dt, const double velocity) {
+                             const Eigen::VectorXd & state_w, const double & input, const double dt,
+                             const double velocity) {
     const auto yaw = state_w(2);
 
     Eigen::VectorXd dstate = Eigen::VectorXd::Zero(4);

--- a/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -83,29 +83,25 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
 
   // create initial state in the world coordinate
   Eigen::VectorXd state_w = [&]() {
-    Eigen::VectorXd state = Eigen::VectorXd::Zero(4);
+    Eigen::VectorXd state = Eigen::VectorXd::Zero(3);
     const auto lateral_error_0 = x0(0);
     const auto yaw_error_0 = x0(1);
     state(0, 0) = t.x.at(0) - std::sin(t.yaw.at(0)) * lateral_error_0;  // world-x
     state(1, 0) = t.y.at(0) + std::cos(t.yaw.at(0)) * lateral_error_0;  // world-y
     state(2, 0) = t.yaw.at(0) + yaw_error_0;                            // world-yaw
-    state(3, 0) = x0(2);                                                // steering
     return state;
   }();
 
   // update state in the world coordinate
   const auto updateState = [&](
-                             const Eigen::VectorXd & state_w, const Eigen::MatrixXd & input,
+                             const Eigen::VectorXd & state_w, const double & input,
                              const double dt, const double velocity) {
     const auto yaw = state_w(2);
-    const auto steer = state_w(3);
-    const auto desired_steer = input(0);
 
     Eigen::VectorXd dstate = Eigen::VectorXd::Zero(4);
     dstate(0) = velocity * std::cos(yaw);
     dstate(1) = velocity * std::sin(yaw);
-    dstate(2) = velocity * std::tan(steer) / m_wheelbase;
-    dstate(3) = -(steer - desired_steer) / m_steer_tau;
+    dstate(2) = velocity * std::tan(input) / m_wheelbase;
 
     // Note: don't do "return state_w + dstate * dt", which does not work due to the lazy evaluation
     // in Eigen.
@@ -117,7 +113,7 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
   const auto DIM_U = getDimU();
 
   for (size_t i = 0; i < reference_trajectory.size(); ++i) {
-    state_w = updateState(state_w, Uex.block(i * DIM_U, 0, DIM_U, 1), dt, t.vx.at(i));
+    state_w = updateState(state_w, Uex(i * DIM_U, 0), dt, t.vx.at(i));
     mpc_predicted_trajectory.push_back(
       state_w(0), state_w(1), t.z.at(i), state_w(2), t.vx.at(i), t.k.at(i), t.smooth_k.at(i),
       t.relative_time.at(i));


### PR DESCRIPTION
## Description

fix calculation method of predicted trajectory.

As a premise, the MPC optimization result considers a first-order delay applied to the ideal steering angle calculated based on the path curvature.
The original method for calculating the predicted path was as follows:
```
  // update state in the world coordinate
  const auto updateState = [&](
                             const Eigen::VectorXd & state_w, const Eigen::MatrixXd & input,
                             const double dt, const double velocity) {
    const auto yaw = state_w(2);
    const auto steer = state_w(3);
    const auto desired_steer = input(0);

    Eigen::VectorXd dstate = Eigen::VectorXd::Zero(4);
    dstate(0) = velocity * std::cos(yaw);
    dstate(1) = velocity * std::sin(yaw);
    dstate(2) = velocity * std::tan(steer) / m_wheelbase;
    dstate(3) = -(steer - desired_steer) / m_steer_tau;

    // Note: don't do "return state_w + dstate * dt", which does not work due to the lazy evaluation
    // in Eigen.
    const Eigen::VectorXd next_state = state_w + dstate * dt;
    return next_state;
  };
```
It calculats the desired steering angle based on the MPC optimization result, and then computed the predicted steering angle at each time step. This approach inadvertently considered the first-order delay twice.
As a result, the following issue occurred: 

![image](https://github.com/user-attachments/assets/5b9dae49-f544-46d4-9f2d-def354c9d36d)

the predicted path became unstable at low speeds.
In this PR, I confirmed that the problem was resolved by removing the term that considers the steering's first-order delay during the predicted path calculation.

![image](https://github.com/user-attachments/assets/beadd2d5-dde9-4ccd-8a25-e2bf267e221e)



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] run psim
- [x] passed [TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/dac8d32d-3dbd-5bad-8ffa-2628c8db10ee?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

## Effects on system behavior

None.
