### PR TITLE
feat(mission_planner): reroute with current route start pose when triggered by modifed goal

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -125,8 +125,8 @@ private:
     const Header & header, const std::vector<LaneletSegment> & segments, const Pose & goal_pose,
     const UUID & uuid, const bool allow_goal_modification);
   LaneletRoute create_route(
-    const Header & header, const std::vector<Pose> & waypoints, const Pose & goal_pose,
-    const UUID & uuid, const bool allow_goal_modification);
+    const Header & header, const std::vector<Pose> & waypoints, const Pose & start_pose,
+    const Pose & goal_pose, const UUID & uuid, const bool allow_goal_modification);
 
   void publish_pose_log(const Pose & pose, const std::string & pose_type);
 

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1898,13 +1898,29 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
     std::remove_if(
       candidates.begin(), candidates.end(), [&](const auto & l) { return !isRoadLanelet(l); }),
     candidates.end());
-  if (!lanelet::utils::query::getClosestLanelet(candidates, goal_checkpoint, &goal_lanelet)) {
-    RCLCPP_WARN_STREAM(
-      logger_, "Failed to find closest lanelet."
-                 << std::endl
-                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
-                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
-    return false;
+  // if there is a lanelet in candidates that is included in previous preferred lanelets,
+  // set it as goal_lanelet.
+  // this is to select the same lane as much as possible when rerouting with waypoints.
+  const auto findGoalClosestPreferredLanelet = [&]() -> std::optional<lanelet::ConstLanelet> {
+    lanelet::ConstLanelet closest_lanelet;
+    if (getClosestPreferredLaneletWithinRoute(goal_checkpoint, &closest_lanelet)) {
+      if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
+        return closest_lanelet;
+      }
+    }
+    return std::nullopt;
+  };
+  if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
+    goal_lanelet = closest_lanelet.value();
+  } else {
+    if (!lanelet::utils::query::getClosestLanelet(candidates, goal_checkpoint, &goal_lanelet)) {
+      RCLCPP_WARN_STREAM(
+        logger_, "Failed to find closest lanelet."
+                   << std::endl
+                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
+      return false;
+    }
   }
 
   lanelet::Optional<lanelet::routing::Route> optional_route;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1905,7 +1905,9 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
     lanelet::ConstLanelet closest_lanelet;
     if (getClosestPreferredLaneletWithinRoute(goal_checkpoint, &closest_lanelet)) {
       if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
-        return closest_lanelet;
+        if (lanelet::utils::isInLanelet(goal_checkpoint, closest_lanelet)) {
+          return closest_lanelet;
+        }
       }
     }
     return std::nullopt;


### PR DESCRIPTION
## Description

Rerouting from the current ego position during a run is a potential source of bugs, as it is necessary to be aware of cases where the planner's internally maintained lanes are no longer included in the route.
Rerouting with modifed goal assumes a slight modification near the goal lane. It is assumed that ego and goal are at least an extension of current_route. Therefore, the start pose of current_route is used as the start pose. This prevents the route from being shortened by rerouting.

## Related links

- https://github.com/autowarefoundation/autoware.universe/pull/8238
- https://github.com/autowarefoundation/autoware.universe/pull/9129


**Private Links:**

- https://tier4.atlassian.net/browse/RT1-7972


## How was this PR tested?

psim

2024/10/28 [Evaluator](https://evaluation.tier4.jp/evaluation/reports/bb5cf5a7-aa4f-5d45-8a39-a19fbbc6d768/?project_id=prd_jt)


before (planned new route is short)


https://github.com/user-attachments/assets/d545b28a-a039-4f87-8d72-49d33b7718f7


after:

https://github.com/user-attachments/assets/a39b3cf5-0d7d-48f8-bc93-1743852bf579


2024/10/22 https://evaluation.tier4.jp/evaluation/reports/c6bf8b79-f69b-507e-a8b3-a2220d5dd22a/?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
