### PR TITLE
fix(autoware_image_projection_based_fusion): fix bugprone-misplaced-widening-cast

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
@@ -159,8 +159,10 @@ void updateOutputFusedObjects(
     cluster.data.resize(clusters_data_size.at(i));
     auto & feature_obj = output_objs.at(i);
     if (
-      cluster.data.size() < static_cast<std::size_t>(min_cluster_size) * static_cast<std::size_t>(cluster.point_step) ||
-      cluster.data.size() >= static_cast<std::size_t>(max_cluster_size) * static_cast<std::size_t>(cluster.point_step)) {
+      cluster.data.size() <
+        static_cast<std::size_t>(min_cluster_size) * static_cast<std::size_t>(cluster.point_step) ||
+      cluster.data.size() >=
+        static_cast<std::size_t>(max_cluster_size) * static_cast<std::size_t>(cluster.point_step)) {
       continue;
     }
 
@@ -169,7 +171,9 @@ void updateOutputFusedObjects(
     sensor_msgs::msg::PointCloud2 refine_cluster;
     closest_cluster(
       cluster, cluster_2d_tolerance, min_cluster_size, camera_orig_point_frame, refine_cluster);
-    if (refine_cluster.data.size() < static_cast<std::size_t>(min_cluster_size) * static_cast<std::size_t>(cluster.point_step)) {
+    if (
+      refine_cluster.data.size() <
+      static_cast<std::size_t>(min_cluster_size) * static_cast<std::size_t>(cluster.point_step)) {
       continue;
     }
 

--- a/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
@@ -159,8 +159,8 @@ void updateOutputFusedObjects(
     cluster.data.resize(clusters_data_size.at(i));
     auto & feature_obj = output_objs.at(i);
     if (
-      cluster.data.size() < std::size_t(min_cluster_size * cluster.point_step) ||
-      cluster.data.size() >= std::size_t(max_cluster_size * cluster.point_step)) {
+      cluster.data.size() < static_cast<std::size_t>(min_cluster_size) * static_cast<std::size_t>(cluster.point_step) ||
+      cluster.data.size() >= static_cast<std::size_t>(max_cluster_size) * static_cast<std::size_t>(cluster.point_step)) {
       continue;
     }
 
@@ -169,7 +169,7 @@ void updateOutputFusedObjects(
     sensor_msgs::msg::PointCloud2 refine_cluster;
     closest_cluster(
       cluster, cluster_2d_tolerance, min_cluster_size, camera_orig_point_frame, refine_cluster);
-    if (refine_cluster.data.size() < std::size_t(min_cluster_size * cluster.point_step)) {
+    if (refine_cluster.data.size() < static_cast<std::size_t>(min_cluster_size) * static_cast<std::size_t>(cluster.point_step)) {
       continue;
     }
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-misplaced-widening-cast` error.
`min_cluster_size` and `max_cluster_size` are always assumed to be positive numbers.
Also, `cluster.point_step` is always a positive number because it is of type `uint32`.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:162:29: error: either cast from 'unsigned int' to 'std::size_t' (aka 'unsigned long') is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast,-warnings-as-errors]
      cluster.data.size() < std::size_t(min_cluster_size * cluster.point_step) ||
                            ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:163:30: error: either cast from 'unsigned int' to 'std::size_t' (aka 'unsigned long') is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast,-warnings-as-errors]
      cluster.data.size() >= std::size_t(max_cluster_size * cluster.point_step)) {
                             ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:172:38: error: either cast from 'unsigned int' to 'std::size_t' (aka 'unsigned long') is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast,-warnings-as-errors]
    if (refine_cluster.data.size() < std::size_t(min_cluster_size * cluster.point_step)) {
                                     ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
