### PR TITLE
fix(autoware_perception_rviz_plugin, autoware_test_utils): add missing packages and library linking

### DIFF
--- a/common/autoware_perception_rviz_plugin/CMakeLists.txt
+++ b/common/autoware_perception_rviz_plugin/CMakeLists.txt
@@ -4,7 +4,12 @@ project(autoware_perception_rviz_plugin)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(autoware_perception_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(rviz_common REQUIRED)
+find_package(rviz_default_plugins REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 set(OD_PLUGIN_LIB_SRC
   src/object_detection/detected_objects_display.cpp

--- a/common/autoware_perception_rviz_plugin/package.xml
+++ b/common/autoware_perception_rviz_plugin/package.xml
@@ -18,8 +18,10 @@
   <build_depend>qtbase5-dev</build_depend>
 
   <depend>autoware_perception_msgs</depend>
+  <depend>pluginlib</depend>
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
+  <depend>visualization_msgs</depend>
 
   <exec_depend>libqt5-widgets</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/common/autoware_test_utils/CMakeLists.txt
+++ b/common/autoware_test_utils/CMakeLists.txt
@@ -10,6 +10,10 @@ ament_auto_add_library(autoware_test_utils SHARED
 ament_auto_add_library(mock_data_parser SHARED
   src/mock_data_parser.cpp)
 
+target_link_libraries(autoware_test_utils
+  yaml-cpp
+)
+
 target_link_libraries(mock_data_parser
   yaml-cpp
 )


### PR DESCRIPTION
## Description

In `autoware_perception_rviz_plugin`, the source code uses objects from packages that are:
 - either missing from `package.xml` 
 - or they are listed under `<depend>` tag in `package.xml` but do not have a corresponding `find_package()` in `CMakeLists.txt`.

This was causing compilation errors when building from source. This PR adds the necessary fixes.

## How was this PR tested?

Without the fixes in the PR, compilation would fail with:
`/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `vtable for YAML::BadConversion'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::insert_map_pair(YAML::detail::node&, YAML::detail::node&)'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::memory::create_node()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::set_null()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `vtable for YAML::InvalidNode'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `typeinfo for YAML::InvalidNode'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::set_scalar(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::end()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::memory_holder::merge(YAML::detail::memory_holder&)'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::empty_scalar[abi:cxx11]()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::InvalidNode::~InvalidNode()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `typeinfo for YAML::BadSubscript'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `typeinfo for YAML::BadConversion'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::convert_to_map(std::shared_ptr<YAML::detail::memory_holder> const&)'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::begin()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::BadConversion::~BadConversion()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `vtable for YAML::RepresentationException'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::BadSubscript::~BadSubscript()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `vtable for YAML::Exception'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::detail::node_data::mark_defined()'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `YAML::convert<bool>::decode(YAML::Node const&, bool&)'
/usr/bin/ld: /home/mukunda/ros/jazzy-src/perception_ws/install/autoware_test_utils/lib/libautoware_test_utils.so: undefined reference to `vtable for YAML::BadSubscript'
collect2: error: ld returned 1 exit status
`
And other errors related to objects from packages like `visualization_msgs` etc.

After the fixes in this PR, the packages `autoware_perception_rviz_plugin` and `autoware_test_utils` compile successfully.

## Effects on system behavior

None.
