### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): fix bugprone-incorrect-roundings

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
@@ -17,6 +17,7 @@
 #include "autoware/probabilistic_occupancy_grid_map/cost_value/cost_value.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 namespace autoware::occupancy_grid_map
 {
@@ -63,7 +64,8 @@ inline unsigned char OccupancyGridMapBBFUpdater::applyBBF(
     po_hat = ((po + (0.5f * inv_v_ratio)) / ((1.f * inv_v_ratio) + 1.f));
   }
   return std::min(
-    std::max(static_cast<unsigned char>(po_hat * 255.f + 0.5f), static_cast<unsigned char>(1)),
+    std::max(
+      static_cast<unsigned char>(std::lround(po_hat * 255.f)), static_cast<unsigned char>(1)),
     static_cast<unsigned char>(254));
 }
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-incorrect-roundings` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp:66:14: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    std::max(static_cast<unsigned char>(po_hat * 255.f + 0.5f), static_cast<unsigned char>(1)),
             ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp:66:41: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    std::max(static_cast<unsigned char>(po_hat * 255.f + 0.5f), static_cast<unsigned char>(1)),
                                        ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Confirmation by running the program.

```
#include <iostream>
#include <cmath>
#include <algorithm>

int calculateMinPointsThreshold(double min_points_and_distance_ratio_, double distance, int min_points_, int max_points_) {
    return std::min(
        std::max(static_cast<int>(std::lround(min_points_and_distance_ratio_ / distance)), min_points_),
        max_points_
    );
}

int calculateMinPointsThreshold_old(double min_points_and_distance_ratio_, double distance, int min_points_, int max_points_) {
    return std::min(
      std::max(static_cast<int>(min_points_and_distance_ratio_ / distance + 0.5f), min_points_),
      max_points_);
}

int main() {
    double min_points_and_distance_ratio = 30;
    double distance = 3.9;
    int min_points = 5;
    int max_points = 15;

    int min_points_threshold = calculateMinPointsThreshold(min_points_and_distance_ratio, distance, min_points, max_points);
    int min_points_threshold_old = calculateMinPointsThreshold_old(min_points_and_distance_ratio, distance, min_points, max_points);

    std::cout << "Calculated min_points_threshold: " << min_points_threshold << std::endl;
    std::cout << "Calculated min_points_threshold_old: " << min_points_threshold_old << std::endl;

    return 0;
}
```

> emb4@emb4-E5-165:~/autoware_cppcheck/autoware.universe$ ./test
> Calculated min_points_threshold: 8
> Calculated min_points_threshold_old: 8
> 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
