### PR TITLE
refactor(autoware_map_based_prediction): refactoring lanelet path prediction and pose path conversion

### DIFF
--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -59,19 +59,15 @@
 namespace std
 {
 template <>
-struct hash<lanelet::routing::LaneletPaths>
+struct hash<lanelet::routing::LaneletPath>
 {
   // 0x9e3779b9 is a magic number. See
   // https://stackoverflow.com/questions/4948780/magic-number-in-boosthash-combine
-  size_t operator()(const lanelet::routing::LaneletPaths & paths) const
+  size_t operator()(const lanelet::routing::LaneletPath & path) const
   {
     size_t seed = 0;
-    for (const auto & path : paths) {
-      for (const auto & lanelet : path) {
-        seed ^= hash<int64_t>{}(lanelet.id()) + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
-      }
-      // Add a separator between paths
-      seed ^= hash<int>{}(0) + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
+    for (const auto & lanelet : path) {
+      seed ^= hash<int64_t>{}(lanelet.id()) + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
     }
     return seed;
   }
@@ -308,21 +304,14 @@ private:
   double calcLeftLateralOffset(
     const lanelet::ConstLineString2d & boundary_line, const geometry_msgs::msg::Pose & search_pose);
   ManeuverProbability calculateManeuverProbability(
-    const Maneuver & predicted_maneuver, const lanelet::routing::LaneletPaths & left_paths,
-    const lanelet::routing::LaneletPaths & right_paths,
-    const lanelet::routing::LaneletPaths & center_paths);
-
-  void addReferencePaths(
-    const std::string  & object_id, const lanelet::routing::LaneletPaths & candidate_paths,
-    const float path_probability, const ManeuverProbability & maneuver_probability,
-    const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths,
-    const double speed_limit = 0.0);
+    const Maneuver & predicted_maneuver, const bool & left_paths_exists, const bool & right_paths_exists,
+  const bool & center_paths_exists) const;
 
   mutable universe_utils::LRUCache<
-    lanelet::routing::LaneletPaths, std::vector<std::pair<PosePath, double>>>
+    lanelet::routing::LaneletPath, std::pair<PosePath, double>>
     lru_cache_of_convert_path_type_{1000};
-  std::vector<std::pair<PosePath, double>> convertPathType(
-    const lanelet::routing::LaneletPaths & paths) const;
+  std::pair<PosePath, double> convertLaneletPathToPosePath(
+    const lanelet::routing::LaneletPath & path) const;
 
   void updateFuturePossibleLanelets(
     const std::string  & object_id, const lanelet::routing::LaneletPaths & paths);

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -298,7 +298,7 @@ private:
     const TrackedObject & object, const LaneletsData & current_lanelets_data,
     const double object_detected_time, const double time_horizon);
   Maneuver predictObjectManeuver(
-    const TrackedObject & object, const LaneletData & current_lanelet_data,
+    const std::string  & object_id, const geometry_msgs::msg::Pose & object_pose, const LaneletData & current_lanelet_data,
     const double object_detected_time);
   geometry_msgs::msg::Pose compensateTimeDelay(
     const geometry_msgs::msg::Pose & delayed_pose, const geometry_msgs::msg::Twist & twist,
@@ -313,7 +313,7 @@ private:
     const lanelet::routing::LaneletPaths & center_paths);
 
   void addReferencePaths(
-    const TrackedObject & object, const lanelet::routing::LaneletPaths & candidate_paths,
+    const std::string  & object_id, const lanelet::routing::LaneletPaths & candidate_paths,
     const float path_probability, const ManeuverProbability & maneuver_probability,
     const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths,
     const double speed_limit = 0.0);
@@ -325,7 +325,7 @@ private:
     const lanelet::routing::LaneletPaths & paths) const;
 
   void updateFuturePossibleLanelets(
-    const TrackedObject & object, const lanelet::routing::LaneletPaths & paths);
+    const std::string  & object_id, const lanelet::routing::LaneletPaths & paths);
 
   bool isDuplicated(
     const std::pair<double, lanelet::ConstLanelet> & target_lanelet,
@@ -342,10 +342,10 @@ private:
     const TrackedObject & object, const Maneuver & maneuver, const size_t obj_num);
 
   Maneuver predictObjectManeuverByTimeToLaneChange(
-    const TrackedObject & object, const LaneletData & current_lanelet_data,
+    const std::string  & object_id, const LaneletData & current_lanelet_data,
     const double object_detected_time);
   Maneuver predictObjectManeuverByLatDiffDistance(
-    const TrackedObject & object, const LaneletData & current_lanelet_data,
+    const std::string  & object_id, const geometry_msgs::msg::Pose & object_pose, const LaneletData & current_lanelet_data,
     const double object_detected_time);
 
   void publish(

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -294,8 +294,8 @@ private:
     const TrackedObject & object, const LaneletsData & current_lanelets_data,
     const double object_detected_time, const double time_horizon);
   Maneuver predictObjectManeuver(
-    const std::string  & object_id, const geometry_msgs::msg::Pose & object_pose, const LaneletData & current_lanelet_data,
-    const double object_detected_time);
+    const std::string & object_id, const geometry_msgs::msg::Pose & object_pose,
+    const LaneletData & current_lanelet_data, const double object_detected_time);
   geometry_msgs::msg::Pose compensateTimeDelay(
     const geometry_msgs::msg::Pose & delayed_pose, const geometry_msgs::msg::Twist & twist,
     const double dt) const;
@@ -304,17 +304,16 @@ private:
   double calcLeftLateralOffset(
     const lanelet::ConstLineString2d & boundary_line, const geometry_msgs::msg::Pose & search_pose);
   ManeuverProbability calculateManeuverProbability(
-    const Maneuver & predicted_maneuver, const bool & left_paths_exists, const bool & right_paths_exists,
-  const bool & center_paths_exists) const;
+    const Maneuver & predicted_maneuver, const bool & left_paths_exists,
+    const bool & right_paths_exists, const bool & center_paths_exists) const;
 
-  mutable universe_utils::LRUCache<
-    lanelet::routing::LaneletPath, std::pair<PosePath, double>>
+  mutable universe_utils::LRUCache<lanelet::routing::LaneletPath, std::pair<PosePath, double>>
     lru_cache_of_convert_path_type_{1000};
   std::pair<PosePath, double> convertLaneletPathToPosePath(
     const lanelet::routing::LaneletPath & path) const;
 
   void updateFuturePossibleLanelets(
-    const std::string  & object_id, const lanelet::routing::LaneletPaths & paths);
+    const std::string & object_id, const lanelet::routing::LaneletPaths & paths);
 
   bool isDuplicated(
     const std::pair<double, lanelet::ConstLanelet> & target_lanelet,
@@ -331,11 +330,11 @@ private:
     const TrackedObject & object, const Maneuver & maneuver, const size_t obj_num);
 
   Maneuver predictObjectManeuverByTimeToLaneChange(
-    const std::string  & object_id, const LaneletData & current_lanelet_data,
+    const std::string & object_id, const LaneletData & current_lanelet_data,
     const double object_detected_time);
   Maneuver predictObjectManeuverByLatDiffDistance(
-    const std::string  & object_id, const geometry_msgs::msg::Pose & object_pose, const LaneletData & current_lanelet_data,
-    const double object_detected_time);
+    const std::string & object_id, const geometry_msgs::msg::Pose & object_pose,
+    const LaneletData & current_lanelet_data, const double object_detected_time);
 
   void publish(
     const PredictedObjects & output,

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -154,6 +154,7 @@ using autoware_perception_msgs::msg::TrafficLightGroupArray;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_debug_msgs::msg::StringStamped;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using LaneletPathWithPathInfo = std::pair<lanelet::routing::LaneletPath, PredictedRefPath>;
 class MapBasedPredictionNode : public rclcpp::Node
 {
 public:
@@ -290,9 +291,12 @@ private:
     const std::string & object_id, std::unordered_map<std::string, TrackedObject> & current_users);
   std::optional<size_t> searchProperStartingRefPathIndex(
     const TrackedObject & object, const PosePath & pose_path) const;
-  std::vector<PredictedRefPath> getPredictedReferencePath(
+  std::vector<LaneletPathWithPathInfo> getPredictedReferencePath(
     const TrackedObject & object, const LaneletsData & current_lanelets_data,
     const double object_detected_time, const double time_horizon);
+  std::vector<PredictedRefPath> convertPredictedReferencePath(
+    const TrackedObject & object,
+    const std::vector<LaneletPathWithPathInfo> & lanelet_ref_paths) const;
   Maneuver predictObjectManeuver(
     const std::string & object_id, const geometry_msgs::msg::Pose & object_pose,
     const LaneletData & current_lanelet_data, const double object_detected_time);

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2602,7 +2602,7 @@ std::optional<size_t> MapBasedPredictionNode::searchProperStartingRefPathIndex(
 
   bool is_position_found = false;
   std::optional<size_t> opt_index{std::nullopt};
-  auto & index = opt_index.emplace();
+  auto & index = opt_index.emplace(0);
 
   // starting segment index is a segment close enough to the object
   const auto obj_point = object.kinematics.pose_with_covariance.pose.position;

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -2445,9 +2445,12 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::convertPredictedReferenceP
   const TrackedObject & object,
   const std::vector<LaneletPathWithPathInfo> & lanelet_ref_paths) const
 {
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
   std::vector<PredictedRefPath> converted_ref_paths;
 
-  // Step 3. Convert lanelet path to pose path
+  // Step 1. Convert lanelet path to pose path
   for (const auto & ref_path : lanelet_ref_paths) {
     const auto & lanelet_path = ref_path.first;
     const auto & ref_path_info = ref_path.second;
@@ -2461,13 +2464,8 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::convertPredictedReferenceP
     converted_ref_paths.push_back(predicted_path);
   }
 
-  // Step 4. Search starting point for each reference path
+  // Step 2. Search starting point for each reference path
   for (auto it = converted_ref_paths.begin(); it != converted_ref_paths.end();) {
-    std::unique_ptr<ScopedTimeTrack> st1_ptr;
-    if (time_keeper_)
-      st1_ptr =
-        std::make_unique<ScopedTimeTrack>("searching_ref_path_starting_point", *time_keeper_);
-
     auto & pose_path = it->path;
     if (pose_path.empty()) {
       continue;


### PR DESCRIPTION
## Description

1. Refactoring lanelet path prediction part and the PosePath conversion part.
2. LRUCache implementation is changed from LaneletPaths to LaneletPath, which can improve the performance.

This PR does not include any logic changes.

## Related links
[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT1-8214)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

* [TIER IV Cloud](https://evaluation.tier4.jp/evaluation/reports/c83a4d75-3368-580c-8d75-d5cd931fe5b2?project_id=prd_jt)  814/814

* processing time
```
🌲 Total Processing Time Tree 🌲
100.00% objectsCallback: total 2805.00 [ms], avg. 5.99 [ms], run count: 468
    ├── 0.08% trafficSignalsCallback: total 2.18 [ms], avg. 0.00 [ms], run count: 468
    ├── 0.02% updateObjectData: total 0.69 [ms], avg. 0.00 [ms], run count: 6604
    ├── 36.16% getCurrentLanelets: total 1014.19 [ms], avg. 0.15 [ms], run count: 6604
    │   ├── 10.24% checkCloseLaneletCondition: total 287.19 [ms], avg. 0.00 [ms], run count: 66040
    │   ├── 2.78% calculateLocalLikelihood: total 77.99 [ms], avg. 0.01 [ms], run count: 6158
    │   └── 23.14% rest: 649.01 [ms]
    ├── 1.82% updateRoadUsersHistory: total 51.10 [ms], avg. 0.01 [ms], run count: 6604
    ├── 0.06% generatePathForLowSpeedVehicle: total 1.76 [ms], avg. 0.00 [ms], run count: 2239
    ├── 8.84% getPredictedReferencePath: total 248.02 [ms], avg. 0.07 [ms], run count: 3651
    │   ├── 3.02% predictObjectManeuver: total 84.83 [ms], avg. 0.02 [ms], run count: 3911
    │   │   ├── 2.80% predictObjectManeuverByLatDiffDistance: total 78.64 [ms], avg. 0.02 [ms], run count: 3911
    │   │   └── 0.22% rest: 6.19 [ms]
    │   ├── 0.02% calculateManeuverProbability: total 0.55 [ms], avg. 0.00 [ms], run count: 3911
    │   └── 5.80% rest: 162.64 [ms]
    ├── 11.64% convertPredictedReferencePath: total 326.50 [ms], avg. 0.09 [ms], run count: 3651
    │   ├── 4.25% convertLaneletPathToPosePath: total 119.26 [ms], avg. 0.01 [ms], run count: 10009
    │   ├── 2.61% searchProperStartingRefPathIndex: total 73.28 [ms], avg. 0.01 [ms], run count: 10009
    │   │   ├── 0.64% find_close_segment_index: total 17.93 [ms], avg. 0.00 [ms], run count: 10009
    │   │   ├── 1.29% find_target_seg_index: total 36.18 [ms], avg. 0.00 [ms], run count: 10009
    │   │   └── 0.68% rest: 19.16 [ms]
    │   └── 4.78% rest: 133.97 [ms]
    ├── 12.59% generatePathForOnLaneVehicle: total 353.07 [ms], avg. 0.04 [ms], run count: 9953
    │   ├── 12.32% generatePolynomialPath: total 345.48 [ms], avg. 0.03 [ms], run count: 9953
    │   │   ├── 0.02% getFrenetPoint: total 0.65 [ms], avg. 0.00 [ms], run count: 9953
    │   │   ├── 0.11% generateFrenetPath: total 3.17 [ms], avg. 0.00 [ms], run count: 9953
    │   │   ├── 6.73% interpolateReferencePath: total 188.90 [ms], avg. 0.02 [ms], run count: 9953
    │   │   │   ├── 0.42% interpolationLerp_double: total 11.88 [ms], avg. 0.00 [ms], run count: 29859
    │   │   │   ├── 0.66% interpolationLerp_quaternion: total 18.38 [ms], avg. 0.00 [ms], run count: 9953
    │   │   │   └── 5.66% rest: 158.65 [ms]
    │   │   ├── 1.24% convertToPredictedPath: total 34.78 [ms], avg. 0.00 [ms], run count: 9953
    │   │   └── 4.21% rest: 117.98 [ms]
    │   └── 0.27% rest: 7.59 [ms]
    ├── 0.04% updateCrosswalkUserHistory: total 1.18 [ms], avg. 0.00 [ms], run count: 859
    ├── 4.48% getPredictedObjectAsCrosswalkUser: total 125.62 [ms], avg. 0.15 [ms], run count: 859
    │   ├── 0.05% generatePathForNonVehicleObject: total 1.45 [ms], avg. 0.00 [ms], run count: 859
    │   ├── 0.15% calcIntentionToCrossWithTrafficSignal: total 4.35 [ms], avg. 0.00 [ms], run count: 1433
    │   │   ├── 0.00% getTrafficSignalElement: total 0.03 [ms], avg. 0.00 [ms], run count: 1433
    │   │   └── 0.15% rest: 4.32 [ms]
    │   ├── 0.03% generatePathForCrosswalkUser: total 0.72 [ms], avg. 0.00 [ms], run count: 793
    │   ├── 0.02% doesPathCrossAnyFence: total 0.56 [ms], avg. 0.00 [ms], run count: 793
    │   ├── 0.01% generatePathToTargetPoint: total 0.21 [ms], avg. 0.00 [ms], run count: 222
    │   └── 4.22% rest: 118.34 [ms]
    ├── 0.21% generatePathForNonVehicleObject: total 5.83 [ms], avg. 0.00 [ms], run count: 5152
    ├── 14.29% publish: total 400.83 [ms], avg. 0.86 [ms], run count: 468
    ├── 0.07% generatePathForOffLaneVehicle: total 1.89 [ms], avg. 0.00 [ms], run count: 723
    └── 9.70% rest: 272.14 [ms]

```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
