### PR TITLE
fix: missing dependency in common components

### DIFF
--- a/common/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
+++ b/common/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
@@ -11,6 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>boost</depend>

--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_vehicle_rviz_plugin/package.xml
+++ b/common/tier4_vehicle_rviz_plugin/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>libqt5-core</depend>


### PR DESCRIPTION
## Description

This PR add / modify dependencies written in package.xml.
The changed dependencies are almost about ament_index_cpp.
Jazzy has a build error due to not having a dependency on ament_index_cpp.
We have found similar errors in other ROS packages and have confirmed that they are not specific to the author's environment.

## Related links

Reference: https://github.com/autowarefoundation/autoware.universe/issues/7598
Base pull request: https://github.com/autowarefoundation/autoware.universe/pull/7600

## How was this PR tested?

colcon test passed.
This PR does not change the behavior of Autoware.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
