### PR TITLE
feat(control_evaluator): add goal accuracy longitudinal, lateral, yaw

### DIFF
--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -56,6 +56,12 @@ public:
     const Trajectory & traj, const Point & ego_point);
   DiagnosticStatus generateYawDeviationDiagnosticStatus(
     const Trajectory & traj, const Pose & ego_pose);
+  DiagnosticStatus generateGoalLongitudinalDeviationDiagnosticStatus(
+    const Pose & ego_pose);
+  DiagnosticStatus generateGoalLateralDeviationDiagnosticStatus(
+    const Pose & ego_pose);
+  DiagnosticStatus generateGoalYawDeviationDiagnosticStatus(
+    const Pose & ego_pose);
 
   DiagnosticStatus generateAEBDiagnosticStatus(const DiagnosticStatus & diag);
   DiagnosticStatus generateLaneletDiagnosticStatus(const Pose & ego_pose) const;

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/deviation_metrics.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/deviation_metrics.hpp
@@ -42,6 +42,30 @@ double calcLateralDeviation(const Trajectory & traj, const Point & point);
  */
 double calcYawDeviation(const Trajectory & traj, const Pose & pose);
 
+/**
+ * @brief calculate longitudinal deviation of the given pose and point
+ * @param [in] pose input pose
+ * @param [in] point input point
+ * @return longitudinal deviation
+ */
+double calcLongitudinalDeviation(const Pose & base_pose, const Point & target_point);
+
+/**
+ * @brief calculate lateral deviation of the given pose and point
+ * @param [in] pose input pose
+ * @param [in] point input point
+ * @return lateral deviation
+ */
+double calcLateralDeviation(const Pose & base_pose, const Point & target_point);
+
+/**
+ * @brief calculate yaw deviation of the given poses
+ * @param [in] pose input pose
+ * @param [in] pose input pose
+ * @return yaw deviation
+ */
+double calcYawDeviation(const Pose & base_pose, const Pose & target_pose);
+
 }  // namespace metrics
 }  // namespace control_diagnostics
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -186,6 +186,54 @@ DiagnosticStatus ControlEvaluatorNode::generateYawDeviationDiagnosticStatus(
   return status;
 }
 
+DiagnosticStatus ControlEvaluatorNode::generateGoalLongitudinalDeviationDiagnosticStatus(
+  const Pose & ego_pose)
+{
+  DiagnosticStatus status;
+  const double long_goal = metrics::calcLongitudinalDeviation(
+    ego_pose, route_handler_.getGoalPose().position);
+
+  status.level = status.OK;
+  status.name = "goal_longitudinal_deviation";
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "metrics_value";
+  key_value.value = std::to_string(long_goal);
+  status.values.push_back(key_value);
+  return status;
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateGoalLateralDeviationDiagnosticStatus(
+  const Pose & ego_pose)
+{
+  DiagnosticStatus status;
+  const double long_goal = metrics::calcLateralDeviation(
+    ego_pose, route_handler_.getGoalPose().position);
+
+  status.level = status.OK;
+  status.name = "goal_lateral_deviation";
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "metrics_value";
+  key_value.value = std::to_string(long_goal);
+  status.values.push_back(key_value);
+  return status;
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateGoalYawDeviationDiagnosticStatus(
+  const Pose & ego_pose)
+{
+  DiagnosticStatus status;
+  const double long_goal = metrics::calcYawDeviation(
+    ego_pose, route_handler_.getGoalPose());
+
+  status.level = status.OK;
+  status.name = "goal_yaw_deviation";
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "metrics_value";
+  key_value.value = std::to_string(long_goal);
+  status.values.push_back(key_value);
+  return status;
+}
+
 void ControlEvaluatorNode::onTimer()
 {
   DiagnosticArray metrics_msg;
@@ -222,6 +270,10 @@ void ControlEvaluatorNode::onTimer()
   if (odom && route_handler_.isHandlerReady()) {
     const Pose ego_pose = odom->pose.pose;
     metrics_msg.status.push_back(generateLaneletDiagnosticStatus(ego_pose));
+
+    metrics_msg.status.push_back(generateGoalLongitudinalDeviationDiagnosticStatus(ego_pose));
+    metrics_msg.status.push_back(generateGoalLateralDeviationDiagnosticStatus(ego_pose));
+    metrics_msg.status.push_back(generateGoalYawDeviationDiagnosticStatus(ego_pose));
   }
 
   if (odom && acc) {

--- a/evaluator/autoware_control_evaluator/src/metrics/deviation_metrics.cpp
+++ b/evaluator/autoware_control_evaluator/src/metrics/deviation_metrics.cpp
@@ -38,5 +38,23 @@ double calcYawDeviation(const Trajectory & traj, const Pose & pose)
     autoware::universe_utils::calcYawDeviation(traj.points[nearest_index].pose, pose));
 }
 
+double calcLongitudinalDeviation(
+  const Pose & base_pose, const Point & target_point)
+{
+  return std::abs(autoware::universe_utils::calcLongitudinalDeviation(base_pose, target_point));
+}
+
+double calcLateralDeviation(
+  const Pose & base_pose, const Point & target_point)
+{
+  return std::abs(autoware::universe_utils::calcLateralDeviation(base_pose, target_point));
+}
+
+double calcYawDeviation(
+  const Pose & base_pose, const Pose & target_pose)
+{
+  return std::abs(autoware::universe_utils::calcYawDeviation(base_pose, target_pose));
+}
+
 }  // namespace metrics
 }  // namespace control_diagnostics


### PR DESCRIPTION
## Description

Added goal accuracy (longitudinal, lateral, yaw) to control_evaluator.

## Related links

<!-- ⬇️🟢
**Private Links:**
- [Slack link](https://star4.slack.com/archives/C03QW0GU6P7/p1729589131928899)
⬆️🟢 -->

## How was this PR tested?

`ros2 topic echo /control/control_evaluator/metrics`

![image](https://github.com/user-attachments/assets/3b116a39-e42e-4822-81f9-a5764c1194fc)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
