### PR TITLE
fix(autoware_detected_object_validation): fix bugprone-incorrect-roundings

### DIFF
--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -30,6 +30,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <cmath>
+
 namespace autoware::detected_object_validation
 {
 namespace obstacle_pointcloud
@@ -54,10 +56,9 @@ size_t Validator::getThresholdPointCloud(
     object.kinematics.pose_with_covariance.pose.position.x,
     object.kinematics.pose_with_covariance.pose.position.y);
   size_t threshold_pc = std::clamp(
-    static_cast<size_t>(
+    static_cast<size_t>(std::lround(
       points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
-        object_distance +
-      0.5f),
+      object_distance)),
     static_cast<size_t>(points_num_threshold_param_.min_points_num.at(object_label_id)),
     static_cast<size_t>(points_num_threshold_param_.max_points_num.at(object_label_id)));
   return threshold_pc;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-incorrect-roundings` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp:57:5: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    static_cast<size_t>(
    ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp:58:7: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
      points_num_threshold_param_.min_points_and_distance_ratio.at(object_label_id) /
      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Confirmation by running the program.

```
#include <iostream>
#include <cmath>
#include <algorithm>

int calculateMinPointsThreshold(double min_points_and_distance_ratio_, double distance, int min_points_, int max_points_) {
    return std::min(
        std::max(static_cast<int>(std::lround(min_points_and_distance_ratio_ / distance)), min_points_),
        max_points_
    );
}

int calculateMinPointsThreshold_old(double min_points_and_distance_ratio_, double distance, int min_points_, int max_points_) {
    return std::min(
      std::max(static_cast<int>(min_points_and_distance_ratio_ / distance + 0.5f), min_points_),
      max_points_);
}

int main() {
    double min_points_and_distance_ratio = 30;
    double distance = 3.9;
    int min_points = 5;
    int max_points = 15;

    int min_points_threshold = calculateMinPointsThreshold(min_points_and_distance_ratio, distance, min_points, max_points);
    int min_points_threshold_old = calculateMinPointsThreshold_old(min_points_and_distance_ratio, distance, min_points, max_points);

    std::cout << "Calculated min_points_threshold: " << min_points_threshold << std::endl;
    std::cout << "Calculated min_points_threshold_old: " << min_points_threshold_old << std::endl;

    return 0;
}
```

> emb4@emb4-E5-165:~/autoware_cppcheck/autoware.universe$ ./test
> Calculated min_points_threshold: 8
> Calculated min_points_threshold_old: 8
> 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
