### PR TITLE
feat(mission_planner): skip modified goal reroute if goal lane is the same

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -200,6 +200,16 @@ void MissionPlanner::on_modified_goal(const PoseWithUuidStamped::ConstSharedPtr 
     RCLCPP_ERROR(get_logger(), "The planned route is empty.");
   }
 
+  // skip reroute if the new goal lane is the same as the current goal lane
+  if (
+    current_route_->segments.back().preferred_primitive.id ==
+    route.segments.back().preferred_primitive.id) {
+    cancel_route();
+    change_state(RouteState::SET);
+    RCLCPP_INFO(get_logger(), "New goal lane is the same as the current goal lane. Skip reroute.");
+    return;
+  }
+
   change_route(route);
   change_state(RouteState::SET);
   RCLCPP_INFO(get_logger(), "Changed the route with the modified goal");


### PR DESCRIPTION
## Description


skip modified goal reroute if goal lane is the same

Rerouting with modified goal is only a minor rerouting near the goal.
It is not expected that ego will reroute the route away from the original route. In other words, the start pose is not important, and it is sufficient to reroute only when the goal pose changes.
Rerouting with modified goal may cause bugs because there is no safety check. Rerouting should be done only when it is really necessary.

This is not a radical solution, but it is a temporary fix for reroutes that are bad for path creation.
Fixing behavior paths is also inherently necessary.

before

https://github.com/user-attachments/assets/04b87cda-a4fd-4931-910a-bca406999f0e




after

https://github.com/user-attachments/assets/6de6eb81-149f-40e0-b6f4-5fa2911fccf4



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- psim
- https://evaluation.tier4.jp/evaluation/reports/66da7d1c-3b0e-51ed-b4c7-244c905dcade?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
