### PR TITLE
feat(autoware_map_based_prediction): find side lanelet of the next current lanelet

### DIFF
--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2037,18 +2037,28 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
         return *opt;
       }
       if (!consider_only_routable_neighbours_) {
+        // 1. adjacent lanelet
         const auto adjacent = get_left ? routing_graph_ptr_->adjacentLeft(lanelet)
                                        : routing_graph_ptr_->adjacentRight(lanelet);
         if (!!adjacent) {
           return *adjacent;
         }
-        // search for unconnected lanelet
+        // 2. search for unconnected lanelet
         const auto unconnected_lanelets =
           get_left ? getLeftLineSharingLanelets(lanelet, lanelet_map_ptr_)
                    : getRightLineSharingLanelets(lanelet, lanelet_map_ptr_);
         // just return first candidate of unconnected lanelet for now
         if (!unconnected_lanelets.empty()) {
           return unconnected_lanelets.front();
+        }
+        // 3. search side of the next lanelet
+        const lanelet::ConstLanelets next_lanelet = routing_graph_ptr_->following(lanelet);
+        if (!next_lanelet.empty()) {
+          const auto next = get_left ? routing_graph_ptr_->left(next_lanelet.front())
+                                     : routing_graph_ptr_->right(next_lanelet.front());
+          if (!!next) {
+            return *next;
+          }
         }
       }
 


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
