### PR TITLE
fix(tier4_map_launch): remove parameter use_intra_process

### DIFF
--- a/launch/tier4_map_launch/launch/map.launch.xml
+++ b/launch/tier4_map_launch/launch/map.launch.xml
@@ -11,9 +11,6 @@
   <arg name="map_tf_generator_param_path"/>
   <arg name="map_projection_loader_param_path"/>
 
-  <!-- whether use intra-process -->
-  <arg name="use_intra_process" default="false"/>
-
   <!-- select container type -->
   <arg name="use_multithread" default="false"/>
   <let name="container_type" value="component_container" unless="$(var use_multithread)"/>
@@ -32,25 +29,21 @@
         <remap from="service/get_partial_pcd_map" to="/map/get_partial_pointcloud_map"/>
         <remap from="service/get_differential_pcd_map" to="/map/get_differential_pointcloud_map"/>
         <remap from="service/get_selected_pcd_map" to="/map/get_selected_pointcloud_map"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
       </composable_node>
 
       <composable_node pkg="map_loader" plugin="Lanelet2MapLoaderNode" name="lanelet2_map_loader">
         <param from="$(var lanelet2_map_loader_param_path)"/>
         <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
         <remap from="output/lanelet2_map" to="vector_map"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
       </composable_node>
 
       <composable_node pkg="map_loader" plugin="Lanelet2MapVisualizationNode" name="lanelet2_map_visualization">
         <remap from="input/lanelet2_map" to="vector_map"/>
         <remap from="output/lanelet2_map_marker" to="vector_map_marker"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
       </composable_node>
 
       <composable_node pkg="autoware_map_tf_generator" plugin="autoware::map_tf_generator::VectorMapTFGeneratorNode" name="vector_map_tf_generator">
         <param from="$(var map_tf_generator_param_path)"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
       </composable_node>
     </node_container>
 


### PR DESCRIPTION
## Description
The default value  of parameter `use_intra_process` is `false` in package [tier4_map_launch](https://github.com/autowarefoundation/autoware.universe/blob/ae24913390600d95b3194f7e3ddf43ac823261ce/launch/tier4_map_launch/launch/map.launch.xml#L15), but if set it to true, there will be an error. That's because map component uses [transient_local](https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp#L130C75-L130C90), so it may not be possible to set use_intra_process=true. 

To avoid unnecessary errors, delete parameter `use_intra_process`.

## Related links

**Parent Issue:** [issue 9117](https://github.com/autowarefoundation/autoware.universe/issues/9117)

## How was this PR tested?

Build successful.

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `use_intra_process`   | `bool` | `false`         | Not used |

## Effects on system behavior

None.
