### PR TITLE
fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1049,9 +1049,16 @@ bool isWithinIntersection(
     return false;
   }
 
-  const auto lanelet_polygon =
-    route_handler->getLaneletMapPtr()->polygonLayer.get(std::atoi(id.c_str()));
+  if (!std::atoi(id.c_str())) {
+    return false;
+  }
 
+  const auto lanelet_polygon_opt = route_handler->getLaneletMapPtr()->polygonLayer.find(std::atoi(id.c_str()));
+  if (lanelet_polygon_opt == route_handler->getLaneletMapPtr()->polygonLayer.end()) {
+    return false;
+  }
+  const auto& lanelet_polygon = *lanelet_polygon_opt;
+  
   return boost::geometry::within(
     polygon, utils::toPolygon2d(lanelet::utils::to2D(lanelet_polygon.basicPolygon())));
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -1193,12 +1193,19 @@ std::vector<lanelet::ConstPoint3d> getBoundWithIntersectionAreas(
       continue;
     }
 
+    if (!std::atoi(id.c_str())) {
+      continue;
+    }
+
     // Step1. extract intersection partial bound.
     std::vector<lanelet::ConstPoint3d> intersection_bound{};
     {
-      const auto polygon =
-        route_handler->getLaneletMapPtr()->polygonLayer.get(std::atoi(id.c_str()));
-
+      const auto polygon_opt = route_handler->getLaneletMapPtr()->polygonLayer.find(std::atoi(id.c_str()));
+      if (polygon_opt == route_handler->getLaneletMapPtr()->polygonLayer.end()) {
+        continue;
+      }
+      const auto& polygon = *polygon_opt;
+      
       const auto is_clockwise_polygon =
         boost::geometry::is_valid(lanelet::utils::to2D(polygon.basicPolygon()));
       const auto is_clockwise_iteration = is_clockwise_polygon ? is_left : !is_left;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -251,14 +251,21 @@ bool isWithinIntersection(
     return false;
   }
 
+  if (!std::atoi(area_id.c_str())) {
+    return false;
+  }
+
   const std::string location = object.overhang_lanelet.attributeOr("location", "else");
   if (location == "private") {
     return false;
   }
 
-  const auto polygon =
-    route_handler->getLaneletMapPtr()->polygonLayer.get(std::atoi(area_id.c_str()));
-
+  const auto polygon_opt = route_handler->getLaneletMapPtr()->polygonLayer.find(std::atoi(area_id.c_str()));
+  if (polygon_opt == route_handler->getLaneletMapPtr()->polygonLayer.end()) {
+    return false;
+  }
+  const auto& polygon = *polygon_opt;
+  
   return boost::geometry::within(
     lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
       .basicPoint(),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -342,7 +342,7 @@ std::optional<autoware::universe_utils::Polygon2d> getIntersectionArea(
 {
   const std::string area_id_str = assigned_lane.attributeOr("intersection_area", "else");
   if (area_id_str == "else") return std::nullopt;
-  if (!std::atoi(area_id_str.c_str())) return std::nullopt
+  if (!std::atoi(area_id_str.c_str())) return std::nullopt;
 
   const lanelet::Id area_id = std::atoi(area_id_str.c_str());
   const auto polygon_opt = lanelet_map_ptr->polygonLayer.find(area_id);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -344,7 +344,7 @@ std::optional<autoware::universe_utils::Polygon2d> getIntersectionArea(
   if (area_id_str == "else") return std::nullopt;
   if (!std::atoi(area_id_str.c_str())) return std::nullopt;
 
-           const lanelet::Id area_id = std::atoi(area_id_str.c_str());
+  const lanelet::Id area_id = std::atoi(area_id_str.c_str());
   const auto polygon_opt = lanelet_map_ptr->polygonLayer.find(area_id);
   if (polygon_opt == lanelet_map_ptr->polygonLayer.end()) return std::nullopt;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -342,8 +342,12 @@ std::optional<autoware::universe_utils::Polygon2d> getIntersectionArea(
 {
   const std::string area_id_str = assigned_lane.attributeOr("intersection_area", "else");
   if (area_id_str == "else") return std::nullopt;
+  if (!std::atoi(area_id_str.c_str())) return std::nullopt
 
   const lanelet::Id area_id = std::atoi(area_id_str.c_str());
+  const auto polygon_opt = lanelet_map_ptr->polygonLayer.find(area_id);
+  if (polygon_opt == lanelet_map_ptr->polygonLayer.end()) return std::nullopt;
+  
   const auto poly_3d = lanelet_map_ptr->polygonLayer.get(area_id);
   Polygon2d poly{};
   for (const auto & p : poly_3d) poly.outer().emplace_back(p.x(), p.y());


### PR DESCRIPTION
## Description
Fix to not read invalid lanelet-map polygon layer ID. Add checking for invalid ID.

e.g. 1
```
  '1724991158.7707169 [component_container_mt-35]     @     0x762a335f24d6 google::(anonymous namespace)::FailureSignalHandler()',
  '1724991158.7741981 [component_container_mt-35]     @     0x762a32a42520 (unknown)',
  '1724991158.7773001 [component_container_mt-35]     @     0x762a32a969fc pthread_kill',
  '1724991158.7798305 [component_container_mt-35]     @     0x762a32a42476 raise',
  '1724991158.7822514 [component_container_mt-35]     @     0x762a32a287f3 abort',
  '1724991158.7848880 [component_container_mt-35]     @     0x762a32ea2b9e (unknown)',
  '1724991158.7884953 [component_container_mt-35]     @     0x762a32eae20c (unknown)',
  '1724991158.7907829 [component_container_mt-35]     @     0x762a32eae277 std::terminate()',
  '1724991158.7930424 [component_container_mt-35]     @     0x762a32eae4d8 __cxa_throw',
  '1724991158.7950559 [component_container_mt-35]     @     0x762a0c0e6325 (unknown)',
  '1724991158.7971447 [component_container_mt-35]     @     0x762a2839aacd autoware::behavior_path_planner::utils::getBoundWithIntersectionAreas()',
  '1724991158.7991152 [component_container_mt-35]     @     0x762a2839ceab autoware::behavior_path_planner::utils::calcBound()',
  '1724991158.8003454 [component_container_mt-35]     @     0x762a04344ced autoware::behavior_path_planner::StaticObstacleAvoidanceModule::fillFundamentalData()',
  '1724991158.8015015 [component_container_mt-35]     @     0x762a04345e44 autoware::behavior_path_planner::StaticObstacleAvoidanceModule::updateData()',
  '1724991158.8038318 [component_container_mt-35]     @     0x762a0c4e45b3 autoware::behavior_path_planner::PlannerManager::getRequestModules()',
  '1724991158.8062282 [component_container_mt-35]     @     0x762a0c4ef170 _ZZN8autoware21behavior_path_planner14PlannerManager3runERKSt10shared_ptrINS0_11PlannerDataEEENKUlvE0_clEv',
  '1724991158.8088937 [component_container_mt-35]     @     0x762a0c4f0092 autoware::behavior_path_planner::PlannerManager::run()',
  '1724991158.8114202 [component_container_mt-35]     @     0x762a0c546449 autoware::behavior_path_planner::BehaviorPathPlannerNode::run()',
  '1724991158.8134098 [component_container_mt-35]     @     0x762a0c54fbd5 rclcpp::GenericTimer<>::execute_callback()',
  '1724991158.8159237 [component_container_mt-35]     @     0x762a3335effe rclcpp::Executor::execute_any_executable()',
  '1724991158.8184681 [component_container_mt-35]     @     0x762a33365432 rclcpp::executors::MultiThreadedExecutor::run()',
  '1724991158.8207543 [component_container_mt-35]     @     0x762a32edc253 (unknown)',
  '1724991158.8228254 [component_container_mt-35]     @     0x762a32a94ac3 (unknown)',
  '1724991158.8248127 [component_container_mt-35]     @     0x762a32b26850 (unknown)'
```

e.g. 2 
```
1725019155.6671865 [component_container_mt-35] @ 0x7b18f13513e5 autoware::behavior_velocity_planner::util::getIntersectionArea()
1725019155.6672549 [component_container_mt-35] @ 0x7b18f140d941 autoware::behavior_velocity_planner::IntersectionModule::updateObjectInfoManagerArea()
1725019155.6672997 [component_container_mt-35] @ 0x7b18f137beb5 autoware::behavior_velocity_planner::IntersectionModule::modifyPathVelocityDetail()
1725019155.6679757 [component_container_mt-35] @ 0x7b18f137ec67 autoware::behavior_velocity_planner::IntersectionModule::modifyPathVelocity()
1725019155.6689417 [component_container_mt-35] @ 0x7b19aeee9491 autoware::behavior_velocity_planner::SceneModuleManagerInterface::modifyPathVelocity()
1725019155.6702878 [component_container_mt-35] @ 0x7b19aeee0f22 autoware::behavior_velocity_planner::SceneModuleManagerInterfaceWithRTC::plan()
1725019155.6715858 [component_container_mt-35] @ 0x7b19aed78b0e autoware::behavior_velocity_planner::BehaviorVelocityPlannerManager::planPathVelocity()
1725019155.6727095 [component_container_mt-35] @ 0x7b19aec8b2be autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode::generatePath()
1725019155.6741042 [component_container_mt-35] @ 0x7b19aec8b8e0 autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode::onTrigger()
1725019155.6753044 [component_container_mt-35] @ 0x7b19aecd8b27 std::_Function_handler<>::_M_invoke()
```

## Related links
[Vector Map Builder](https://tools.tier4.jp/vector_map_builder_ll2/?projectId=prd_jt&areaMapId=1423&versionId=1423-20240830082322733717)
[Link](https://tier4.atlassian.net/wiki/spaces/~6061477cafe465006afac8aa/pages/3356789607/intersection+area+Autoware)

## How was this PR tested?
Using map including bug (prd_jt/shinagawa_odaiba), launch psim and check if the process does not die.
Use letterbox to check if the process does not die.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.