### PR TITLE
fix(autoware_freespace_planning_algorithms): fix bugprone-unused-raii

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
+++ b/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
@@ -171,9 +171,10 @@ PYBIND11_MODULE(autoware_freespace_planning_algorithms_pybind, p)
       .def_readwrite("max_steering", &freespace_planning_algorithms::VehicleShape::max_steering)
       .def_readwrite("base2back", &freespace_planning_algorithms::VehicleShape::base2back);
 
-  py::class_<freespace_planning_algorithms::AbstractPlanningAlgorithm>(
-    p, "AbstractPlanningAlgorithm");
-  py::class_<
+  auto pyAbstractPlanningAlgorithm =
+    py::class_<freespace_planning_algorithms::AbstractPlanningAlgorithm>(
+      p, "AbstractPlanningAlgorithm");
+  auto pyAstarSearchCpp = py::class_<
     freespace_planning_algorithms::AstarSearch,
     freespace_planning_algorithms::AbstractPlanningAlgorithm>(p, "AstarSearchCpp");
   py::class_<AstarSearchPython, freespace_planning_algorithms::AstarSearch>(p, "AstarSearch")


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-unused-raii` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp:174:3: error: object destroyed immediately after creation; did you mean to name the object? [bugprone-unused-raii,-warnings-as-errors]
  py::class_<freespace_planning_algorithms::AbstractPlanningAlgorithm>(
  ^
                                                                       give_me_a_name
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp:176:3: error: object destroyed immediately after creation; did you mean to name the object? [bugprone-unused-raii,-warnings-as-errors]
  py::class_<
  ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
