### PR TITLE
fix(bpp): prevent accessing nullopt

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -98,7 +98,7 @@ std::optional<double> calcDistanceToRedTrafficLight(
 
       const auto & ego_pos = planner_data->self_odometry->pose.pose.position;
       lanelet::ConstLineString3d stop_line = *(element->stopLine());
-      if (!stop_line) return std::nullopt;
+      if (!stop_line.empty()) return std::nullopt;
       const auto x = 0.5 * (stop_line.front().x() + stop_line.back().x());
       const auto y = 0.5 * (stop_line.front().y() + stop_line.back().y());
       const auto z = 0.5 * (stop_line.front().z() + stop_line.back().z());

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -98,6 +98,7 @@ std::optional<double> calcDistanceToRedTrafficLight(
 
       const auto & ego_pos = planner_data->self_odometry->pose.pose.position;
       lanelet::ConstLineString3d stop_line = *(element->stopLine());
+      if (!stop_line) return std::nullopt;
       const auto x = 0.5 * (stop_line.front().x() + stop_line.back().x());
       const auto y = 0.5 * (stop_line.front().y() + stop_line.back().y());
       const auto z = 0.5 * (stop_line.front().z() + stop_line.back().z());


### PR DESCRIPTION
## Description

Prevent accessing nullopt in calcDistanceToRedTrafficLight stopline

![image (23)](https://github.com/user-attachments/assets/8c1bd722-046b-44eb-9691-c9b5504f4627)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
