### PR TITLE
fix(utils): fix envelope polygon update logic

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1486,7 +1486,7 @@ void fillObjectEnvelopePolygon(
     calcErrorEclipseLongRadius(object_data.object.kinematics.initial_pose_with_covariance);
 
   if (error_eclipse_long_radius > object_parameter.th_error_eclipse_long_radius) {
-    if (error_eclipse_long_radius < object_data.error_eclipse_max) {
+    if (error_eclipse_long_radius < same_id_obj->error_eclipse_max) {
       object_data.error_eclipse_max = error_eclipse_long_radius;
       object_data.envelope_poly = one_shot_envelope_poly;
       return;


### PR DESCRIPTION
## Description

I found a wrong implementation of envelope polygon update logic. It seemed that object's envelope polygon was updated even when the latest observed data was more acculate than previous one.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/3fbf20a1-b8c1-5e39-933d-9748e43c6194?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
