### PR TITLE
feat(autoware_test_utils): add traffic light msgs parser

### DIFF
--- a/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
@@ -16,9 +16,11 @@
 #define AUTOWARE_TEST_UTILS__MOCK_DATA_PARSER_HPP_
 
 #include <builtin_interfaces/msg/duration.hpp>
+#include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_primitive.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/lanelet_segment.hpp>
@@ -42,10 +44,15 @@ using autoware_perception_msgs::msg::PredictedObjectKinematics;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
 using autoware_perception_msgs::msg::Shape;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
 using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::LaneletSegment;
 using builtin_interfaces::msg::Duration;
+using builtin_interfaces::msg::Time;
 using geometry_msgs::msg::Accel;
 using geometry_msgs::msg::AccelWithCovariance;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
@@ -78,6 +85,9 @@ Header parse(const YAML::Node & node);
 
 template <>
 Duration parse(const YAML::Node & node);
+
+template <>
+Time parse(const YAML::Node & node);
 
 template <>
 std::vector<Point> parse(const YAML::Node & node);
@@ -141,6 +151,15 @@ PredictedObject parse(const YAML::Node & node);
 
 template <>
 PredictedObjects parse(const YAML::Node & node);
+
+template <>
+TrafficLightGroupArray parse(const YAML::Node & node);
+
+template <>
+TrafficLightGroup parse(const YAML::Node & node);
+
+template <>
+TrafficLightElement parse(const YAML::Node & node);
 
 /**
  * @brief Parses a YAML file and converts it into an object of type T.

--- a/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp
@@ -38,6 +38,7 @@
 
 namespace autoware::test_utils
 {
+using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjectKinematics;
@@ -160,6 +161,9 @@ TrafficLightGroup parse(const YAML::Node & node);
 
 template <>
 TrafficLightElement parse(const YAML::Node & node);
+
+template <>
+OperationModeState parse(const YAML::Node & node);
 
 /**
  * @brief Parses a YAML file and converts it into an object of type T.

--- a/common/autoware_test_utils/src/mock_data_parser.cpp
+++ b/common/autoware_test_utils/src/mock_data_parser.cpp
@@ -45,6 +45,15 @@ Duration parse(const YAML::Node & node)
 }
 
 template <>
+Time parse(const YAML::Node & node)
+{
+  Time msg;
+  msg.sec = node["sec"].as<int>();
+  msg.nanosec = node["nanosec"].as<int>();
+  return msg;
+}
+
+template <>
 std::array<double, 36> parse(const YAML::Node & node)
 {
   std::array<double, 36> msg{};
@@ -317,6 +326,39 @@ PredictedObjects parse(const YAML::Node & node)
   msg.header = parse<Header>(node["header"]);
   for (const auto & object_node : node["objects"]) {
     msg.objects.push_back(parse<PredictedObject>(object_node));
+  }
+  return msg;
+}
+
+template <>
+TrafficLightElement parse(const YAML::Node & node)
+{
+  TrafficLightElement msg;
+  msg.color = node["color"].as<uint8_t>();
+  msg.shape = node["shape"].as<uint8_t>();
+  msg.status = node["status"].as<uint8_t>();
+  msg.confidence = node["confidence"].as<float>();
+  return msg;
+}
+
+template <>
+TrafficLightGroup parse(const YAML::Node & node)
+{
+  TrafficLightGroup msg;
+  msg.traffic_light_group_id = node["traffic_light_group_id"].as<int>();
+  for (const auto & element_node : node["elements"]) {
+    msg.elements.push_back(parse<TrafficLightElement>(element_node));
+  }
+  return msg;
+}
+
+template <>
+TrafficLightGroupArray parse(const YAML::Node & node)
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = parse<Time>(node["stamp"]);
+  for (const auto & traffic_light_group_node : node["traffic_light_groups"]) {
+    msg.traffic_light_groups.push_back(parse<TrafficLightGroup>(traffic_light_group_node));
   }
   return msg;
 }

--- a/common/autoware_test_utils/src/mock_data_parser.cpp
+++ b/common/autoware_test_utils/src/mock_data_parser.cpp
@@ -364,6 +364,21 @@ TrafficLightGroupArray parse(const YAML::Node & node)
 }
 
 template <>
+OperationModeState parse(const YAML::Node & node)
+{
+  OperationModeState msg;
+  msg.stamp = parse<Time>(node["stamp"]);
+  msg.mode = node["mode"].as<uint8_t>();
+  msg.is_autoware_control_enabled = node["is_autoware_control_enabled"].as<bool>();
+  msg.is_in_transition = node["is_in_transition"].as<bool>();
+  msg.is_stop_mode_available = node["is_stop_mode_available"].as<bool>();
+  msg.is_autonomous_mode_available = node["is_autonomous_mode_available"].as<bool>();
+  msg.is_local_mode_available = node["is_local_mode_available"].as<bool>();
+  msg.is_remote_mode_available = node["is_remote_mode_available"].as<bool>();
+  return msg;
+}
+
+template <>
 LaneletRoute parse(const std::string & filename)
 {
   LaneletRoute lanelet_route;

--- a/common/autoware_test_utils/test/test_mock_data_parser.cpp
+++ b/common/autoware_test_utils/test/test_mock_data_parser.cpp
@@ -541,6 +541,15 @@ TEST(ParseFunctions, CompleteYAMLTest)
   EXPECT_EQ(dynamic_object.objects.at(0).shape.type, 0);
   EXPECT_DOUBLE_EQ(dynamic_object.objects.at(0).shape.dimensions.x, 4.40000);
   EXPECT_DOUBLE_EQ(dynamic_object.objects.at(0).shape.dimensions.y, 1.85564);
+
+  const auto traffic_signal = parse<TrafficLightGroupArray>(config["traffic_signal"]);
+  EXPECT_EQ(traffic_signal.stamp.sec, 1730184609);
+  EXPECT_EQ(traffic_signal.stamp.nanosec, 816275300);
+  EXPECT_EQ(traffic_signal.traffic_light_groups.at(0).traffic_light_group_id, 10352);
+  EXPECT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).color, 3);
+  EXPECT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).shape, 1);
+  EXPECT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).status, 2);
+  EXPECT_FLOAT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).confidence, 1.0);
 }
 
 TEST(ParseFunction, CompleteFromFilename)

--- a/common/autoware_test_utils/test/test_mock_data_parser.cpp
+++ b/common/autoware_test_utils/test/test_mock_data_parser.cpp
@@ -448,6 +448,17 @@ traffic_signal:
           shape: 1
           status: 2
           confidence: 1.00000
+operation_mode:
+  stamp:
+    sec: 0
+    nanosec: 204702031
+  mode: 1
+  is_autoware_control_enabled: true
+  is_in_transition: false
+  is_stop_mode_available: true
+  is_autonomous_mode_available: true
+  is_local_mode_available: true
+  is_remote_mode_available: true
 )";
 
 TEST(ParseFunctions, CompleteYAMLTest)
@@ -550,6 +561,17 @@ TEST(ParseFunctions, CompleteYAMLTest)
   EXPECT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).shape, 1);
   EXPECT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).status, 2);
   EXPECT_FLOAT_EQ(traffic_signal.traffic_light_groups.at(0).elements.at(0).confidence, 1.0);
+
+  const auto operation_mode = parse<OperationModeState>(config["operation_mode"]);
+  EXPECT_EQ(operation_mode.stamp.sec, 0);
+  EXPECT_EQ(operation_mode.stamp.nanosec, 204702031);
+  EXPECT_EQ(operation_mode.mode, 1);
+  EXPECT_EQ(operation_mode.is_autoware_control_enabled, true);
+  EXPECT_EQ(operation_mode.is_in_transition, false);
+  EXPECT_EQ(operation_mode.is_stop_mode_available, true);
+  EXPECT_EQ(operation_mode.is_autonomous_mode_available, true);
+  EXPECT_EQ(operation_mode.is_local_mode_available, true);
+  EXPECT_EQ(operation_mode.is_remote_mode_available, true);
 }
 
 TEST(ParseFunction, CompleteFromFilename)


### PR DESCRIPTION
## Description

check diff for this PR here: https://github.com/tier4/autoware.universe/compare/feat/autoware_test_utils/autoware-msgs...tier4:autoware.universe:feat/autoware_test_utils/traffic-light-msgs

depends https://github.com/autowarefoundation/autoware.universe/pull/9176, https://github.com/autowarefoundation/autoware.universe/pull/9174

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
