### PR TITLE
fix(autoware_test_utils): remove unnecessary cppcheck suppression

### DIFF
--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -139,7 +139,6 @@ std::string get_absolute_path_to_lanelet_map(
   return dir + "/test_map/" + map_filename;
 }
 
-// cppcheck-suppress unusedFunction
 std::string get_absolute_path_to_route(
   const std::string & package_name, const std::string & route_filename)
 {


### PR DESCRIPTION
## Description

Due to [this commit](https://github.com/autowarefoundation/autoware.universe/commit/20ebe9d4375e1349f75e45a0a471fcfb80258d72), `get_absolute_path_to_route` is now used and cppcheck suppression is no more necessary.

```
<error id="unmatchedSuppression" severity="information" msg="Unmatched suppression: unusedFunction" verbose="Unmatched suppression: unusedFunction">
  <location file="common/autoware_test_utils/src/autoware_test_utils.cpp" line="143" column="0"/>
</error>
```

## Related links

This is detected by `cppcheck-weekly` workflow
 - this week: https://github.com/autowarefoundation/autoware.universe/actions/runs/11544993073
 - last week: https://github.com/autowarefoundation/autoware.universe/actions/runs/11430819148

## How was this PR tested?

No

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
