### PR TITLE
fix(evaluator): missing dependency in evaluator components

### DIFF
--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -30,6 +30,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/evaluator/kinematic_evaluator/package.xml
+++ b/evaluator/kinematic_evaluator/package.xml
@@ -29,6 +29,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/evaluator/localization_evaluator/package.xml
+++ b/evaluator/localization_evaluator/package.xml
@@ -25,6 +25,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/evaluator/perception_online_evaluator/package.xml
+++ b/evaluator/perception_online_evaluator/package.xml
@@ -35,6 +35,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
## Description

This PR add / modify dependencies written in package.xml.
The changed dependencies are almost about ament_index_cpp.
Jazzy has a build error due to not having a dependency on ament_index_cpp.
We have found similar errors in other ROS packages and have confirmed that they are not specific to the author's environment.

## Related links

Reference: https://github.com/autowarefoundation/autoware.universe/issues/7598
Base pull request: https://github.com/autowarefoundation/autoware.universe/pull/7600

## How was this PR tested?

colcon test passed.
This PR does not change the behavior of Autoware.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
