### PR TITLE
test(bpp_common): add test for path utils

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/CMakeLists.txt
@@ -34,7 +34,8 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
 
 if(BUILD_TESTING)
   ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_utilities
-  test/test_utils.cpp
+    test/test_utils.cpp
+    test/test_path_utils.cpp
   )
 
   target_link_libraries(test_${PROJECT_NAME}_utilities

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -94,6 +94,12 @@ PathWithLaneId calcCenterLinePath(
   const double longest_dist_to_shift_line,
   const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
 
+/**
+ * @brief combines 2 path with do not overlap
+ * @param [in] path1 first path
+ * @param [in] path2 second path
+ * @return combined path
+ */
 PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 
 BehaviorModuleOutput getReferencePath(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -71,11 +71,28 @@ PathWithLaneId convertWayPointsToPathWithLaneId(
   const autoware::freespace_planning_algorithms::PlannerWaypoints & waypoints,
   const double velocity, const lanelet::ConstLanelets & lanelets);
 
+/**
+ * @brief Get indices where the driving direction would reverse
+ * @param [in] path original path
+ * @return Indices
+ */
 std::vector<size_t> getReversingIndices(const PathWithLaneId & path);
 
+/**
+ * @brief Divide path by given indices
+ * @param [in] path original path
+ * @param [in] indices where to split the path
+ * @return divided paths
+ */
 std::vector<PathWithLaneId> dividePath(
   const PathWithLaneId & path, const std::vector<size_t> & indices);
 
+/**
+ * @brief corrects the velocity implemented in the trajectory by judging the vehicle driving
+ * direction
+ * @param [in] divided_paths multiple path with lane ID
+ * @return
+ */
 void correctDividedPathVelocity(std::vector<PathWithLaneId> & divided_paths);
 
 // only two points is supported
@@ -83,6 +100,13 @@ std::vector<double> spline_two_points(
   const std::vector<double> & base_s, const std::vector<double> & base_x, const double begin_diff,
   const double end_diff, const std::vector<double> & new_s);
 
+/**
+ * @brief interpolates pse between 2 pose
+ * @param [in] start_pose start pose
+ * @param [in] end_pose end pose
+ * @param [in] resample_interval resampling interval
+ * @return array of pose
+ */
 std::vector<Pose> interpolatePose(
   const Pose & start_pose, const Pose & end_pose, const double resample_interval);
 
@@ -95,7 +119,7 @@ PathWithLaneId calcCenterLinePath(
   const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
 
 /**
- * @brief combines 2 path with do not overlap
+ * @brief combines 2 path which do not overlap
  * @param [in] path1 first path
  * @param [in] path2 second path
  * @return combined path

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -58,39 +58,51 @@ PathWithLaneId resamplePathWithSpline(
   const PathWithLaneId & path, const double interval, const bool keep_input_points = false,
   const std::pair<double, double> target_section = {0.0, std::numeric_limits<double>::max()});
 
+/**
+ * @brief Gets index based on target index and arc length.
+ * @param [in] path Path.
+ * @param [in] target_idx Target index.
+ * @param [in] signed_arc Signed arc length. (Positive is forward)
+ * @return Index
+ */
 size_t getIdxByArclength(
   const PathWithLaneId & path, const size_t target_idx, const double signed_arc);
 
+/**
+ * @brief Clips path according to the target index and length.
+ * @param [in] path Path.
+ * @param [in] target_idx Target index.
+ * @param [in] forward Forward distance from target index.
+ * @param [in] backward Backward distance from target index.
+ * @return Index
+ */
 void clipPathLength(
   PathWithLaneId & path, const size_t target_idx, const double forward, const double backward);
-
-void clipPathLength(
-  PathWithLaneId & path, const size_t target_idx, const BehaviorPathPlannerParameters & params);
 
 PathWithLaneId convertWayPointsToPathWithLaneId(
   const autoware::freespace_planning_algorithms::PlannerWaypoints & waypoints,
   const double velocity, const lanelet::ConstLanelets & lanelets);
 
 /**
- * @brief Get indices where the driving direction would reverse
- * @param [in] path original path
- * @return Indices
+ * @brief Get indices where the driving direction would reverse.
+ * @param [in] path Original path.
+ * @return Indices.
  */
 std::vector<size_t> getReversingIndices(const PathWithLaneId & path);
 
 /**
- * @brief Divide path by given indices
- * @param [in] path original path
- * @param [in] indices where to split the path
- * @return divided paths
+ * @brief Divide path by given indices.
+ * @param [in] path Original path.
+ * @param [in] indices Where to split the path.
+ * @return Divided paths.
  */
 std::vector<PathWithLaneId> dividePath(
   const PathWithLaneId & path, const std::vector<size_t> & indices);
 
 /**
- * @brief corrects the velocity implemented in the trajectory by judging the vehicle driving
- * direction
- * @param [in] divided_paths multiple path with lane ID
+ * @brief Corrects the velocity implemented in the trajectory by judging the vehicle driving
+ * direction.
+ * @param [in] divided_paths Multiple path with lane ID.
  * @return
  */
 void correctDividedPathVelocity(std::vector<PathWithLaneId> & divided_paths);
@@ -101,15 +113,21 @@ std::vector<double> spline_two_points(
   const double end_diff, const std::vector<double> & new_s);
 
 /**
- * @brief interpolates pse between 2 pose
- * @param [in] start_pose start pose
- * @param [in] end_pose end pose
- * @param [in] resample_interval resampling interval
- * @return array of pose
+ * @brief Interpolates pose between 2 pose.
+ * @param [in] start_pose Start pose.
+ * @param [in] end_pose End pose.
+ * @param [in] resample_interval Resampling interval.
+ * @return Array of pose
  */
 std::vector<Pose> interpolatePose(
   const Pose & start_pose, const Pose & end_pose, const double resample_interval);
 
+/**
+ * @brief Get ego pose which is not shifted.
+ * @param [in] ego_pose Ego pose.
+ * @param [in] prev_path Previous path with lane ID.
+ * @return Unshifted pose.
+ */
 geometry_msgs::msg::Pose getUnshiftedEgoPose(
   const geometry_msgs::msg::Pose & ego_pose, const ShiftedPath & prev_path);
 
@@ -119,10 +137,10 @@ PathWithLaneId calcCenterLinePath(
   const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
 
 /**
- * @brief combines 2 path which do not overlap
- * @param [in] path1 first path
- * @param [in] path2 second path
- * @return combined path
+ * @brief Combines 2 path which do not overlap.
+ * @param [in] path1 First path.
+ * @param [in] path2 Second path.
+ * @return Combined path.
  */
 PathWithLaneId combinePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_utils.hpp
@@ -79,7 +79,7 @@ std::vector<PathWithLaneId> dividePath(
 void correctDividedPathVelocity(std::vector<PathWithLaneId> & divided_paths);
 
 // only two points is supported
-std::vector<double> splineTwoPoints(
+std::vector<double> spline_two_points(
   const std::vector<double> & base_s, const std::vector<double> & base_x, const double begin_diff,
   const double end_diff, const std::vector<double> & new_s);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -27,7 +27,6 @@
 #include <tf2/utils.h>
 
 #include <algorithm>
-#include <limits>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -102,6 +101,7 @@ PathWithLaneId resamplePathWithSpline(
     transformed_path, 0, transformed_path.size());
   for (size_t i = 0; i < path.points.size(); ++i) {
     const double s = s_vec.at(i);
+
     for (const auto & lane_id : path.points.at(i).lane_ids) {
       if (!keep_input_points && (unique_lane_ids.find(lane_id) != unique_lane_ids.end())) {
         continue;
@@ -311,7 +311,7 @@ void correctDividedPathVelocity(std::vector<PathWithLaneId> & divided_paths)
 }
 
 // only two points is supported
-std::vector<double> splineTwoPoints(
+std::vector<double> spline_two_points(
   const std::vector<double> & base_s, const std::vector<double> & base_x, const double begin_diff,
   const double end_diff, const std::vector<double> & new_s)
 {
@@ -350,10 +350,10 @@ std::vector<Pose> interpolatePose(
     new_s.push_back(s);
   }
 
-  const std::vector<double> interpolated_x = splineTwoPoints(
+  const std::vector<double> interpolated_x = spline_two_points(
     base_s, base_x, std::cos(tf2::getYaw(start_pose.orientation)),
     std::cos(tf2::getYaw(end_pose.orientation)), new_s);
-  const std::vector<double> interpolated_y = splineTwoPoints(
+  const std::vector<double> interpolated_y = spline_two_points(
     base_s, base_y, std::sin(tf2::getYaw(start_pose.orientation)),
     std::sin(tf2::getYaw(end_pose.orientation)), new_s);
   for (size_t i = 0; i < interpolated_x.size(); ++i) {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -202,13 +202,6 @@ void clipPathLength(
   path.points = clipped_points;
 }
 
-// TODO(murooka) This function should be replaced with autoware::motion_utils::cropPoints
-void clipPathLength(
-  PathWithLaneId & path, const size_t target_idx, const BehaviorPathPlannerParameters & params)
-{
-  clipPathLength(path, target_idx, params.forward_path_length, params.backward_path_length);
-}
-
 PathWithLaneId convertWayPointsToPathWithLaneId(
   const autoware::freespace_planning_algorithms::PlannerWaypoints & waypoints,
   const double velocity, const lanelet::ConstLanelets & lanelets)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_utils.cpp
@@ -1,0 +1,190 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
+
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+using tier4_planning_msgs::msg::PathWithLaneId;
+
+using autoware::test_utils::simple_path_with_lane_id;
+
+TEST(BehaviorPathPlanningPathUtilTest, calcPathArcLengthArray)
+{
+  using autoware::behavior_path_planner::utils::calcPathArcLengthArray;
+
+  auto path = simple_path_with_lane_id(10, 1.0);
+  auto arc_length_array = calcPathArcLengthArray(path);
+
+  ASSERT_EQ(arc_length_array.size(), path.points.size());
+
+  size_t i = 0;
+  for (const auto & arc_length : arc_length_array) {
+    EXPECT_DOUBLE_EQ(arc_length, 1.0 * i);
+    i++;
+  }
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, resamplePathWithSpline)
+{
+  using autoware::behavior_path_planner::utils::resamplePathWithSpline;
+
+  // Condition: path point less than 2
+  auto path = simple_path_with_lane_id(1, 1.0);
+  EXPECT_EQ(resamplePathWithSpline(path, 1.0).points.size(), path.points.size());
+
+  // Condition: not enough point for spline interpolation
+  path = simple_path_with_lane_id(10, 0.01);
+  EXPECT_EQ(resamplePathWithSpline(path, 1.0).points.size(), path.points.size());
+
+  // Condition: spline interpolation
+  path = simple_path_with_lane_id(10, 0.1);
+  auto resampled_path = resamplePathWithSpline(path, 1.0);
+  EXPECT_EQ(resampled_path.points.size(), 6);
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, getIdxByArclength)
+{
+  using autoware::behavior_path_planner::utils::getIdxByArclength;
+
+  tier4_planning_msgs::msg::PathWithLaneId path;
+
+  // Condition: empty points
+  EXPECT_ANY_THROW(getIdxByArclength(path, 5, 1.0));
+
+  // Condition: negative arc with idx 0
+  path = simple_path_with_lane_id(10, 1.0);
+  EXPECT_EQ(getIdxByArclength(path, 0, -1.0), 0);
+
+  // Condition: negative arc
+  EXPECT_EQ(getIdxByArclength(path, 5, -2.0), 2);
+
+  // Condition: positive arc
+  EXPECT_EQ(getIdxByArclength(path, 3, 4.0), 8);
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, clipPathLength)
+{
+  using autoware::behavior_path_planner::utils::clipPathLength;
+
+  // Condition: path point less than 3
+  auto path = simple_path_with_lane_id(2, 1.0);
+  clipPathLength(path, 5, 10.0, 1.0);
+  EXPECT_EQ(path.points.size(), 2);
+
+  // Condition: path to be cropped
+  path = simple_path_with_lane_id(10, 1.0);
+  clipPathLength(path, 5, 10.0, 1.0);
+  EXPECT_EQ(path.points.size(), 7);
+
+  size_t i = 0;
+  for (const auto & point : path.points) {
+    EXPECT_DOUBLE_EQ(point.point.pose.position.x, 3.0 + i);
+    i++;
+  }
+
+  // Condition: using parameters
+  BehaviorPathPlannerParameters param;
+  param.forward_path_length = 20.0;
+  param.backward_path_length = 1.0;
+  path = simple_path_with_lane_id(10, 1.0);
+  clipPathLength(path, 5, param);
+  EXPECT_EQ(path.points.size(), 7);
+
+  i = 0;
+  for (const auto & point : path.points) {
+    EXPECT_DOUBLE_EQ(point.point.pose.position.x, 3.0 + i);
+    i++;
+  }
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, getReversingIndices)
+{
+  using autoware::behavior_path_planner::utils::getReversingIndices;
+
+  size_t target_index = 7;
+  auto path = simple_path_with_lane_id(10, 1.0, 1.0);
+  path.points.at(target_index).point.longitudinal_velocity_mps = -1.0;
+  auto reversing_indices = getReversingIndices(path);
+  EXPECT_EQ(reversing_indices.size(), 2);
+
+  size_t i = 0;
+  for (const auto & index : reversing_indices) {
+    EXPECT_EQ(index, target_index - 1 + i);
+    i++;
+  }
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, dividePath)
+{
+  using autoware::behavior_path_planner::utils::dividePath;
+  auto path = simple_path_with_lane_id(10, 1.0);
+
+  // Condition: empty indices
+  std::vector<size_t> indices;
+  auto divided_path = dividePath(path, indices);
+  EXPECT_EQ(divided_path.size(), 1);
+
+  // Condition: divide path
+  indices = {3, 5, 8};
+  divided_path = dividePath(path, indices);
+  ASSERT_EQ(divided_path.size(), 4);
+  EXPECT_EQ(divided_path.at(0).points.size(), 4);
+  EXPECT_EQ(divided_path.at(1).points.size(), 3);
+  EXPECT_EQ(divided_path.at(2).points.size(), 4);
+  EXPECT_EQ(divided_path.at(3).points.size(), 2);
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, correctDividedPathVelocity)
+{
+  using autoware::behavior_path_planner::utils::correctDividedPathVelocity;
+
+  double velocity = 1.0;
+  std::vector<PathWithLaneId> divided_paths;
+  // forward driving
+  divided_paths.push_back(simple_path_with_lane_id(10, 1.0, velocity));
+  // reverse driving
+  divided_paths.push_back(simple_path_with_lane_id(10, -1.0, velocity, M_PI));
+  correctDividedPathVelocity(divided_paths);
+
+  for (const auto & point : divided_paths.at(0).points) {
+    if (point == divided_paths.at(0).points.back()) {
+      EXPECT_DOUBLE_EQ(point.point.longitudinal_velocity_mps, 0.0);
+    } else {
+      EXPECT_DOUBLE_EQ(point.point.longitudinal_velocity_mps, velocity);
+    }
+  }
+
+  for (const auto & point : divided_paths.at(1).points) {
+    if (point == divided_paths.at(1).points.back()) {
+      EXPECT_DOUBLE_EQ(point.point.longitudinal_velocity_mps, 0.0);
+    } else {
+      EXPECT_DOUBLE_EQ(point.point.longitudinal_velocity_mps, -velocity);
+    }
+  }
+}
+
+TEST(BehaviorPathPlanningPathUtilTest, spline_two_points)
+{
+  using autoware::behavior_path_planner::utils::spline_two_points;
+
+  std::vector<double> base_s;
+  std::vector<double> base_x;
+}

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_utils.cpp
@@ -101,20 +101,6 @@ TEST(BehaviorPathPlanningPathUtilTest, clipPathLength)
     EXPECT_DOUBLE_EQ(point.point.pose.position.x, 3.0 + i);
     i++;
   }
-
-  // Condition: using parameters
-  BehaviorPathPlannerParameters param;
-  param.forward_path_length = 20.0;
-  param.backward_path_length = 1.0;
-  path = generateTrajectory<PathWithLaneId>(10, 1.0);
-  clipPathLength(path, 5, param);
-  EXPECT_EQ(path.points.size(), 7);
-
-  i = 0;
-  for (const auto & point : path.points) {
-    EXPECT_DOUBLE_EQ(point.point.pose.position.x, 3.0 + i);
-    i++;
-  }
 }
 
 TEST(BehaviorPathPlanningPathUtilTest, getReversingIndices)

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -1125,7 +1125,9 @@ BehaviorModuleOutput StaticObstacleAvoidanceModule::plan()
   path_reference_ = std::make_shared<PathWithLaneId>(getPreviousModuleOutput().reference_path);
 
   const size_t ego_idx = planner_data_->findEgoIndex(output.path.points);
-  utils::clipPathLength(output.path, ego_idx, planner_data_->parameters);
+  utils::clipPathLength(
+    output.path, ego_idx, planner_data_->parameters.forward_path_length,
+    planner_data_->parameters.backward_path_length);
 
   // Drivable area generation.
   {
@@ -1176,7 +1178,9 @@ CandidateOutput StaticObstacleAvoidanceModule::planCandidate() const
 
   if (data.safe_shift_line.empty()) {
     const size_t ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-    utils::clipPathLength(shifted_path.path, ego_idx, planner_data_->parameters);
+    utils::clipPathLength(
+      shifted_path.path, ego_idx, planner_data_->parameters.forward_path_length,
+      planner_data_->parameters.backward_path_length);
 
     output.path_candidate = shifted_path.path;
     return output;


### PR DESCRIPTION
## Description
- Add unit test for behavior_path_planner_common module `/utils/path_utils.cpp`
- Remove unnecessary function

![Screenshot from 2024-10-21 14-56-55](https://github.com/user-attachments/assets/7ddaf67b-90dd-4480-ba44-09fa75af9bae)

## Related links

## How was this PR tested?
Colcon build

```
1: [----------] 10 tests from BehaviorPathPlanningPathUtilTest
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.calcPathArcLengthArray
1: [       OK ] BehaviorPathPlanningPathUtilTest.calcPathArcLengthArray (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.resamplePathWithSpline
1: [       OK ] BehaviorPathPlanningPathUtilTest.resamplePathWithSpline (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.getIdxByArclength
1: [       OK ] BehaviorPathPlanningPathUtilTest.getIdxByArclength (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.clipPathLength
1: [       OK ] BehaviorPathPlanningPathUtilTest.clipPathLength (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.getReversingIndices
1: [       OK ] BehaviorPathPlanningPathUtilTest.getReversingIndices (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.dividePath
1: [       OK ] BehaviorPathPlanningPathUtilTest.dividePath (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.correctDividedPathVelocity
1: [       OK ] BehaviorPathPlanningPathUtilTest.correctDividedPathVelocity (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.interpolatePose
1: [       OK ] BehaviorPathPlanningPathUtilTest.interpolatePose (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.getUnshiftedEgoPose
1: [       OK ] BehaviorPathPlanningPathUtilTest.getUnshiftedEgoPose (0 ms)
1: [ RUN      ] BehaviorPathPlanningPathUtilTest.combinePath
1: [       OK ] BehaviorPathPlanningPathUtilTest.combinePath (0 ms)
1: [----------] 10 tests from BehaviorPathPlanningPathUtilTest (0 ms total)

```

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
