### PR TITLE
fix(autoware_mpc_lateral_controller): fix bugprone-misplaced-widening-cast

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
+++ b/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
@@ -125,7 +125,7 @@ bool filt_vector(const int num, std::vector<double> & u)
     }
 
     for (int j = -num_tmp; j <= num_tmp; ++j) {
-      tmp += u[static_cast<size_t>(i + j)];
+      tmp += u[static_cast<size_t>(i) + static_cast<size_t>(j)];
       ++count;
     }
     filtered_u[static_cast<size_t>(i)] = tmp / count;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-misplaced-widening-cast` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp:128:16: error: either cast from 'int' to 'size_t' (aka 'unsigned long') is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast,-warnings-as-errors]
      tmp += u[static_cast<size_t>(i + j)];
               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
