### PR TITLE
refactor(virtual_traffic_light): move to utils for unit test

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/debug.cpp
   src/manager.cpp
   src/scene.cpp
+  src/utils.cpp
 )
 
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.cpp
@@ -1,0 +1,123 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils.hpp"
+
+#include <autoware/behavior_velocity_planner_common/utilization/path_utilization.hpp>
+#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/universe_utils/geometry/geometry.hpp>
+
+#include <limits>
+
+namespace autoware::behavior_velocity_planner::virtual_traffic_light
+{
+
+using autoware::universe_utils::calcDistance2d;
+
+tier4_v2x_msgs::msg::KeyValue createKeyValue(const std::string & key, const std::string & value)
+{
+  return tier4_v2x_msgs::build<tier4_v2x_msgs::msg::KeyValue>().key(key).value(value);
+}
+
+autoware::universe_utils::LineString3d toAutowarePoints(
+  const lanelet::ConstLineString3d & line_string)
+{
+  autoware::universe_utils::LineString3d output;
+  for (const auto & p : line_string) {
+    output.emplace_back(p.x(), p.y(), p.z());
+  }
+  return output;
+}
+
+std::optional<autoware::universe_utils::LineString3d> toAutowarePoints(
+  const lanelet::Optional<lanelet::ConstLineString3d> & line_string)
+{
+  if (!line_string) {
+    return {};
+  }
+  return toAutowarePoints(*line_string);
+}
+
+std::vector<autoware::universe_utils::LineString3d> toAutowarePoints(
+  const lanelet::ConstLineStrings3d & line_strings)
+{
+  std::vector<autoware::universe_utils::LineString3d> output;
+  for (const auto & line_string : line_strings) {
+    output.emplace_back(toAutowarePoints(line_string));
+  }
+  return output;
+}
+
+autoware::universe_utils::Point3d calcCenter(
+  const autoware::universe_utils::LineString3d & line_string)
+{
+  const auto p1 = line_string.front();
+  const auto p2 = line_string.back();
+  const auto p_center = (p1 + p2) / 2;
+  return {p_center.x(), p_center.y(), p_center.z()};
+}
+
+geometry_msgs::msg::Pose calcHeadPose(
+  const geometry_msgs::msg::Pose & base_link_pose, const double base_link_to_front)
+{
+  return autoware::universe_utils::calcOffsetPose(base_link_pose, base_link_to_front, 0.0, 0.0);
+}
+
+geometry_msgs::msg::Point convertToGeomPoint(const autoware::universe_utils::Point3d & p)
+{
+  geometry_msgs::msg::Point geom_p;
+  geom_p.x = p.x();
+  geom_p.y = p.y();
+
+  return geom_p;
+}
+
+void insertStopVelocityFromStart(tier4_planning_msgs::msg::PathWithLaneId * path)
+{
+  for (auto & p : path->points) {
+    p.point.longitudinal_velocity_mps = 0.0;
+  }
+}
+
+std::optional<size_t> insertStopVelocityAtCollision(
+  const SegmentIndexWithPoint & collision, const double offset,
+  tier4_planning_msgs::msg::PathWithLaneId * path)
+{
+  const auto collision_offset = autoware::motion_utils::calcLongitudinalOffsetToSegment(
+    path->points, collision.index, collision.point);
+
+  const auto offset_segment =
+    arc_lane_utils::findOffsetSegment(*path, collision.index, offset + collision_offset);
+  if (!offset_segment) {
+    return {};
+  }
+
+  const auto interpolated_pose = arc_lane_utils::calcTargetPose(*path, *offset_segment);
+
+  if (offset_segment->second < 0) {
+    insertStopVelocityFromStart(path);
+    return 0;
+  }
+
+  auto insert_index = static_cast<size_t>(offset_segment->first + 1);
+  auto insert_point = path->points.at(insert_index);
+  insert_point.point.pose = interpolated_pose;
+  // Insert 0 velocity after stop point or replace velocity with 0
+  autoware::behavior_velocity_planner::planning_utils::insertVelocity(
+    *path, insert_point, 0.0, insert_index);
+  return insert_index;
+}
+
+}  // namespace autoware::behavior_velocity_planner::virtual_traffic_light

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
@@ -1,0 +1,107 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS_HPP_
+#define UTILS_HPP_
+
+#include <autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp>
+#include <autoware_lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
+
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#include <tier4_v2x_msgs/msg/key_value.hpp>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::behavior_velocity_planner::virtual_traffic_light
+{
+struct SegmentIndexWithPoint
+{
+  size_t index;
+  geometry_msgs::msg::Point point;
+};
+
+struct SegmentIndexWithOffset
+{
+  size_t index;
+};
+
+tier4_v2x_msgs::msg::KeyValue createKeyValue(const std::string & key, const std::string & value);
+
+autoware::universe_utils::LineString3d toAutowarePoints(
+  const lanelet::ConstLineString3d & line_string);
+
+std::optional<autoware::universe_utils::LineString3d> toAutowarePoints(
+  const lanelet::Optional<lanelet::ConstLineString3d> & line_string);
+
+std::vector<autoware::universe_utils::LineString3d> toAutowarePoints(
+  const lanelet::ConstLineStrings3d & line_strings);
+
+autoware::universe_utils::Point3d calcCenter(
+  const autoware::universe_utils::LineString3d & line_string);
+
+geometry_msgs::msg::Pose calcHeadPose(
+  const geometry_msgs::msg::Pose & base_link_pose, const double base_link_to_front);
+
+geometry_msgs::msg::Point convertToGeomPoint(const autoware::universe_utils::Point3d & p);
+
+void insertStopVelocityFromStart(tier4_planning_msgs::msg::PathWithLaneId * path);
+
+std::optional<size_t> insertStopVelocityAtCollision(
+  const SegmentIndexWithPoint & collision, const double offset,
+  tier4_planning_msgs::msg::PathWithLaneId * path);
+
+template <class T>
+std::optional<SegmentIndexWithPoint> findLastCollisionBeforeEndLine(
+  const T & points, const autoware::universe_utils::LineString3d & target_line,
+  const size_t end_line_idx)
+{
+  const auto target_line_p1 = convertToGeomPoint(target_line.at(0));
+  const auto target_line_p2 = convertToGeomPoint(target_line.at(1));
+
+  for (size_t i = end_line_idx; 0 < i;
+       --i) {  // NOTE: size_t can be used since it will not be negative.
+    const auto & p1 = autoware::universe_utils::getPoint(points.at(i));
+    const auto & p2 = autoware::universe_utils::getPoint(points.at(i - 1));
+    const auto collision_point =
+      arc_lane_utils::checkCollision(p1, p2, target_line_p1, target_line_p2);
+
+    if (collision_point) {
+      return SegmentIndexWithPoint{i, collision_point.value()};
+    }
+  }
+
+  return {};
+}
+
+template <class T>
+std::optional<SegmentIndexWithPoint> findLastCollisionBeforeEndLine(
+  const T & points, const std::vector<autoware::universe_utils::LineString3d> & lines,
+  const size_t end_line_idx)
+{
+  for (const auto & line : lines) {
+    const auto collision = findLastCollisionBeforeEndLine(points, line, end_line_idx);
+    if (collision) {
+      return collision;
+    }
+  }
+
+  return {};
+}
+
+}  // namespace autoware::behavior_velocity_planner::virtual_traffic_light
+
+#endif  // UTILS_HPP_


### PR DESCRIPTION
## Description

move some functions to utils for unit tests

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/9107

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

2024/10/17 https://evaluation.tier4.jp/evaluation/reports/12a8ef10-d489-5d4e-bcba-cb48a51df2ad/?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
