### PR TITLE
fix(autoware_euclidean_cluster): fix bugprone-misplaced-widening-cast

### DIFF
--- a/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -117,7 +117,9 @@ bool VoxelGridBasedEuclideanCluster::cluster(
       voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
     if (map.find(index) != map.end()) {
       auto & cluster_data_size = clusters_data_size.at(map[index]);
-      if (cluster_data_size > std::size_t(max_cluster_size_ * point_step)) {
+      if (
+        cluster_data_size >
+        static_cast<std::size_t>(max_cluster_size_) * static_cast<std::size_t>(point_step)) {
         continue;
       }
       std::memcpy(


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-misplaced-widening-cast` error.
Other errors also exist, but they are not corrected at this time because of their low severity.

`max_cluster_size` is always assumed to be positive numbers.
Also, `cluster.point_step` is always a positive number because it is of type uint32.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp:120:31: error: either cast from 'int' to 'std::size_t' (aka 'unsigned long') is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast,-warnings-as-errors]
      if (cluster_data_size > std::size_t(max_cluster_size_ * point_step)) {
                              ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
