### PR TITLE
fix(control): missing dependency in control components

### DIFF
--- a/control/autoware_autonomous_emergency_braking/package.xml
+++ b/control/autoware_autonomous_emergency_braking/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>

--- a/control/autoware_control_validator/package.xml
+++ b/control/autoware_control_validator/package.xml
@@ -32,6 +32,7 @@
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>

--- a/control/autoware_trajectory_follower_node/package.xml
+++ b/control/autoware_trajectory_follower_node/package.xml
@@ -37,6 +37,7 @@
   <exec_depend>ros2launch</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_index_python</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/control/autoware_vehicle_cmd_gate/package.xml
+++ b/control/autoware_vehicle_cmd_gate/package.xml
@@ -39,6 +39,7 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
## Description

This PR add / modify dependencies written in package.xml.
The changed dependencies are almost about ament_index_cpp.
Jazzy has a build error due to not having a dependency on ament_index_cpp.
We have found similar errors in other ROS packages and have confirmed that they are not specific to the author's environment.

## Related links

Reference: https://github.com/autowarefoundation/autoware.universe/issues/7598
Base pull request: https://github.com/autowarefoundation/autoware.universe/pull/7600

## How was this PR tested?

colcon test passed.
This PR does not change the behavior of Autoware.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
