### PR TITLE
fix(simple_planning_simulator): change orger of IDX in SimModelDelayS…

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp
@@ -63,8 +63,8 @@ private:
     YAW,
     VX,
     STEER,
-    PEDAL_ACCX,
     ACCX,
+    PEDAL_ACCX,
   };
   enum IDX_U { PEDAL_ACCX_DES = 0, GEAR, SLOPE_ACCX, STEER_DES };
 


### PR DESCRIPTION
## Description
During work with vehicle models from [simple_planning_simulator](https://github.com/autowarefoundation/autoware.universe/tree/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model),
I noticed that practically all models use a standardized form of the `IDX` vector -  see the table below.
Such approach (promise) certainly makes sense if we want to make sure, for example, that `YAW` is always at index `2` of the `IDX` vector.

This is especially useful for the case where in one common part of the code (method) we use different vehicle models and want to use IDX vector indexes (without using enums classes).

However, this approach (promise) is broken in the case of the recently added vehicle model [SimModelDelaySteerAccGearedWoFallGuard](https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp#L60-L68) - see table below.
In [SimModelDelaySteerAccGearedWoFallGuard](https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp#L60-L68) `ACCX` is not on index `5` as in any other model but on index `6`. 
On index `5` is the newly added `PEDAL_ACCX`.

This break in the `IDX` vector form standardization, makes the code prone to bugs, for this reason I propose to provide such standardization also for the [SimModelDelaySteerAccGearedWoFallGuard](https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp#L60-L68)  vehicle model.

In this PR, I simply change the order of the `IDX` vector in the [SimModelDelaySteerAccGearedWoFallGuard](https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp#L60-L68) model.

<table>
    <tr>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.hpp#L185-L192">SimModelActuationCmd</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.hpp#L61-L68">SimModelDelaySteerAcc</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp#L61-L68">SimModelDelaySteerAccGeared</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp#L60-L68">SimModelDelaySteerAccGearedWoFallGuard</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp#L112-L119">SimModelDelaySteerMapAccGeared</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.hpp#L61-L67">SimModelDelaySteerVel</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc.hpp#L44">SimModelIdealSteerAcc</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp#L44">SimModelIdealSteerAccGeared</a></th>
      <th><a href="https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_vel.hpp#L43">SimModelIdealSteerVel</a></th>
    </tr>
    <tr>
    
  <td>
  
  ![Screenshot from 2024-10-21 11-02-44](https://github.com/user-attachments/assets/9ef8875e-fee5-44b4-90ab-aff480414978)

  
  </td>
  <td>
  
  ![sim_model_delay_steer_acc](https://github.com/user-attachments/assets/d1177aea-2929-469f-a06b-0d887c889a55)
  
  </td>
  <td>
  
  ![sim_model_delay_steer_acc_geared](https://github.com/user-attachments/assets/e807daea-4783-474a-b936-e247979d52c0)
  
  </td>
  <td>
  
  ![sim_model_delay_steer_acc_geared_wo_fall_guard](https://github.com/user-attachments/assets/8ae90faf-8066-45ef-9998-afeebd19b5bc)
  
  </td>
  <td>
  
  ![sim_model_delay_steer_map_acc_geared](https://github.com/user-attachments/assets/31da4a6b-1f5a-4981-a66f-c5e6c4185260)
  
  </td>
  <td>
  
  ![sim_model_delay_steer_vel](https://github.com/user-attachments/assets/a4f3481d-673a-4fbb-9efc-25f8e50ea65f)
  
  </td>
  <td>
  
 ![Screenshot from 2024-10-21 11-03-47](https://github.com/user-attachments/assets/f33d2f9f-fcc2-4c1b-b11a-5ae6c0a2a1cb)
  
  </td>
  <td>
  
![Screenshot from 2024-10-21 11-03-47](https://github.com/user-attachments/assets/783efda3-792f-4bcf-b2a3-0ecd907622a8)

  </td>
  <td>
  
![Screenshot from 2024-10-21 11-04-56](https://github.com/user-attachments/assets/b7455eb9-4e51-4109-b701-84540a8e4f01)

  </td>
  </tr>
  </table>

## Related links
None.

<!-- ⬇️🟢
**Private Links:**

- [tier4 jira](https://tier4.atlassian.net/browse/RJD-1349?focusedCommentId=190727)
⬆️🟢 -->

## How was this PR tested?

The `Autoware` operation with modified vehicle model `SimModelDelaySteerAccGearedWoFallGuard` has been tested using `scenario_simulator_v2`, more precisely [this scenario](https://evaluation.tier4.jp/evaluation/reports/06cb193c-e32f-524f-a603-e2e8a93a1e48/tests/8d44c227-7cdd-5117-b5ef-79a1f841b372/fa55aa8f-16e0-5c80-920e-669e28da8523/a38a1190-b3a2-5adf-af85-754b030b7b04?project_id=prd_jt) and [this branch](https://github.com/tier4/scenario_simulator_v2/tree/feat/add_new_vehicle_model) - video below. (tier4 access rights may be required).

https://github.com/user-attachments/assets/40ea8d78-9d11-4515-85b3-7147bbea8a01

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

The  [SimModelDelaySteerAccGearedWoFallGuard](https://github.com/autowarefoundation/autoware.universe/blob/23f4c8646764969eecdd1694bca9bed3b0ec9e08/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp#L60-L68) model vehicle has the order of the `IDX` vector changed - in order to try to maintain the promise.
