### PR TITLE
feat(static_obstacle_avoidance): operator request for ambiguous vehicle

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -593,6 +593,8 @@ struct AvoidancePlanningData
   double to_start_point{std::numeric_limits<double>::lowest()};
 
   double to_return_point{std::numeric_limits<double>::max()};
+
+  bool request_operator{false};
 };
 
 /*

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -89,7 +89,7 @@ private:
       rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
         uuid_map_.at("left"), isExecutionReady(), State::WAITING_FOR_EXECUTION,
         candidate.start_distance_to_path_change, candidate.finish_distance_to_path_change,
-        clock_->now());
+        clock_->now(), avoid_data_.request_operator);
       candidate_uuid_ = uuid_map_.at("left");
       return;
     }
@@ -97,7 +97,7 @@ private:
       rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
         uuid_map_.at("right"), isExecutionReady(), State::WAITING_FOR_EXECUTION,
         candidate.start_distance_to_path_change, candidate.finish_distance_to_path_change,
-        clock_->now());
+        clock_->now(), avoid_data_.request_operator);
       candidate_uuid_ = uuid_map_.at("right");
       return;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -531,8 +531,10 @@ void StaticObstacleAvoidanceModule::fillShiftLine(
    */
   data.comfortable = helper_->isComfortable(data.new_shift_line);
   data.safe = isSafePath(data.candidate_path, debug);
+  auto avoidance_ready = helper_->isReady(data.target_objects);
   data.ready = helper_->isReady(data.new_shift_line, path_shifter_.getLastShiftLength()) &&
-               helper_->isReady(data.target_objects);
+               avoidance_ready.first;
+  data.request_operator = avoidance_ready.second;
 }
 
 void StaticObstacleAvoidanceModule::fillEgoStatus(

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -531,7 +531,7 @@ void StaticObstacleAvoidanceModule::fillShiftLine(
    */
   data.comfortable = helper_->isComfortable(data.new_shift_line);
   data.safe = isSafePath(data.candidate_path, debug);
-  auto avoidance_ready = helper_->isReady(data.target_objects);
+  const auto avoidance_ready = helper_->isReady(data.target_objects);
   data.ready = helper_->isReady(data.new_shift_line, path_shifter_.getLastShiftLength()) &&
                avoidance_ready.first;
   data.request_operator = avoidance_ready.second;


### PR DESCRIPTION
## Description
This PR would enable operator request via `rtc_interface` for ambiguous objects.
A new variable `request_operator` is introduced in `AvoidancePlanningData` which would be used to update the cooperate status msg in the `rtc_interface`.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/9202

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/1ea74b18-8e29-5d35-ab1d-98e2ca2d3bd3?project_id=prd_jt)
- [x] Put ambiguous vehicle in PSim, and check that the cooperate status is set appropriately 
[Screencast from 2024年10月31日 13時03分09秒.webm](https://github.com/user-attachments/assets/36debac6-b90d-4171-855f-07e77afd81aa)

## Notes for reviewers
The TIER IV internal evaluator would be successful by merging https://github.com/autowarefoundation/autoware.universe/pull/9211 first.

## Interface changes
None.

## Effects on system behavior
None.
