### PR TITLE
fix(intersection): handle pass judge after red/arrow-signal to ignore NPCs after the signal changed to green again

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -1341,8 +1341,8 @@ IntersectionModule::PassJudgeStatus IntersectionModule::isOverPassJudgeLinesStat
     if (std::holds_alternative<Safe>(prev_decision_result_)) {
       return true;
     }
-    if (std::holds_alternative<intersection::FullyPrioritized>(prev_decision_result_)) {
-      const auto & prev_decision = std::get<intersection::FullyPrioritized>(prev_decision_result_);
+    if (std::holds_alternative<FullyPrioritized>(prev_decision_result_)) {
+      const auto & prev_decision = std::get<FullyPrioritized>(prev_decision_result_);
       return !prev_decision.collision_detected;
     }
     if (std::holds_alternative<OccludedAbsenceTrafficLight>(prev_decision_result_)) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -1341,6 +1341,10 @@ IntersectionModule::PassJudgeStatus IntersectionModule::isOverPassJudgeLinesStat
     if (std::holds_alternative<Safe>(prev_decision_result_)) {
       return true;
     }
+    if (std::holds_alternative<intersection::FullyPrioritized>(prev_decision_result_)) {
+      const auto & prev_decision = std::get<intersection::FullyPrioritized>(prev_decision_result_);
+      return !prev_decision.collision_detected;
+    }
     if (std::holds_alternative<OccludedAbsenceTrafficLight>(prev_decision_result_)) {
       const auto & state = std::get<OccludedAbsenceTrafficLight>(prev_decision_result_);
       return !state.collision_detected;


### PR DESCRIPTION
## Description

Pass-judge handling was not implemented for red/arrow-signal case. This causes the vehicle to react to the NPCs on the entire attention area if the signal changed to blue while passing the intersection.

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/RT0-33896

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

### before this PR

the pass judge line does not turn red

https://github.com/user-attachments/assets/73141b80-396c-4483-86a5-ca289b2f87bb

### after this PR

the pass judge line turns red

https://github.com/user-attachments/assets/35b42515-5ab7-41d7-bc92-8e09f024c34f


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
