### PR TITLE
fix(autoware_lidar_apollo_instance_segmentation): fix cppcheck suspiciousFloatingPointCast

### DIFF
--- a/perception/autoware_lidar_apollo_instance_segmentation/src/log_table.cpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/src/log_table.cpp
@@ -26,7 +26,7 @@ struct LogTable
   {
     data.resize(256 * 10);
     for (size_t i = 0; i < data.size(); ++i) {
-      data[i] = std::log1p(static_cast<float>(i / 10.0));
+      data[i] = std::log1p(static_cast<float>(i) * 0.1f);
     }
   }
 };
@@ -44,7 +44,7 @@ float calcApproximateLog(float num)
   if (integer_num < static_cast<int>(log_table.data.size())) {
     return log_table.data[integer_num];
   }
-  return std::log(static_cast<float>(1.0 + num));
+  return std::log1p(num);
 }
 }  // namespace lidar_apollo_instance_segmentation
 }  // namespace autoware


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning
```
perception/autoware_lidar_apollo_instance_segmentation/src/log_table.cpp:29:46: style: Floating-point cast causes loss of precision. [suspiciousFloatingPointCast]
      data[i] = std::log1p(static_cast<float>(i / 10.0));
                                             ^
perception/autoware_lidar_apollo_instance_segmentation/src/log_table.cpp:47:37: style: Floating-point cast causes loss of precision. [suspiciousFloatingPointCast]
  return std::log(static_cast<float>(1.0 + num));
                                    ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
