### PR TITLE
chore(goal_planner): compare sampled/filtered candidate paths on plot

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
@@ -3,7 +3,7 @@ project(autoware_behavior_path_goal_planner_module)
 
 set(ament_cmake_lint_cmake_FOUND TRUE)
 
-option(BUILD_EXAMPLES "Build examples" OFF)
+option(BUILD_EXAMPLES "Build examples" ON)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
@@ -3,7 +3,7 @@ project(autoware_behavior_path_goal_planner_module)
 
 set(ament_cmake_lint_cmake_FOUND TRUE)
 
-option(BUILD_EXAMPLES "Build examples" ON)
+option(BUILD_EXAMPLES "Build examples" OFF)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
@@ -27,7 +27,7 @@ if(BUILD_EXAMPLES)
   FetchContent_Declare(
     matplotlibcpp17
     GIT_REPOSITORY https://github.com/soblin/matplotlibcpp17.git
-    GIT_TAG v1.0.5
+    GIT_TAG main
   )
   FetchContent_MakeAvailable(matplotlibcpp17)
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
@@ -27,7 +27,7 @@ if(BUILD_EXAMPLES)
   FetchContent_Declare(
     matplotlibcpp17
     GIT_REPOSITORY https://github.com/soblin/matplotlibcpp17.git
-    GIT_TAG master
+    GIT_TAG v1.0.5
   )
   FetchContent_MakeAvailable(matplotlibcpp17)
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -329,7 +329,7 @@ std::vector<PullOverPath> selectPullOverPaths(
   }
 
   std::vector<PullOverPath> selected;
-  for (const auto & sorted_indice : sorted_path_indices) {
+  for (const auto & sorted_index : sorted_path_indices) {
     selected.push_back(pull_over_path_candidates.at(sorted_indice));
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -55,7 +55,8 @@ using autoware_planning_msgs::msg::LaneletRoute;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
 void plot_path_with_lane_id(
-  matplotlibcpp17::axes::Axes & axes, const PathWithLaneId path, const std::string color = "red")
+  matplotlibcpp17::axes::Axes & axes, const PathWithLaneId & path,
+  const std::string & color = "red")
 {
   std::vector<double> xs, ys;
   for (const auto & point : path.points) {
@@ -173,9 +174,9 @@ bool hasEnoughDistance(
 }
 
 std::vector<PullOverPath> selectPullOverPaths(
-  const std::vector<PullOverPath> pull_over_path_candidates, const GoalCandidates & goal_candidates,
-  const std::shared_ptr<const PlannerData> planner_data, const GoalPlannerParameters & parameters,
-  const BehaviorModuleOutput & previous_module_output)
+  const std::vector<PullOverPath> & pull_over_path_candidates,
+  const GoalCandidates & goal_candidates, const std::shared_ptr<const PlannerData> planner_data,
+  const GoalPlannerParameters & parameters, const BehaviorModuleOutput & previous_module_output)
 {
   using autoware::behavior_path_planner::utils::getExtendedCurrentLanesFromPath;
   using autoware::motion_utils::calcSignedArcLength;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -262,10 +262,12 @@ int main(int argc, char ** argv)
   lane_departure_checker_params.footprint_extra_margin =
     goal_planner_parameter.lane_departure_check_expansion_margin;
   lane_departure_checker.setParam(lane_departure_checker_params);
+  autoware::behavior_path_planner::GoalCandidate goal_candidate;
+  goal_candidate.goal_pose = route_msg.goal_pose;
   auto shift_pull_over_planner = autoware::behavior_path_planner::ShiftPullOver(
     *node, goal_planner_parameter, lane_departure_checker);
   const auto pull_over_path_opt =
-    shift_pull_over_planner.plan(0, 0, planner_data, reference_path, route_msg.goal_pose);
+    shift_pull_over_planner.plan(goal_candidate, 0, planner_data, reference_path);
 
   pybind11::scoped_interpreter guard{};
   auto plt = matplotlibcpp17::pyplot::import();
@@ -282,7 +284,7 @@ int main(int argc, char ** argv)
   std::cout << pull_over_path_opt.has_value() << std::endl;
   if (pull_over_path_opt) {
     const auto & pull_over_path = pull_over_path_opt.value();
-    const auto & full_path = pull_over_path.full_path;
+    const auto & full_path = pull_over_path.full_path();
     plot_path_with_lane_id(ax, full_path);
   }
   ax.set_aspect(Args("equal"));

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -330,7 +330,7 @@ std::vector<PullOverPath> selectPullOverPaths(
 
   std::vector<PullOverPath> selected;
   for (const auto & sorted_index : sorted_path_indices) {
-    selected.push_back(pull_over_path_candidates.at(sorted_indice));
+    selected.push_back(pull_over_path_candidates.at(sorted_index));
   }
 
   return selected;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/behavior_path_goal_planner_module/goal_searcher.hpp"
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/behavior_path_goal_planner_module/manager.hpp>
 #include <autoware/behavior_path_goal_planner_module/pull_over_planner/shift_pull_over.hpp>
@@ -82,24 +84,39 @@ void plot_lanelet(
     Kwargs("color"_a = "black", "linewidth"_a = linewidth, "linestyle"_a = "dashed"));
 }
 
-int main(int argc, char ** argv)
+std::shared_ptr<const autoware::behavior_path_planner::PlannerData> instantiate_planner_data(
+  rclcpp::Node::SharedPtr node, const std::string & map_path,
+  const autoware_planning_msgs::msg::LaneletRoute & route_msg)
 {
-  rclcpp::init(argc, argv);
-
-  const auto road_shoulder_test_map_path =
-    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner_common") +
-    "/test_map/road_shoulder/lanelet2_map.osm";
-
   lanelet::ErrorMessages errors{};
   lanelet::projection::MGRSProjector projector{};
-  const lanelet::LaneletMapPtr lanelet_map_ptr =
-    lanelet::load(road_shoulder_test_map_path, projector, &errors);
+  const lanelet::LaneletMapPtr lanelet_map_ptr = lanelet::load(map_path, projector, &errors);
   if (!errors.empty()) {
     for (const auto & error : errors) {
       std::cout << error << std::endl;
     }
-    return 1;
+    return nullptr;
   }
+  autoware_map_msgs::msg::LaneletMapBin map_bin;
+  lanelet::utils::conversion::toBinMsg(
+    lanelet_map_ptr, &map_bin);  // TODO(soblin): pass lanelet_map_ptr to RouteHandler
+
+  auto planner_data = std::make_shared<autoware::behavior_path_planner::PlannerData>();
+  planner_data->init_parameters(*node);
+  planner_data->route_handler->setMap(map_bin);
+  planner_data->route_handler->setRoute(route_msg);
+
+  nav_msgs::msg::Odometry odom;
+  odom.pose.pose = route_msg.start_pose;
+  auto odometry = std::make_shared<const nav_msgs::msg::Odometry>(odom);
+  planner_data->self_odometry = odometry;
+
+  return planner_data;
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
 
   autoware_planning_msgs::msg::LaneletRoute route_msg;
   route_msg.start_pose = geometry_msgs::build<geometry_msgs::msg::Pose>()
@@ -122,15 +139,6 @@ int main(int argc, char ** argv)
                                          .y(0.0)
                                          .z(-0.3361155457734493)
                                          .w(0.9418207578352774));
-  /*
-  route_msg.goal_pose =
-    geometry_msgs::build<geometry_msgs::msg::Pose>()
-      .position(
-        geometry_msgs::build<geometry_msgs::msg::Point>().x(568.836731).y(437.871904).z(100.0))
-      .orientation(
-        geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(0.0).y(0.0).z(-0.292125).w(
-          0.956380));
-  */
 
   route_msg.segments = std::vector<autoware_planning_msgs::msg::LaneletSegment>{
     autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletSegment>()
@@ -174,43 +182,7 @@ int main(int argc, char ** argv)
       }),
   };
   route_msg.allow_modification = false;
-  autoware_map_msgs::msg::LaneletMapBin map_bin;
-  lanelet::utils::conversion::toBinMsg(
-    lanelet_map_ptr, &map_bin);  // TODO(soblin): pass lanelet_map_ptr to RouteHandler
 
-  /*
-    reference:
-    https://github.com/ros2/rclcpp/blob/ee94bc63e4ce47a502891480a2796b53d54fcdfc/rclcpp/test/rclcpp/test_parameter_client.cpp#L927
-   */
-  /*
-  auto node = rclcpp::Node::make_shared(
-    "node", "namespace", rclcpp::NodeOptions().allow_undeclared_parameters(true));
-  auto param_node = std::make_shared<rclcpp::AsyncParametersClient>(node, "");
-  {
-    auto future = param_node->load_parameters(
-      ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner") +
-      "/config/behavior_path_planner.param.yaml");
-    if (rclcpp::spin_until_future_complete(node, future) != rclcpp::FutureReturnCode::SUCCESS) {
-      RCLCPP_INFO(node->get_logger(), "failed to load behavior_path_planner.param.yaml");
-    }
-  }
-  {
-    auto future = param_node->load_parameters(
-      ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner") +
-      "/config/drivable_area_expansion.param.yaml");
-    if (rclcpp::spin_until_future_complete(node, future) != rclcpp::FutureReturnCode::SUCCESS) {
-      RCLCPP_INFO(node->get_logger(), "failed to load drivable_area_expansion.param.yaml");
-    }
-  }
-  {
-    auto future = param_node->load_parameters(
-      ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner") +
-      "/config/scene_module_manager.param.yaml");
-    if (rclcpp::spin_until_future_complete(node, future) != rclcpp::FutureReturnCode::SUCCESS) {
-      RCLCPP_INFO(node->get_logger(), "failed to load scene_module_manager.param.yaml");
-    }
-  }
-  */
   auto node_options = rclcpp::NodeOptions{};
   node_options.parameter_overrides(
     std::vector<rclcpp::Parameter>{{"launch_modules", std::vector<std::string>{}}});
@@ -238,18 +210,15 @@ int main(int argc, char ** argv)
       "/config/goal_planner.param.yaml"});
   auto node = rclcpp::Node::make_shared("plot_map", node_options);
 
-  auto planner_data = std::make_shared<autoware::behavior_path_planner::PlannerData>();
-  planner_data->init_parameters(*node);
-  planner_data->route_handler->setMap(map_bin);
-  planner_data->route_handler->setRoute(route_msg);
-  nav_msgs::msg::Odometry odom;
-  odom.pose.pose = route_msg.start_pose;
-  auto odometry = std::make_shared<const nav_msgs::msg::Odometry>(odom);
-  planner_data->self_odometry = odometry;
+  auto planner_data = instantiate_planner_data(
+    node,
+    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner_common") +
+      "/test_map/road_shoulder/lanelet2_map.osm",
+    route_msg);
+
   lanelet::ConstLanelet current_route_lanelet;
   planner_data->route_handler->getClosestLaneletWithinRoute(
     route_msg.start_pose, &current_route_lanelet);
-  std::cout << "current_route_lanelet is " << current_route_lanelet.id() << std::endl;
   const auto reference_path =
     autoware::behavior_path_planner::utils::getReferencePath(current_route_lanelet, planner_data);
   auto goal_planner_parameter =
@@ -262,12 +231,9 @@ int main(int argc, char ** argv)
   lane_departure_checker_params.footprint_extra_margin =
     goal_planner_parameter.lane_departure_check_expansion_margin;
   lane_departure_checker.setParam(lane_departure_checker_params);
-  autoware::behavior_path_planner::GoalCandidate goal_candidate;
-  goal_candidate.goal_pose = route_msg.goal_pose;
-  auto shift_pull_over_planner = autoware::behavior_path_planner::ShiftPullOver(
-    *node, goal_planner_parameter, lane_departure_checker);
-  const auto pull_over_path_opt =
-    shift_pull_over_planner.plan(goal_candidate, 0, planner_data, reference_path);
+  autoware::behavior_path_planner::GoalSearcher goal_searcher(
+    goal_planner_parameter, vehicle_info.createFootprint());
+  const auto goal_candidates = goal_searcher.search(planner_data);
 
   pybind11::scoped_interpreter guard{};
   auto plt = matplotlibcpp17::pyplot::import();
@@ -276,16 +242,21 @@ int main(int argc, char ** argv)
   const std::vector<lanelet::Id> ids{17756, 17757, 18493, 18494, 18496, 18497,
                                      18492, 18495, 18498, 18499, 18500};
   for (const auto & id : ids) {
-    const auto lanelet = lanelet_map_ptr->laneletLayer.get(id);
+    const auto lanelet = planner_data->route_handler->getLaneletMapPtr()->laneletLayer.get(id);
     plot_lanelet(ax, lanelet);
   }
 
   plot_path_with_lane_id(ax, reference_path.path);
-  std::cout << pull_over_path_opt.has_value() << std::endl;
-  if (pull_over_path_opt) {
-    const auto & pull_over_path = pull_over_path_opt.value();
-    const auto & full_path = pull_over_path.full_path();
-    plot_path_with_lane_id(ax, full_path);
+  for (const auto & goal_candidate : goal_candidates) {
+    auto shift_pull_over_planner = autoware::behavior_path_planner::ShiftPullOver(
+      *node, goal_planner_parameter, lane_departure_checker);
+    const auto pull_over_path_opt =
+      shift_pull_over_planner.plan(goal_candidate, 0, planner_data, reference_path);
+    if (pull_over_path_opt) {
+      const auto & pull_over_path = pull_over_path_opt.value();
+      const auto & full_path = pull_over_path.full_path();
+      plot_path_with_lane_id(ax, full_path);
+    }
   }
   ax.set_aspect(Args("equal"));
   plt.show();

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -19,6 +19,7 @@
 #include <autoware/behavior_path_goal_planner_module/pull_over_planner/shift_pull_over.hpp>
 #include <autoware/behavior_path_planner/behavior_path_planner_node.hpp>
 #include <autoware/behavior_path_planner_common/data_manager.hpp>
+#include <autoware/behavior_path_planner_common/utils/parking_departure/utils.hpp>
 #include <autoware/behavior_path_planner_common/utils/path_utils.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
@@ -43,14 +44,15 @@
 using namespace std::chrono_literals;  // NOLINT
 
 void plot_path_with_lane_id(
-  matplotlibcpp17::axes::Axes & axes, const tier4_planning_msgs::msg::PathWithLaneId path)
+  matplotlibcpp17::axes::Axes & axes, const tier4_planning_msgs::msg::PathWithLaneId path,
+  const std::string color = "red")
 {
   std::vector<double> xs, ys;
   for (const auto & point : path.points) {
     xs.push_back(point.point.pose.position.x);
     ys.push_back(point.point.pose.position.y);
   }
-  axes.plot(Args(xs, ys), Kwargs("color"_a = "red", "linewidth"_a = 1.0));
+  axes.plot(Args(xs, ys), Kwargs("color"_a = color, "linewidth"_a = 1.0));
 }
 
 void plot_lanelet(
@@ -111,7 +113,113 @@ std::shared_ptr<const autoware::behavior_path_planner::PlannerData> instantiate_
   auto odometry = std::make_shared<const nav_msgs::msg::Odometry>(odom);
   planner_data->self_odometry = odometry;
 
+  geometry_msgs::msg::AccelWithCovarianceStamped accel;
+  accel.accel.accel.linear.x = 0.537018510955429;
+  accel.accel.accel.linear.y = -0.2435352815388478;
+  auto accel_ptr = std::make_shared<const geometry_msgs::msg::AccelWithCovarianceStamped>(accel);
+  planner_data->self_acceleration = accel_ptr;
   return planner_data;
+}
+
+bool hasEnoughDistance(
+  const autoware::behavior_path_planner::PullOverPath & pull_over_path,
+  const tier4_planning_msgs::msg::PathWithLaneId & long_tail_reference_path,
+  const std::shared_ptr<const autoware::behavior_path_planner::PlannerData> planner_data,
+  const autoware::behavior_path_planner::GoalPlannerParameters & parameters)
+{
+  const Pose & current_pose = planner_data->self_odometry->pose.pose;
+  const double current_vel = planner_data->self_odometry->twist.twist.linear.x;
+
+  // when the path is separated and start_pose is close,
+  // once stopped, the vehicle cannot start again.
+  // so need enough distance to restart.
+  // distance to restart should be less than decide_path_distance.
+  // otherwise, the goal would change immediately after departure.
+  const bool is_separated_path = pull_over_path.partial_paths().size() > 1;
+  const double distance_to_start = autoware::motion_utils::calcSignedArcLength(
+    long_tail_reference_path.points, current_pose.position, pull_over_path.start_pose().position);
+  const double distance_to_restart = parameters.decide_path_distance / 2;
+  const double eps_vel = 0.01;
+  const bool is_stopped = std::abs(current_vel) < eps_vel;
+  if (is_separated_path && is_stopped && distance_to_start < distance_to_restart) {
+    return false;
+  }
+
+  const auto current_to_stop_distance =
+    autoware::behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
+      planner_data, parameters.maximum_deceleration, parameters.maximum_jerk, 0.0);
+  if (!current_to_stop_distance) {
+    return false;
+  }
+
+  /*
+  // If the stop line is subtly exceeded, it is assumed that there is not enough distance to the
+  // starting point of parking, so to prevent this, once the vehicle has stopped, it also has a
+  // stop_distance_buffer to allow for the amount exceeded.
+  const double buffer = is_stopped ? stop_distance_buffer_ : 0.0;
+  if (distance_to_start + buffer < *current_to_stop_distance) {
+    return false;
+    }*/
+
+  return true;
+}
+
+std::vector<autoware::behavior_path_planner::PullOverPath> selectPullOverPaths(
+  const std::vector<autoware::behavior_path_planner::PullOverPath> pull_over_path_candidates,
+  const autoware::behavior_path_planner::GoalCandidates & goal_candidates,
+  const std::shared_ptr<const autoware::behavior_path_planner::PlannerData> planner_data,
+  const autoware::behavior_path_planner::GoalPlannerParameters & parameters,
+  const autoware::behavior_path_planner::BehaviorModuleOutput & previous_module_output)
+{
+  const auto & goal_pose = planner_data->route_handler->getOriginalGoalPose();
+  const double backward_length =
+    parameters.backward_goal_search_length + parameters.decide_path_distance;
+
+  std::vector<size_t> sorted_path_indices;
+  sorted_path_indices.reserve(pull_over_path_candidates.size());
+
+  std::unordered_map<int, autoware::behavior_path_planner::GoalCandidate> goal_candidate_map;
+  for (const auto & goal_candidate : goal_candidates) {
+    goal_candidate_map[goal_candidate.id] = goal_candidate;
+  }
+  for (size_t i = 0; i < pull_over_path_candidates.size(); ++i) {
+    const auto & path = pull_over_path_candidates[i];
+    const auto goal_candidate_it = goal_candidate_map.find(path.goal_id());
+    if (goal_candidate_it != goal_candidate_map.end() && goal_candidate_it->second.is_safe) {
+      sorted_path_indices.push_back(i);
+    }
+  }
+
+  const double prev_path_front_to_goal_dist = autoware::motion_utils::calcSignedArcLength(
+    previous_module_output.path.points,
+    previous_module_output.path.points.front().point.pose.position, goal_pose.position);
+  const auto & long_tail_reference_path = [&]() {
+    if (prev_path_front_to_goal_dist > backward_length) {
+      return previous_module_output.path;
+    }
+    // get road lanes which is at least backward_length[m] behind the goal
+    const auto road_lanes = autoware::behavior_path_planner::utils::getExtendedCurrentLanesFromPath(
+      previous_module_output.path, planner_data, backward_length, 0.0, false);
+    const auto goal_pose_length = lanelet::utils::getArcCoordinates(road_lanes, goal_pose).length;
+    return planner_data->route_handler->getCenterLinePath(
+      road_lanes, std::max(0.0, goal_pose_length - backward_length),
+      goal_pose_length + parameters.forward_goal_search_length);
+  }();
+
+  sorted_path_indices.erase(
+    std::remove_if(
+      sorted_path_indices.begin(), sorted_path_indices.end(),
+      [&](const size_t i) {
+        return !hasEnoughDistance(
+          pull_over_path_candidates[i], long_tail_reference_path, planner_data, parameters);
+      }),
+    sorted_path_indices.end());
+
+  std::vector<autoware::behavior_path_planner::PullOverPath> selected;
+  for (const auto & sorted_indice : sorted_path_indices) {
+    selected.push_back(pull_over_path_candidates.at(sorted_indice));
+  }
+  return selected;
 }
 
 int main(int argc, char ** argv)
@@ -119,65 +227,67 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   autoware_planning_msgs::msg::LaneletRoute route_msg;
-  route_msg.start_pose = geometry_msgs::build<geometry_msgs::msg::Pose>()
-                           .position(geometry_msgs::build<geometry_msgs::msg::Point>()
-                                       .x(530.707103865218)
-                                       .y(436.8758309382301)
-                                       .z(100.0))
-                           .orientation(geometry_msgs::build<geometry_msgs::msg::Quaternion>()
-                                          .x(0.0)
-                                          .y(0.0)
-                                          .z(0.2187392230193602)
-                                          .w(0.9757833531644647));
-  route_msg.goal_pose = geometry_msgs::build<geometry_msgs::msg::Pose>()
-                          .position(geometry_msgs::build<geometry_msgs::msg::Point>()
-                                      .x(571.8018955394537)
-                                      .y(435.6819504507543)
-                                      .z(100.0))
-                          .orientation(geometry_msgs::build<geometry_msgs::msg::Quaternion>()
-                                         .x(0.0)
-                                         .y(0.0)
-                                         .z(-0.3361155457734493)
-                                         .w(0.9418207578352774));
+  route_msg.start_pose =
+    geometry_msgs::build<geometry_msgs::msg::Pose>()
+      .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(729.944).y(695.124).z(381.18))
+      .orientation(
+        geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(0.0).y(0.0).z(0.437138).w(
+          0.899395));
+  route_msg.goal_pose =
+    geometry_msgs::build<geometry_msgs::msg::Pose>()
+      .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(797.526).y(694.105).z(381.18))
+      .orientation(
+        geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(0.0).y(0.0).z(-0.658723).w(
+          0.752386));
 
   route_msg.segments = std::vector<autoware_planning_msgs::msg::LaneletSegment>{
     autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletSegment>()
       .preferred_primitive(
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(17757)
+          .id(15214)
           .primitive_type(""))
       .primitives(std::vector<autoware_planning_msgs::msg::LaneletPrimitive>{
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(17756)
+          .id(15214)
           .primitive_type("lane"),
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(17757)
+          .id(15213)
           .primitive_type("lane"),
       }),
     autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletSegment>()
       .preferred_primitive(
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(18494)
+          .id(15226)
           .primitive_type(""))
       .primitives(std::vector<autoware_planning_msgs::msg::LaneletPrimitive>{
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(18494)
+          .id(15226)
           .primitive_type("lane"),
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(18493)
+          .id(15225)
           .primitive_type("lane"),
       }),
     autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletSegment>()
       .preferred_primitive(
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(18496)
+          .id(15228)
           .primitive_type(""))
       .primitives(std::vector<autoware_planning_msgs::msg::LaneletPrimitive>{
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(18496)
+          .id(15228)
           .primitive_type("lane"),
         autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
-          .id(18497)
+          .id(15229)
+          .primitive_type("lane"),
+      }),
+    autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletSegment>()
+      .preferred_primitive(
+        autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
+          .id(15231)
+          .primitive_type(""))
+      .primitives(std::vector<autoware_planning_msgs::msg::LaneletPrimitive>{
+        autoware_planning_msgs::build<autoware_planning_msgs::msg::LaneletPrimitive>()
+          .id(15231)
           .primitive_type("lane"),
       }),
   };
@@ -212,7 +322,7 @@ int main(int argc, char ** argv)
 
   auto planner_data = instantiate_planner_data(
     node,
-    ament_index_cpp::get_package_share_directory("autoware_behavior_path_planner_common") +
+    ament_index_cpp::get_package_share_directory("autoware_test_utils") +
       "/test_map/road_shoulder/lanelet2_map.osm",
     route_msg);
 
@@ -239,14 +349,16 @@ int main(int argc, char ** argv)
   auto plt = matplotlibcpp17::pyplot::import();
   auto [fig, ax] = plt.subplots();
 
-  const std::vector<lanelet::Id> ids{17756, 17757, 18493, 18494, 18496, 18497,
-                                     18492, 18495, 18498, 18499, 18500};
+  const std::vector<lanelet::Id> ids{15213, 15214, 15225, 15226, 15224, 15227,
+                                     15228, 15229, 15230, 15231, 15232};
   for (const auto & id : ids) {
     const auto lanelet = planner_data->route_handler->getLaneletMapPtr()->laneletLayer.get(id);
     plot_lanelet(ax, lanelet);
   }
 
-  plot_path_with_lane_id(ax, reference_path.path);
+  plot_path_with_lane_id(ax, reference_path.path, "green");
+
+  std::vector<autoware::behavior_path_planner::PullOverPath> candidates;
   for (const auto & goal_candidate : goal_candidates) {
     auto shift_pull_over_planner = autoware::behavior_path_planner::ShiftPullOver(
       *node, goal_planner_parameter, lane_departure_checker);
@@ -255,9 +367,16 @@ int main(int argc, char ** argv)
     if (pull_over_path_opt) {
       const auto & pull_over_path = pull_over_path_opt.value();
       const auto & full_path = pull_over_path.full_path();
+      candidates.push_back(pull_over_path);
       plot_path_with_lane_id(ax, full_path);
     }
   }
+  const auto filtered_paths = selectPullOverPaths(
+    candidates, goal_candidates, planner_data, goal_planner_parameter, reference_path);
+  for (const auto & filtered_path : filtered_paths) {
+    plot_path_with_lane_id(ax, filtered_path.full_path(), "blue");
+  }
+
   ax.set_aspect(Args("equal"));
   plt.show();
 


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/e8a9cc4b-9313-48d0-96ad-f26020d28d2f)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
