### PR TITLE
refactor(goal_planner): move last_previous_module_output_path out of ThreadSafeData

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -219,9 +219,13 @@ private:
    */
   struct GoalPlannerData
   {
-    GoalPlannerData(const PlannerData & planner_data, const GoalPlannerParameters & parameters)
+    GoalPlannerData(
+      const PlannerData & planner_data, const GoalPlannerParameters & parameters,
+      const BehaviorModuleOutput & previous_module_output_)
     {
       initializeOccupancyGridMap(planner_data, parameters);
+      previous_module_output = previous_module_output_;
+      last_previous_module_output = previous_module_output_;
     };
     GoalPlannerParameters parameters;
     autoware::universe_utils::LinearRing2d vehicle_footprint;
@@ -229,6 +233,7 @@ private:
     PlannerData planner_data;
     ModuleStatus current_status;
     BehaviorModuleOutput previous_module_output;
+    BehaviorModuleOutput last_previous_module_output;  //<! previous "previous_module_output"
     // collision detector
     // need to be shared_ptr to be used in planner and goal searcher
     std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map;
@@ -437,9 +442,12 @@ private:
   TurnSignalInfo calcTurnSignalInfo(const PullOverContextData & context_data);
   std::optional<lanelet::Id> ignore_signal_{std::nullopt};
 
-  bool hasPreviousModulePathShapeChanged(const BehaviorModuleOutput & previous_module_output) const;
+  bool hasPreviousModulePathShapeChanged(
+    const BehaviorModuleOutput & previous_module_output,
+    const BehaviorModuleOutput & last_previous_module_output) const;
   bool hasDeviatedFromLastPreviousModulePath(
-    const std::shared_ptr<const PlannerData> planner_data) const;
+    const std::shared_ptr<const PlannerData> planner_data,
+    const BehaviorModuleOutput & last_previous_module_output) const;
   bool hasDeviatedFromCurrentPreviousModulePath(
     const std::shared_ptr<const PlannerData> planner_data,
     const BehaviorModuleOutput & previous_module_output) const;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -109,7 +109,6 @@ public:
     goal_candidates_.clear();
     last_path_update_time_ = std::nullopt;
     closest_start_pose_ = std::nullopt;
-    last_previous_module_output_ = std::nullopt;
     prev_data_ = PathDecisionState{};
   }
 
@@ -118,7 +117,6 @@ public:
   DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, dynamic_target_objects)
   // main --> lane
   DEFINE_SETTER_GETTER_WITH_MUTEX(PathDecisionState, prev_data)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<BehaviorModuleOutput>, last_previous_module_output)
 
   // lane --> main
   DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<Pose>, closest_start_pose)
@@ -150,7 +148,6 @@ private:
   void set_no_lock(const std::vector<PullOverPath> & arg) { pull_over_path_candidates_ = arg; }
   void set_no_lock(const std::shared_ptr<PullOverPath> & arg) { set_pull_over_path_no_lock(arg); }
   void set_no_lock(const PullOverPath & arg) { set_pull_over_path_no_lock(arg); }
-  void set_no_lock(const BehaviorModuleOutput & arg) { last_previous_module_output_ = arg; }
   void set_no_lock(const utils::path_safety_checker::CollisionCheckDebugMap & arg)
   {
     collision_check_ = arg;
@@ -161,7 +158,6 @@ private:
   GoalCandidates goal_candidates_{};
   std::optional<rclcpp::Time> last_path_update_time_;
   std::optional<Pose> closest_start_pose_{};
-  std::optional<BehaviorModuleOutput> last_previous_module_output_{};
   utils::path_safety_checker::CollisionCheckDebugMap collision_check_{};
   PredictedObjects static_target_objects_{};
   PredictedObjects dynamic_target_objects_{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -144,21 +144,17 @@ GoalPlannerModule::GoalPlannerModule(
 }
 
 bool GoalPlannerModule::hasPreviousModulePathShapeChanged(
-  const BehaviorModuleOutput & previous_module_output) const
+  const BehaviorModuleOutput & previous_module_output,
+  const BehaviorModuleOutput & last_previous_module_output) const
 {
-  const auto last_previous_module_output = thread_safe_data_.get_last_previous_module_output();
-  if (!last_previous_module_output) {
-    return true;
-  }
-
   // Calculate the lateral distance between each point of the current path and the nearest point of
   // the last path
   constexpr double LATERAL_DEVIATION_THRESH = 0.3;
   for (const auto & p : previous_module_output.path.points) {
     const size_t nearest_seg_idx = autoware::motion_utils::findNearestSegmentIndex(
-      last_previous_module_output->path.points, p.point.pose.position);
-    const auto seg_front = last_previous_module_output->path.points.at(nearest_seg_idx);
-    const auto seg_back = last_previous_module_output->path.points.at(nearest_seg_idx + 1);
+      last_previous_module_output.path.points, p.point.pose.position);
+    const auto seg_front = last_previous_module_output.path.points.at(nearest_seg_idx);
+    const auto seg_back = last_previous_module_output.path.points.at(nearest_seg_idx + 1);
     // Check if the target point is within the segment
     const Eigen::Vector3d segment_vec{
       seg_back.point.pose.position.x - seg_front.point.pose.position.x,
@@ -174,7 +170,7 @@ bool GoalPlannerModule::hasPreviousModulePathShapeChanged(
       continue;
     }
     const double lateral_distance = std::abs(autoware::motion_utils::calcLateralOffset(
-      last_previous_module_output->path.points, p.point.pose.position, nearest_seg_idx));
+      last_previous_module_output.path.points, p.point.pose.position, nearest_seg_idx));
     if (lateral_distance > LATERAL_DEVIATION_THRESH) {
       return true;
     }
@@ -183,14 +179,11 @@ bool GoalPlannerModule::hasPreviousModulePathShapeChanged(
 }
 
 bool GoalPlannerModule::hasDeviatedFromLastPreviousModulePath(
-  const std::shared_ptr<const PlannerData> planner_data) const
+  const std::shared_ptr<const PlannerData> planner_data,
+  const BehaviorModuleOutput & last_previous_module_output) const
 {
-  const auto last_previous_module_output = thread_safe_data_.get_last_previous_module_output();
-  if (!last_previous_module_output) {
-    return true;
-  }
   return std::abs(autoware::motion_utils::calcLateralOffset(
-           last_previous_module_output->path.points,
+           last_previous_module_output.path.points,
            planner_data->self_odometry->pose.pose.position)) > 0.3;
 }
 
@@ -212,6 +205,7 @@ void GoalPlannerModule::onTimer()
   std::shared_ptr<const PlannerData> local_planner_data{nullptr};
   std::optional<ModuleStatus> current_status_opt{std::nullopt};
   std::optional<BehaviorModuleOutput> previous_module_output_opt{std::nullopt};
+  std::optional<BehaviorModuleOutput> last_previous_module_output_opt{std::nullopt};
   std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map{nullptr};
   std::optional<GoalPlannerParameters> parameters_opt{std::nullopt};
   std::shared_ptr<GoalSearcherBase> goal_searcher{nullptr};
@@ -224,6 +218,7 @@ void GoalPlannerModule::onTimer()
       local_planner_data = std::make_shared<const PlannerData>(gp_planner_data.planner_data);
       current_status_opt = gp_planner_data.current_status;
       previous_module_output_opt = gp_planner_data.previous_module_output;
+      last_previous_module_output_opt = gp_planner_data.last_previous_module_output;
       occupancy_grid_map = gp_planner_data.occupancy_grid_map;
       parameters_opt = gp_planner_data.parameters;
       goal_searcher = gp_planner_data.goal_searcher;
@@ -232,7 +227,7 @@ void GoalPlannerModule::onTimer()
   // end of critical section
   if (
     !local_planner_data || !current_status_opt || !previous_module_output_opt ||
-    !occupancy_grid_map || !parameters_opt || !goal_searcher) {
+    !last_previous_module_output_opt || !occupancy_grid_map || !parameters_opt || !goal_searcher) {
     RCLCPP_ERROR(
       getLogger(),
       "failed to get valid "
@@ -242,6 +237,7 @@ void GoalPlannerModule::onTimer()
   }
   const auto & current_status = current_status_opt.value();
   const auto & previous_module_output = previous_module_output_opt.value();
+  const auto & last_previous_module_output = last_previous_module_output_opt.value();
   const auto & parameters = parameters_opt.value();
 
   if (current_status == ModuleStatus::IDLE) {
@@ -280,12 +276,12 @@ void GoalPlannerModule::onTimer()
     if (thread_safe_data_.get_pull_over_path_candidates().empty()) {
       return true;
     }
-    if (hasPreviousModulePathShapeChanged(previous_module_output)) {
+    if (hasPreviousModulePathShapeChanged(previous_module_output, last_previous_module_output)) {
       RCLCPP_DEBUG(getLogger(), "has previous module path shape changed");
       return true;
     }
     if (
-      hasDeviatedFromLastPreviousModulePath(local_planner_data) &&
+      hasDeviatedFromLastPreviousModulePath(local_planner_data, last_previous_module_output) &&
       current_state != PathDecisionState::DecisionKind::DECIDED) {
       RCLCPP_DEBUG(getLogger(), "has deviated from last previous module path");
       return true;
@@ -369,8 +365,6 @@ void GoalPlannerModule::onTimer()
   thread_safe_data_.set_pull_over_path_candidates(path_candidates);
   thread_safe_data_.set_closest_start_pose(closest_start_pose);
   RCLCPP_INFO(getLogger(), "generated %lu pull over path candidates", path_candidates.size());
-
-  thread_safe_data_.set_last_previous_module_output(previous_module_output);
 }
 
 void GoalPlannerModule::onFreespaceParkingTimer()
@@ -518,7 +512,7 @@ void GoalPlannerModule::updateData()
   {
     std::lock_guard<std::mutex> guard(gp_planner_data_mutex_);
     if (!gp_planner_data_) {
-      gp_planner_data_ = GoalPlannerData(*planner_data_, *parameters_);
+      gp_planner_data_ = GoalPlannerData(*planner_data_, *parameters_, getPreviousModuleOutput());
     }
     auto & gp_planner_data = gp_planner_data_.value();
     // NOTE: for the above reasons, PlannerManager/behavior_path_planner_node ensure that
@@ -2618,7 +2612,8 @@ void GoalPlannerModule::GoalPlannerData::initializeOccupancyGridMap(
 
 GoalPlannerModule::GoalPlannerData GoalPlannerModule::GoalPlannerData::clone() const
 {
-  GoalPlannerModule::GoalPlannerData gp_planner_data(planner_data, parameters);
+  GoalPlannerModule::GoalPlannerData gp_planner_data(
+    planner_data, parameters, last_previous_module_output);
   gp_planner_data.update(
     parameters, planner_data, current_status, previous_module_output, goal_searcher,
     vehicle_footprint);
@@ -2637,6 +2632,7 @@ void GoalPlannerModule::GoalPlannerData::update(
   planner_data = planner_data_;
   planner_data.route_handler = std::make_shared<RouteHandler>(*(planner_data_.route_handler));
   current_status = current_status_;
+  last_previous_module_output = previous_module_output;
   previous_module_output = previous_module_output_;
   occupancy_grid_map->setMap(*(planner_data.occupancy_grid));
   // to create a deepcopy of GoalPlanner(not GoalPlannerBase), goal_searcher_ is not enough, so


### PR DESCRIPTION
## Description

move last_previous_module_output from ThreadSafeData to GoalPlannerData because it is only used in `onTimer` calculation

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/4458f31f-bb44-5493-958d-4bea4c7443bb?project_id=prd_jt&state=failed

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
