### PR TITLE
fix(drivable_area): add gurad to fix invalid access

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -291,9 +291,11 @@ PolygonPoint transformBoundFrenetCoordinate(
     dist_to_bound_segment_vec.push_back(dist_to_bound_segment);
   }
 
-  const size_t min_dist_seg_idx = std::distance(
-    dist_to_bound_segment_vec.begin(),
-    std::min_element(dist_to_bound_segment_vec.begin(), dist_to_bound_segment_vec.end()));
+  const size_t min_dist_seg_idx =
+    std::distance(
+      dist_to_bound_segment_vec.begin(),
+      std::min_element(dist_to_bound_segment_vec.begin(), dist_to_bound_segment_vec.end())) -
+    1;
   const double lon_dist_to_segment = autoware::motion_utils::calcLongitudinalOffsetToSegment(
     bound_points, min_dist_seg_idx, target_point);
   const double lat_dist_to_segment =
@@ -306,6 +308,9 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
   const bool is_object_right)
 {
   constexpr double invalid_lat_dist_to_bound = 10.0;
+
+  // it can't execute this process if the bound point size is less than 2.
+  if (bound.size() < 2) return {};
 
   std::vector<PolygonPoint> full_polygon;
   for (const auto & edge_point : edge_points) {


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
