### PR TITLE
refactor(component_interface_utils): prefix package and namespace with autoware

### DIFF
--- a/common/autoware_component_interface_utils/CMakeLists.txt
+++ b/common/autoware_component_interface_utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(component_interface_utils)
+project(autoware_component_interface_utils)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()

--- a/common/autoware_component_interface_utils/README.md
+++ b/common/autoware_component_interface_utils/README.md
@@ -1,4 +1,4 @@
-# component_interface_utils
+# autoware_component_interface_utils
 
 ## Features
 
@@ -40,13 +40,13 @@ Create the wrapper using the above definition as follows.
 
 ```cpp
 // header file
-component_interface_utils::Service<SampleService>::SharedPtr srv_;
-component_interface_utils::Client<SampleService>::SharedPtr cli_;
-component_interface_utils::Publisher<SampleMessage>::SharedPtr pub_;
-component_interface_utils::Subscription<SampleMessage>::SharedPtr sub_;
+autoware::component_interface_utils::Service<SampleService>::SharedPtr srv_;
+autoware::component_interface_utils::Client<SampleService>::SharedPtr cli_;
+autoware::component_interface_utils::Publisher<SampleMessage>::SharedPtr pub_;
+autoware::component_interface_utils::Subscription<SampleMessage>::SharedPtr sub_;
 
 // source file
-const auto node = component_interface_utils::NodeAdaptor(this);
+const auto node = autoware::component_interface_utils::NodeAdaptor(this);
 node.init_srv(srv_, callback);
 node.init_cli(cli_);
 node.init_pub(pub_);
@@ -94,7 +94,7 @@ void service_callback(Request req, Response res)
 There are utilities for relaying services and messages of the same type.
 
 ```cpp
-const auto node = component_interface_utils::NodeAdaptor(this);
+const auto node = autoware::component_interface_utils::NodeAdaptor(this);
 service_callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 node.relay_message(pub_, sub_);
 node.relay_service(cli_, srv_, service_callback_group_);  // group is for avoiding deadlocks

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
 
-#include <component_interface_utils/rclcpp/create_interface.hpp>
-#include <component_interface_utils/rclcpp/interface.hpp>
-#include <component_interface_utils/rclcpp/service_client.hpp>
-#include <component_interface_utils/rclcpp/service_server.hpp>
-#include <component_interface_utils/rclcpp/topic_publisher.hpp>
-#include <component_interface_utils/rclcpp/topic_subscription.hpp>
+#include <autoware/component_interface_utils/rclcpp/create_interface.hpp>
+#include <autoware/component_interface_utils/rclcpp/interface.hpp>
+#include <autoware/component_interface_utils/rclcpp/service_client.hpp>
+#include <autoware/component_interface_utils/rclcpp/service_server.hpp>
+#include <autoware/component_interface_utils/rclcpp/topic_publisher.hpp>
+#include <autoware/component_interface_utils/rclcpp/topic_subscription.hpp>
 
 #include <memory>
 #include <optional>
 #include <utility>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 class NodeAdaptor
@@ -123,6 +123,6 @@ private:
   NodeInterface::SharedPtr interface_;
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
 
-#include <component_interface_utils/rclcpp/interface.hpp>
-#include <component_interface_utils/rclcpp/service_client.hpp>
-#include <component_interface_utils/rclcpp/service_server.hpp>
-#include <component_interface_utils/rclcpp/topic_publisher.hpp>
-#include <component_interface_utils/rclcpp/topic_subscription.hpp>
-#include <component_interface_utils/specs.hpp>
+#include <autoware/component_interface_utils/rclcpp/interface.hpp>
+#include <autoware/component_interface_utils/rclcpp/service_client.hpp>
+#include <autoware/component_interface_utils/rclcpp/service_server.hpp>
+#include <autoware/component_interface_utils/rclcpp/topic_publisher.hpp>
+#include <autoware/component_interface_utils/rclcpp/topic_subscription.hpp>
+#include <autoware/component_interface_utils/specs.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <utility>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 /// Create a client wrapper for logging. This is a private implementation.
@@ -72,6 +72,6 @@ typename Subscription<SpecT>::SharedPtr create_subscription_impl(
   return Subscription<SpecT>::make_shared(subscription);
 }
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/exceptions.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/exceptions.hpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__EXCEPTIONS_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__EXCEPTIONS_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__EXCEPTIONS_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__EXCEPTIONS_HPP_
 
 #include <autoware_adapi_v1_msgs/msg/response_status.hpp>
 
 #include <exception>
 #include <string>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 class ServiceException : public std::exception
@@ -104,6 +104,6 @@ public:
   }
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__EXCEPTIONS_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__EXCEPTIONS_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__INTERFACE_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__INTERFACE_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__INTERFACE_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__INTERFACE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -23,7 +23,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 struct NodeInterface
@@ -68,6 +68,6 @@ struct NodeInterface
   std::string node_name;
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__INTERFACE_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__INTERFACE_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_CLIENT_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_CLIENT_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_CLIENT_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_CLIENT_HPP_
 
-#include <component_interface_utils/rclcpp/exceptions.hpp>
-#include <component_interface_utils/rclcpp/interface.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/interface.hpp>
 #include <rclcpp/node.hpp>
 
 #include <tier4_system_msgs/msg/service_log.hpp>
@@ -25,7 +25,7 @@
 #include <string>
 #include <utility>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 /// The wrapper class of rclcpp::Client for logging.
@@ -104,6 +104,6 @@ private:
   NodeInterface::SharedPtr interface_;
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_CLIENT_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_CLIENT_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_server.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_server.hpp
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
 
-#include <component_interface_utils/rclcpp/exceptions.hpp>
-#include <component_interface_utils/rclcpp/interface.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/interface.hpp>
 #include <rclcpp/node.hpp>
 
 #include <tier4_system_msgs/msg/service_log.hpp>
 
 #include <string>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 /// The wrapper class of rclcpp::Service for logging.
@@ -94,6 +94,6 @@ private:
   NodeInterface::SharedPtr interface_;
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_publisher.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_publisher.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
 
 #include <rclcpp/publisher.hpp>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 /// The wrapper class of rclcpp::Publisher. This is for future use and no functionality now.
@@ -43,6 +43,6 @@ private:
   typename WrapType::SharedPtr publisher_;
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
-#define COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
 
 #include <rclcpp/subscription.hpp>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 /// The wrapper class of rclcpp::Subscription. This is for future use and no functionality now.
@@ -40,6 +40,6 @@ private:
   typename WrapType::SharedPtr subscription_;
 };
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/specs.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/specs.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__SPECS_HPP_
-#define COMPONENT_INTERFACE_UTILS__SPECS_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__SPECS_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__SPECS_HPP_
 
 #include <rclcpp/qos.hpp>
 
-namespace component_interface_utils
+namespace autoware::component_interface_utils
 {
 
 template <class SpecT>
@@ -29,6 +29,6 @@ rclcpp::QoS get_qos()
   return qos;
 }
 
-}  // namespace component_interface_utils
+}  // namespace autoware::component_interface_utils
 
-#endif  // COMPONENT_INTERFACE_UTILS__SPECS_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__SPECS_HPP_

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/status.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/status.hpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_INTERFACE_UTILS__STATUS_HPP_
-#define COMPONENT_INTERFACE_UTILS__STATUS_HPP_
+#ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__STATUS_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_UTILS__STATUS_HPP_
 
-namespace component_interface_utils::status
+namespace autoware::component_interface_utils::status
 {
 
 template <class T1, class T2>
@@ -26,6 +26,6 @@ void copy(const T1 & src, T2 & dst)  // NOLINT(build/include_what_you_use): cppl
   dst->status.message = src->status.message;
 }
 
-}  // namespace component_interface_utils::status
+}  // namespace autoware::component_interface_utils::status
 
-#endif  // COMPONENT_INTERFACE_UTILS__STATUS_HPP_
+#endif  // AUTOWARE__COMPONENT_INTERFACE_UTILS__STATUS_HPP_

--- a/common/autoware_component_interface_utils/package.xml
+++ b/common/autoware_component_interface_utils/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>component_interface_utils</name>
+  <name>autoware_component_interface_utils</name>
   <version>0.0.0</version>
-  <description>The component_interface_utils package</description>
+  <description>The autoware_component_interface_utils package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
+++ b/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "component_interface_utils/rclcpp/exceptions.hpp"
-#include "component_interface_utils/specs.hpp"
-#include "component_interface_utils/status.hpp"
+#include "autoware/component_interface_utils/rclcpp/exceptions.hpp"
+#include "autoware/component_interface_utils/specs.hpp"
+#include "autoware/component_interface_utils/status.hpp"
 #include "gtest/gtest.h"
 
 TEST(interface, utils)
 {
   {
-    using component_interface_utils::ServiceException;
+    using autoware::component_interface_utils::ServiceException;
     using ResponseStatus = autoware_adapi_v1_msgs::msg::ResponseStatus;
     using ResponseStatusCode = ResponseStatus::_code_type;
 
@@ -34,7 +34,7 @@ TEST(interface, utils)
   }
 
   {
-    using component_interface_utils::ServiceException;
+    using autoware::component_interface_utils::ServiceException;
     using ResponseStatus = autoware_adapi_v1_msgs::msg::ResponseStatus;
     using ResponseStatusCode = ResponseStatus::_code_type;
 
@@ -48,10 +48,10 @@ TEST(interface, utils)
   }
 
   {
-    using component_interface_utils::ServiceException;
+    using autoware::component_interface_utils::ServiceException;
     using ResponseStatus = autoware_adapi_v1_msgs::msg::ResponseStatus;
     using ResponseStatusCode = ResponseStatus::_code_type;
-    using component_interface_utils::status::copy;
+    using autoware::component_interface_utils::status::copy;
 
     class status_test
     {

--- a/common/autoware_test_utils/package.xml
+++ b/common/autoware_test_utils/package.xml
@@ -17,6 +17,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
@@ -24,7 +25,6 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>lanelet2_io</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/common/tier4_adapi_rviz_plugin/package.xml
+++ b/common/tier4_adapi_rviz_plugin/package.xml
@@ -13,8 +13,8 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_ad_api_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_adapi_rviz_plugin/src/door_panel.cpp
+++ b/common/tier4_adapi_rviz_plugin/src/door_panel.cpp
@@ -94,7 +94,7 @@ void DoorPanel::onInitialize()
   auto lock = getDisplayContext()->getRosNodeAbstraction().lock();
   auto node = lock->get_raw_node();
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(node.get());
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node.get());
   adaptor.init_cli(cli_command_);
   adaptor.init_cli(cli_layout_);
   adaptor.init_sub(sub_status_, on_status);

--- a/common/tier4_adapi_rviz_plugin/src/door_panel.hpp
+++ b/common/tier4_adapi_rviz_plugin/src/door_panel.hpp
@@ -18,8 +18,8 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_ad_api_specs/vehicle.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
 
@@ -40,9 +40,9 @@ public:
   void onInitialize() override;
 
 private:
-  component_interface_utils::Client<DoorCommand>::SharedPtr cli_command_;
-  component_interface_utils::Client<DoorLayout>::SharedPtr cli_layout_;
-  component_interface_utils::Subscription<DoorStatus>::SharedPtr sub_status_;
+  autoware::component_interface_utils::Client<DoorCommand>::SharedPtr cli_command_;
+  autoware::component_interface_utils::Client<DoorLayout>::SharedPtr cli_layout_;
+  autoware::component_interface_utils::Subscription<DoorStatus>::SharedPtr sub_status_;
 
   struct DoorUI
   {

--- a/common/tier4_adapi_rviz_plugin/src/route_panel.cpp
+++ b/common/tier4_adapi_rviz_plugin/src/route_panel.cpp
@@ -107,7 +107,7 @@ void RoutePanel::onInitialize()
     "/rviz/routing/pose", rclcpp::QoS(1),
     std::bind(&RoutePanel::onPose, this, std::placeholders::_1));
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(node.get());
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node.get());
   adaptor.init_cli(cli_clear_);
   adaptor.init_cli(cli_set_);
   adaptor.init_cli(cli_change_);

--- a/common/tier4_adapi_rviz_plugin/src/route_panel.hpp
+++ b/common/tier4_adapi_rviz_plugin/src/route_panel.hpp
@@ -20,8 +20,8 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QPushButton>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_ad_api_specs/routing.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
 
@@ -63,9 +63,9 @@ private:
   enum AdapiMode { Set, Change };
   AdapiMode adapi_mode_;
 
-  component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
-  component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_set_;
-  component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_change_;
+  autoware::component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
+  autoware::component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_set_;
+  autoware::component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_change_;
   void requestRoute(const PoseStamped & pose);
   void asyncSendRequest(SetRoutePoints::Service::Request::SharedPtr req);
 

--- a/common/tier4_camera_view_rviz_plugin/package.xml
+++ b/common/tier4_camera_view_rviz_plugin/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_ad_api_specs</depend>
-  <depend>component_interface_utils</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/control/autoware_operation_mode_transition_manager/package.xml
+++ b/control/autoware_operation_mode_transition_manager/package.xml
@@ -13,12 +13,12 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/control/autoware_operation_mode_transition_manager/src/node.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.cpp
@@ -14,7 +14,7 @@
 
 #include "node.hpp"
 
-#include <component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
 
 namespace autoware::operation_mode_transition_manager
 {
@@ -27,7 +27,7 @@ OperationModeTransitionManager::OperationModeTransitionManager(const rclcpp::Nod
 
   // component interface
   {
-    const auto node = component_interface_utils::NodeAdaptor(this);
+    const auto node = autoware::component_interface_utils::NodeAdaptor(this);
     node.init_srv(
       srv_autoware_control_, this, &OperationModeTransitionManager::onChangeAutowareControl);
     node.init_srv(
@@ -90,7 +90,7 @@ void OperationModeTransitionManager::onChangeOperationMode(
 {
   const auto mode = toEnum(*request);
   if (!mode) {
-    throw component_interface_utils::ParameterError("The operation mode is invalid.");
+    throw autoware::component_interface_utils::ParameterError("The operation mode is invalid.");
   }
   changeOperationMode(mode.value());
   response->status.success = true;
@@ -121,23 +121,25 @@ void OperationModeTransitionManager::changeOperationMode(std::optional<Operation
   const bool request_control = request_mode ? false : true;
 
   if (current_mode_ == request_mode) {
-    throw component_interface_utils::NoEffectWarning("The mode is the same as the current.");
+    throw autoware::component_interface_utils::NoEffectWarning(
+      "The mode is the same as the current.");
   }
 
   if (current_control && request_control) {
-    throw component_interface_utils::NoEffectWarning("Autoware already controls the vehicle.");
+    throw autoware::component_interface_utils::NoEffectWarning(
+      "Autoware already controls the vehicle.");
   }
 
   // TODO(Takagi, Isamu): Consider mode change request during transition.
   if (transition_ && request_mode != OperationMode::STOP) {
-    throw component_interface_utils::ServiceException(
+    throw autoware::component_interface_utils::ServiceException(
       ServiceResponse::ERROR_IN_TRANSITION, "The mode transition is in progress.");
   }
 
   // Enter transition mode if the vehicle is being or will be controlled by Autoware.
   if (current_control || request_control) {
     if (!available_mode_change_[request_mode.value_or(current_mode_)]) {
-      throw component_interface_utils::ServiceException(
+      throw autoware::component_interface_utils::ServiceException(
         ServiceResponse::ERROR_NOT_AVAILABLE, "The mode change condition is not satisfied.");
     }
     if (request_control) {

--- a/control/autoware_operation_mode_transition_manager/src/node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.hpp
@@ -19,8 +19,8 @@
 #include "state.hpp"
 
 #include <autoware/component_interface_specs/system.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/universe_utils/ros/polling_subscriber.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
@@ -39,9 +39,12 @@ private:
     autoware::component_interface_specs::system::ChangeAutowareControl;
   using ChangeOperationModeAPI = autoware::component_interface_specs::system::ChangeOperationMode;
   using OperationModeStateAPI = autoware::component_interface_specs::system::OperationModeState;
-  component_interface_utils::Service<ChangeAutowareControlAPI>::SharedPtr srv_autoware_control_;
-  component_interface_utils::Service<ChangeOperationModeAPI>::SharedPtr srv_operation_mode_;
-  component_interface_utils::Publisher<OperationModeStateAPI>::SharedPtr pub_operation_mode_;
+  autoware::component_interface_utils::Service<ChangeAutowareControlAPI>::SharedPtr
+    srv_autoware_control_;
+  autoware::component_interface_utils::Service<ChangeOperationModeAPI>::SharedPtr
+    srv_operation_mode_;
+  autoware::component_interface_utils::Publisher<OperationModeStateAPI>::SharedPtr
+    pub_operation_mode_;
   void onChangeAutowareControl(
     const ChangeAutowareControlAPI::Service::Request::SharedPtr request,
     const ChangeAutowareControlAPI::Service::Response::SharedPtr response);

--- a/control/autoware_vehicle_cmd_gate/package.xml
+++ b/control/autoware_vehicle_cmd_gate/package.xml
@@ -17,12 +17,12 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.cpp
@@ -19,7 +19,7 @@ namespace autoware::vehicle_cmd_gate
 
 AdapiPauseInterface::AdapiPauseInterface(rclcpp::Node * node) : node_(node)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(node);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node);
   adaptor.init_srv(srv_set_pause_, this, &AdapiPauseInterface::on_pause);
   adaptor.init_pub(pub_is_paused_);
   adaptor.init_pub(pub_is_start_requested_);

--- a/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/adapi_pause_interface.hpp
@@ -16,7 +16,7 @@
 #define ADAPI_PAUSE_INTERFACE_HPP_
 
 #include <autoware/component_interface_specs/control.hpp>
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
@@ -46,9 +46,10 @@ private:
   std::optional<bool> prev_is_start_requested_;
 
   rclcpp::Node * node_;
-  component_interface_utils::Service<SetPause>::SharedPtr srv_set_pause_;
-  component_interface_utils::Publisher<IsPaused>::SharedPtr pub_is_paused_;
-  component_interface_utils::Publisher<IsStartRequested>::SharedPtr pub_is_start_requested_;
+  autoware::component_interface_utils::Service<SetPause>::SharedPtr srv_set_pause_;
+  autoware::component_interface_utils::Publisher<IsPaused>::SharedPtr pub_is_paused_;
+  autoware::component_interface_utils::Publisher<IsStartRequested>::SharedPtr
+    pub_is_start_requested_;
 
   void on_pause(
     const SetPause::Service::Request::SharedPtr req,

--- a/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.cpp
@@ -19,7 +19,7 @@ namespace autoware::vehicle_cmd_gate
 
 ModerateStopInterface::ModerateStopInterface(rclcpp::Node * node) : node_(node)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(node);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(node);
   adaptor.init_srv(srv_set_stop_, this, &ModerateStopInterface::on_stop_request);
   adaptor.init_pub(pub_is_stopped_);
 

--- a/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/moderate_stop_interface.hpp
@@ -16,7 +16,7 @@
 #define MODERATE_STOP_INTERFACE_HPP_
 
 #include <autoware/component_interface_specs/control.hpp>
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <string>
@@ -43,8 +43,8 @@ private:
   std::optional<std::unordered_map<std::string, bool>> prev_stop_map_;
 
   rclcpp::Node * node_;
-  component_interface_utils::Service<SetStop>::SharedPtr srv_set_stop_;
-  component_interface_utils::Publisher<IsStopped>::SharedPtr pub_is_stopped_;
+  autoware::component_interface_utils::Service<SetStop>::SharedPtr srv_set_stop_;
+  autoware::component_interface_utils::Publisher<IsStopped>::SharedPtr pub_is_stopped_;
 
   void on_stop_request(
     const SetStop::Service::Request::SharedPtr req,

--- a/control/predicted_path_checker/include/predicted_path_checker/predicted_path_checker_node.hpp
+++ b/control/predicted_path_checker/include/predicted_path_checker/predicted_path_checker_node.hpp
@@ -16,13 +16,13 @@
 #define PREDICTED_PATH_CHECKER__PREDICTED_PATH_CHECKER_NODE_HPP_
 
 #include <autoware/component_interface_specs/control.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/motion_utils/trajectory/conversion.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/self_pose_listener.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <predicted_path_checker/collision_checker.hpp>
 #include <predicted_path_checker/utils.hpp>
@@ -96,11 +96,11 @@ private:
     sub_predicted_trajectory_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_accel_;
-  component_interface_utils::Subscription<
+  autoware::component_interface_utils::Subscription<
     autoware::component_interface_specs::control::IsStopped>::SharedPtr sub_stop_state_;
 
   // Client
-  component_interface_utils::Client<
+  autoware::component_interface_utils::Client<
     autoware::component_interface_specs::control::SetStop>::SharedPtr cli_set_stop_;
 
   // Data Buffer

--- a/control/predicted_path_checker/package.xml
+++ b/control/predicted_path_checker/package.xml
@@ -13,13 +13,13 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>boost</depend>
-  <depend>component_interface_utils</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/control/predicted_path_checker/src/predicted_path_checker_node/predicted_path_checker_node.cpp
+++ b/control/predicted_path_checker/src/predicted_path_checker_node/predicted_path_checker_node.cpp
@@ -34,7 +34,7 @@ PredictedPathCheckerNode::PredictedPathCheckerNode(const rclcpp::NodeOptions & n
 {
   using std::placeholders::_1;
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_cli(cli_set_stop_, group_cli_);
   adaptor.init_sub(sub_stop_state_, this, &PredictedPathCheckerNode::onIsStopped);

--- a/localization/autoware_geo_pose_projector/package.xml
+++ b/localization/autoware_geo_pose_projector/package.xml
@@ -18,8 +18,8 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
-  <depend>component_interface_utils</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/localization/autoware_geo_pose_projector/src/geo_pose_projector.cpp
+++ b/localization/autoware_geo_pose_projector/src/geo_pose_projector.cpp
@@ -31,7 +31,7 @@ GeoPoseProjector::GeoPoseProjector(const rclcpp::NodeOptions & options)
 : rclcpp::Node("geo_pose_projector", options), publish_tf_(declare_parameter<bool>("publish_tf"))
 {
   // Subscribe to map_projector_info topic
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_sub(
     sub_map_projector_info_,
     [this](const MapProjectorInfo::Message::ConstSharedPtr msg) { projector_info_ = *msg; });

--- a/localization/autoware_geo_pose_projector/src/geo_pose_projector.hpp
+++ b/localization/autoware_geo_pose_projector/src/geo_pose_projector.hpp
@@ -16,7 +16,7 @@
 #define GEO_POSE_PROJECTOR_HPP_
 
 #include <autoware/component_interface_specs/map.hpp>
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geographic_msgs/msg/geo_pose_with_covariance_stamped.hpp>
@@ -43,7 +43,8 @@ public:
 private:
   void on_geo_pose(const GeoPoseWithCovariance::ConstSharedPtr msg);
 
-  component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
+  autoware::component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr
+    sub_map_projector_info_;
   rclcpp::Subscription<GeoPoseWithCovariance>::SharedPtr geo_pose_sub_;
   rclcpp::Publisher<PoseWithCovariance>::SharedPtr pose_pub_;
 

--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -20,11 +20,11 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_localization_util</depend>
   <depend>autoware_map_height_fitter</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_universe_utils</depend>
-  <depend>component_interface_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/localization/autoware_pose_initializer/src/ekf_localization_trigger_module.cpp
+++ b/localization/autoware_pose_initializer/src/ekf_localization_trigger_module.cpp
@@ -15,14 +15,14 @@
 #include "ekf_localization_trigger_module.hpp"
 
 #include <autoware/component_interface_specs/localization.hpp>
-#include <component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
 
 #include <memory>
 #include <string>
 
 namespace autoware::pose_initializer
 {
-using ServiceException = component_interface_utils::ServiceException;
+using ServiceException = autoware::component_interface_utils::ServiceException;
 using Initialize = autoware::component_interface_specs::localization::Initialize;
 
 EkfLocalizationTriggerModule::EkfLocalizationTriggerModule(rclcpp::Node * node) : node_(node)
@@ -50,7 +50,8 @@ void EkfLocalizationTriggerModule::send_request(bool flag, bool need_spin) const
   }
 
   if (!client_ekf_trigger_->service_is_ready()) {
-    throw component_interface_utils::ServiceUnready("EKF triggering service is not ready");
+    throw autoware::component_interface_utils::ServiceUnready(
+      "EKF triggering service is not ready");
   }
 
   auto future_ekf = client_ekf_trigger_->async_send_request(req);

--- a/localization/autoware_pose_initializer/src/gnss_module.cpp
+++ b/localization/autoware_pose_initializer/src/gnss_module.cpp
@@ -15,7 +15,7 @@
 #include "gnss_module.hpp"
 
 #include <autoware/component_interface_specs/localization.hpp>
-#include <component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
 
 #include <memory>
 
@@ -40,13 +40,13 @@ geometry_msgs::msg::PoseWithCovarianceStamped GnssModule::get_pose()
   using Initialize = autoware::component_interface_specs::localization::Initialize;
 
   if (!pose_) {
-    throw component_interface_utils::ServiceException(
+    throw autoware::component_interface_utils::ServiceException(
       Initialize::Service::Response::ERROR_GNSS, "The GNSS pose has not arrived.");
   }
 
   const auto elapsed = rclcpp::Time(pose_->header.stamp) - clock_->now();
   if (timeout_ < elapsed.seconds()) {
-    throw component_interface_utils::ServiceException(
+    throw autoware::component_interface_utils::ServiceException(
       Initialize::Service::Response::ERROR_GNSS, "The GNSS pose is out of date.");
   }
 

--- a/localization/autoware_pose_initializer/src/localization_module.cpp
+++ b/localization/autoware_pose_initializer/src/localization_module.cpp
@@ -15,14 +15,14 @@
 #include "localization_module.hpp"
 
 #include <autoware/component_interface_specs/localization.hpp>
-#include <component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
 
 #include <memory>
 #include <string>
 
 namespace autoware::pose_initializer
 {
-using ServiceException = component_interface_utils::ServiceException;
+using ServiceException = autoware::component_interface_utils::ServiceException;
 using Initialize = autoware::component_interface_specs::localization::Initialize;
 using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
@@ -39,7 +39,7 @@ std::tuple<PoseWithCovarianceStamped, bool> LocalizationModule::align_pose(
   req->pose_with_covariance = pose;
 
   if (!cli_align_->service_is_ready()) {
-    throw component_interface_utils::ServiceUnready("align server is not ready.");
+    throw autoware::component_interface_utils::ServiceUnready("align server is not ready.");
   }
 
   RCLCPP_INFO(logger_, "Call align server.");

--- a/localization/autoware_pose_initializer/src/ndt_localization_trigger_module.cpp
+++ b/localization/autoware_pose_initializer/src/ndt_localization_trigger_module.cpp
@@ -15,14 +15,14 @@
 #include "ndt_localization_trigger_module.hpp"
 
 #include <autoware/component_interface_specs/localization.hpp>
-#include <component_interface_utils/rclcpp/exceptions.hpp>
+#include <autoware/component_interface_utils/rclcpp/exceptions.hpp>
 
 #include <memory>
 #include <string>
 
 namespace autoware::pose_initializer
 {
-using ServiceException = component_interface_utils::ServiceException;
+using ServiceException = autoware::component_interface_utils::ServiceException;
 using Initialize = autoware::component_interface_specs::localization::Initialize;
 
 NdtLocalizationTriggerModule::NdtLocalizationTriggerModule(rclcpp::Node * node) : node_(node)
@@ -50,7 +50,8 @@ void NdtLocalizationTriggerModule::send_request(bool flag, bool need_spin) const
   }
 
   if (!client_ndt_trigger_->service_is_ready()) {
-    throw component_interface_utils::ServiceUnready("NDT triggering service is not ready");
+    throw autoware::component_interface_utils::ServiceUnready(
+      "NDT triggering service is not ready");
   }
 
   auto future_ndt = client_ndt_trigger_->async_send_request(req);

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -31,7 +31,7 @@ namespace autoware::pose_initializer
 PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
 : rclcpp::Node("pose_initializer", options)
 {
-  const auto node = component_interface_utils::NodeAdaptor(this);
+  const auto node = autoware::component_interface_utils::NodeAdaptor(this);
   group_srv_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   node.init_pub(pub_state_);
   node.init_srv(srv_initialize_, this, &PoseInitializer::on_initialize, group_srv_);

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -18,8 +18,8 @@
 #include "autoware/localization_util/diagnostics_module.hpp"
 
 #include <autoware/component_interface_specs/localization.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/universe_utils/ros/logger_level_configure.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -41,15 +41,15 @@ public:
   explicit PoseInitializer(const rclcpp::NodeOptions & options);
 
 private:
-  using ServiceException = component_interface_utils::ServiceException;
+  using ServiceException = autoware::component_interface_utils::ServiceException;
   using Initialize = autoware::component_interface_specs::localization::Initialize;
   using State = autoware::component_interface_specs::localization::InitializationState;
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
   rclcpp::CallbackGroup::SharedPtr group_srv_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_reset_;
-  component_interface_utils::Publisher<State>::SharedPtr pub_state_;
-  component_interface_utils::Service<Initialize>::SharedPtr srv_initialize_;
+  autoware::component_interface_utils::Publisher<State>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Service<Initialize>::SharedPtr srv_initialize_;
   State::Message state_;
   std::array<double, 36> output_pose_covariance_{};
   std::array<double, 36> gnss_particle_covariance_{};

--- a/map/autoware_map_projection_loader/include/autoware/map_projection_loader/map_projection_loader.hpp
+++ b/map/autoware_map_projection_loader/include/autoware/map_projection_loader/map_projection_loader.hpp
@@ -18,7 +18,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <autoware/component_interface_specs/map.hpp>
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 
 #include <string>
 
@@ -35,7 +35,7 @@ public:
 
 private:
   using MapProjectorInfo = autoware::component_interface_specs::map::MapProjectorInfo;
-  component_interface_utils::Publisher<MapProjectorInfo>::SharedPtr publisher_;
+  autoware::component_interface_utils::Publisher<MapProjectorInfo>::SharedPtr publisher_;
 };
 }  // namespace autoware::map_projection_loader
 

--- a/map/autoware_map_projection_loader/package.xml
+++ b/map/autoware_map_projection_loader/package.xml
@@ -17,8 +17,8 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_lanelet2_extension</depend>
-  <depend>component_interface_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_map_msgs</depend>

--- a/map/autoware_map_projection_loader/src/map_projection_loader.cpp
+++ b/map/autoware_map_projection_loader/src/map_projection_loader.cpp
@@ -91,7 +91,7 @@ MapProjectionLoader::MapProjectionLoader(const rclcpp::NodeOptions & options)
     load_map_projector_info(yaml_filename, lanelet2_map_filename);
 
   // Publish the message
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_pub(publisher_);
   publisher_->publish(msg);
 }

--- a/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
+++ b/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
@@ -16,8 +16,8 @@
 #define MAP_LOADER__LANELET2_MAP_LOADER_NODE_HPP_
 
 #include <autoware/component_interface_specs/map.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_lanelet2_extension/version.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -48,7 +48,8 @@ private:
 
   void on_map_projector_info(const MapProjectorInfo::Message::ConstSharedPtr msg);
 
-  component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
+  autoware::component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr
+    sub_map_projector_info_;
   rclcpp::Publisher<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr pub_map_bin_;
 };
 

--- a/map/map_loader/package.xml
+++ b/map/map_loader/package.xml
@@ -20,10 +20,10 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -58,7 +58,7 @@ using tier4_map_msgs::msg::MapProjectorInfo;
 Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options)
 : Node("lanelet2_map_loader", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
 
   // subscription
   adaptor.init_sub(

--- a/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
@@ -31,7 +31,7 @@
   }
 
 #include <autoware/component_interface_specs/planning.hpp>
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>

--- a/planning/autoware_planning_test_manager/package.xml
+++ b/planning/autoware_planning_test_manager/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
@@ -24,7 +25,6 @@
   <depend>autoware_test_utils</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>lanelet2_io</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
@@ -15,7 +15,7 @@
 #define AUTOWARE__GNSS_POSER__GNSS_POSER_NODE_HPP_
 
 #include <autoware/component_interface_specs/map.hpp>
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_sensing_msgs/msg/gnss_ins_orientation_stamped.hpp>
@@ -79,7 +79,8 @@ private:
   tf2_ros::TransformListener tf2_listener_;
   tf2_ros::TransformBroadcaster tf2_broadcaster_;
 
-  component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
+  autoware::component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr
+    sub_map_projector_info_;
   rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr nav_sat_fix_sub_;
   rclcpp::Subscription<autoware_sensing_msgs::msg::GnssInsOrientationStamped>::SharedPtr
     autoware_orientation_sub_;

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -20,9 +20,9 @@
   <build_depend>libboost-dev</build_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_sensing_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>geographic_msgs</depend>
   <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -39,7 +39,7 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   gnss_pose_pub_method_(static_cast<int>(declare_parameter<int>("gnss_pose_pub_method")))
 {
   // Subscribe to map_projector_info topic
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_sub(
     sub_map_projector_info_, [this](const MapProjectorInfo::Message::ConstSharedPtr msg) {
       callback_map_projector_info(msg);

--- a/system/autoware_default_adapi/package.xml
+++ b/system/autoware_default_adapi/package.xml
@@ -16,13 +16,13 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_adapi_version_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>diagnostic_graph_utils</depend>
   <depend>geographic_msgs</depend>
   <depend>nav_msgs</depend>

--- a/system/autoware_default_adapi/src/compatibility/autoware_state.cpp
+++ b/system/autoware_default_adapi/src/compatibility/autoware_state.cpp
@@ -41,7 +41,7 @@ AutowareStateNode::AutowareStateNode(const rclcpp::NodeOptions & options)
     "/autoware/shutdown",
     std::bind(&AutowareStateNode::on_shutdown, this, std::placeholders::_1, std::placeholders::_2));
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_sub(sub_localization_, this, &AutowareStateNode::on_localization);
   adaptor.init_sub(sub_routing_, this, &AutowareStateNode::on_routing);
   adaptor.init_sub(sub_operation_mode_, this, &AutowareStateNode::on_operation_mode);

--- a/system/autoware_default_adapi/src/fail_safe.cpp
+++ b/system/autoware_default_adapi/src/fail_safe.cpp
@@ -19,7 +19,7 @@ namespace autoware::default_adapi
 
 FailSafeNode::FailSafeNode(const rclcpp::NodeOptions & options) : Node("fail_safe", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_pub(pub_mrm_state_);
   adaptor.init_sub(sub_mrm_state_, this, &FailSafeNode::on_state);
 

--- a/system/autoware_default_adapi/src/fail_safe.hpp
+++ b/system/autoware_default_adapi/src/fail_safe.hpp
@@ -16,8 +16,8 @@
 #define FAIL_SAFE_HPP_
 
 #include <autoware/component_interface_specs/system.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_ad_api_specs/fail_safe.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.

--- a/system/autoware_default_adapi/src/heartbeat.cpp
+++ b/system/autoware_default_adapi/src/heartbeat.cpp
@@ -29,7 +29,7 @@ HeartbeatNode::HeartbeatNode(const rclcpp::NodeOptions & options) : Node("heartb
     pub_->publish(heartbeat);
   };
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_pub(pub_);
 
   const auto period = rclcpp::Rate(10.0).period();

--- a/system/autoware_default_adapi/src/interface.cpp
+++ b/system/autoware_default_adapi/src/interface.cpp
@@ -25,7 +25,7 @@ InterfaceNode::InterfaceNode(const rclcpp::NodeOptions & options) : Node("interf
     res->patch = 0;
   };
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_srv(srv_, on_interface_version);
 }
 

--- a/system/autoware_default_adapi/src/localization.cpp
+++ b/system/autoware_default_adapi/src/localization.cpp
@@ -22,7 +22,7 @@ namespace autoware::default_adapi
 LocalizationNode::LocalizationNode(const rclcpp::NodeOptions & options)
 : Node("localization", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.relay_message(pub_state_, sub_state_);
   adaptor.init_cli(cli_initialize_);

--- a/system/autoware_default_adapi/src/motion.cpp
+++ b/system/autoware_default_adapi/src/motion.cpp
@@ -27,7 +27,7 @@ MotionNode::MotionNode(const rclcpp::NodeOptions & options)
   require_accept_start_ = declare_parameter<bool>("require_accept_start");
   is_calling_set_pause_ = false;
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_srv(srv_accept_, this, &MotionNode::on_accept);
   adaptor.init_pub(pub_state_);
@@ -154,7 +154,7 @@ void MotionNode::on_accept(
 {
   if (state_ != State::Starting) {
     using AcceptStartResponse = autoware_ad_api::motion::AcceptStart::Service::Response;
-    throw component_interface_utils::ServiceException(
+    throw autoware::component_interface_utils::ServiceException(
       AcceptStartResponse::ERROR_NOT_STARTING, "The motion state is not starting");
   }
   change_state(State::Resuming);

--- a/system/autoware_default_adapi/src/motion.hpp
+++ b/system/autoware_default_adapi/src/motion.hpp
@@ -16,10 +16,10 @@
 #define MOTION_HPP_
 
 #include <autoware/component_interface_specs/control.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/status.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <autoware_ad_api_specs/motion.hpp>
-#include <component_interface_utils/rclcpp.hpp>
-#include <component_interface_utils/status.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.

--- a/system/autoware_default_adapi/src/operation_mode.cpp
+++ b/system/autoware_default_adapi/src/operation_mode.cpp
@@ -26,7 +26,7 @@ using ServiceResponse = autoware_adapi_v1_msgs::srv::ChangeOperationMode::Respon
 OperationModeNode::OperationModeNode(const rclcpp::NodeOptions & options)
 : Node("operation_mode", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_sub(sub_state_, this, &OperationModeNode::on_state);
   adaptor.init_pub(pub_state_);
@@ -70,13 +70,13 @@ void OperationModeNode::change_mode(
       get_logger(),
       "The target mode is not available. Please check the cause with "
       "rqt_diagnostics_graph_monitor");
-    throw component_interface_utils::ServiceException(
+    throw autoware::component_interface_utils::ServiceException(
       ServiceResponse::ERROR_NOT_AVAILABLE,
       "The target mode is not available. Please check the diagnostics.");
   }
   const auto req = std::make_shared<OperationModeRequest>();
   req->mode = mode;
-  component_interface_utils::status::copy(cli_mode_->call(req), res);  // NOLINT
+  autoware::component_interface_utils::status::copy(cli_mode_->call(req), res);  // NOLINT
 }
 
 void OperationModeNode::on_change_to_stop(
@@ -112,12 +112,12 @@ void OperationModeNode::on_enable_autoware_control(
   const EnableAutowareControl::Service::Response::SharedPtr res)
 {
   if (!mode_available_[curr_state_.mode]) {
-    throw component_interface_utils::ServiceException(
+    throw autoware::component_interface_utils::ServiceException(
       ServiceResponse::ERROR_NOT_AVAILABLE, "The mode change is blocked by the system.");
   }
   const auto req = std::make_shared<AutowareControlRequest>();
   req->autoware_control = true;
-  component_interface_utils::status::copy(cli_control_->call(req), res);  // NOLINT
+  autoware::component_interface_utils::status::copy(cli_control_->call(req), res);  // NOLINT
 }
 
 void OperationModeNode::on_disable_autoware_control(
@@ -126,7 +126,7 @@ void OperationModeNode::on_disable_autoware_control(
 {
   const auto req = std::make_shared<AutowareControlRequest>();
   req->autoware_control = false;
-  component_interface_utils::status::copy(cli_control_->call(req), res);  // NOLINT
+  autoware::component_interface_utils::status::copy(cli_control_->call(req), res);  // NOLINT
 }
 
 void OperationModeNode::on_state(const OperationModeState::Message::ConstSharedPtr msg)

--- a/system/autoware_default_adapi/src/operation_mode.hpp
+++ b/system/autoware_default_adapi/src/operation_mode.hpp
@@ -16,8 +16,8 @@
 #define OPERATION_MODE_HPP_
 
 #include <autoware/component_interface_specs/system.hpp>
+#include <autoware/component_interface_utils/status.hpp>
 #include <autoware_ad_api_specs/operation_mode.hpp>
-#include <component_interface_utils/status.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <string>

--- a/system/autoware_default_adapi/src/perception.cpp
+++ b/system/autoware_default_adapi/src/perception.cpp
@@ -34,7 +34,7 @@ std::unordered_map<uint8_t, uint8_t> shape_type_ = {
 
 PerceptionNode::PerceptionNode(const rclcpp::NodeOptions & options) : Node("perception", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_pub(pub_object_recognized_);
   adaptor.init_sub(sub_object_recognized_, this, &PerceptionNode::object_recognize);
 }

--- a/system/autoware_default_adapi/src/planning.cpp
+++ b/system/autoware_default_adapi/src/planning.cpp
@@ -98,7 +98,7 @@ PlanningNode::PlanningNode(const rclcpp::NodeOptions & options) : Node("planning
   sub_steering_factors_ =
     init_factors<SteeringFactorArray>(this, steering_factors_, steering_factor_topics);
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_pub(pub_velocity_factors_);
   adaptor.init_pub(pub_steering_factors_);
   adaptor.init_sub(sub_kinematic_state_, this, &PlanningNode::on_kinematic_state);

--- a/system/autoware_default_adapi/src/routing.cpp
+++ b/system/autoware_default_adapi/src/routing.cpp
@@ -50,7 +50,7 @@ namespace autoware::default_adapi
 
 RoutingNode::RoutingNode(const rclcpp::NodeOptions & options) : Node("routing", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_pub(pub_state_);
   adaptor.init_pub(pub_route_);

--- a/system/autoware_default_adapi/src/routing.hpp
+++ b/system/autoware_default_adapi/src/routing.hpp
@@ -17,8 +17,8 @@
 
 #include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/component_interface_specs/system.hpp>
+#include <autoware/component_interface_utils/status.hpp>
 #include <autoware_ad_api_specs/routing.hpp>
-#include <component_interface_utils/status.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.

--- a/system/autoware_default_adapi/src/utils/topics.hpp
+++ b/system/autoware_default_adapi/src/utils/topics.hpp
@@ -15,7 +15,7 @@
 #ifndef UTILS__TOPICS_HPP_
 #define UTILS__TOPICS_HPP_
 
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/time.hpp>
 
 #include <optional>

--- a/system/autoware_default_adapi/src/utils/types.hpp
+++ b/system/autoware_default_adapi/src/utils/types.hpp
@@ -15,19 +15,19 @@
 #ifndef UTILS__TYPES_HPP_
 #define UTILS__TYPES_HPP_
 
-#include <component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 
 namespace autoware::default_adapi
 {
 
 template <class T>
-using Pub = typename component_interface_utils::Publisher<T>::SharedPtr;
+using Pub = typename autoware::component_interface_utils::Publisher<T>::SharedPtr;
 template <class T>
-using Sub = typename component_interface_utils::Subscription<T>::SharedPtr;
+using Sub = typename autoware::component_interface_utils::Subscription<T>::SharedPtr;
 template <class T>
-using Cli = typename component_interface_utils::Client<T>::SharedPtr;
+using Cli = typename autoware::component_interface_utils::Client<T>::SharedPtr;
 template <class T>
-using Srv = typename component_interface_utils::Service<T>::SharedPtr;
+using Srv = typename autoware::component_interface_utils::Service<T>::SharedPtr;
 
 }  // namespace autoware::default_adapi
 

--- a/system/autoware_default_adapi/src/vehicle.cpp
+++ b/system/autoware_default_adapi/src/vehicle.cpp
@@ -62,7 +62,7 @@ std::unordered_map<uint8_t, uint8_t> hazard_light_type_ = {
 
 VehicleNode::VehicleNode(const rclcpp::NodeOptions & options) : Node("vehicle", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_pub(pub_kinematics_);
   adaptor.init_pub(pub_status_);

--- a/system/autoware_default_adapi/src/vehicle_door.cpp
+++ b/system/autoware_default_adapi/src/vehicle_door.cpp
@@ -22,7 +22,7 @@ namespace autoware::default_adapi
 VehicleDoorNode::VehicleDoorNode(const rclcpp::NodeOptions & options)
 : Node("vehicle_door", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.relay_service(cli_command_, srv_command_, group_cli_, 3.0);
   adaptor.relay_service(cli_layout_, srv_layout_, group_cli_, 3.0);

--- a/system/autoware_default_adapi/src/vehicle_info.cpp
+++ b/system/autoware_default_adapi/src/vehicle_info.cpp
@@ -61,7 +61,7 @@ VehicleInfoNode::VehicleInfoNode(const rclcpp::NodeOptions & options)
   dimensions_.footprint.points.push_back(create_point(-b, -l));
   dimensions_.footprint.points.push_back(create_point(-b, +r));
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_srv(srv_dimensions_, on_vehicle_dimensions);
 }
 

--- a/system/default_ad_api_helpers/ad_api_adaptors/package.xml
+++ b/system/default_ad_api_helpers/ad_api_adaptors/package.xml
@@ -14,8 +14,8 @@
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_map_height_fitter</depend>
-  <depend>component_interface_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/initial_pose_adaptor.cpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/initial_pose_adaptor.cpp
@@ -42,7 +42,7 @@ InitialPoseAdaptor::InitialPoseAdaptor(const rclcpp::NodeOptions & options)
     "~/initialpose", rclcpp::QoS(1),
     std::bind(&InitialPoseAdaptor::on_initial_pose, this, std::placeholders::_1));
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_cli(cli_initialize_);
 }
 

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/initial_pose_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/initial_pose_adaptor.hpp
@@ -15,9 +15,9 @@
 #ifndef INITIAL_POSE_ADAPTOR_HPP_
 #define INITIAL_POSE_ADAPTOR_HPP_
 
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/map_height_fitter/map_height_fitter.hpp>
 #include <autoware_ad_api_specs/localization.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -34,7 +34,7 @@ private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Initialize = autoware_ad_api::localization::Initialize;
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_initial_pose_;
-  component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
+  autoware::component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
   std::array<double, 36> rviz_particle_covariance_;
   autoware::map_height_fitter::MapHeightFitter fitter_;
 

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.cpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.cpp
@@ -33,7 +33,7 @@ RoutingAdaptor::RoutingAdaptor(const rclcpp::NodeOptions & options)
   sub_waypoint_ = create_subscription<PoseStamped>(
     "~/input/waypoint", 10, std::bind(&RoutingAdaptor::on_waypoint, this, _1));
 
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   adaptor.init_cli(cli_reroute_);
   adaptor.init_cli(cli_route_);
   adaptor.init_cli(cli_clear_);

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
@@ -15,8 +15,8 @@
 #ifndef ROUTING_ADAPTOR_HPP_
 #define ROUTING_ADAPTOR_HPP_
 
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_ad_api_specs/routing.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -37,10 +37,10 @@ private:
   using ChangeRoutePoints = autoware_ad_api::routing::ChangeRoutePoints;
   using ClearRoute = autoware_ad_api::routing::ClearRoute;
   using RouteState = autoware_ad_api::routing::RouteState;
-  component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_reroute_;
-  component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
-  component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
-  component_interface_utils::Subscription<RouteState>::SharedPtr sub_state_;
+  autoware::component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_reroute_;
+  autoware::component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
+  autoware::component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
+  autoware::component_interface_utils::Subscription<RouteState>::SharedPtr sub_state_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_fixed_goal_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_rough_goal_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_waypoint_;

--- a/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
@@ -14,7 +14,7 @@
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>component_interface_utils</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/system/default_ad_api_helpers/automatic_pose_initializer/src/automatic_pose_initializer.cpp
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/src/automatic_pose_initializer.cpp
@@ -22,7 +22,7 @@ namespace automatic_pose_initializer
 AutomaticPoseInitializer::AutomaticPoseInitializer(const rclcpp::NodeOptions & options)
 : Node("automatic_pose_initializer", options)
 {
-  const auto adaptor = component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_cli(cli_initialize_, group_cli_);
   adaptor.init_sub(sub_state_, [this](const State::Message::ConstSharedPtr msg) { state_ = *msg; });
@@ -41,7 +41,7 @@ void AutomaticPoseInitializer::on_timer()
     try {
       const auto req = std::make_shared<Initialize::Service::Request>();
       cli_initialize_->call(req);
-    } catch (const component_interface_utils::ServiceException & error) {
+    } catch (const autoware::component_interface_utils::ServiceException & error) {
     }
   }
   timer_->reset();

--- a/system/default_ad_api_helpers/automatic_pose_initializer/src/automatic_pose_initializer.hpp
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/src/automatic_pose_initializer.hpp
@@ -15,8 +15,8 @@
 #ifndef AUTOMATIC_POSE_INITIALIZER_HPP_
 #define AUTOMATIC_POSE_INITIALIZER_HPP_
 
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_ad_api_specs/localization.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace automatic_pose_initializer
@@ -33,8 +33,8 @@ private:
   using State = autoware_ad_api::localization::InitializationState;
   rclcpp::CallbackGroup::SharedPtr group_cli_;
   rclcpp::TimerBase::SharedPtr timer_;
-  component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
-  component_interface_utils::Subscription<State>::SharedPtr sub_state_;
+  autoware::component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
+  autoware::component_interface_utils::Subscription<State>::SharedPtr sub_state_;
   State::Message state_;
 };
 


### PR DESCRIPTION
## Description

prefix package and namespace with autoware

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5077
- https://github.com/autowarefoundation/autoware/issues/4569

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
