### PR TITLE
fix(autoware_lidar_transfusion): set tensor names by matching with predefined values.

### DIFF
--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/utils.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/utils.hpp
@@ -36,7 +36,7 @@ struct Box3D
   float yaw;
 };
 
-enum NetworkIO { voxels = 0, num_points, coors, cls_score, dir_pred, bbox_pred, ENUM_SIZE };
+enum NetworkIO { voxels = 0, num_points, coors, cls_score, bbox_pred, dir_pred, ENUM_SIZE };
 
 // cspell: ignore divup
 template <typename T1, typename T2>

--- a/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
@@ -23,7 +23,7 @@
 namespace autoware::lidar_transfusion
 {
 
-inline NetworkIO nameToNetworkIO(const char* name)
+inline NetworkIO nameToNetworkIO(const char * name)
 {
   static const std::unordered_map<std::string_view, NetworkIO> name_to_enum = {
     {"voxels", NetworkIO::voxels},
@@ -31,8 +31,7 @@ inline NetworkIO nameToNetworkIO(const char* name)
     {"coors", NetworkIO::coors},
     {"cls_score0", NetworkIO::cls_score},
     {"dir_cls_pred0", NetworkIO::dir_pred},
-    {"bbox_pred0", NetworkIO::bbox_pred}
-  };
+    {"bbox_pred0", NetworkIO::bbox_pred}};
 
   auto it = name_to_enum.find(name);
   if (it != name_to_enum.end()) {
@@ -271,14 +270,14 @@ bool NetworkTRT::validateNetworkIO()
       << ". Actual size: " << engine->getNbIOTensors() << "." << std::endl;
     throw std::runtime_error("Failed to initialize TRT network.");
   }
-  
+
   // Initialize tensors_names_ with null values
   tensors_names_.resize(NetworkIO::ENUM_SIZE, nullptr);
 
   // Loop over the tensor names and place them in the correct positions
   for (int i = 0; i < NetworkIO::ENUM_SIZE; ++i) {
-      const char* name = engine->getIOTensorName(i);
-      tensors_names_[nameToNetworkIO(name)] = name;
+    const char * name = engine->getIOTensorName(i);
+    tensors_names_[nameToNetworkIO(name)] = name;
   }
 
   // Log the network IO

--- a/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
@@ -26,12 +26,10 @@ namespace autoware::lidar_transfusion
 inline NetworkIO nameToNetworkIO(const char * name)
 {
   static const std::unordered_map<std::string_view, NetworkIO> name_to_enum = {
-    {"voxels", NetworkIO::voxels},
-    {"num_points", NetworkIO::num_points},
-    {"coors", NetworkIO::coors},
-    {"cls_score0", NetworkIO::cls_score},
-    {"bbox_pred0", NetworkIO::bbox_pred},
-    {"dir_cls_pred0", NetworkIO::dir_pred},};
+    {"voxels", NetworkIO::voxels},        {"num_points", NetworkIO::num_points},
+    {"coors", NetworkIO::coors},          {"cls_score0", NetworkIO::cls_score},
+    {"bbox_pred0", NetworkIO::bbox_pred}, {"dir_cls_pred0", NetworkIO::dir_pred},
+  };
 
   auto it = name_to_enum.find(name);
   if (it != name_to_enum.end()) {

--- a/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
@@ -26,9 +26,12 @@ namespace autoware::lidar_transfusion
 inline NetworkIO nameToNetworkIO(const char * name)
 {
   static const std::unordered_map<std::string_view, NetworkIO> name_to_enum = {
-    {"voxels", NetworkIO::voxels},        {"num_points", NetworkIO::num_points},
-    {"coors", NetworkIO::coors},          {"cls_score0", NetworkIO::cls_score},
-    {"bbox_pred0", NetworkIO::bbox_pred}, {"dir_cls_pred0", NetworkIO::dir_pred},
+    {"voxels", NetworkIO::voxels}, 
+    {"num_points", NetworkIO::num_points},
+    {"coors", NetworkIO::coors},
+    {"cls_score0", NetworkIO::cls_score},
+    {"bbox_pred0", NetworkIO::bbox_pred},
+    {"dir_cls_pred0", NetworkIO::dir_pred}
   };
 
   auto it = name_to_enum.find(name);

--- a/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
@@ -26,13 +26,9 @@ namespace autoware::lidar_transfusion
 inline NetworkIO nameToNetworkIO(const char * name)
 {
   static const std::unordered_map<std::string_view, NetworkIO> name_to_enum = {
-    {"voxels", NetworkIO::voxels}, 
-    {"num_points", NetworkIO::num_points},
-    {"coors", NetworkIO::coors},
-    {"cls_score0", NetworkIO::cls_score},
-    {"bbox_pred0", NetworkIO::bbox_pred},
-    {"dir_cls_pred0", NetworkIO::dir_pred}
-  };
+    {"voxels", NetworkIO::voxels},        {"num_points", NetworkIO::num_points},
+    {"coors", NetworkIO::coors},          {"cls_score0", NetworkIO::cls_score},
+    {"bbox_pred0", NetworkIO::bbox_pred}, {"dir_cls_pred0", NetworkIO::dir_pred}};
 
   auto it = name_to_enum.find(name);
   if (it != name_to_enum.end()) {

--- a/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
@@ -23,6 +23,24 @@
 namespace autoware::lidar_transfusion
 {
 
+inline NetworkIO nameToNetworkIO(const char* name)
+{
+  static const std::unordered_map<std::string_view, NetworkIO> name_to_enum = {
+    {"voxels", NetworkIO::voxels},
+    {"num_points", NetworkIO::num_points},
+    {"coors", NetworkIO::coors},
+    {"cls_score0", NetworkIO::cls_score},
+    {"dir_cls_pred0", NetworkIO::dir_pred},
+    {"bbox_pred0", NetworkIO::bbox_pred}
+  };
+
+  auto it = name_to_enum.find(name);
+  if (it != name_to_enum.end()) {
+    return it->second;
+  }
+  throw std::runtime_error("Invalid input name: " + std::string(name));
+}
+
 std::ostream & operator<<(std::ostream & os, const ProfileDimension & profile)
 {
   std::string delim = "";
@@ -253,8 +271,14 @@ bool NetworkTRT::validateNetworkIO()
       << ". Actual size: " << engine->getNbIOTensors() << "." << std::endl;
     throw std::runtime_error("Failed to initialize TRT network.");
   }
+  
+  // Initialize tensors_names_ with null values
+  tensors_names_.resize(NetworkIO::ENUM_SIZE, nullptr);
+
+  // Loop over the tensor names and place them in the correct positions
   for (int i = 0; i < NetworkIO::ENUM_SIZE; ++i) {
-    tensors_names_.push_back(engine->getIOTensorName(i));
+      const char* name = engine->getIOTensorName(i);
+      tensors_names_[nameToNetworkIO(name)] = name;
   }
 
   // Log the network IO

--- a/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/network/network_trt.cpp
@@ -30,8 +30,8 @@ inline NetworkIO nameToNetworkIO(const char * name)
     {"num_points", NetworkIO::num_points},
     {"coors", NetworkIO::coors},
     {"cls_score0", NetworkIO::cls_score},
-    {"dir_cls_pred0", NetworkIO::dir_pred},
-    {"bbox_pred0", NetworkIO::bbox_pred}};
+    {"bbox_pred0", NetworkIO::bbox_pred},
+    {"dir_cls_pred0", NetworkIO::dir_pred},};
 
   auto it = name_to_enum.find(name);
   if (it != name_to_enum.end()) {


### PR DESCRIPTION
# Description
When making minor architectural changes to onnx checkpoints, we found that the tensorrt IO tensor order changed, which results in the current code failing because the order of tensors is fixed in current code.
https://github.com/autowarefoundation/autoware.universe/blob/c2438fd2841bce7792be4bc57e88edbe6b34276d/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/utils.hpp#L39

It seems that the tensor output order of the optimized tensorrt engine can be different from onnx IO order, but the tensor names match the onnx IO names. So, it is better to use the names from trt engine API to find the IO tensor positions. 

We also found out that the current deployed models have faulty output names i.e the names of dir_cls_pred0 and bbox_pred0 are swapped, so they do not work with this PR. Therefore, we had to update the deployed onnx models with this PR. 

Merge with https://github.com/autowarefoundation/autoware/pull/5318
