### PR TITLE
refactor(goal_planner): remove prev_data / last_path_idx_time from ThreadSafeData

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GOAL_PLANNER_MODULE_HPP_
 #define AUTOWARE__BEHAVIOR_PATH_GOAL_PLANNER_MODULE__GOAL_PLANNER_MODULE_HPP_
 
+#include "autoware/behavior_path_goal_planner_module/decision_state.hpp"
 #include "autoware/behavior_path_goal_planner_module/fixed_goal_planner_base.hpp"
 #include "autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp"
 #include "autoware/behavior_path_goal_planner_module/goal_searcher.hpp"
@@ -111,12 +112,15 @@ struct PullOverContextData
   explicit PullOverContextData(
     const bool is_stable_safe_path, const PredictedObjects & static_objects,
     const PredictedObjects & dynamic_objects, std::optional<PullOverPath> && pull_over_path_opt,
-    const std::vector<PullOverPath> & pull_over_path_candidates)
+    const std::vector<PullOverPath> & pull_over_path_candidates,
+    const PathDecisionState & prev_state)
   : is_stable_safe_path(is_stable_safe_path),
     static_target_objects(static_objects),
     dynamic_target_objects(dynamic_objects),
     pull_over_path_opt(pull_over_path_opt),
-    pull_over_path_candidates(pull_over_path_candidates)
+    pull_over_path_candidates(pull_over_path_candidates),
+    prev_state_for_debug(prev_state),
+    last_path_idx_increment_time(std::nullopt)
   {
   }
   const bool is_stable_safe_path;
@@ -126,6 +130,8 @@ struct PullOverContextData
   std::optional<PullOverPath> pull_over_path_opt;
   const std::vector<PullOverPath> pull_over_path_candidates;
   // TODO(soblin): goal_candidate_from_thread, modifed_goal_pose_from_thread, closest_start_pose
+  const PathDecisionState prev_state_for_debug;
+  std::optional<rclcpp::Time> last_path_idx_increment_time;
 };
 
 class GoalPlannerModule : public SceneModuleInterface
@@ -364,7 +370,8 @@ private:
   PathWithLaneId generateStopPath(const PullOverContextData & context_data) const;
   PathWithLaneId generateFeasibleStopPath(const PathWithLaneId & path) const;
 
-  void keepStoppedWithCurrentPath(PathWithLaneId & path) const;
+  void keepStoppedWithCurrentPath(
+    const PullOverContextData & ctx_data, PathWithLaneId & path) const;
   double calcSignedArcLengthFromEgo(const PathWithLaneId & path, const Pose & pose) const;
 
   // status
@@ -464,7 +471,7 @@ private:
    */
   bool isSafePath(
     const std::shared_ptr<const PlannerData> planner_data, const bool found_pull_over_path,
-    const std::optional<PullOverPath> & pull_over_path_opt,
+    const std::optional<PullOverPath> & pull_over_path_opt, const PathDecisionState & prev_data,
     const GoalPlannerParameters & parameters,
     const std::shared_ptr<EgoPredictedPathParams> & ego_predicted_path_params,
     const std::shared_ptr<ObjectsFilteringParams> & objects_filtering_params,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -63,11 +63,7 @@ public:
       return false;
     }
 
-    if (pull_over_path_->incrementPathIndex()) {
-      last_path_idx_increment_time_ = clock_->now();
-      return true;
-    }
-    return false;
+    return pull_over_path_->incrementPathIndex();
   }
 
   void set_pull_over_path(const PullOverPath & path)
@@ -112,25 +108,29 @@ public:
     pull_over_path_candidates_.clear();
     goal_candidates_.clear();
     last_path_update_time_ = std::nullopt;
-    last_path_idx_increment_time_ = std::nullopt;
     closest_start_pose_ = std::nullopt;
     last_previous_module_output_ = std::nullopt;
     prev_data_ = PathDecisionState{};
   }
 
-  DEFINE_GETTER_WITH_MUTEX(std::shared_ptr<PullOverPath>, pull_over_path)
-  DEFINE_GETTER_WITH_MUTEX(std::optional<rclcpp::Time>, last_path_update_time)
-  DEFINE_GETTER_WITH_MUTEX(std::optional<rclcpp::Time>, last_path_idx_increment_time)
-
-  DEFINE_SETTER_GETTER_WITH_MUTEX(std::vector<PullOverPath>, pull_over_path_candidates)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(GoalCandidates, goal_candidates)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<Pose>, closest_start_pose)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<BehaviorModuleOutput>, last_previous_module_output)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(
-    utils::path_safety_checker::CollisionCheckDebugMap, collision_check)
+  // main --> lane/freespace
   DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, static_target_objects)
   DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, dynamic_target_objects)
+  // main --> lane
   DEFINE_SETTER_GETTER_WITH_MUTEX(PathDecisionState, prev_data)
+  DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<BehaviorModuleOutput>, last_previous_module_output)
+
+  // lane --> main
+  DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<Pose>, closest_start_pose)
+  DEFINE_SETTER_GETTER_WITH_MUTEX(std::vector<PullOverPath>, pull_over_path_candidates)
+
+  // main <--> lane/freespace
+  DEFINE_GETTER_WITH_MUTEX(std::shared_ptr<PullOverPath>, pull_over_path)
+  DEFINE_GETTER_WITH_MUTEX(std::optional<rclcpp::Time>, last_path_update_time)
+
+  DEFINE_SETTER_GETTER_WITH_MUTEX(GoalCandidates, goal_candidates)
+  DEFINE_SETTER_GETTER_WITH_MUTEX(
+    utils::path_safety_checker::CollisionCheckDebugMap, collision_check)
 
 private:
   void set_pull_over_path_no_lock(const PullOverPath & path)
@@ -160,7 +160,6 @@ private:
   std::vector<PullOverPath> pull_over_path_candidates_;
   GoalCandidates goal_candidates_{};
   std::optional<rclcpp::Time> last_path_update_time_;
-  std::optional<rclcpp::Time> last_path_idx_increment_time_;
   std::optional<Pose> closest_start_pose_{};
   std::optional<BehaviorModuleOutput> last_previous_module_output_{};
   utils::path_safety_checker::CollisionCheckDebugMap collision_check_{};


### PR DESCRIPTION
## Description

 depends https://github.com/autowarefoundation/autoware.universe/pull/9063

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/RT1-7966

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/fc9ed895-a2d8-53b1-889c-b09d1b4bffc4?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
