### PR TITLE
fix(autoware_compare_map_segmentation): fix cppcheck constVariableReference

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp
@@ -207,10 +207,13 @@ public:
   }
   inline std::vector<std::string> getCurrentMapIDs()
   {
-    std::vector<std::string> current_map_ids{};
-    std::lock_guard<std::mutex> lock(dynamic_map_loader_mutex_);
-    for (auto & kv : current_voxel_grid_dict_) {
-      current_map_ids.push_back(kv.first);
+    std::vector<std::string> current_map_ids;
+    {
+      std::lock_guard<std::mutex> lock(dynamic_map_loader_mutex_);
+      current_map_ids.reserve(current_voxel_grid_dict_.size());
+      for (const auto & kv : current_voxel_grid_dict_) {
+        current_map_ids.push_back(kv.first);
+      }
     }
     return current_map_ids;
   }


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning
```
perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.hpp:212:17: style: Variable 'kv' can be declared as reference to const [constVariableReference]
    for (auto & kv : current_voxel_grid_dict_) {
                ^
```

And made some optimization in `getCurrentMapIDs`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
