### PR TITLE
feat(collision_detector): add autoware_collision_detector

### DIFF
--- a/control/autoware_collision_detector/CMakeLists.txt
+++ b/control/autoware_collision_detector/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_collision_detector)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
+
+include_directories(
+  SYSTEM
+    ${EIGEN3_INCLUDE_DIR}
+)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/node.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${PCL_LIBRARIES}
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::collision_detector::CollisionDetectorNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+  config
+  launch
+)

--- a/control/autoware_collision_detector/README.md
+++ b/control/autoware_collision_detector/README.md
@@ -1,4 +1,4 @@
-# Collision Checker
+# Collision Detector
 
 ## Purpose
 
@@ -13,6 +13,30 @@ This module subscribes required data (ego-pose, obstacles, etc), and publishes d
 ### Check data
 
 Check that `collision_detector` receives no ground pointcloud, dynamic objects.
+
+### Object Filtering
+
+#### Recognition Assumptions
+
+1. If the classification changes but it's considered the same object, the uuid does not change.
+2. It's possible for the same uuid to be recognized after being lost for a few frames.
+3. Once an object is determined to be excluded, it continues to be excluded for a certain period of time.
+
+#### Filtering Process
+
+1. Initial Recognition and Exclusion:
+
+   - The system checks if a newly recognized object's classification is listed in `nearby_object_type_filters`.
+   - If so, and the object is within the `nearby_filter_radius`, it is marked for exclusion.
+
+2. New Object Determination:
+
+   - An object is considered "new" based on its UUID.
+   - If the UUID is not found in recent frame data, the object is treated as new.
+
+3. Exclusion Mechanism:
+   - Newly excluded objects are recorded by their UUID.
+   - These objects continue to be excluded for a set period (`keep_ignoring_time`) as long as they maintain the classification specified in `nearby_object_type_filters` and remain within the `nearby_filter_radius`.
 
 ### Get distance to nearest object
 
@@ -38,11 +62,14 @@ In this function, it calculates the minimum distance between the polygon of ego 
 
 ## Parameters
 
-| Name                 | Type     | Description                                                      | Default value |
-| :------------------- | :------- | :--------------------------------------------------------------- | :------------ |
-| `use_pointcloud`     | `bool`   | Use pointcloud as obstacle check                                 | `false`       |
-| `use_dynamic_object` | `bool`   | Use dynamic object as obstacle check                             | `true`        |
-| `collision_distance` | `double` | If objects exist in this distance, publish error diagnostics [m] | 0.1           |
+| Name                         | Type                    | Description                                                                                     | Default value                    |
+| :--------------------------- | :---------------------- | :---------------------------------------------------------------------------------------------- | :------------------------------- |
+| `use_pointcloud`             | `bool`                  | Use pointcloud as obstacle check                                                                | `true`                           |
+| `use_dynamic_object`         | `bool`                  | Use dynamic object as obstacle check                                                            | `true`                           |
+| `collision_distance`         | `double`                | If objects exist in this distance, publish error diagnostics [m]                                | 0.15                             |
+| `nearby_filter_radius`       | `double`                | If objects appear in this distance with specified classification, publish error diagnostics [m] | 5.0                              |
+| `keep_ignoring_time`         | `double`                | Time to keep filtering objects that first appeared in the vicinity [sec]                        | 10.0                             |
+| `nearby_object_type_filters` | `object of bool values` | Specifies which object types to filter. Only objects with `true` value will be filtered.        | `{unknown: true, others: false}` |
 
 ## Assumptions / Known limits
 

--- a/control/autoware_collision_detector/README.md
+++ b/control/autoware_collision_detector/README.md
@@ -1,0 +1,49 @@
+# Collision Checker
+
+## Purpose
+
+This module subscribes required data (ego-pose, obstacles, etc), and publishes diagnostics if an object is within a specific distance.
+
+## Inner-workings / Algorithms
+
+### Flow chart
+
+### Algorithms
+
+### Check data
+
+Check that `collision_detector` receives no ground pointcloud, dynamic objects.
+
+### Get distance to nearest object
+
+Calculate distance between ego vehicle and the nearest object.
+In this function, it calculates the minimum distance between the polygon of ego vehicle and all points in pointclouds and the polygons of dynamic objects.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                                           | Type                                              | Description                                                        |
+| ---------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
+| `/perception/obstacle_segmentation/pointcloud` | `sensor_msgs::msg::PointCloud2`                   | Pointcloud of obstacles which the ego-vehicle should stop or avoid |
+| `/perception/object_recognition/objects`       | `autoware_perception_msgs::msg::PredictedObjects` | Dynamic objects                                                    |
+| `/tf`                                          | `tf2_msgs::msg::TFMessage`                        | TF                                                                 |
+| `/tf_static`                                   | `tf2_msgs::msg::TFMessage`                        | TF static                                                          |
+
+### Output
+
+| Name           | Type                                    | Description |
+| -------------- | --------------------------------------- | ----------- |
+| `/diagnostics` | `diagnostic_msgs::msg::DiagnosticArray` | Diagnostics |
+
+## Parameters
+
+| Name                 | Type     | Description                                                      | Default value |
+| :------------------- | :------- | :--------------------------------------------------------------- | :------------ |
+| `use_pointcloud`     | `bool`   | Use pointcloud as obstacle check                                 | `false`       |
+| `use_dynamic_object` | `bool`   | Use dynamic object as obstacle check                             | `true`        |
+| `collision_distance` | `double` | If objects exist in this distance, publish error diagnostics [m] | 0.1           |
+
+## Assumptions / Known limits
+
+- This module is based on `surround_obstacle_checker`

--- a/control/autoware_collision_detector/README.md
+++ b/control/autoware_collision_detector/README.md
@@ -62,14 +62,14 @@ In this function, it calculates the minimum distance between the polygon of ego 
 
 ## Parameters
 
-| Name                         | Type                    | Description                                                                                     | Default value                    |
-| :--------------------------- | :---------------------- | :---------------------------------------------------------------------------------------------- | :------------------------------- |
-| `use_pointcloud`             | `bool`                  | Use pointcloud as obstacle check                                                                | `true`                           |
-| `use_dynamic_object`         | `bool`                  | Use dynamic object as obstacle check                                                            | `true`                           |
-| `collision_distance`         | `double`                | If objects exist in this distance, publish error diagnostics [m]                                | 0.15                             |
-| `nearby_filter_radius`       | `double`                | If objects appear in this distance with specified classification, publish error diagnostics [m] | 5.0                              |
-| `keep_ignoring_time`         | `double`                | Time to keep filtering objects that first appeared in the vicinity [sec]                        | 10.0                             |
-| `nearby_object_type_filters` | `object of bool values` | Specifies which object types to filter. Only objects with `true` value will be filtered.        | `{unknown: true, others: false}` |
+| Name                         | Type                    | Description                                                                              | Default value                    |
+| :--------------------------- | :---------------------- | :--------------------------------------------------------------------------------------- | :------------------------------- |
+| `use_pointcloud`             | `bool`                  | Use pointcloud as obstacle check                                                         | `true`                           |
+| `use_dynamic_object`         | `bool`                  | Use dynamic object as obstacle check                                                     | `true`                           |
+| `collision_distance`         | `double`                | Distance threshold at which an object is considered a collision. [m]                     | 0.15                             |
+| `nearby_filter_radius`       | `double`                | Distance range for filtering objects. Objects within this radius are considered. [m]     | 5.0                              |
+| `keep_ignoring_time`         | `double`                | Time to keep filtering objects that first appeared in the vicinity [sec]                 | 10.0                             |
+| `nearby_object_type_filters` | `object of bool values` | Specifies which object types to filter. Only objects with `true` value will be filtered. | `{unknown: true, others: false}` |
 
 ## Assumptions / Known limits
 

--- a/control/autoware_collision_detector/config/collision_detector.param.yaml
+++ b/control/autoware_collision_detector/config/collision_detector.param.yaml
@@ -1,0 +1,5 @@
+/**:
+  ros__parameters:
+    use_pointcloud: false # use pointcloud as obstacle check
+    use_dynamic_object: true # use dynamic object as obstacle check
+    collision_distance: 0.1 # Distance at which an object is determined to have collided with ego [m]

--- a/control/autoware_collision_detector/config/collision_detector.param.yaml
+++ b/control/autoware_collision_detector/config/collision_detector.param.yaml
@@ -3,3 +3,14 @@
     use_pointcloud: false # use pointcloud as obstacle check
     use_dynamic_object: true # use dynamic object as obstacle check
     collision_distance: 0.1 # Distance at which an object is determined to have collided with ego [m]
+    nearby_filter_radius: 5.0 # Radius to filter nearby objects [m]
+    keep_ignoring_time: 10.0 # Time to keep filtering objects that first appeared in the vicinity
+    nearby_object_type_filters: # Classes subject to filtering for objects first appearing in the vicinity
+      filter_car: false
+      filter_truck: false
+      filter_bus: false
+      filter_trailer: false
+      filter_bicycle: false
+      filter_motorcycle: false
+      filter_pedestrian: false
+      filter_unknown: true

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -86,7 +86,7 @@ private:
     std::vector<TimestampedObject> & container, const rclcpp::Time & current_time,
     const rclcpp::Duration & duration_sec);
 
-  bool shouldBeFiltered(
+  bool shouldBeExcluded(
     const autoware_perception_msgs::msg::ObjectClassification::_label_type & classification) const;
 
   void checkCollision(diagnostic_updater::DiagnosticStatusWrapper & stat);

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -1,0 +1,102 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COLLISION_DETECTOR__NODE_HPP_
+#define AUTOWARE__COLLISION_DETECTOR__NODE_HPP_
+
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <boost/optional.hpp>
+
+#include <tf2/utils.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <string>
+#include <utility>
+
+namespace autoware::collision_detector
+{
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_adapi_v1_msgs::msg::OperationModeState;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
+
+using Obstacle = std::pair<double /* distance */, geometry_msgs::msg::Point>;
+
+class CollisionDetectorNode : public rclcpp::Node
+{
+public:
+  explicit CollisionDetectorNode(const rclcpp::NodeOptions & node_options);
+
+  struct NodeParam
+  {
+    bool use_pointcloud;
+    bool use_dynamic_object;
+    double collision_distance;
+  };
+
+private:
+  void checkCollision(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+
+  void onDynamicObjects(const PredictedObjects::ConstSharedPtr msg);
+
+  void onOperationMode(const OperationModeState::ConstSharedPtr msg);
+
+  boost::optional<Obstacle> getNearestObstacle() const;
+
+  boost::optional<Obstacle> getNearestObstacleByPointCloud() const;
+
+  boost::optional<Obstacle> getNearestObstacleByDynamicObject() const;
+
+  boost::optional<geometry_msgs::msg::TransformStamped> getTransform(
+    const std::string & source, const std::string & target, const rclcpp::Time & stamp,
+    double duration_sec) const;
+
+  // ros
+  mutable tf2_ros::Buffer tf_buffer_{get_clock()};
+  mutable tf2_ros::TransformListener tf_listener_{tf_buffer_};
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  // publisher and subscriber
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pointcloud_;
+  rclcpp::Subscription<PredictedObjects>::SharedPtr sub_dynamic_objects_;
+  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
+
+  // parameter
+  NodeParam node_param_;
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+
+  // data
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_ptr_;
+  PredictedObjects::ConstSharedPtr object_ptr_;
+  OperationModeState::ConstSharedPtr operation_mode_ptr_;
+  rclcpp::Time last_obstacle_found_stamp_;
+
+  // Diagnostic Updater
+  diagnostic_updater::Updater updater_;
+};
+}  // namespace autoware::collision_detector
+
+#endif  // AUTOWARE__COLLISION_DETECTOR__NODE_HPP_

--- a/control/autoware_collision_detector/launch/collision_detector.launch.xml
+++ b/control/autoware_collision_detector/launch/collision_detector.launch.xml
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="param_path" default="$(find-pkg-share autoware_collision_detector)/config/collision_detector.param.yaml"/>
+
+  <arg name="input_objects" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
+
+  <node pkg="autoware_collision_detector" exec="autoware_collision_detector_node" name="collision_detector" output="screen">
+    <param from="$(var param_path)"/>
+    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+    <remap from="~/input/objects" to="$(var input_objects)"/>
+  </node>
+</launch>

--- a/control/autoware_collision_detector/package.xml
+++ b/control/autoware_collision_detector/package.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_collision_detector</name>
+  <version>0.1.0</version>
+  <description>The collision_detector package</description>
+  <maintainer email="shinnosuke.hirakawa@tier4.jp">Shinnosuke Hirakawa</maintainer>
+  <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
+  <maintainer email="go.sakayori@tier4.jp">Go Sakayori</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="shinnosuke.hirakawa@tier4.jp">Shinnosuke Hirakawa</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <build_depend>autoware_cmake</build_depend>
+
+  <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_utils</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
+  <depend>eigen</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>pcl_conversions</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/control/autoware_collision_detector/package.xml
+++ b/control/autoware_collision_detector/package.xml
@@ -4,7 +4,7 @@
   <name>autoware_collision_detector</name>
   <version>0.1.0</version>
   <description>The collision_detector package</description>
-  <maintainer email="shinnosuke.hirakawa@tier4.jp">Shinnosuke Hirakawa</maintainer>
+
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="go.sakayori@tier4.jp">Go Sakayori</maintainer>
 

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -170,7 +170,7 @@ CollisionDetectorNode::CollisionDetectorNode(const rclcpp::NodeOptions & node_op
 
   // Diagnostics Updater
   updater_.setHardwareID("collision_detector");
-  updater_.add("collision_check", this, &CollisionDetectorNode::checkCollision);
+  updater_.add("collision_detect", this, &CollisionDetectorNode::checkCollision);
   updater_.setPeriod(0.1);
 }
 

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -74,8 +74,8 @@ Polygon2d createObjPolygon(
 Polygon2d createObjPolygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & size)
 {
-  const double & length_m = size.x / 2.0;
-  const double & width_m = size.y / 2.0;
+  const double length_m = size.x / 2.0;
+  const double width_m = size.y / 2.0;
 
   geometry_msgs::msg::Polygon polygon{};
 

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -213,10 +213,10 @@ PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & i
     const double object_distance = transformed_position.head<2>().norm();
     const bool is_within_range = (object_distance <= node_param_.nearby_filter_radius);
 
-    // Determine if the object should be filtered based on its classification
-    bool should_be_filtered_class = shouldBeFiltered(object.classification.front().label);
+    // Determine if the object should be excluded based on its classification
+    bool should_be_excluded = shouldBeExcluded(object.classification.front().label);
 
-    const bool is_within_range_and_filtering_class = is_within_range && should_be_filtered_class;
+    const bool is_within_range_and_filtering_class = is_within_range && should_be_excluded;
 
     // If the object is not within range or not a class to be filtered, add it directly
     if (!is_within_range_and_filtering_class) {
@@ -273,7 +273,7 @@ PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & i
 
     if (was_observed) {
       observed_it->timestamp = current_object_time;
-      // Add without filtering
+      // Add without exclusion check
       filtered_objects.objects.push_back(object);
     } else {
       // Add as a newly observed object and to the ignore list
@@ -298,7 +298,7 @@ void CollisionDetectorNode::removeOldObjects(
     container.end());
 }
 
-bool CollisionDetectorNode::shouldBeFiltered(
+bool CollisionDetectorNode::shouldBeExcluded(
   const autoware_perception_msgs::msg::ObjectClassification::_label_type & classification) const
 {
   switch (classification) {

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -1,0 +1,357 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/collision_detector/node.hpp"
+
+#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <boost/assert.hpp>
+#include <boost/assign/list_of.hpp>
+#include <boost/format.hpp>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+#include <pcl/common/transforms.h>
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#define EIGEN_MPL2_ONLY
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace autoware::collision_detector
+{
+namespace bg = boost::geometry;
+using Point2d = bg::model::d2::point_xy<double>;
+using Polygon2d = bg::model::polygon<Point2d>;
+using autoware::universe_utils::createPoint;
+using autoware::universe_utils::pose2transform;
+
+namespace
+{
+
+geometry_msgs::msg::Point32 createPoint32(const double x, const double y, const double z)
+{
+  geometry_msgs::msg::Point32 p;
+  p.x = x;
+  p.y = y;
+  p.z = z;
+  return p;
+}
+
+Polygon2d createObjPolygon(
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Polygon & footprint)
+{
+  geometry_msgs::msg::Polygon transformed_polygon{};
+  geometry_msgs::msg::TransformStamped geometry_tf{};
+  geometry_tf.transform = pose2transform(pose);
+  tf2::doTransform(footprint, transformed_polygon, geometry_tf);
+
+  Polygon2d object_polygon;
+  for (const auto & p : transformed_polygon.points) {
+    object_polygon.outer().push_back(Point2d(p.x, p.y));
+  }
+
+  bg::correct(object_polygon);
+
+  return object_polygon;
+}
+
+Polygon2d createObjPolygon(
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & size)
+{
+  const double & length_m = size.x / 2.0;
+  const double & width_m = size.y / 2.0;
+
+  geometry_msgs::msg::Polygon polygon{};
+
+  polygon.points.push_back(createPoint32(length_m, -width_m, 0.0));
+  polygon.points.push_back(createPoint32(length_m, width_m, 0.0));
+  polygon.points.push_back(createPoint32(-length_m, width_m, 0.0));
+  polygon.points.push_back(createPoint32(-length_m, -width_m, 0.0));
+
+  return createObjPolygon(pose, polygon);
+}
+
+Polygon2d createObjPolygonForCylinder(const geometry_msgs::msg::Pose & pose, const double diameter)
+{
+  geometry_msgs::msg::Polygon polygon{};
+
+  const double radius = diameter * 0.5;
+  // add hexagon points
+  for (int i = 0; i < 6; ++i) {
+    const double angle = 2.0 * M_PI * static_cast<double>(i) / 6.0;
+    const double x = radius * std::cos(angle);
+    const double y = radius * std::sin(angle);
+    polygon.points.push_back(createPoint32(x, y, 0.0));
+  }
+
+  return createObjPolygon(pose, polygon);
+}
+
+Polygon2d createSelfPolygon(const VehicleInfo & vehicle_info)
+{
+  const double & front_m = vehicle_info.max_longitudinal_offset_m;
+  const double & width_left_m = vehicle_info.max_lateral_offset_m;
+  const double & width_right_m = vehicle_info.min_lateral_offset_m;
+  const double & rear_m = vehicle_info.min_longitudinal_offset_m;
+
+  Polygon2d ego_polygon;
+
+  ego_polygon.outer().push_back(Point2d(front_m, width_left_m));
+  ego_polygon.outer().push_back(Point2d(front_m, width_right_m));
+  ego_polygon.outer().push_back(Point2d(rear_m, width_right_m));
+  ego_polygon.outer().push_back(Point2d(rear_m, width_left_m));
+
+  bg::correct(ego_polygon);
+
+  return ego_polygon;
+}
+}  // namespace
+
+CollisionDetectorNode::CollisionDetectorNode(const rclcpp::NodeOptions & node_options)
+: Node("collision_detector_node", node_options),
+  node_param_(),
+  vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo()),
+  updater_(this)
+{
+  // Parameters
+  {
+    auto & p = node_param_;
+    p.use_pointcloud = this->declare_parameter<bool>("use_pointcloud");
+    p.use_dynamic_object = this->declare_parameter<bool>("use_dynamic_object");
+    p.collision_distance = this->declare_parameter<double>("collision_distance");
+  }
+
+  vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
+
+  // Subscribers
+  sub_pointcloud_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+    "~/input/pointcloud", rclcpp::SensorDataQoS(),
+    std::bind(&CollisionDetectorNode::onPointCloud, this, std::placeholders::_1));
+  sub_dynamic_objects_ = this->create_subscription<PredictedObjects>(
+    "~/input/objects", 1,
+    std::bind(&CollisionDetectorNode::onDynamicObjects, this, std::placeholders::_1));
+
+  sub_operation_mode_ = this->create_subscription<autoware_adapi_v1_msgs::msg::OperationModeState>(
+    "/api/operation_mode/state", rclcpp::QoS{1}.transient_local(),
+    std::bind(&CollisionDetectorNode::onOperationMode, this, std::placeholders::_1));
+
+  last_obstacle_found_stamp_ = this->now();
+
+  // Diagnostics Updater
+  updater_.setHardwareID("collision_detector");
+  updater_.add("collision_check", this, &CollisionDetectorNode::checkCollision);
+  updater_.setPeriod(0.1);
+}
+
+void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  if (node_param_.use_pointcloud && !pointcloud_ptr_) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for pointcloud info...");
+    return;
+  }
+
+  if (node_param_.use_dynamic_object && !object_ptr_) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
+    return;
+  }
+
+  if (!operation_mode_ptr_) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for operation mode info...");
+    return;
+  }
+
+  const auto nearest_obstacle = getNearestObstacle();
+
+  const auto is_obstacle_found =
+    !nearest_obstacle ? false : nearest_obstacle.get().first < node_param_.collision_distance;
+
+  if (is_obstacle_found) {
+    last_obstacle_found_stamp_ = this->now();
+  }
+
+  const auto is_obstacle_found_recently =
+    (this->now() - last_obstacle_found_stamp_).seconds() < 1.0;
+
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  if (
+    operation_mode_ptr_->mode == OperationModeState::AUTONOMOUS &&
+    (is_obstacle_found || is_obstacle_found_recently)) {
+    status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    status.message = "collision detected";
+    if (is_obstacle_found) {
+      stat.addf("Distance to nearest neighbor object", "%lf", nearest_obstacle.get().first);
+    }
+  } else {
+    status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  }
+
+  stat.summary(status.level, status.message);
+}
+
+void CollisionDetectorNode::onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
+{
+  pointcloud_ptr_ = msg;
+}
+
+void CollisionDetectorNode::onDynamicObjects(const PredictedObjects::ConstSharedPtr msg)
+{
+  object_ptr_ = msg;
+}
+
+void CollisionDetectorNode::onOperationMode(const OperationModeState::ConstSharedPtr msg)
+{
+  operation_mode_ptr_ = msg;
+}
+
+boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacle() const
+{
+  boost::optional<Obstacle> nearest_pointcloud{boost::none};
+  boost::optional<Obstacle> nearest_object{boost::none};
+
+  if (node_param_.use_pointcloud) {
+    nearest_pointcloud = getNearestObstacleByPointCloud();
+  }
+
+  if (node_param_.use_dynamic_object) {
+    nearest_object = getNearestObstacleByDynamicObject();
+  }
+
+  if (!nearest_pointcloud && !nearest_object) {
+    return {};
+  }
+
+  if (!nearest_pointcloud) {
+    return nearest_object;
+  }
+
+  if (!nearest_object) {
+    return nearest_pointcloud;
+  }
+
+  return nearest_pointcloud.get().first < nearest_object.get().first ? nearest_pointcloud
+                                                                     : nearest_object;
+}
+
+boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByPointCloud() const
+{
+  const auto transform_stamped =
+    getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
+
+  geometry_msgs::msg::Point nearest_point;
+  auto minimum_distance = std::numeric_limits<double>::max();
+
+  if (!transform_stamped) {
+    return {};
+  }
+
+  Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.get().transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
+  pcl::fromROSMsg(*pointcloud_ptr_, transformed_pointcloud);
+  pcl::transformPointCloud(transformed_pointcloud, transformed_pointcloud, isometry);
+
+  const auto ego_polygon = createSelfPolygon(vehicle_info_);
+
+  for (const auto & p : transformed_pointcloud) {
+    Point2d boost_point(p.x, p.y);
+
+    const auto distance_to_object = bg::distance(ego_polygon, boost_point);
+
+    if (distance_to_object < minimum_distance) {
+      nearest_point = createPoint(p.x, p.y, p.z);
+      minimum_distance = distance_to_object;
+    }
+  }
+
+  return std::make_pair(minimum_distance, nearest_point);
+}
+
+boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByDynamicObject() const
+{
+  const auto transform_stamped =
+    getTransform(object_ptr_->header.frame_id, "base_link", object_ptr_->header.stamp, 0.5);
+
+  geometry_msgs::msg::Point nearest_point;
+  auto minimum_distance = std::numeric_limits<double>::max();
+
+  if (!transform_stamped) {
+    return {};
+  }
+
+  tf2::Transform tf_src2target;
+  tf2::fromMsg(transform_stamped.get().transform, tf_src2target);
+
+  const auto ego_polygon = createSelfPolygon(vehicle_info_);
+
+  for (const auto & object : object_ptr_->objects) {
+    const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
+
+    tf2::Transform tf_src2object;
+    tf2::fromMsg(object_pose, tf_src2object);
+
+    geometry_msgs::msg::Pose transformed_object_pose;
+    tf2::toMsg(tf_src2target.inverse() * tf_src2object, transformed_object_pose);
+
+    const auto object_polygon = [&]() {
+      switch (object.shape.type) {
+        case Shape::POLYGON:
+          return createObjPolygon(transformed_object_pose, object.shape.footprint);
+        case Shape::CYLINDER:
+          return createObjPolygonForCylinder(transformed_object_pose, object.shape.dimensions.x);
+        case Shape::BOUNDING_BOX:
+          return createObjPolygon(transformed_object_pose, object.shape.dimensions);
+        default:
+          // node return warning
+          RCLCPP_WARN(this->get_logger(), "Unsupported shape type: %d", object.shape.type);
+          return createObjPolygon(transformed_object_pose, object.shape.dimensions);
+      }
+    }();
+
+    const auto distance_to_object = bg::distance(ego_polygon, object_polygon);
+
+    if (distance_to_object < minimum_distance) {
+      nearest_point = object_pose.position;
+      minimum_distance = distance_to_object;
+    }
+  }
+
+  return std::make_pair(minimum_distance, nearest_point);
+}
+
+boost::optional<geometry_msgs::msg::TransformStamped> CollisionDetectorNode::getTransform(
+  const std::string & source, const std::string & target, const rclcpp::Time & stamp,
+  double duration_sec) const
+{
+  geometry_msgs::msg::TransformStamped transform_stamped;
+
+  try {
+    transform_stamped =
+      tf_buffer_.lookupTransform(source, target, stamp, tf2::durationFromSec(duration_sec));
+  } catch (tf2::TransformException & ex) {
+    return {};
+  }
+
+  return transform_stamped;
+}
+
+}  // namespace autoware::collision_detector
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::collision_detector::CollisionDetectorNode)


### PR DESCRIPTION
## Description
This PR contains the initial implementation of the autoware_collision_detector.
Please refer to this [issue](https://github.com/autowarefoundation/autoware.universe/issues/9145) for further information.

## Related links

**Parent Issue:**
- https://github.com/autowarefoundation/autoware.universe/issues/9145


## How was this PR tested?
Colcon build is successful 

## Notes for reviewers
Launch files for control would be changed in a different PR

## Interface changes
### Input

| Name                                           | Type                                                   | Description                                                        |
| ---------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------ |
| `/perception/obstacle_segmentation/pointcloud` | `sensor_msgs::msg::PointCloud2`                        | Pointcloud of obstacles which the ego-vehicle should stop or avoid |
| `/perception/object_recognition/objects`       | `autoware_perception_msgs::msg::PredictedObjects` | Dynamic objects                                                    |
| `/tf`                                          | `tf2_msgs::msg::TFMessage`                             | TF                                                                 |
| `/tf_static`                                   | `tf2_msgs::msg::TFMessage`                             | TF static                                                          |

### Output

| Name           | Type                                    | Description |
| -------------- | --------------------------------------- | ----------- |
| `/diagnostics` | `diagnostic_msgs::msg::DiagnosticArray` | Diagnostics |

## Parameters

| Name                         | Type                    | Description                                                                              | Default value                    |
| :--------------------------- | :---------------------- | :--------------------------------------------------------------------------------------- | :------------------------------- |
| `use_pointcloud`             | `bool`                  | Use pointcloud as obstacle check                                                         | `true`                           |
| `use_dynamic_object`         | `bool`                  | Use dynamic object as obstacle check                                                     | `true`                           |
| `collision_distance`         | `double`                | Distance threshold at which an object is considered a collision. [m]                     | 0.15                             |
| `nearby_filter_radius`       | `double`                | Distance range for filtering objects. Objects within this radius are considered. [m]     | 5.0                              |
| `keep_ignoring_time`         | `double`                | Time to keep filtering objects that first appeared in the vicinity [sec]                 | 10.0                             |
| `nearby_object_type_filters` | `object of bool values` | Specifies which object types to filter. Only objects with `true` value will be filtered. | `{unknown: true, others: false}` |

## Effects on system behavior

None.
