### PR TITLE
fix(rtc_interface): update requested field for every cooperateStatus state

### DIFF
--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -279,6 +279,7 @@ void RTCInterface::updateCooperateStatus(
   auto update_status = [&](auto & status) {
     status.stamp = stamp;
     status.safe = safe;
+    status.requested = requested;
     status.state.type = state;
     status.start_distance = start_distance;
     status.finish_distance = finish_distance;

--- a/planning/autoware_rtc_interface/test/test_rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/test/test_rtc_interface.cpp
@@ -153,7 +153,7 @@ TEST_F(RTCInterfaceTest, uuid_to_string)
   // allowed)
   rtc_interface_->updateCooperateStatus(
     uuid, true, State::WAITING_FOR_EXECUTION, 10.0, 100.0, stamp, true);
-  rtc_interface_->updateCooperateStatus(uuid, true, State::RUNNING, 10.0, 100.0, stamp);
+  rtc_interface_->updateCooperateStatus(uuid, true, State::RUNNING, 10.0, 100.0, stamp, true);
   EXPECT_TRUE(rtc_interface_->isRegistered(uuid));
   EXPECT_FALSE(rtc_interface_->isActivated(uuid));
   EXPECT_FALSE(rtc_interface_->isForceActivated(uuid));


### PR DESCRIPTION
## Description
The `requested` field was not updated, when the uuid was updated (it was updated when it was once registered).
This PR fixes the problem.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/9202

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/1ea74b18-8e29-5d35-ab1d-98e2ca2d3bd3?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
