### PR TITLE
ci(build-and-test): reduce cores used by colcon build

### DIFF
--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -76,7 +76,7 @@ jobs:
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
-          build-pre-command: taskset --cpu-list 0-6
+          build-pre-command: taskset --cpu-list 0-5
 
       - name: Test
         id: test

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -46,7 +46,7 @@ jobs:
             build-depends-repos: build_depends.repos
           - container-suffix: -cuda
             runner: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
-            build-pre-command: taskset --cpu-list 0-6
+            build-pre-command: taskset --cpu-list 0-5
           - container-suffix: ""
             runner: ubuntu-latest
             build-pre-command: ""

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -93,7 +93,7 @@ jobs:
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
-          build-pre-command: taskset --cpu-list 0-6
+          build-pre-command: taskset --cpu-list 0-5
 
       - name: Show ccache stats after build
         run: du -sh ${CCACHE_DIR} && ccache -s


### PR DESCRIPTION
## Description

Due to codebuild machines possibly running out of memory, this PR attempts to reduce cores used by colcon build to indirectly reduce the memory usage.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/9088

Failed CIs:
- https://github.com/autowarefoundation/autoware.universe/actions/runs/11549889824/job/32143784165
- https://github.com/autowarefoundation/autoware.universe/actions/runs/11345527037

## How was this PR tested?



## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

CI will run slower but more stable.
