### PR TITLE
fix(behavior_velocity_planner_common): fix calcTargetPose

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
@@ -165,6 +165,10 @@ geometry_msgs::msg::Pose calcTargetPose(const T & path, const PathIndexWithOffse
   const auto p_eigen_back = Eigen::Vector2d(p_back.x, p_back.y);
 
   // Calculate interpolation ratio
+  /**
+  * (front) <--  (seg_length - remain_length) --> (interp) <-- remain_length --> (back)
+  * r : (1 - r)
+  */ 
   const auto segment_length = (p_eigen_back - p_eigen_front).norm();
   const auto interpolate_ratio = (segment_length - remain_offset_length) / segment_length;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
@@ -166,9 +166,9 @@ geometry_msgs::msg::Pose calcTargetPose(const T & path, const PathIndexWithOffse
 
   // Calculate interpolation ratio
   /**
-  * (front) <--  (seg_length - remain_length) --> (interp) <-- remain_length --> (back)
-  * r : (1 - r)
-  */ 
+   * (front) <--  (seg_length - remain_length) --> (interp) <-- remain_length --> (back)
+   * r : (1 - r)
+   */
   const auto segment_length = (p_eigen_back - p_eigen_front).norm();
   const auto interpolate_ratio = (segment_length - remain_offset_length) / segment_length;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
@@ -165,7 +165,8 @@ geometry_msgs::msg::Pose calcTargetPose(const T & path, const PathIndexWithOffse
   const auto p_eigen_back = Eigen::Vector2d(p_back.x, p_back.y);
 
   // Calculate interpolation ratio
-  const auto interpolate_ratio = remain_offset_length / (p_eigen_back - p_eigen_front).norm();
+  const auto segment_length = (p_eigen_back - p_eigen_front).norm();
+  const auto interpolate_ratio = (segment_length - remain_offset_length) / segment_length;
 
   // Add offset to front point
   const auto target_point_2d = p_eigen_front + interpolate_ratio * (p_eigen_back - p_eigen_front);


### PR DESCRIPTION
## Description

interpolate_ratio seems wrong

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
tested in later PR unit test ( https://github.com/autowarefoundation/autoware.universe/pull/9107) 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
