### PR TITLE
feat(autoware_test_utils): add path with lane id parser

### DIFF
--- a/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
@@ -37,23 +37,58 @@ using std_msgs::msg::Header;
 using tier4_planning_msgs::msg::PathPointWithLaneId;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-Pose parse_pose(const YAML::Node & node);
+/**
+ * @brief Parses a YAML node and converts it into an object of type T.
+ *
+ * This function extracts data from the given YAML node and converts it into an object of type T.
+ * If no specialization exists for T, it will result in a compile-time error.
+ *
+ * @tparam T The type of object to parse the node contents into.
+ * @param node The YAML node to be parsed.
+ * @return T An object of type T containing the parsed data.
+ */
+template <typename T>
+T parse(const YAML::Node & node);
 
-LaneletPrimitive parse_lanelet_primitive(const YAML::Node & node);
+template <>
+Pose parse(const YAML::Node & node);
 
-std::vector<LaneletPrimitive> parse_lanelet_primitives(const YAML::Node & node);
+template <>
+LaneletPrimitive parse(const YAML::Node & node);
 
-std::vector<LaneletSegment> parse_segments(const YAML::Node & node);
+template <>
+std::vector<LaneletPrimitive> parse(const YAML::Node & node);
 
-Header parse_header(const YAML::Node & node);
+template <>
+std::vector<LaneletSegment> parse(const YAML::Node & node);
 
-std::vector<Point> parse_geom_points(const YAML::Node & node);
+template <>
+std::vector<Point> parse(const YAML::Node & node);
 
-std::vector<PathPointWithLaneId> parse_path_points_with_lane_id(const YAML::Node & node);
+template <>
+Header parse(const YAML::Node & node);
 
-LaneletRoute parse_lanelet_route_file(const std::string & filename);
+template <>
+std::vector<PathPointWithLaneId> parse(const YAML::Node & node);
 
-PathWithLaneId parse_path_with_lane_id_file(const std::string & filename);
+/**
+ * @brief Parses a YAML file and converts it into an object of type T.
+ *
+ * This function reads the specified YAML file and converts its contents into an object of the given
+ * type T. If no specialization exists for T, it will result in a compile-time error.
+ *
+ * @tparam T The type of object to parse the file contents into.
+ * @param filename The path to the YAML file to be parsed.
+ * @return T An object of type T containing the parsed data.
+ */
+template <typename T>
+T parse(const std::string & filename);
+
+template <>
+LaneletRoute parse(const std::string & filename);
+
+template <>
+PathWithLaneId parse(const std::string & filename);
 }  // namespace autoware::test_utils
 
 #endif  // AUTOWARE_TEST_UTILS__MOCK_DATA_PARSER_HPP_

--- a/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
@@ -19,6 +19,7 @@
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/lanelet_segment.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <yaml-cpp/yaml.h>
 
@@ -30,7 +31,11 @@ namespace autoware::test_utils
 using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::LaneletSegment;
+using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
+using std_msgs::msg::Header;
+using tier4_planning_msgs::msg::PathPointWithLaneId;
+using tier4_planning_msgs::msg::PathWithLaneId;
 
 Pose parse_pose(const YAML::Node & node);
 
@@ -40,7 +45,15 @@ std::vector<LaneletPrimitive> parse_lanelet_primitives(const YAML::Node & node);
 
 std::vector<LaneletSegment> parse_segments(const YAML::Node & node);
 
+Header parse_header(const YAML::Node & node);
+
+std::vector<Point> parse_geom_points(const YAML::Node & node);
+
+std::vector<PathPointWithLaneId> parse_path_points_with_lane_id(const YAML::Node & node);
+
 LaneletRoute parse_lanelet_route_file(const std::string & filename);
+
+PathWithLaneId parse_path_with_lane_id_file(const std::string & filename);
 }  // namespace autoware::test_utils
 
 #endif  // AUTOWARE_TEST_UTILS__MOCK_DATA_PARSER_HPP_

--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -14,6 +14,7 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_test_utils/mock_data_parser.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
 #include <rclcpp/logging.hpp>
@@ -301,60 +302,7 @@ PathWithLaneId loadPathWithLaneIdInYaml()
 {
   const auto yaml_path =
     get_absolute_path_to_config("autoware_test_utils", "path_with_lane_id_data.yaml");
-  YAML::Node yaml_node = YAML::LoadFile(yaml_path);
-  PathWithLaneId path_msg;
 
-  // Convert YAML data to PathWithLaneId message
-  // Fill the header
-  path_msg.header.stamp.sec = yaml_node["header"]["stamp"]["sec"].as<int>();
-  path_msg.header.stamp.nanosec = yaml_node["header"]["stamp"]["nanosec"].as<uint32_t>();
-  path_msg.header.frame_id = yaml_node["header"]["frame_id"].as<std::string>();
-
-  // Fill the points
-  for (const auto & point_node : yaml_node["points"]) {
-    PathPointWithLaneId point;
-    // Fill the PathPoint data
-    point.point.pose.position.x = point_node["point"]["pose"]["position"]["x"].as<double>();
-    point.point.pose.position.y = point_node["point"]["pose"]["position"]["y"].as<double>();
-    point.point.pose.position.z = point_node["point"]["pose"]["position"]["z"].as<double>();
-    point.point.pose.orientation.x = point_node["point"]["pose"]["orientation"]["x"].as<double>();
-    point.point.pose.orientation.y = point_node["point"]["pose"]["orientation"]["y"].as<double>();
-    point.point.pose.orientation.z = point_node["point"]["pose"]["orientation"]["z"].as<double>();
-    point.point.pose.orientation.w = point_node["point"]["pose"]["orientation"]["w"].as<double>();
-    point.point.longitudinal_velocity_mps =
-      point_node["point"]["longitudinal_velocity_mps"].as<float>();
-    point.point.lateral_velocity_mps = point_node["point"]["lateral_velocity_mps"].as<float>();
-    point.point.heading_rate_rps = point_node["point"]["heading_rate_rps"].as<float>();
-    point.point.is_final = point_node["point"]["is_final"].as<bool>();
-    // Fill the lane_ids
-    for (const auto & lane_id_node : point_node["lane_ids"]) {
-      point.lane_ids.push_back(lane_id_node.as<int64_t>());
-    }
-
-    path_msg.points.push_back(point);
-  }
-
-  // Fill the left_bound
-  for (const auto & point_node : yaml_node["left_bound"]) {
-    Point point;
-    // Fill the Point data (left_bound)
-    point.x = point_node["x"].as<double>();
-    point.y = point_node["y"].as<double>();
-    point.z = point_node["z"].as<double>();
-
-    path_msg.left_bound.push_back(point);
-  }
-
-  // Fill the right_bound
-  for (const auto & point_node : yaml_node["right_bound"]) {
-    Point point;
-    // Fill the Point data
-    point.x = point_node["x"].as<double>();
-    point.y = point_node["y"].as<double>();
-    point.z = point_node["z"].as<double>();
-
-    path_msg.right_bound.push_back(point);
-  }
-  return path_msg;
+  return parse_path_with_lane_id_file(yaml_path);
 }
 }  // namespace autoware::test_utils

--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -303,6 +303,6 @@ PathWithLaneId loadPathWithLaneIdInYaml()
   const auto yaml_path =
     get_absolute_path_to_config("autoware_test_utils", "path_with_lane_id_data.yaml");
 
-  return parse_path_with_lane_id_file(yaml_path);
+  return parse<PathWithLaneId>(yaml_path);
 }
 }  // namespace autoware::test_utils

--- a/common/autoware_test_utils/src/mock_data_parser.cpp
+++ b/common/autoware_test_utils/src/mock_data_parser.cpp
@@ -75,6 +75,71 @@ std::vector<LaneletSegment> parse_segments(const YAML::Node & node)
   return segments;
 }
 
+std::vector<Point> parse_geom_points(const YAML::Node & node)
+{
+  std::vector<Point> geom_points;
+
+  std::transform(
+    node.begin(), node.end(), std::back_inserter(geom_points), [&](const YAML::Node & input) {
+      Point point;
+      point.x = input["x"].as<double>();
+      point.y = input["y"].as<double>();
+      point.z = input["z"].as<double>();
+      return point;
+    });
+
+  return geom_points;
+}
+
+Header parse_header(const YAML::Node & node)
+{
+  Header header;
+
+  if (!node["header"]) {
+    return header;
+  }
+
+  header.stamp.sec = node["header"]["stamp"]["sec"].as<int>();
+  header.stamp.nanosec = node["header"]["stamp"]["nanosec"].as<uint32_t>();
+  header.frame_id = node["header"]["frame_id"].as<std::string>();
+
+  return header;
+}
+
+std::vector<PathPointWithLaneId> parse_path_points_with_lane_id(const YAML::Node & node)
+{
+  std::vector<PathPointWithLaneId> path_points;
+
+  if (!node["points"]) {
+    return path_points;
+  }
+
+  const auto & points = node["points"];
+  path_points.reserve(points.size());
+  std::transform(
+    points.begin(), points.end(), std::back_inserter(path_points), [&](const YAML::Node & input) {
+      PathPointWithLaneId point;
+      if (!input["point"]) {
+        return point;
+      }
+      const auto & point_node = input["point"];
+      point.point.pose = parse_pose(point_node["pose"]);
+
+      point.point.longitudinal_velocity_mps = point_node["longitudinal_velocity_mps"].as<float>();
+      point.point.lateral_velocity_mps = point_node["lateral_velocity_mps"].as<float>();
+      point.point.heading_rate_rps = point_node["heading_rate_rps"].as<float>();
+      point.point.is_final = point_node["is_final"].as<bool>();
+      // Fill the lane_ids
+      for (const auto & lane_id_node : input["lane_ids"]) {
+        point.lane_ids.push_back(lane_id_node.as<int64_t>());
+      }
+
+      return point;
+    });
+
+  return path_points;
+}
+
 // cppcheck-suppress unusedFunction
 LaneletRoute parse_lanelet_route_file(const std::string & filename)
 {
@@ -89,5 +154,22 @@ LaneletRoute parse_lanelet_route_file(const std::string & filename)
     RCLCPP_DEBUG(rclcpp::get_logger("autoware_test_utils"), "Exception caught: %s", e.what());
   }
   return lanelet_route;
+}
+
+PathWithLaneId parse_path_with_lane_id_file(const std::string & filename)
+{
+  PathWithLaneId path;
+  try {
+    YAML::Node yaml_node = YAML::LoadFile(filename);
+
+    path.header = parse_header(yaml_node);
+    path.points = parse_path_points_with_lane_id(yaml_node);
+    path.left_bound = parse_geom_points(yaml_node["left_bound"]);
+    path.right_bound = parse_geom_points(yaml_node["right_bound"]);
+  } catch (const std::exception & e) {
+    RCLCPP_DEBUG(rclcpp::get_logger("autoware_test_utils"), "Exception caught: %s", e.what());
+  }
+
+  return path;
 }
 }  // namespace autoware::test_utils

--- a/common/autoware_test_utils/test/test_mock_data_parser.cpp
+++ b/common/autoware_test_utils/test/test_mock_data_parser.cpp
@@ -132,4 +132,53 @@ TEST(ParseFunction, CompleteFromFilename)
   EXPECT_EQ(segment1.primitives[3].id, 88);
   EXPECT_EQ(segment1.primitives[3].primitive_type, "lane");
 }
+
+TEST(ParseFunction, ParsePathWithLaneID)
+{
+  const auto autoware_test_utils_dir =
+    ament_index_cpp::get_package_share_directory("autoware_test_utils");
+  const auto parser_test_path =
+    autoware_test_utils_dir + "/test_data/path_with_lane_id_parser_test.yaml";
+
+  const auto path = parse_path_with_lane_id_file(parser_test_path);
+  EXPECT_EQ(path.header.stamp.sec, 20);
+  EXPECT_EQ(path.header.stamp.nanosec, 5);
+
+  const auto path_points = path.points;
+  const auto & p1 = path_points.front();
+  EXPECT_DOUBLE_EQ(p1.point.pose.position.x, 12.9);
+  EXPECT_DOUBLE_EQ(p1.point.pose.position.y, 3.8);
+  EXPECT_DOUBLE_EQ(p1.point.pose.position.z, 4.7);
+  EXPECT_DOUBLE_EQ(p1.point.pose.orientation.x, 1.0);
+  EXPECT_DOUBLE_EQ(p1.point.pose.orientation.y, 2.0);
+  EXPECT_DOUBLE_EQ(p1.point.pose.orientation.z, 3.0);
+  EXPECT_DOUBLE_EQ(p1.point.pose.orientation.w, 4.0);
+  EXPECT_FLOAT_EQ(p1.point.longitudinal_velocity_mps, 1.2);
+  EXPECT_FLOAT_EQ(p1.point.lateral_velocity_mps, 3.4);
+  EXPECT_FLOAT_EQ(p1.point.heading_rate_rps, 5.6);
+  EXPECT_TRUE(p1.point.is_final);
+  EXPECT_EQ(p1.lane_ids.front(), 912);
+
+  const auto & p2 = path_points.back();
+  EXPECT_DOUBLE_EQ(p2.point.pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(p2.point.pose.position.y, 20.5);
+  EXPECT_DOUBLE_EQ(p2.point.pose.position.z, 90.11);
+  EXPECT_DOUBLE_EQ(p2.point.pose.orientation.x, 4.0);
+  EXPECT_DOUBLE_EQ(p2.point.pose.orientation.y, 3.0);
+  EXPECT_DOUBLE_EQ(p2.point.pose.orientation.z, 2.0);
+  EXPECT_DOUBLE_EQ(p2.point.pose.orientation.w, 1.0);
+  EXPECT_FLOAT_EQ(p2.point.longitudinal_velocity_mps, 2.1);
+  EXPECT_FLOAT_EQ(p2.point.lateral_velocity_mps, 4.3);
+  EXPECT_FLOAT_EQ(p2.point.heading_rate_rps, 6.5);
+  EXPECT_FALSE(p2.point.is_final);
+  EXPECT_EQ(p2.lane_ids.front(), 205);
+
+  EXPECT_DOUBLE_EQ(path.left_bound.front().x, 55.0);
+  EXPECT_DOUBLE_EQ(path.left_bound.front().y, 66.0);
+  EXPECT_DOUBLE_EQ(path.left_bound.front().z, 77.0);
+
+  EXPECT_DOUBLE_EQ(path.right_bound.front().x, 0.55);
+  EXPECT_DOUBLE_EQ(path.right_bound.front().y, 0.66);
+  EXPECT_DOUBLE_EQ(path.right_bound.front().z, 0.77);
+}
 }  // namespace autoware::test_utils

--- a/common/autoware_test_utils/test/test_mock_data_parser.cpp
+++ b/common/autoware_test_utils/test/test_mock_data_parser.cpp
@@ -18,8 +18,12 @@
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "autoware_test_utils/mock_data_parser.hpp"
 
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+
 namespace autoware::test_utils
 {
+using tier4_planning_msgs::msg::PathWithLaneId;
+
 // Example YAML structure as a string for testing
 const char g_complete_yaml[] = R"(
 start_pose:
@@ -58,8 +62,8 @@ TEST(ParseFunctions, CompleteYAMLTest)
   YAML::Node config = YAML::Load(g_complete_yaml);
 
   // Test parsing of start_pose and goal_pose
-  Pose start_pose = parse_pose(config["start_pose"]);
-  Pose goal_pose = parse_pose(config["goal_pose"]);
+  Pose start_pose = parse<Pose>(config["start_pose"]);
+  Pose goal_pose = parse<Pose>(config["goal_pose"]);
 
   EXPECT_DOUBLE_EQ(start_pose.position.x, 1.0);
   EXPECT_DOUBLE_EQ(start_pose.position.y, 2.0);
@@ -79,7 +83,7 @@ TEST(ParseFunctions, CompleteYAMLTest)
   EXPECT_DOUBLE_EQ(goal_pose.orientation.w, 0.8);
 
   // Test parsing of segments
-  std::vector<LaneletSegment> segments = parse_segments(config["segments"]);
+  const auto segments = parse<std::vector<LaneletSegment>>(config["segments"]);
   ASSERT_EQ(
     segments.size(), uint64_t(1));  // Assuming only one segment in the provided YAML for this test
 
@@ -99,7 +103,7 @@ TEST(ParseFunction, CompleteFromFilename)
   const auto parser_test_route =
     autoware_test_utils_dir + "/test_data/lanelet_route_parser_test.yaml";
 
-  const auto lanelet_route = parse_lanelet_route_file(parser_test_route);
+  const auto lanelet_route = parse<LaneletRoute>(parser_test_route);
   EXPECT_DOUBLE_EQ(lanelet_route.start_pose.position.x, 1.0);
   EXPECT_DOUBLE_EQ(lanelet_route.start_pose.position.y, 2.0);
   EXPECT_DOUBLE_EQ(lanelet_route.start_pose.position.z, 3.0);
@@ -140,7 +144,7 @@ TEST(ParseFunction, ParsePathWithLaneID)
   const auto parser_test_path =
     autoware_test_utils_dir + "/test_data/path_with_lane_id_parser_test.yaml";
 
-  const auto path = parse_path_with_lane_id_file(parser_test_path);
+  const auto path = parse<PathWithLaneId>(parser_test_path);
   EXPECT_EQ(path.header.stamp.sec, 20);
   EXPECT_EQ(path.header.stamp.nanosec, 5);
 

--- a/common/autoware_test_utils/test_data/path_with_lane_id_parser_test.yaml
+++ b/common/autoware_test_utils/test_data/path_with_lane_id_parser_test.yaml
@@ -1,0 +1,48 @@
+header:
+  stamp:
+    sec: 20
+    nanosec: 5
+  frame_id: autoware
+points:
+  - point:
+      pose:
+        position:
+          x: 12.9
+          y: 3.8
+          z: 4.7
+        orientation:
+          x: 1.0
+          y: 2.0
+          z: 3.0
+          w: 4.0
+      longitudinal_velocity_mps: 1.2
+      lateral_velocity_mps: 3.4
+      heading_rate_rps: 5.6
+      is_final: true
+    lane_ids:
+      - 912
+  - point:
+      pose:
+        position:
+          x: 0.0
+          y: 20.5
+          z: 90.11
+        orientation:
+          x: 4.0
+          y: 3.0
+          z: 2.0
+          w: 1.0
+      longitudinal_velocity_mps: 2.1
+      lateral_velocity_mps: 4.3
+      heading_rate_rps: 6.5
+      is_final: false
+    lane_ids:
+      - 205
+left_bound:
+  - x: 55.0
+    y: 66.0
+    z: 77.0
+right_bound:
+  - x: 0.55
+    y: 0.66
+    z: 0.77

--- a/planning/autoware_route_handler/test/test_route_handler.hpp
+++ b/planning/autoware_route_handler/test/test_route_handler.hpp
@@ -68,7 +68,7 @@ public:
   {
     const auto rh_test_route =
       get_absolute_path_to_route(autoware_route_handler_dir, route_filename);
-    route_handler_->setRoute(autoware::test_utils::parse_lanelet_route_file(rh_test_route));
+    route_handler_->setRoute(autoware::test_utils::parse<LaneletRoute>(rh_test_route));
   }
 
   lanelet::ConstLanelets get_current_lanes()

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_lane_change_scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_lane_change_scene.cpp
@@ -21,6 +21,8 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
+#include "autoware_planning_msgs/msg/lanelet_route.hpp"
+
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -38,6 +40,7 @@ using autoware::test_utils::get_absolute_path_to_config;
 using autoware::test_utils::get_absolute_path_to_lanelet_map;
 using autoware::test_utils::get_absolute_path_to_route;
 using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_planning_msgs::msg::LaneletRoute;
 using geometry_msgs::msg::Pose;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
@@ -116,7 +119,7 @@ public:
     auto route_handler_ptr = std::make_shared<RouteHandler>(map_bin_msg);
     const auto rh_test_route =
       get_absolute_path_to_route(autoware_route_handler_dir, lane_change_right_test_route_filename);
-    route_handler_ptr->setRoute(autoware::test_utils::parse_lanelet_route_file(rh_test_route));
+    route_handler_ptr->setRoute(autoware::test_utils::parse<LaneletRoute>(rh_test_route));
 
     return route_handler_ptr;
   }


### PR DESCRIPTION
## Description

Some test might require path as input, so this PR adds a parser, so that user can use path for unit testing.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Build and test, and not unit test failure observed.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
