### PR TITLE
feat(mission_planner): use allow_while_using_route

### DIFF
--- a/planning/autoware_mission_planner/config/mission_planner.param.yaml
+++ b/planning/autoware_mission_planner/config/mission_planner.param.yaml
@@ -10,4 +10,3 @@
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
     check_footprint_inside_lanes: true
-    allow_reroute_in_autonomous_mode: true

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -47,7 +47,6 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   map_frame_ = declare_parameter<std::string>("map_frame");
   reroute_time_threshold_ = declare_parameter<double>("reroute_time_threshold");
   minimum_reroute_length_ = declare_parameter<double>("minimum_reroute_length");
-  allow_reroute_in_autonomous_mode_ = declare_parameter<bool>("allow_reroute_in_autonomous_mode");
 
   planner_ =
     plugin_loader_.createSharedInstance("autoware::mission_planner::lanelet2::DefaultPlanner");
@@ -242,9 +241,9 @@ void MissionPlanner::on_set_lanelet_route(
                               operation_mode_state_->is_autoware_control_enabled
                           : false;
 
-  if (is_reroute && !allow_reroute_in_autonomous_mode_ && is_autonomous_driving) {
+  if (is_reroute && !req->allow_while_using_route) {
     throw service_utils::ServiceException(
-      ResponseCode::ERROR_INVALID_STATE, "Reroute is not allowed in autonomous mode.");
+      ResponseCode::ERROR_INVALID_STATE, "Reroute is not allowed while using the route.");
   }
 
   if (is_reroute && is_autonomous_driving) {

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -241,7 +241,7 @@ void MissionPlanner::on_set_lanelet_route(
                               operation_mode_state_->is_autoware_control_enabled
                           : false;
 
-  if (is_reroute && !req->allow_while_using_route) {
+  if (is_reroute && is_autonomous_driving && !req->allow_while_using_route) {
     throw service_utils::ServiceException(
       ResponseCode::ERROR_INVALID_STATE, "Reroute is not allowed while using the route.");
   }

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -135,9 +135,7 @@ private:
 
   double reroute_time_threshold_;
   double minimum_reroute_length_;
-  // flag to allow reroute in autonomous driving mode.
-  // if false, reroute fails. if true, only safe reroute is allowed.
-  bool allow_reroute_in_autonomous_mode_;
+
   bool check_reroute_safety(const LaneletRoute & original_route, const LaneletRoute & target_route);
 
   std::unique_ptr<autoware::universe_utils::LoggerLevelConfigure> logger_configure_;


### PR DESCRIPTION
## Description


use allow_while_using_route
https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/features/routing/#allow_while_using_route

This is because there was a request to change the route only when it is not in use, so that it does not affect the behavior of the vehicle.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- 2024/10/30 https://evaluation.tier4.jp/evaluation/reports/98f703d9-3601-5070-8c20-2e91c8ea0c88/?project_id=prd_jt
- not tested with this option because converter is not implemented

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
