### PR TITLE
fix(mpc_lateral_controller): correctly resample the MPC trajectory yaws

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -143,7 +143,7 @@ std::pair<bool, MPCTrajectory> resampleMPCTrajectoryByDistance(
   output.x = spline_arc_length(input.x);
   output.y = spline_arc_length(input.y);
   output.z = spline_arc_length(input.z);
-  output.yaw = spline_arc_length(input.yaw);
+  output.yaw = spline_arc_length(input_yaw);
   output.vx = lerp_arc_length(input.vx);  // must be linear
   output.k = spline_arc_length(input.k);
   output.smooth_k = spline_arc_length(input.smooth_k);


### PR DESCRIPTION
## Description

Fix a bug where the trajectory yaw values were incorrectly calculated inside the MPC controller.

When interpolating, we need the yaw values to not "loop" (e.g., `3.14 + epsilon` = `-3.14`). These values were calculated but not used, so this PR simply uses the non-looping values for interpolation.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
