### PR TITLE
fix(autoware_image_projection_based_fusion): fix bugprone-misplaced-widening-cast

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -42,14 +42,14 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
   cluster_debug_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("debug/clusters", 1);
 }
 
-void RoiPointCloudFusionNode::preprocess(__attribute__((unused))
-                                         sensor_msgs::msg::PointCloud2 & pointcloud_msg)
+void RoiPointCloudFusionNode::preprocess(
+  __attribute__((unused)) sensor_msgs::msg::PointCloud2 & pointcloud_msg)
 {
   return;
 }
 
-void RoiPointCloudFusionNode::postprocess(__attribute__((unused))
-                                          sensor_msgs::msg::PointCloud2 & pointcloud_msg)
+void RoiPointCloudFusionNode::postprocess(
+  __attribute__((unused)) sensor_msgs::msg::PointCloud2 & pointcloud_msg)
 {
   const auto objects_sub_count = pub_objects_ptr_->get_subscription_count() +
                                  pub_objects_ptr_->get_intra_process_subscription_count();

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -42,14 +42,14 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
   cluster_debug_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("debug/clusters", 1);
 }
 
-void RoiPointCloudFusionNode::preprocess(
-  __attribute__((unused)) sensor_msgs::msg::PointCloud2 & pointcloud_msg)
+void RoiPointCloudFusionNode::preprocess(__attribute__((unused))
+                                         sensor_msgs::msg::PointCloud2 & pointcloud_msg)
 {
   return;
 }
 
-void RoiPointCloudFusionNode::postprocess(
-  __attribute__((unused)) sensor_msgs::msg::PointCloud2 & pointcloud_msg)
+void RoiPointCloudFusionNode::postprocess(__attribute__((unused))
+                                          sensor_msgs::msg::PointCloud2 & pointcloud_msg)
 {
   const auto objects_sub_count = pub_objects_ptr_->get_subscription_count() +
                                  pub_objects_ptr_->get_intra_process_subscription_count();
@@ -151,7 +151,9 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
       const auto & check_roi = feature_obj.feature.roi;
       auto & cluster = clusters.at(i);
 
-      if (clusters_data_size.at(i) >= static_cast<size_t>(max_cluster_size_ * point_step)) {
+      if (
+        clusters_data_size.at(i) >=
+        static_cast<size_t>(max_cluster_size_) * static_cast<size_t>(point_step)) {
         continue;
       }
       if (


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy bugprone-misplaced-widening-cast error.
Other errors also exist, but they are not corrected at this time because of their low severity.

`max_cluster_size` is always assumed to be positive numbers.
Also, `cluster.point_step` is always a positive number because it is of type uint32.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp:154:39: error: either cast from 'int' to 'size_t' (aka 'unsigned long') is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast,-warnings-as-errors]
      if (clusters_data_size.at(i) >= static_cast<size_t>(max_cluster_size_ * point_step)) {
                                      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
