### PR TITLE
fix(autoware_traffic_light_arbiter): fix build error

### DIFF
--- a/perception/autoware_traffic_light_arbiter/test/test_node.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_node.cpp
@@ -15,6 +15,7 @@
 #include "autoware/traffic_light_arbiter/traffic_light_arbiter.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
## Description
Fix build error in autoware_traffic_light_arbiter package.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/8747#
https://github.com/autowarefoundation/autoware.universe/issues/9187

## How was this PR tested?
Colcon build in local PC
```
Starting >>> autoware_traffic_light_arbiter
Finished <<< autoware_traffic_light_arbiter [14.8s]                       

Summary: 1 package finished [16.4s]
```

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
