### PR TITLE
fix(avoidance): don't insert stop line if the ego can't avoid or return

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
@@ -323,7 +323,7 @@ public:
 
   bool isFeasible(const AvoidLineArray & shift_lines) const
   {
-    const auto JERK_BUFFER = 0.1;  // [m/sss]
+    constexpr double JERK_BUFFER = 0.1;  // [m/sss]
     const auto & values = parameters_->velocity_map;
     const auto idx = getConstraintsMapIndex(0.0, values);  // use minimum avoidance speed
     const auto jerk_limit = parameters_->lateral_max_jerk_map.at(idx);

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
@@ -321,6 +321,19 @@ public:
     });
   }
 
+  bool isFeasible(const AvoidLineArray & shift_lines) const
+  {
+    const auto JERK_BUFFER = 0.1;  // [m/sss]
+    const auto & values = parameters_->velocity_map;
+    const auto idx = getConstraintsMapIndex(0.0, values);  // use minimum avoidance speed
+    const auto jerk_limit = parameters_->lateral_max_jerk_map.at(idx);
+    return std::all_of(shift_lines.begin(), shift_lines.end(), [&](const auto & line) {
+      return PathShifter::calcJerkFromLatLonDistance(
+               line.getRelativeLength(), line.getRelativeLongitudinal(), values.at(idx)) <
+             jerk_limit + JERK_BUFFER;
+    });
+  }
+
   bool isReady(const ObjectDataArray & objects) const
   {
     if (objects.empty()) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
@@ -328,7 +328,7 @@ public:
     const auto idx = getConstraintsMapIndex(0.0, values);  // use minimum avoidance speed
     const auto jerk_limit = parameters_->lateral_max_jerk_map.at(idx);
     return std::all_of(shift_lines.begin(), shift_lines.end(), [&](const auto & line) {
-      return PathShifter::calcJerkFromLatLonDistance(
+      return autoware::motion_utils::calc_jerk_from_lat_lon_distance(
                line.getRelativeLength(), line.getRelativeLongitudinal(), values.at(idx)) <
              jerk_limit + JERK_BUFFER;
     });


### PR DESCRIPTION
## Description

Sometimes, the avoidance module inserted stop point even when the ego overran the dead line to avoid/return manuever.
In this PR, I fixed logic not to insert stop point if the ego exceeds stop  line in order to prevent stuck.

Additionally, I fixed not to insert stop point on dead line for return maneuver if it's in following condition:

- there is no new shift line.
- return shift line is NOT feasible.

![Screenshot from 2024-10-16 09-35-57](https://github.com/user-attachments/assets/cb369169-1ad4-486a-b719-a54e1cbde9ec)

## Related links

**Parent Issue:**

- ticket: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-33610)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?


https://github.com/user-attachments/assets/5130c5e6-9eb8-4812-9d3a-7e6f5df7381c

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/deebc6b7-a130-50ab-b2c8-bda253bff92e?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
