### PR TITLE
fix(autoware_tensorrt_yolox): modify tensorrt_yolox_node name

### DIFF
--- a/perception/autoware_tensorrt_yolox/launch/multiple_yolox.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/multiple_yolox.launch.xml
@@ -11,34 +11,50 @@
   <arg name="output_topic" default="rois"/>
 
   <include if="$(eval &quot;'$(var image_number)'>='1'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox0"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node0"/>
     <arg name="input/image" value="$(var image_raw0)"/>
     <arg name="output/objects" value="rois0"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='2'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox1"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node1"/>
     <arg name="input/image" value="$(var image_raw1)"/>
     <arg name="output/objects" value="rois1"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='3'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox2"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node2"/>
     <arg name="input/image" value="$(var image_raw2)"/>
     <arg name="output/objects" value="rois2"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='4'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox3"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node3"/>
     <arg name="input/image" value="$(var image_raw3)"/>
     <arg name="output/objects" value="rois3"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='5'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox4"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node4"/>
     <arg name="input/image" value="$(var image_raw4)"/>
     <arg name="output/objects" value="rois4"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='6'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox5"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node5"/>
     <arg name="input/image" value="$(var image_raw5)"/>
     <arg name="output/objects" value="rois5"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='7'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox6"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node6"/>
     <arg name="input/image" value="$(var image_raw6)"/>
     <arg name="output/objects" value="rois6"/>
   </include>
   <include if="$(eval &quot;'$(var image_number)'>='8'&quot;)" file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+    <arg name="yolox_node_name" value="tensorrt_yolox7"/>
+    <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node7"/>
     <arg name="input/image" value="$(var image_raw7)"/>
     <arg name="output/objects" value="rois7"/>
   </include>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
@@ -15,13 +15,13 @@
   <arg name="build_only" default="false" description="exit after trt engine is built"/>
 
   <arg name="param_file" default="$(find-pkg-share autoware_image_transport_decompressor)/config/image_transport_decompressor.param.yaml"/>
-  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="image_transport_decompressor_node" if="$(var use_decompress)">
+  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="$(anon image_transport_decompressor_node)" if="$(var use_decompress)">
     <remap from="~/input/compressed_image" to="$(var input/image)/compressed"/>
     <remap from="~/output/raw_image" to="$(var input/image)"/>
     <param from="$(var param_file)"/>
   </node>
 
-  <node pkg="autoware_tensorrt_yolox" exec="autoware_tensorrt_yolox_node_exe" name="tensorrt_yolox" output="screen">
+  <node pkg="autoware_tensorrt_yolox" exec="autoware_tensorrt_yolox_node_exe" name="$(anon tensorrt_yolox)" output="screen">
     <remap from="~/in/image" to="$(var input/image)"/>
     <remap from="~/out/objects" to="$(var output/objects)"/>
     <remap from="~/out/mask" to="$(var output/mask)"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <!-- cspell: ignore semseg, finetune  -->
+  <arg name="yolox_node_name" default="tensorrt_yolox"/>
+  <arg name="image_transport_decompressor_node_name" default="image_transport_decompressor_node"/>
   <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>
   <arg name="output/mask" default="/perception/object_recognition/detection/mask0"/>
@@ -15,13 +17,13 @@
   <arg name="build_only" default="false" description="exit after trt engine is built"/>
 
   <arg name="param_file" default="$(find-pkg-share autoware_image_transport_decompressor)/config/image_transport_decompressor.param.yaml"/>
-  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="$(anon image_transport_decompressor_node)" if="$(var use_decompress)">
+  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="$(var image_transport_decompressor_node_name)" if="$(var use_decompress)">
     <remap from="~/input/compressed_image" to="$(var input/image)/compressed"/>
     <remap from="~/output/raw_image" to="$(var input/image)"/>
     <param from="$(var param_file)"/>
   </node>
 
-  <node pkg="autoware_tensorrt_yolox" exec="autoware_tensorrt_yolox_node_exe" name="$(anon tensorrt_yolox)" output="screen">
+  <node pkg="autoware_tensorrt_yolox" exec="autoware_tensorrt_yolox_node_exe" name="$(var yolox_node_name)" output="screen">
     <remap from="~/in/image" to="$(var input/image)"/>
     <remap from="~/out/objects" to="$(var output/objects)"/>
     <remap from="~/out/mask" to="$(var output/mask)"/>


### PR DESCRIPTION
## Description

When use `multiple_yolox.launch.xml` launch many `tensorrt_yolox` node, the names of these nodes are same.

**Solution:**
Adding two parameters `yolox_node_name` and `image_transport_decompressor_node_name` for node name in `yolox_s_plus_opt.launch.xml` and explicitly assign them in `multiple_yolox.launch.xml`.

## Related links

[9146](https://github.com/autowarefoundation/autoware.universe/issues/9146)

## How was this PR tested?

Run the following command for testing:
`ros2 launch autoware_tensorrt_yolox multiple_yolox.launch.xml`
`ros2 node list`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
