### PR TITLE
fix(behavior_path_planner): suppress reseting root lanelet

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -551,8 +551,10 @@ private:
   /**
    * @brief find and set the closest lanelet within the route to current route lanelet
    * @param planner data.
+   * @param is any approved module running.
    */
-  void updateCurrentRouteLanelet(const std::shared_ptr<PlannerData> & data);
+  void updateCurrentRouteLanelet(
+    const std::shared_ptr<PlannerData> & data, const bool is_any_approved_module_running);
 
   void generateCombinedDrivableArea(
     BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & data) const;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -351,9 +351,9 @@ void BehaviorPathPlannerNode::run()
     if (!is_first_time && !has_same_route_id) {
       RCLCPP_INFO(get_logger(), "New uuid route is received. Resetting modules.");
       planner_manager_->reset();
+      planner_manager_->resetCurrentRouteLanelet(planner_data_);
       planner_data_->prev_modified_goal.reset();
     }
-    planner_manager_->resetCurrentRouteLanelet(planner_data_);
   }
   const auto controlled_by_autoware_autonomously =
     planner_data_->operation_mode->mode == OperationModeState::AUTONOMOUS &&

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -135,7 +135,7 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
   const bool is_any_module_running =
     is_any_approved_module_running || is_any_candidate_module_running_or_idle;
 
-  updateCurrentRouteLanelet(data);
+  updateCurrentRouteLanelet(data, is_any_approved_module_running);
 
   const bool is_out_of_route = utils::isEgoOutOfRoute(
     data->self_odometry->pose.pose, current_route_lanelet_->value(), data->prev_modified_goal,
@@ -228,7 +228,8 @@ void PlannerManager::generateCombinedDrivableArea(
   utils::extractObstaclesFromDrivableArea(output.path, di.obstacles);
 }
 
-void PlannerManager::updateCurrentRouteLanelet(const std::shared_ptr<PlannerData> & data)
+void PlannerManager::updateCurrentRouteLanelet(
+  const std::shared_ptr<PlannerData> & data, const bool is_any_approved_module_running)
 {
   const auto & route_handler = data->route_handler;
   const auto & pose = data->self_odometry->pose.pose;
@@ -256,10 +257,11 @@ void PlannerManager::updateCurrentRouteLanelet(const std::shared_ptr<PlannerData
       p.ego_nearest_yaw_threshold) ||
     lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lane);
 
-  if (could_calculate_closest_lanelet)
+  if (could_calculate_closest_lanelet) {
     *current_route_lanelet_ = closest_lane;
-  else
+  } else if (!is_any_approved_module_running) {
     resetCurrentRouteLanelet(data);
+  }
 }
 
 BehaviorModuleOutput PlannerManager::getReferencePath(


### PR DESCRIPTION
## Description

suppress reseting root lanelet. 

root lanelet is not updated when 
- receiving same uuid route (e.g. rerouting with modifiled goal ) 
- failing getting closest lanelet while any approved module is running


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

2024/10/21 https://evaluation.tier4.jp/evaluation/reports/698116ac-225c-5427-9e03-ada876229a76/?project_id=prd_jt


before

https://github.com/user-attachments/assets/5a39cb7c-9be7-4653-9422-895437bf5c6e




after

https://github.com/user-attachments/assets/d545b28a-a039-4f87-8d72-49d33b7718f7



https://github.com/user-attachments/assets/77476e44-8c3b-47d5-ac71-b95f7bce8614

I also checked that root lanelet update when lc -> pull over 



https://github.com/user-attachments/assets/b29869f1-8978-41f6-9d00-730cbe47182a





## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
