### PR TITLE
fix(crosswalk): fix occlusion detection range calculation and add debug markers

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -208,52 +208,54 @@
       <extra_arg name="use_intra_process_comms" value="false"/>
     </composable_node>
 
+    <composable_node pkg="autoware_behavior_velocity_planner" plugin="autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode" name="behavior_velocity_planner" namespace="">
+      <!-- topic remap -->
+      <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>
+      <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
+      <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state"/>
+      <remap from="~/input/accel" to="/localization/acceleration"/>
+      <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
+      <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+      <remap from="~/input/compare_map_filtered_pointcloud" to="compare_map_filtered/pointcloud"/>
+      <remap from="~/input/vector_map_inside_area_filtered_pointcloud" to="vector_map_inside_area_filtered/pointcloud"/>
+      <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity_default"/>
+      <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
+      <remap from="~/input/virtual_traffic_light_states" to="$(var input_virtual_traffic_light_topic_name)"/>
+      <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>
+      <remap from="~/output/path" to="path"/>
+      <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
+      <remap from="~/output/infrastructure_commands" to="/planning/scenario_planning/status/infrastructure_commands"/>
+      <remap from="~/output/traffic_signal" to="debug/traffic_signal"/>
+      <!-- params -->
+      <param from="$(var common_param_path)"/>
+      <param from="$(var vehicle_param_file)"/>
+      <param from="$(var nearest_search_param_path)"/>
+      <param from="$(var velocity_smoother_param_path)"/>
+      <param from="$(var behavior_velocity_smoother_type_param_path)"/>
+      <param from="$(var behavior_velocity_planner_common_param_path)"/>
+      <param name="launch_modules" value="$(var behavior_velocity_planner_launch_modules)"/>
+      <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
+      <param name="is_simulation" value="$(var is_simulation)"/>
+      <!-- <param from="$(var template_param_path)"/> -->
+      <param from="$(var behavior_velocity_planner_blind_spot_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_crosswalk_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_walkway_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_detection_area_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_intersection_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_stop_line_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_traffic_light_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_virtual_traffic_light_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_occlusion_spot_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_no_stopping_area_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_run_out_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_speed_bump_module_param_path)"/>
+      <param from="$(var behavior_velocity_planner_no_drivable_lane_module_param_path)"/>
+      <!-- composable node config -->
+      <extra_arg name="use_intra_process_comms" value="false"/>
+    </composable_node>
+
     <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
   </node_container>
-
-  <node pkg="autoware_behavior_velocity_planner" exec="autoware_behavior_velocity_planner_node" name="behavior_velocity_planner" namespace="" launch-prefix="konsole -e gdb -ex run --args">
-    <!-- topic remap -->
-    <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>
-    <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
-    <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state"/>
-    <remap from="~/input/accel" to="/localization/acceleration"/>
-    <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
-    <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-    <remap from="~/input/compare_map_filtered_pointcloud" to="compare_map_filtered/pointcloud"/>
-    <remap from="~/input/vector_map_inside_area_filtered_pointcloud" to="vector_map_inside_area_filtered/pointcloud"/>
-    <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity_default"/>
-    <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
-    <remap from="~/input/virtual_traffic_light_states" to="$(var input_virtual_traffic_light_topic_name)"/>
-    <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>
-    <remap from="~/output/path" to="path"/>
-    <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
-    <remap from="~/output/infrastructure_commands" to="/planning/scenario_planning/status/infrastructure_commands"/>
-    <remap from="~/output/traffic_signal" to="debug/traffic_signal"/>
-    <!-- params -->
-    <param from="$(var common_param_path)"/>
-    <param from="$(var vehicle_param_file)"/>
-    <param from="$(var nearest_search_param_path)"/>
-    <param from="$(var velocity_smoother_param_path)"/>
-    <param from="$(var behavior_velocity_smoother_type_param_path)"/>
-    <param from="$(var behavior_velocity_planner_common_param_path)"/>
-    <param name="launch_modules" value="$(var behavior_velocity_planner_launch_modules)"/>
-    <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
-    <param name="is_simulation" value="$(var is_simulation)"/>
-    <!-- <param from="$(var template_param_path)"/> -->
-    <param from="$(var behavior_velocity_planner_blind_spot_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_crosswalk_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_walkway_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_detection_area_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_intersection_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_stop_line_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_traffic_light_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_virtual_traffic_light_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_occlusion_spot_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_no_stopping_area_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_run_out_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_speed_bump_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_no_drivable_lane_module_param_path)"/>
-  </node>
 
   <group if="$(var launch_compare_map_pipeline)">
     <!-- use pointcloud container -->

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -208,54 +208,52 @@
       <extra_arg name="use_intra_process_comms" value="false"/>
     </composable_node>
 
-    <composable_node pkg="autoware_behavior_velocity_planner" plugin="autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode" name="behavior_velocity_planner" namespace="">
-      <!-- topic remap -->
-      <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>
-      <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
-      <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state"/>
-      <remap from="~/input/accel" to="/localization/acceleration"/>
-      <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
-      <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-      <remap from="~/input/compare_map_filtered_pointcloud" to="compare_map_filtered/pointcloud"/>
-      <remap from="~/input/vector_map_inside_area_filtered_pointcloud" to="vector_map_inside_area_filtered/pointcloud"/>
-      <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity_default"/>
-      <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
-      <remap from="~/input/virtual_traffic_light_states" to="$(var input_virtual_traffic_light_topic_name)"/>
-      <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>
-      <remap from="~/output/path" to="path"/>
-      <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
-      <remap from="~/output/infrastructure_commands" to="/planning/scenario_planning/status/infrastructure_commands"/>
-      <remap from="~/output/traffic_signal" to="debug/traffic_signal"/>
-      <!-- params -->
-      <param from="$(var common_param_path)"/>
-      <param from="$(var vehicle_param_file)"/>
-      <param from="$(var nearest_search_param_path)"/>
-      <param from="$(var velocity_smoother_param_path)"/>
-      <param from="$(var behavior_velocity_smoother_type_param_path)"/>
-      <param from="$(var behavior_velocity_planner_common_param_path)"/>
-      <param name="launch_modules" value="$(var behavior_velocity_planner_launch_modules)"/>
-      <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
-      <param name="is_simulation" value="$(var is_simulation)"/>
-      <!-- <param from="$(var template_param_path)"/> -->
-      <param from="$(var behavior_velocity_planner_blind_spot_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_crosswalk_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_walkway_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_detection_area_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_intersection_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_stop_line_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_traffic_light_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_virtual_traffic_light_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_occlusion_spot_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_no_stopping_area_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_run_out_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_speed_bump_module_param_path)"/>
-      <param from="$(var behavior_velocity_planner_no_drivable_lane_module_param_path)"/>
-      <!-- composable node config -->
-      <extra_arg name="use_intra_process_comms" value="false"/>
-    </composable_node>
-
     <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
   </node_container>
+
+  <node pkg="autoware_behavior_velocity_planner" exec="autoware_behavior_velocity_planner_node" name="behavior_velocity_planner" namespace="" launch-prefix="konsole -e gdb -ex run --args">
+    <!-- topic remap -->
+    <remap from="~/input/path_with_lane_id" to="path_with_lane_id"/>
+    <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
+    <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state"/>
+    <remap from="~/input/accel" to="/localization/acceleration"/>
+    <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
+    <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+    <remap from="~/input/compare_map_filtered_pointcloud" to="compare_map_filtered/pointcloud"/>
+    <remap from="~/input/vector_map_inside_area_filtered_pointcloud" to="vector_map_inside_area_filtered/pointcloud"/>
+    <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity_default"/>
+    <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
+    <remap from="~/input/virtual_traffic_light_states" to="$(var input_virtual_traffic_light_topic_name)"/>
+    <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>
+    <remap from="~/output/path" to="path"/>
+    <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
+    <remap from="~/output/infrastructure_commands" to="/planning/scenario_planning/status/infrastructure_commands"/>
+    <remap from="~/output/traffic_signal" to="debug/traffic_signal"/>
+    <!-- params -->
+    <param from="$(var common_param_path)"/>
+    <param from="$(var vehicle_param_file)"/>
+    <param from="$(var nearest_search_param_path)"/>
+    <param from="$(var velocity_smoother_param_path)"/>
+    <param from="$(var behavior_velocity_smoother_type_param_path)"/>
+    <param from="$(var behavior_velocity_planner_common_param_path)"/>
+    <param name="launch_modules" value="$(var behavior_velocity_planner_launch_modules)"/>
+    <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
+    <param name="is_simulation" value="$(var is_simulation)"/>
+    <!-- <param from="$(var template_param_path)"/> -->
+    <param from="$(var behavior_velocity_planner_blind_spot_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_crosswalk_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_walkway_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_detection_area_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_intersection_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_stop_line_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_traffic_light_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_virtual_traffic_light_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_occlusion_spot_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_no_stopping_area_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_run_out_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_speed_bump_module_param_path)"/>
+    <param from="$(var behavior_velocity_planner_no_drivable_lane_module_param_path)"/>
+  </node>
 
   <group if="$(var launch_compare_map_pipeline)">
     <!-- use pointcloud container -->

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
@@ -15,15 +15,12 @@
 #ifndef AUTOWARE__BEHAVIOR_VELOCITY_CROSSWALK_MODULE__UTIL_HPP_
 #define AUTOWARE__BEHAVIOR_VELOCITY_CROSSWALK_MODULE__UTIL_HPP_
 
-#include <geometry_msgs/msg/detail/point__struct.hpp>
-
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 
-#include <limits>
 #include <memory>
 #include <optional>
 #include <set>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/include/autoware/behavior_velocity_crosswalk_module/util.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__BEHAVIOR_VELOCITY_CROSSWALK_MODULE__UTIL_HPP_
 #define AUTOWARE__BEHAVIOR_VELOCITY_CROSSWALK_MODULE__UTIL_HPP_
 
+#include <geometry_msgs/msg/detail/point__struct.hpp>
+
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/geometry.hpp>
@@ -83,6 +85,10 @@ struct DebugData
   std::vector<geometry_msgs::msg::Point> crosswalk_polygon;
   std::vector<std::vector<geometry_msgs::msg::Point>> ego_polygons;
   std::vector<std::vector<geometry_msgs::msg::Point>> obj_polygons;
+
+  // occlusion data
+  std::vector<lanelet::BasicPolygon2d> occlusion_detection_areas;
+  geometry_msgs::msg::Point crosswalk_origin;
 };
 
 std::vector<std::pair<int64_t, lanelet::ConstLanelet>> getCrosswalksOnPath(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/debug.cpp
@@ -173,6 +173,26 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     msg.markers.push_back(marker);
   }
 
+  if (!debug_data.occlusion_detection_areas.empty()) {
+    auto marker = createDefaultMarker(
+      "map", now, "occlusion_detection_areas", uid, Marker::LINE_LIST,
+      createMarkerScale(0.25, 0.25, 0.0), createMarkerColor(1.0, 1.0, 1.0, 0.5));
+    for (const auto & area : debug_data.occlusion_detection_areas) {
+      for (auto i = 0UL; i + 1 < area.size(); ++i) {
+        const auto & p1 = area[i];
+        const auto & p2 = area[i + 1];
+        marker.points.push_back(createPoint(p1.x(), p1.y(), 0.0));
+        marker.points.push_back(createPoint(p2.x(), p2.y(), 0.0));
+      }
+    }
+    msg.markers.push_back(marker);
+    marker = createDefaultMarker(
+      "map", now, "crosswalk_origin", uid, Marker::SPHERE, createMarkerScale(0.25, 0.25, 0.25),
+      createMarkerColor(1.0, 1.0, 1.0, 0.5));
+    marker.pose.position = debug_data.crosswalk_origin;
+    msg.markers.push_back(marker);
+  }
+
   return msg;
 }
 }  // namespace

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/debug.cpp
@@ -24,8 +24,6 @@
 namespace autoware::behavior_velocity_planner
 {
 
-using autoware::motion_utils::createSlowDownVirtualWallMarker;
-using autoware::motion_utils::createStopVirtualWallMarker;
 using autoware::universe_utils::appendMarkerArray;
 using autoware::universe_utils::calcOffsetPose;
 using autoware::universe_utils::createDefaultMarker;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
@@ -14,8 +14,6 @@
 
 #include "occluded_crosswalk.hpp"
 
-#include "autoware/behavior_velocity_crosswalk_module/util.hpp"
-
 #include <autoware_grid_map_utils/polygon_iterator.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 
@@ -27,7 +25,7 @@
 namespace autoware::behavior_velocity_planner
 {
 bool is_occluded(
-  const grid_map::GridMap & grid_map, const int min_nb_of_cells, const grid_map::Index idx,
+  const grid_map::GridMap & grid_map, const int min_nb_of_cells, const grid_map::Index & idx,
   const autoware::behavior_velocity_planner::CrosswalkModule::PlannerParam & params)
 {
   grid_map::Index idx_offset;
@@ -114,7 +112,7 @@ void clear_occlusions_behind_objects(
   };
   const lanelet::BasicPoint2d grid_map_position = grid_map.getPosition();
   const auto range = grid_map.getLength().maxCoeff() / 2.0;
-  for (auto object : objects) {
+  for (auto & object : objects) {
     const lanelet::BasicPoint2d object_position = {
       object.kinematics.initial_pose_with_covariance.pose.position.x,
       object.kinematics.initial_pose_with_covariance.pose.position.y};

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
@@ -169,6 +169,6 @@ double calculate_detection_range(
 {
   constexpr double min_ego_velocity = 1.0;
   const auto time_to_crosswalk = dist_ego_to_crosswalk / std::max(min_ego_velocity, ego_velocity);
-  return time_to_crosswalk > 0.0 ? time_to_crosswalk / occluded_object_velocity : 20.0;
+  return time_to_crosswalk > 0.0 ? time_to_crosswalk * occluded_object_velocity : 20.0;
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
@@ -19,6 +19,8 @@
 #include <autoware_grid_map_utils/polygon_iterator.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 
+#include <lanelet2_core/primitives/Polygon.h>
+
 #include <algorithm>
 #include <vector>
 
@@ -137,9 +139,8 @@ void clear_occlusions_behind_objects(
 }
 
 bool is_crosswalk_occluded(
-  const lanelet::ConstLanelet & crosswalk_lanelet,
   const nav_msgs::msg::OccupancyGrid & occupancy_grid,
-  const geometry_msgs::msg::Point & path_intersection, const double detection_range,
+  const std::vector<lanelet::BasicPolygon2d> & detection_areas,
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & dynamic_objects,
   const autoware::behavior_velocity_planner::CrosswalkModule::PlannerParam & params)
 {
@@ -153,8 +154,7 @@ bool is_crosswalk_occluded(
     clear_occlusions_behind_objects(grid_map, objects);
   }
   const auto min_nb_of_cells = std::ceil(params.occlusion_min_size / grid_map.getResolution());
-  for (const auto & detection_area : calculate_detection_areas(
-         crosswalk_lanelet, {path_intersection.x, path_intersection.y}, detection_range)) {
+  for (const auto & detection_area : detection_areas) {
     grid_map::Polygon poly;
     for (const auto & p : detection_area) poly.addVertex(grid_map::Position(p.x(), p.y()));
     for (autoware::grid_map_utils::PolygonIterator iter(grid_map, poly); !iter.isPastEnd(); ++iter)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
@@ -50,17 +50,14 @@ lanelet::BasicPoint2d interpolate_point(
   const lanelet::BasicSegment2d & segment, const double extra_distance);
 
 /// @brief check if the crosswalk is occluded
-/// @param crosswalk_lanelet lanelet of the crosswalk
 /// @param occupancy_grid occupancy grid with the occlusion information
-/// @param path_intersection intersection between the crosswalk and the ego path
-/// @param detection_range range away from the crosswalk until occlusions are considered
+/// @param detection_areas areas to check for occlusions
 /// @param dynamic_objects dynamic objects
 /// @param params parameters
 /// @return true if the crosswalk is occluded
 bool is_crosswalk_occluded(
-  const lanelet::ConstLanelet & crosswalk_lanelet,
   const nav_msgs::msg::OccupancyGrid & occupancy_grid,
-  const geometry_msgs::msg::Point & path_intersection, const double detection_range,
+  const std::vector<lanelet::BasicPolygon2d> & detection_areas,
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & dynamic_objects,
   const autoware::behavior_velocity_planner::CrosswalkModule::PlannerParam & params);
 
@@ -89,6 +86,15 @@ std::vector<autoware_perception_msgs::msg::PredictedObject> select_and_inflate_o
 void clear_occlusions_behind_objects(
   grid_map::GridMap & grid_map,
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & objects);
+
+/// @brief calculate areas to check for occlusions around the given crosswalk
+/// @param crosswalk_lanelet crosswalk lanelet
+/// @param crosswalk_origin crosswalk point from which to calculate the distances
+/// @param detection_range [m] desired distance from the crosswalk origin
+/// @return detection areas within the detection range of the crosswalk
+std::vector<lanelet::BasicPolygon2d> calculate_detection_areas(
+  const lanelet::ConstLanelet & crosswalk_lanelet, const lanelet::BasicPoint2d & crosswalk_origin,
+  const double detection_range);
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // OCCLUDED_CROSSWALK_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.hpp
@@ -26,7 +26,6 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/Point.h>
 
-#include <optional>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner
@@ -39,7 +38,7 @@ namespace autoware::behavior_velocity_planner
 /// @param [in] params parameters
 /// @return true if the index is occluded
 bool is_occluded(
-  const grid_map::GridMap & grid_map, const int min_nb_of_cells, const grid_map::Index idx,
+  const grid_map::GridMap & grid_map, const int min_nb_of_cells, const grid_map::Index & idx,
   const autoware::behavior_velocity_planner::CrosswalkModule::PlannerParam & params);
 
 /// @brief interpolate a point beyond the end of the given segment

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -954,6 +954,8 @@ void CrosswalkModule::applySlowDownByOcclusion(
   const auto detection_areas = calculate_detection_areas(
     crosswalk_, {first_path_point_on_crosswalk.x, first_path_point_on_crosswalk.y},
     detection_range);
+  debug_data_.occlusion_detection_areas = detection_areas;
+  debug_data_.crosswalk_origin = first_path_point_on_crosswalk;
   if (is_crosswalk_occluded(
         *planner_data_->occupancy_grid, detection_areas, objects_ptr->objects, planner_param_)) {
     if (!current_initial_occlusion_time_) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -936,37 +936,44 @@ void CrosswalkModule::applySlowDownByOcclusion(
   const auto is_crosswalk_ignored =
     (planner_param_.occlusion_ignore_with_traffic_light && crosswalk_has_traffic_light) ||
     crosswalk_.hasAttribute("skip_occluded_slowdown");
-  if (planner_param_.occlusion_enable && !is_crosswalk_ignored) {
-    const auto dist_ego_to_crosswalk =
-      calcSignedArcLength(output.points, ego_pos, first_path_point_on_crosswalk);
-    const auto detection_range =
-      planner_data_->vehicle_info_.max_lateral_offset_m +
-      calculate_detection_range(
-        planner_param_.occlusion_occluded_object_velocity, dist_ego_to_crosswalk,
-        planner_data_->current_velocity->twist.linear.x);
-    const auto is_ego_on_the_crosswalk =
-      dist_ego_to_crosswalk <= planner_data_->vehicle_info_.max_longitudinal_offset_m;
-    if (!is_ego_on_the_crosswalk) {
-      if (is_crosswalk_occluded(
-            crosswalk_, *planner_data_->occupancy_grid, first_path_point_on_crosswalk,
-            detection_range, objects_ptr->objects, planner_param_)) {
-        if (!current_initial_occlusion_time_) current_initial_occlusion_time_ = now;
-        if (cmp_with_time_buffer(current_initial_occlusion_time_, std::greater_equal<double>{}))
-          most_recent_occlusion_time_ = now;
-      } else if (!cmp_with_time_buffer(most_recent_occlusion_time_, std::greater<double>{})) {
-        current_initial_occlusion_time_.reset();
-      }
-
-      if (cmp_with_time_buffer(most_recent_occlusion_time_, std::less_equal<double>{})) {
-        const auto target_velocity = calcTargetVelocity(first_path_point_on_crosswalk, output);
-        applySlowDown(
-          output, first_path_point_on_crosswalk, last_path_point_on_crosswalk,
-          std::max(target_velocity, planner_param_.occlusion_slow_down_velocity));
-        debug_data_.virtual_wall_suffix = " (occluded)";
-      } else {
-        most_recent_occlusion_time_.reset();
-      }
+  if (!planner_param_.occlusion_enable || is_crosswalk_ignored) {
+    return;
+  }
+  const auto dist_ego_to_crosswalk =
+    calcSignedArcLength(output.points, ego_pos, first_path_point_on_crosswalk);
+  const auto is_ego_on_the_crosswalk =
+    dist_ego_to_crosswalk <= planner_data_->vehicle_info_.max_longitudinal_offset_m;
+  if (is_ego_on_the_crosswalk) {
+    return;
+  }
+  const auto detection_range =
+    planner_data_->vehicle_info_.max_lateral_offset_m +
+    calculate_detection_range(
+      planner_param_.occlusion_occluded_object_velocity, dist_ego_to_crosswalk,
+      planner_data_->current_velocity->twist.linear.x);
+  const auto detection_areas = calculate_detection_areas(
+    crosswalk_, {first_path_point_on_crosswalk.x, first_path_point_on_crosswalk.y},
+    detection_range);
+  if (is_crosswalk_occluded(
+        *planner_data_->occupancy_grid, detection_areas, objects_ptr->objects, planner_param_)) {
+    if (!current_initial_occlusion_time_) {
+      current_initial_occlusion_time_ = now;
     }
+    if (cmp_with_time_buffer(current_initial_occlusion_time_, std::greater_equal<double>{})) {
+      most_recent_occlusion_time_ = now;
+    }
+  } else if (!cmp_with_time_buffer(most_recent_occlusion_time_, std::greater<double>{})) {
+    current_initial_occlusion_time_.reset();
+  }
+
+  if (cmp_with_time_buffer(most_recent_occlusion_time_, std::less_equal<double>{})) {
+    const auto target_velocity = calcTargetVelocity(first_path_point_on_crosswalk, output);
+    applySlowDown(
+      output, first_path_point_on_crosswalk, last_path_point_on_crosswalk,
+      std::max(target_velocity, planner_param_.occlusion_slow_down_velocity));
+    debug_data_.virtual_wall_suffix = " (occluded)";
+  } else {
+    most_recent_occlusion_time_.reset();
   }
 }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -49,13 +49,11 @@ using autoware::motion_utils::calcLongitudinalOffsetPose;
 using autoware::motion_utils::calcSignedArcLength;
 using autoware::motion_utils::calcSignedArcLengthPartialSum;
 using autoware::motion_utils::findNearestSegmentIndex;
-using autoware::motion_utils::insertTargetPoint;
 using autoware::motion_utils::resamplePath;
 using autoware::universe_utils::createPoint;
 using autoware::universe_utils::getPose;
 using autoware::universe_utils::Point2d;
 using autoware::universe_utils::Polygon2d;
-using autoware::universe_utils::pose2transform;
 using autoware::universe_utils::toHexString;
 
 namespace


### PR DESCRIPTION
## Description

Fix a mistake in the detection range calculation.
- Before: detection range (`m`) = time for ego to reach the crosswalk (`s`) _divided_ by occluded object velocity (`m/s`).
    - seconds divided by meters per seconds --> second squared per meter :warning:
- After: detection range (`m`) = time for ego to reach the crosswalk (`s`) _multiplied_ by occluded object velocity (`m/s`).
    - seconds multiplied by meters per seconds --> meters. :heavy_check_mark: 

Also do a small refactoring and add some markers to visualize the occlusion detection area
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
