### PR TITLE
fix(-):  non uniformity of concatenated pointcloud publishing speed

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -425,6 +425,8 @@ void PointCloudConcatenateDataSynchronizerComponent::publish()
   // publish concatenated pointcloud
   if (concat_cloud_ptr) {
     auto output = std::make_unique<sensor_msgs::msg::PointCloud2>(*concat_cloud_ptr);
+    std::cout << "publishing concatenated pointcloud"  << std::endl;
+    std::cout << "num points: " << output->width * output->height << std::endl;
     pub_output_->publish(std::move(output));
   } else {
     RCLCPP_WARN(this->get_logger(), "concat_cloud_ptr is nullptr, skipping pointcloud publish.");
@@ -435,6 +437,8 @@ void PointCloudConcatenateDataSynchronizerComponent::publish()
     for (const auto & e : transformed_raw_points) {
       if (e.second) {
         auto output = std::make_unique<sensor_msgs::msg::PointCloud2>(*e.second);
+        std::cout << "publishing " << e.first << std::endl;
+        std::cout << "num points: " << e.second->width * e.second->height << std::endl;
         transformed_raw_pc_publisher_map_[e.first]->publish(std::move(output));
       } else {
         RCLCPP_WARN(


### PR DESCRIPTION
## Description

The number of point clouds to be publish is suddenly reduced, which has negative effects such as unstable ROI shape.

[pointpainting_roi_cluster_fusion_objects_before.webm](https://github.com/user-attachments/assets/366b16fb-a898-4dfb-a147-addf6b5b706c)


## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/8842

<!-- ⬇️🟢
**Private Links:**

- https://tier4.atlassian.net/browse/RT1-4647
- https://tier4.atlassian.net/browse/RT1-883
- Test with this [ros bag data](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/bbc8bad5-1702-4ca1-abfd-b7c9457a7293).


⬆️🟢 -->

## How was this PR tested?
- Test with this [ros bag data](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/bbc8bad5-1702-4ca1-abfd-b7c9457a7293).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
