### PR TITLE
perf(costmap_generator): manual blurring and fill polygons without OpenCV

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
@@ -3,8 +3,7 @@
   <group if="$(var launch_parking_module)">
     <push-ros-namespace namespace="parking"/>
 
-    <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
-      <composable_node pkg="autoware_costmap_generator" plugin="autoware::costmap_generator::CostmapGenerator" name="costmap_generator" namespace="">
+      <node pkg="autoware_costmap_generator" exec="costmap_generator" name="costmap_generator" namespace="" launch-prefix="konsole -e gdb -ex run --args">
         <!-- topic remap -->
         <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
         <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -15,9 +14,10 @@
         <!-- params -->
         <param from="$(var vehicle_param_file)"/>
         <param from="$(var costmap_generator_param_path)"/>
-        <extra_arg name="use_intra_process_comms" value="false"/>
-      </composable_node>
+        <!-- <extra_arg name="use_intra_process_comms" value="false"/> -->
+      </node>
 
+    <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
       <composable_node pkg="autoware_freespace_planner" plugin="autoware::freespace_planner::FreespacePlannerNode" name="freespace_planner" namespace="">
         <!-- topic remap -->
         <remap from="~/input/route" to="/planning/mission_planning/route"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
@@ -3,7 +3,8 @@
   <group if="$(var launch_parking_module)">
     <push-ros-namespace namespace="parking"/>
 
-      <node pkg="autoware_costmap_generator" exec="costmap_generator" name="costmap_generator" namespace="" launch-prefix="konsole -e gdb -ex run --args">
+    <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
+      <composable_node pkg="autoware_costmap_generator" plugin="autoware::costmap_generator::CostmapGenerator" name="costmap_generator" namespace="">
         <!-- topic remap -->
         <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
         <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -14,10 +15,9 @@
         <!-- params -->
         <param from="$(var vehicle_param_file)"/>
         <param from="$(var costmap_generator_param_path)"/>
-        <!-- <extra_arg name="use_intra_process_comms" value="false"/> -->
-      </node>
+        <extra_arg name="use_intra_process_comms" value="false"/>
+      </composable_node>
 
-    <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
       <composable_node pkg="autoware_freespace_planner" plugin="autoware::freespace_planner::FreespacePlannerNode" name="freespace_planner" namespace="">
         <!-- topic remap -->
         <remap from="~/input/route" to="/planning/mission_planning/route"/>

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
@@ -106,7 +106,7 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  std::vector<std::vector<geometry_msgs::msg::Point>> primitives_points_;
+  std::vector<geometry_msgs::msg::Polygon> primitives_polygons_;
 
   PointsToCostmap points2costmap_;
   ObjectsToCostmap objects2costmap_;
@@ -150,19 +150,19 @@ private:
   /// \param[in] gridmap with calculated cost
   void publishCostmap(const grid_map::GridMap & costmap);
 
-  /// \brief set area_points from lanelet polygons
-  /// \param [in] input lanelet_map
-  /// \param [out] calculated area_points of lanelet polygons
+  /// \brief fill a vector with road area polygons
+  /// \param [in] lanelet_map input lanelet map
+  /// \param [out] area_polygons polygon vector to fill
   void loadRoadAreasFromLaneletMap(
     const lanelet::LaneletMapPtr lanelet_map,
-    std::vector<std::vector<geometry_msgs::msg::Point>> * area_points);
+    std::vector<geometry_msgs::msg::Polygon> & area_polygons);
 
-  /// \brief set area_points from parking-area polygons
-  /// \param [in] input lanelet_map
-  /// \param [out] calculated area_points of lanelet polygons
+  /// \brief fill a vector with parking-area polygons
+  /// \param [in] lanelet_map input lanelet map
+  /// \param [out] area_polygons polygon vector to fill
   void loadParkingAreasFromLaneletMap(
     const lanelet::LaneletMapPtr lanelet_map,
-    std::vector<std::vector<geometry_msgs::msg::Point>> * area_points);
+    std::vector<geometry_msgs::msg::Polygon> & area_polygons);
 
   /// \brief calculate cost from pointcloud data
   /// \param[in] in_points: subscribed pointcloud data

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/costmap_generator.hpp
@@ -70,7 +70,6 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace autoware::costmap_generator
@@ -108,7 +107,7 @@ private:
 
   std::vector<geometry_msgs::msg::Polygon> primitives_polygons_;
 
-  PointsToCostmap points2costmap_;
+  PointsToCostmap points2costmap_{};
   ObjectsToCostmap objects2costmap_;
 
   tier4_planning_msgs::msg::Scenario::ConstSharedPtr scenario_;
@@ -153,14 +152,14 @@ private:
   /// \brief fill a vector with road area polygons
   /// \param [in] lanelet_map input lanelet map
   /// \param [out] area_polygons polygon vector to fill
-  void loadRoadAreasFromLaneletMap(
+  static void loadRoadAreasFromLaneletMap(
     const lanelet::LaneletMapPtr lanelet_map,
     std::vector<geometry_msgs::msg::Polygon> & area_polygons);
 
   /// \brief fill a vector with parking-area polygons
   /// \param [in] lanelet_map input lanelet map
   /// \param [out] area_polygons polygon vector to fill
-  void loadParkingAreasFromLaneletMap(
+  static void loadParkingAreasFromLaneletMap(
     const lanelet::LaneletMapPtr lanelet_map,
     std::vector<geometry_msgs::msg::Polygon> & area_polygons);
 

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/object_map_utils.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/object_map_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020-2024 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,46 +33,38 @@
 #ifndef AUTOWARE_COSTMAP_GENERATOR__OBJECT_MAP_UTILS_HPP_
 #define AUTOWARE_COSTMAP_GENERATOR__OBJECT_MAP_UTILS_HPP_
 
-#include <grid_map_cv/grid_map_cv.hpp>
 #include <grid_map_ros/grid_map_ros.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <geometry_msgs/msg/polygon.hpp>
 #include <grid_map_msgs/msg/grid_map.hpp>
-
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <string>
 #include <vector>
 
-namespace object_map
+namespace autoware::costmap_generator::object_map
 {
 /*!
- * Projects the in_area_points forming the road, stores the result in out_grid_map.
+ * Fill the grid_map in the areas defined by the given polygons
  * @param[out] out_grid_map GridMap object to add the road grid
- * @param[in] in_points Array of points containing the selected primitives
+ * @param[in] in_polygons polygons to fill in the grid map
  * @param[in] in_grid_layer_name Name to assign to the layer
  * @param[in] in_layer_background_value Empty state value
- * @param[in] in_fill_color Value to fill on selected primitives
- * @param[in] in_layer_min_value Minimum value in the layer
- * @param[in] in_layer_max_value Maximum value in the layer
+ * @param[in] in_fill_value Value to fill inside the given polygons
  * @param[in] in_tf_target_frame Target frame to transform the points
  * @param[in] in_tf_source_frame Source frame, where the points are located
  * @param[in] in_tf_listener Valid listener to obtain the transformation
  */
-void FillPolygonAreas(
-  grid_map::GridMap & out_grid_map,
-  const std::vector<std::vector<geometry_msgs::msg::Point>> & in_points,
-  const std::string & in_grid_layer_name, const int in_layer_background_value,
-  const int in_fill_color, const int in_layer_min_value, const int in_layer_max_value,
-  const std::string & in_tf_target_frame, const std::string & in_tf_source_frame,
-  const tf2_ros::Buffer & in_tf_buffer);
+void fill_polygon_areas(
+  grid_map::GridMap & out_grid_map, const std::vector<geometry_msgs::msg::Polygon> & in_polygons,
+  const std::string & in_grid_layer_name, const float in_layer_background_value,
+  const float in_fill_value, const std::string & in_tf_target_frame,
+  const std::string & in_tf_source_frame, const tf2_ros::Buffer & in_tf_buffer);
 
-}  // namespace object_map
+}  // namespace autoware::costmap_generator::object_map
 
 #endif  // AUTOWARE_COSTMAP_GENERATOR__OBJECT_MAP_UTILS_HPP_

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/objects_to_costmap.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/objects_to_costmap.hpp
@@ -103,7 +103,7 @@ private:
   /// \param[in] in_corner_point one of convex hull points
   /// \param[in] expand_polygon_size  the param for expanding convex_hull points
   /// \param[out] expanded point
-  geometry_msgs::msg::Point makeExpandedPoint(
+  static geometry_msgs::msg::Point makeExpandedPoint(
     const geometry_msgs::msg::Point & in_centroid,
     const geometry_msgs::msg::Point32 & in_corner_point, const double expand_polygon_size);
 
@@ -111,7 +111,7 @@ private:
   /// \param[in] in_centroid: object's centroid
   /// \param[in] expand_polygon_size: expanding convex_hull points
   /// \param[out] polygon object with convex hull points
-  grid_map::Polygon makePolygonFromObjectConvexHull(
+  static grid_map::Polygon makePolygonFromObjectConvexHull(
     const std_msgs::msg::Header & header,
     const autoware_perception_msgs::msg::PredictedObject & in_object,
     const double expand_polygon_size);
@@ -121,7 +121,7 @@ private:
   /// \param[in] gridmap_layer_name: target gridmap layer name for calculated cost
   /// \param[in] score: set score as a cost for costmap
   /// \param[in] objects_costmap: update cost in this objects_costmap[gridmap_layer_name]
-  void setCostInPolygon(
+  static void setCostInPolygon(
     const grid_map::Polygon & polygon, const std::string & gridmap_layer_name, const float score,
     grid_map::GridMap & objects_costmap);
 };

--- a/planning/autoware_costmap_generator/include/autoware_costmap_generator/objects_to_costmap.hpp
+++ b/planning/autoware_costmap_generator/include/autoware_costmap_generator/objects_to_costmap.hpp
@@ -72,7 +72,7 @@ public:
   /// \param[out] calculated cost in grid_map::Matrix format
   grid_map::Matrix makeCostmapFromObjects(
     const grid_map::GridMap & costmap, const double expand_polygon_size,
-    const double size_of_expansion_kernel,
+    const int64_t size_of_expansion_kernel,
     const autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr in_objects);
 
 private:

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
@@ -92,15 +92,14 @@ std::shared_ptr<lanelet::ConstPolygon3d> findNearestParkinglot(
   const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr,
   const lanelet::BasicPoint2d & current_position)
 {
-  const auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
+  auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
   const auto result = lanelet::utils::query::getLinkedParkingLot(
     current_position, lanelet_map_ptr, linked_parking_lot.get());
 
   if (result) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 // copied from scenario selector
@@ -336,11 +335,10 @@ bool CostmapGenerator::isActive()
       }
     }
     return false;
-  } else {
-    const auto & current_pose_wrt_map = getCurrentPose(tf_buffer_, this->get_logger());
-    if (!current_pose_wrt_map) return false;
-    return isInParkingLot(lanelet_map_, current_pose_wrt_map->pose);
   }
+  const auto & current_pose_wrt_map = getCurrentPose(tf_buffer_, this->get_logger());
+  if (!current_pose_wrt_map) return false;
+  return isInParkingLot(lanelet_map_, current_pose_wrt_map->pose);
 }
 
 void CostmapGenerator::initGridmap()
@@ -393,7 +391,8 @@ autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr transformObjects
   }
 
   for (auto & object : objects->objects) {
-    geometry_msgs::msg::PoseStamped output_stamped, input_stamped;
+    geometry_msgs::msg::PoseStamped output_stamped;
+    geometry_msgs::msg::PoseStamped input_stamped;
     input_stamped.pose = object.kinematics.initial_pose_with_covariance.pose;
     tf2::doTransform(input_stamped, output_stamped, objects2costmap);
     object.kinematics.initial_pose_with_covariance.pose = output_stamped.pose;

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/costmap_generator_node.cpp
@@ -52,6 +52,7 @@
 #include <pcl_ros/transforms.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
+#include <lanelet2_core/Forward.h>
 #include <lanelet2_core/geometry/Polygon.h>
 #include <tf2/time.h>
 #include <tf2/utils.h>
@@ -118,20 +119,6 @@ bool isInParkingLot(
   }
 
   return lanelet::geometry::within(search_point, nearest_parking_lot->basicPolygon());
-}
-
-// Convert from Point32 to Point
-std::vector<geometry_msgs::msg::Point> poly2vector(const geometry_msgs::msg::Polygon & poly)
-{
-  std::vector<geometry_msgs::msg::Point> ps;
-  for (const auto & p32 : poly.points) {
-    geometry_msgs::msg::Point p;
-    p.x = p32.x;
-    p.y = p32.y;
-    p.z = p32.z;
-    ps.push_back(p);
-  }
-  return ps;
 }
 
 pcl::PointCloud<pcl::PointXYZ> getTransformedPointCloud(
@@ -206,7 +193,7 @@ CostmapGenerator::CostmapGenerator(const rclcpp::NodeOptions & node_options)
 
 void CostmapGenerator::loadRoadAreasFromLaneletMap(
   const lanelet::LaneletMapPtr lanelet_map,
-  std::vector<std::vector<geometry_msgs::msg::Point>> * area_points)
+  std::vector<geometry_msgs::msg::Polygon> & area_polygons)
 {
   // use all lanelets in map of subtype road to give way area
   lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map);
@@ -215,21 +202,25 @@ void CostmapGenerator::loadRoadAreasFromLaneletMap(
   // convert lanelets to polygons and put into area_points array
   for (const auto & ll : road_lanelets) {
     geometry_msgs::msg::Polygon poly;
-    lanelet::visualization::lanelet2Polygon(ll, &poly);
-    area_points->push_back(poly2vector(poly));
+    geometry_msgs::msg::Point32 pt;
+    for (const auto & p : ll.polygon3d().basicPolygon()) {
+      lanelet::utils::conversion::toGeomMsgPt32(p, &pt);
+      poly.points.push_back(pt);
+    }
+    area_polygons.push_back(poly);
   }
 }
 
 void CostmapGenerator::loadParkingAreasFromLaneletMap(
   const lanelet::LaneletMapPtr lanelet_map,
-  std::vector<std::vector<geometry_msgs::msg::Point>> * area_points)
+  std::vector<geometry_msgs::msg::Polygon> & area_polygons)
 {
   // Parking lots
   lanelet::ConstPolygons3d all_parking_lots = lanelet::utils::query::getAllParkingLots(lanelet_map);
   for (const auto & ll_poly : all_parking_lots) {
     geometry_msgs::msg::Polygon poly;
     lanelet::utils::conversion::toGeomMsgPoly(ll_poly, &poly);
-    area_points->push_back(poly2vector(poly));
+    area_polygons.push_back(poly);
   }
 
   // Parking spaces
@@ -238,10 +229,9 @@ void CostmapGenerator::loadParkingAreasFromLaneletMap(
   for (const auto & parking_space : all_parking_spaces) {
     lanelet::ConstPolygon3d ll_poly;
     lanelet::utils::lineStringWithWidthToPolygon(parking_space, &ll_poly);
-
     geometry_msgs::msg::Polygon poly;
     lanelet::utils::conversion::toGeomMsgPoly(ll_poly, &poly);
-    area_points->push_back(poly2vector(poly));
+    area_polygons.push_back(poly);
   }
 }
 
@@ -252,11 +242,11 @@ void CostmapGenerator::onLaneletMapBin(
   lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_);
 
   if (param_->use_wayarea) {
-    loadRoadAreasFromLaneletMap(lanelet_map_, &primitives_points_);
+    loadRoadAreasFromLaneletMap(lanelet_map_, primitives_polygons_);
   }
 
   if (param_->use_parkinglot) {
-    loadParkingAreasFromLaneletMap(lanelet_map_, &primitives_points_);
+    loadParkingAreasFromLaneletMap(lanelet_map_, primitives_polygons_);
   }
 }
 
@@ -428,11 +418,10 @@ grid_map::Matrix CostmapGenerator::generateObjectsCostmap(
 grid_map::Matrix CostmapGenerator::generatePrimitivesCostmap()
 {
   grid_map::GridMap lanelet2_costmap = costmap_;
-  if (!primitives_points_.empty()) {
-    object_map::FillPolygonAreas(
-      lanelet2_costmap, primitives_points_, LayerName::primitives, param_->grid_max_value,
-      param_->grid_min_value, param_->grid_min_value, param_->grid_max_value, param_->costmap_frame,
-      param_->map_frame, tf_buffer_);
+  if (!primitives_polygons_.empty()) {
+    object_map::fill_polygon_areas(
+      lanelet2_costmap, primitives_polygons_, LayerName::primitives, param_->grid_max_value,
+      param_->grid_min_value, param_->costmap_frame, param_->map_frame, tf_buffer_);
   }
   return lanelet2_costmap[LayerName::primitives];
 }

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/objects_to_costmap.cpp
@@ -44,6 +44,7 @@
 
 #include "autoware_costmap_generator/objects_to_costmap.hpp"
 
+#include <autoware_grid_map_utils/polygon_iterator.hpp>
 #include <grid_map_core/TypeDefs.hpp>
 
 #include <Eigen/src/Core/util/Constants.h>
@@ -151,7 +152,7 @@ void ObjectsToCostmap::setCostInPolygon(
   const grid_map::Polygon & polygon, const std::string & gridmap_layer_name, const float score,
   grid_map::GridMap & objects_costmap)
 {
-  for (grid_map::PolygonIterator itr(objects_costmap, polygon); !itr.isPastEnd(); ++itr) {
+  for (grid_map_utils::PolygonIterator itr(objects_costmap, polygon); !itr.isPastEnd(); ++itr) {
     const float current_score = objects_costmap.at(gridmap_layer_name, *itr);
     if (score > current_score) {
       objects_costmap.at(gridmap_layer_name, *itr) = score;

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/objects_to_costmap.cpp
@@ -44,6 +44,9 @@
 
 #include "autoware_costmap_generator/objects_to_costmap.hpp"
 
+#include <grid_map_core/TypeDefs.hpp>
+
+#include <Eigen/src/Core/util/Constants.h>
 #include <tf2/utils.h>
 
 #include <cmath>
@@ -156,14 +159,39 @@ void ObjectsToCostmap::setCostInPolygon(
   }
 }
 
+void naive_mean_filter_on_grid_edges(
+  grid_map::Matrix & output, const grid_map::Matrix & input, const int kernel_size)
+{
+  for (auto i = 0; i < input.rows(); ++i) {
+    for (auto j = 0; j < input.cols(); ++j) {
+      const auto is_inside =
+        (i > kernel_size + 1 && j > kernel_size + 1) &&
+        (i + kernel_size + 1 < input.rows() && j + kernel_size + 1 < input.cols());
+      if (is_inside) {
+        continue;
+      }
+      auto size = 0.0f;
+      auto sum = 0.0f;
+      for (auto i_offset = std::max(0, i - kernel_size);
+           i_offset < i + kernel_size && i_offset < input.rows(); ++i_offset) {
+        for (auto j_offset = std::max(0, j - kernel_size);
+             j_offset < j + kernel_size && j_offset < input.cols(); ++j_offset) {
+          ++size;
+          sum += input(i_offset, j_offset);
+        }
+      }
+      output(i, j) = sum / size;
+    }
+  }
+}
+
 grid_map::Matrix ObjectsToCostmap::makeCostmapFromObjects(
   const grid_map::GridMap & costmap, const double expand_polygon_size,
-  const double size_of_expansion_kernel,
+  const int64_t size_of_expansion_kernel,
   const autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr in_objects)
 {
   grid_map::GridMap objects_costmap = costmap;
   objects_costmap.add(OBJECTS_COSTMAP_LAYER_, 0);
-  objects_costmap.add(BLURRED_OBJECTS_COSTMAP_LAYER_, 0);
 
   for (const auto & object : in_objects->objects) {
     grid_map::Polygon polygon;
@@ -180,21 +208,26 @@ grid_map::Matrix ObjectsToCostmap::makeCostmapFromObjects(
       [](const auto & c1, const auto & c2) { return c1.probability < c2.probability; });
     const double highest_probability = static_cast<double>(highest_probability_label.probability);
     setCostInPolygon(polygon, OBJECTS_COSTMAP_LAYER_, highest_probability, objects_costmap);
-    setCostInPolygon(polygon, BLURRED_OBJECTS_COSTMAP_LAYER_, highest_probability, objects_costmap);
   }
+  objects_costmap.add(BLURRED_OBJECTS_COSTMAP_LAYER_, 0.0);
 
   // Applying mean filter to expanded gridmap
-  const grid_map::SlidingWindowIterator::EdgeHandling edge_handling =
-    grid_map::SlidingWindowIterator::EdgeHandling::CROP;
-  for (grid_map::SlidingWindowIterator iterator(
-         objects_costmap, BLURRED_OBJECTS_COSTMAP_LAYER_, edge_handling, size_of_expansion_kernel);
-       !iterator.isPastEnd(); ++iterator) {
-    objects_costmap.at(BLURRED_OBJECTS_COSTMAP_LAYER_, *iterator) =
-      iterator.getData().meanOfFinites();  // Blurring.
+  const auto & original_matrix = objects_costmap[OBJECTS_COSTMAP_LAYER_];
+  Eigen::MatrixXf & filtered_matrix = objects_costmap[BLURRED_OBJECTS_COSTMAP_LAYER_];
+  // edge of the grid: naive filter
+  const auto kernel_size = static_cast<int>(size_of_expansion_kernel / 2.0);
+  naive_mean_filter_on_grid_edges(filtered_matrix, original_matrix, kernel_size);
+  // inside the grid: optimized filter using Eigen block
+  for (auto i = 0; i < filtered_matrix.rows() - size_of_expansion_kernel; ++i) {
+    for (auto j = 0; j < filtered_matrix.cols() - size_of_expansion_kernel; ++j) {
+      const auto mean =
+        original_matrix.block(i, j, size_of_expansion_kernel, size_of_expansion_kernel).mean();
+      filtered_matrix(i + kernel_size, j + kernel_size) = mean;
+    }
   }
 
-  objects_costmap[OBJECTS_COSTMAP_LAYER_] = objects_costmap[OBJECTS_COSTMAP_LAYER_].cwiseMax(
-    objects_costmap[BLURRED_OBJECTS_COSTMAP_LAYER_]);
+  objects_costmap[OBJECTS_COSTMAP_LAYER_] =
+    objects_costmap[OBJECTS_COSTMAP_LAYER_].cwiseMax(filtered_matrix);
 
   return objects_costmap[OBJECTS_COSTMAP_LAYER_];
 }

--- a/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/nodes/autoware_costmap_generator/objects_to_costmap.cpp
@@ -161,7 +161,8 @@ void ObjectsToCostmap::setCostInPolygon(
 }
 
 void naive_mean_filter_on_grid_edges(
-  grid_map::Matrix & output, const grid_map::Matrix & input, const int kernel_size)
+  // cppcheck-suppress constParameterReference
+  const grid_map::Matrix & input, const int kernel_size, grid_map::Matrix & output)
 {
   for (auto i = 0; i < input.rows(); ++i) {
     for (auto j = 0; j < input.cols(); ++j) {
@@ -207,8 +208,8 @@ grid_map::Matrix ObjectsToCostmap::makeCostmapFromObjects(
     const auto highest_probability_label = *std::max_element(
       object.classification.begin(), object.classification.end(),
       [](const auto & c1, const auto & c2) { return c1.probability < c2.probability; });
-    const double highest_probability = static_cast<double>(highest_probability_label.probability);
-    setCostInPolygon(polygon, OBJECTS_COSTMAP_LAYER_, highest_probability, objects_costmap);
+    setCostInPolygon(
+      polygon, OBJECTS_COSTMAP_LAYER_, highest_probability_label.probability, objects_costmap);
   }
   objects_costmap.add(BLURRED_OBJECTS_COSTMAP_LAYER_, 0.0);
 
@@ -216,8 +217,8 @@ grid_map::Matrix ObjectsToCostmap::makeCostmapFromObjects(
   const auto & original_matrix = objects_costmap[OBJECTS_COSTMAP_LAYER_];
   Eigen::MatrixXf & filtered_matrix = objects_costmap[BLURRED_OBJECTS_COSTMAP_LAYER_];
   // edge of the grid: naive filter
-  const auto kernel_size = static_cast<int>(size_of_expansion_kernel / 2.0);
-  naive_mean_filter_on_grid_edges(filtered_matrix, original_matrix, kernel_size);
+  const auto kernel_size = static_cast<int>(static_cast<double>(size_of_expansion_kernel) / 2.0);
+  naive_mean_filter_on_grid_edges(original_matrix, kernel_size, filtered_matrix);
   // inside the grid: optimized filter using Eigen block
   for (auto i = 0; i < filtered_matrix.rows() - size_of_expansion_kernel; ++i) {
     for (auto j = 0; j < filtered_matrix.cols() - size_of_expansion_kernel; ++j) {

--- a/planning/autoware_costmap_generator/package.xml
+++ b/planning/autoware_costmap_generator/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_grid_map_utils</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>


### PR DESCRIPTION
## Description

Decrease runtime from 20ms (with 30ms spikes) to 8ms (with 10ms spikes) in my local tests.
The resulting costmap is slightly different but.
| Current | With this PR |
| - | - |
| ![main_occ_grid](https://github.com/user-attachments/assets/6ae13cae-fe85-42d3-ad12-13c2b6903db7) | ![PR_occ_grid](https://github.com/user-attachments/assets/491600b8-2bfd-4ccf-ae3b-a8c5dfa216ec) |


## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-8233)

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
