### PR TITLE
feat(test_utils): add simple path with lane id generator

### DIFF
--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -46,6 +46,7 @@
 #include <tf2_ros/buffer.h>
 #include <yaml-cpp/yaml.h>
 
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -369,9 +370,9 @@ T generateTrajectory(
 
   T traj;
   for (size_t i = 0; i < num_points; ++i) {
-    const double theta = init_theta + i * delta_theta;
-    const double x = i * point_interval * std::cos(theta);
-    const double y = i * point_interval * std::sin(theta);
+    const double theta = init_theta + static_cast<double>(i) * delta_theta;
+    const double x = static_cast<double>(i) * point_interval * std::cos(theta);
+    const double y = static_cast<double>(i) * point_interval * std::sin(theta);
 
     Point p;
     p.pose = createPose(x, y, 0.0, 0.0, 0.0, theta);
@@ -395,19 +396,20 @@ inline PathWithLaneId generateTrajectory<PathWithLaneId>(
   PathWithLaneId traj;
 
   for (size_t i = 0; i < num_points; i++) {
-    const double theta = init_theta + i * delta_theta;
-    const double x = i * point_interval * std::cos(theta);
-    const double y = i * point_interval * std::sin(theta);
+    const double theta = init_theta + static_cast<double>(i) * delta_theta;
+    const double x = static_cast<double>(i) * point_interval * std::cos(theta);
+    const double y = static_cast<double>(i) * point_interval * std::sin(theta);
 
     PathPointWithLaneId p;
     p.point.pose = createPose(x, y, 0.0, 0.0, 0.0, theta);
-    p.point.longitudinal_velocity_mps = velocity;
-    p.lane_ids.push_back(i);
+    p.point.longitudinal_velocity_mps = static_cast<float>(velocity);
+    p.lane_ids.push_back(static_cast<int64_t>(i));
     traj.points.push_back(p);
 
     if (i == overlapping_point_index) {
       auto value_to_insert = traj.points.at(overlapping_point_index);
-      traj.points.insert(traj.points.begin() + overlapping_point_index + 1, value_to_insert);
+      traj.points.insert(
+        traj.points.begin() + static_cast<int64_t>(overlapping_point_index) + 1, value_to_insert);
     }
   }
   return traj;

--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -46,7 +46,6 @@
 #include <tf2_ros/buffer.h>
 #include <yaml-cpp/yaml.h>
 
-#include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>

--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -344,6 +344,21 @@ void updateNodeOptions(
 PathWithLaneId loadPathWithLaneIdInYaml();
 
 /**
+ * @brief Generates a path with lane ID. (Converts trajectory to path with lane ID)
+ * @param num_points The number of points in path.
+ * @param point_interval The distance between consecutive points.
+ * @param velocity The longitudinal velocity for each point.
+ * @param init_theta The initial theta angle.
+ * @param delta_theta The change in theta per point.
+ * @param overlapping_point_index The index of the point to overlap.
+ * @return A path with lane ID.
+ */
+PathWithLaneId generate_simple_path_with_lane_id(
+  const size_t num_points, const double point_interval, const double velocity = 0.0,
+  const double init_theta = 0.0, const double delta_theta = 0.0,
+  const size_t overlapping_point_index = std::numeric_limits<size_t>::max());
+
+/**
  * @brief Generates a trajectory with specified parameters.
  *
  * This function generates a trajectory of type T with a given number of points,

--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -357,27 +357,4 @@ PathWithLaneId loadPathWithLaneIdInYaml()
   }
   return path_msg;
 }
-
-PathWithLaneId generate_simple_path_with_lane_id(
-  const size_t num_points, const double point_interval, const double velocity,
-  const double init_theta, const double delta_theta, const size_t overlapping_point_index)
-{
-  auto trajectory = generateTrajectory<autoware_planning_msgs::msg::Trajectory>(
-    num_points, point_interval, velocity, init_theta, delta_theta, overlapping_point_index);
-
-  PathWithLaneId path_with_lane_id;
-  PathPointWithLaneId path_point_with_lane_id;
-  size_t i = 0;
-  for (const auto & point : trajectory.points) {
-    path_point_with_lane_id.point.pose = point.pose;
-    path_point_with_lane_id.point.lateral_velocity_mps = point.lateral_velocity_mps;
-    path_point_with_lane_id.point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
-    path_point_with_lane_id.point.heading_rate_rps = point.heading_rate_rps;
-    path_point_with_lane_id.lane_ids.push_back(static_cast<int64_t>(i));
-    path_with_lane_id.points.push_back(path_point_with_lane_id);
-    i++;
-  }
-  return path_with_lane_id;
-}
-
 }  // namespace autoware::test_utils

--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -358,4 +358,26 @@ PathWithLaneId loadPathWithLaneIdInYaml()
   return path_msg;
 }
 
+PathWithLaneId generate_simple_path_with_lane_id(
+  const size_t num_points, const double point_interval, const double velocity,
+  const double init_theta, const double delta_theta, const size_t overlapping_point_index)
+{
+  auto trajectory = generateTrajectory<autoware_planning_msgs::msg::Trajectory>(
+    num_points, point_interval, velocity, init_theta, delta_theta, overlapping_point_index);
+
+  PathWithLaneId path_with_lane_id;
+  PathPointWithLaneId path_point_with_lane_id;
+  size_t i = 0;
+  for (const auto & point : trajectory.points) {
+    path_point_with_lane_id.point.pose = point.pose;
+    path_point_with_lane_id.point.lateral_velocity_mps = point.lateral_velocity_mps;
+    path_point_with_lane_id.point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
+    path_point_with_lane_id.point.heading_rate_rps = point.heading_rate_rps;
+    path_point_with_lane_id.lane_ids.push_back(static_cast<int64_t>(i));
+    path_with_lane_id.points.push_back(path_point_with_lane_id);
+    i++;
+  }
+  return path_with_lane_id;
+}
+
 }  // namespace autoware::test_utils

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -27,21 +27,7 @@ using tier4_planning_msgs::msg::PathWithLaneId;
 using ObjectClassification = autoware_perception_msgs::msg::ObjectClassification;
 
 using autoware::test_utils::createPose;
-using autoware::test_utils::generateTrajectory;
-
-PathWithLaneId trajectory_to_path_with_lane_id(const Trajectory & trajectory)
-{
-  PathWithLaneId path_with_lane_id;
-  PathPointWithLaneId path_point_with_lane_id;
-  for (const auto & point : trajectory.points) {
-    path_point_with_lane_id.point.pose = point.pose;
-    path_point_with_lane_id.point.lateral_velocity_mps = point.lateral_velocity_mps;
-    path_point_with_lane_id.point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
-    path_point_with_lane_id.point.heading_rate_rps = point.heading_rate_rps;
-    path_with_lane_id.points.push_back(path_point_with_lane_id);
-  }
-  return path_with_lane_id;
-}
+using autoware::test_utils::generate_simple_path_with_lane_id;
 
 TEST(BehaviorPathPlanningUtilTest, l2Norm)
 {
@@ -79,12 +65,12 @@ TEST(BehaviorPathPlanningUtilTest, checkCollisionBetweenPathFootprintsAndObjects
     checkCollisionBetweenPathFootprintsAndObjects(base_footprint, ego_path, objs, margin));
 
   // Condition: object in front of path
-  ego_path = trajectory_to_path_with_lane_id(generateTrajectory<Trajectory>(5, 1.0));
+  ego_path = generate_simple_path_with_lane_id(5, 1.0);
   EXPECT_FALSE(
     checkCollisionBetweenPathFootprintsAndObjects(base_footprint, ego_path, objs, margin));
 
   // Condition: object overlapping path
-  ego_path = trajectory_to_path_with_lane_id(generateTrajectory<Trajectory>(10, 1.0));
+  ego_path = generate_simple_path_with_lane_id(10, 1.0);
   EXPECT_TRUE(
     checkCollisionBetweenPathFootprintsAndObjects(base_footprint, ego_path, objs, margin));
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -27,7 +27,7 @@ using tier4_planning_msgs::msg::PathWithLaneId;
 using ObjectClassification = autoware_perception_msgs::msg::ObjectClassification;
 
 using autoware::test_utils::createPose;
-using autoware::test_utils::generate_simple_path_with_lane_id;
+using autoware::test_utils::generateTrajectory;
 
 TEST(BehaviorPathPlanningUtilTest, l2Norm)
 {
@@ -65,12 +65,12 @@ TEST(BehaviorPathPlanningUtilTest, checkCollisionBetweenPathFootprintsAndObjects
     checkCollisionBetweenPathFootprintsAndObjects(base_footprint, ego_path, objs, margin));
 
   // Condition: object in front of path
-  ego_path = generate_simple_path_with_lane_id(5, 1.0);
+  ego_path = generateTrajectory<PathWithLaneId>(5, 1.0);
   EXPECT_FALSE(
     checkCollisionBetweenPathFootprintsAndObjects(base_footprint, ego_path, objs, margin));
 
   // Condition: object overlapping path
-  ego_path = generate_simple_path_with_lane_id(10, 1.0);
+  ego_path = generateTrajectory<PathWithLaneId>(10, 1.0);
   EXPECT_TRUE(
     checkCollisionBetweenPathFootprintsAndObjects(base_footprint, ego_path, objs, margin));
 }


### PR DESCRIPTION
## Description
Some test require `PathWithLaneId` as input, so this PR adds a simple path generator.

## Related links
None

## How was this PR tested?
Build and colcon test for behavior_path_planner_common module.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
