### PR TITLE
feat(autoware_lidar _ransfusion): fix 3d bounding box orientation

### DIFF
--- a/perception/autoware_lidar_transfusion/lib/postprocess/postprocess_kernel.cu
+++ b/perception/autoware_lidar_transfusion/lib/postprocess/postprocess_kernel.cu
@@ -83,8 +83,8 @@ __global__ void generateBoxes3D_kernel(
   det_boxes3d[point_idx].y =
     box_output[point_idx + num_proposals] * num_point_values * voxel_size_y + min_y_range;
   det_boxes3d[point_idx].z = box_output[point_idx + 2 * num_proposals];
-  det_boxes3d[point_idx].width = expf(box_output[point_idx + 3 * num_proposals]);
-  det_boxes3d[point_idx].length = expf(box_output[point_idx + 4 * num_proposals]);
+  det_boxes3d[point_idx].length = expf(box_output[point_idx + 3 * num_proposals]);
+  det_boxes3d[point_idx].width = expf(box_output[point_idx + 4 * num_proposals]);
   det_boxes3d[point_idx].height = expf(box_output[point_idx + 5 * num_proposals]);
   det_boxes3d[point_idx].yaw =
     atan2f(dir_cls_output[point_idx], dir_cls_output[point_idx + num_proposals]);

--- a/perception/autoware_lidar_transfusion/lib/ros_utils.cpp
+++ b/perception/autoware_lidar_transfusion/lib/ros_utils.cpp
@@ -28,7 +28,6 @@ void box3DToDetectedObject(
   autoware_perception_msgs::msg::DetectedObject & obj)
 {
   obj.existence_probability = box3d.score;
-
   // classification
   autoware_perception_msgs::msg::ObjectClassification classification;
   classification.probability = 1.0f;
@@ -39,24 +38,21 @@ void box3DToDetectedObject(
     RCLCPP_WARN_STREAM(
       rclcpp::get_logger("lidar_transfusion"), "Unexpected label: UNKNOWN is set.");
   }
-
   if (object_recognition_utils::isCarLikeVehicle(classification.label)) {
     obj.kinematics.orientation_availability =
       autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
   }
-
   obj.classification.emplace_back(classification);
-
   // pose and shape
   // mmdet3d yaw format to ros yaw format
-  float yaw = box3d.yaw + autoware::universe_utils::pi / 2;
+  float yaw = box3d.yaw;
   obj.kinematics.pose_with_covariance.pose.position =
     autoware::universe_utils::createPoint(box3d.x, box3d.y, box3d.z);
   obj.kinematics.pose_with_covariance.pose.orientation =
     autoware::universe_utils::createQuaternionFromYaw(yaw);
   obj.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   obj.shape.dimensions =
-    autoware::universe_utils::createTranslation(box3d.length, box3d.width, box3d.height);
+    autoware::universe_utils::createTranslation(box3d.width, box3d.length, box3d.height);
 }
 
 uint8_t getSemanticType(const std::string & class_name)

--- a/perception/autoware_lidar_transfusion/lib/ros_utils.cpp
+++ b/perception/autoware_lidar_transfusion/lib/ros_utils.cpp
@@ -28,6 +28,7 @@ void box3DToDetectedObject(
   autoware_perception_msgs::msg::DetectedObject & obj)
 {
   obj.existence_probability = box3d.score;
+
   // classification
   autoware_perception_msgs::msg::ObjectClassification classification;
   classification.probability = 1.0f;
@@ -38,11 +39,14 @@ void box3DToDetectedObject(
     RCLCPP_WARN_STREAM(
       rclcpp::get_logger("lidar_transfusion"), "Unexpected label: UNKNOWN is set.");
   }
+
   if (object_recognition_utils::isCarLikeVehicle(classification.label)) {
     obj.kinematics.orientation_availability =
       autoware_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
   }
+
   obj.classification.emplace_back(classification);
+
   // pose and shape
   // mmdet3d yaw format to ros yaw format
   float yaw = box3d.yaw;

--- a/perception/autoware_lidar_transfusion/lib/ros_utils.cpp
+++ b/perception/autoware_lidar_transfusion/lib/ros_utils.cpp
@@ -48,15 +48,13 @@ void box3DToDetectedObject(
   obj.classification.emplace_back(classification);
 
   // pose and shape
-  // mmdet3d yaw format to ros yaw format
-  float yaw = box3d.yaw;
   obj.kinematics.pose_with_covariance.pose.position =
     autoware::universe_utils::createPoint(box3d.x, box3d.y, box3d.z);
   obj.kinematics.pose_with_covariance.pose.orientation =
-    autoware::universe_utils::createQuaternionFromYaw(yaw);
+    autoware::universe_utils::createQuaternionFromYaw(box3d.yaw);
   obj.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   obj.shape.dimensions =
-    autoware::universe_utils::createTranslation(box3d.width, box3d.length, box3d.height);
+    autoware::universe_utils::createTranslation(box3d.length, box3d.width, box3d.height);
 }
 
 uint8_t getSemanticType(const std::string & class_name)


### PR DESCRIPTION
## Description
We found that the 3d bounding boxes were rotated by 90 degrees for transfusion
![image](https://github.com/user-attachments/assets/2c08e906-2338-4875-8a7d-f2ee5b04f146)

This PR fixes the issue.