### PR TITLE
fix(crosswalk): don't use vehicle stop checker to remove unnecessary callback

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -199,8 +199,6 @@ CrosswalkModule::CrosswalkModule(
 
   collision_info_pub_ =
     node.create_publisher<tier4_debug_msgs::msg::StringStamped>("~/debug/collision_info", 1);
-
-  vehicle_stop_checker_ = std::make_unique<autoware::motion_utils::VehicleStopChecker>(&node);
 }
 
 bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
@@ -1389,8 +1387,7 @@ void CrosswalkModule::planStop(
 bool CrosswalkModule::checkRestartSuppression(
   const PathWithLaneId & ego_path, const std::optional<StopFactor> & stop_factor) const
 {
-  const auto is_vehicle_stopped = vehicle_stop_checker_->isVehicleStopped();
-  if (!is_vehicle_stopped) {
+  if (!planner_data_->isVehicleStopped()) {
     return false;
   }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -18,7 +18,6 @@
 #include "autoware/behavior_velocity_crosswalk_module/util.hpp"
 
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
-#include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
@@ -473,8 +472,6 @@ private:
 
   // Debug
   mutable DebugData debug_data_;
-
-  std::unique_ptr<autoware::motion_utils::VehicleStopChecker> vehicle_stop_checker_{nullptr};
 
   // Stop watch
   StopWatch<std::chrono::milliseconds> stop_watch_;


### PR DESCRIPTION
## Description

vehicle stop checker, which is a utility class to check ego behavior, has subscriber and callback function. Currently, crosswalk module uses it.

On the other hand, `planner_data` of behavior velocity planner has already had function to check if the ego is stopping or not.

Additionally, this redundant implementation may cause data race in multithread.

```
[component_container_mt-34] *** Aborted at 1730424553 (unix time) try "date -d @1730424553" if you are using GNU date ***
[component_container_mt-34] PC: @                0x0 (unknown)
[component_container_mt-34] *** SIGSEGV (@0xa8) received by PID 3375 (TID 0x7f9722ffd640) from PID 168; stack trace: ***
[component_container_mt-34]     @     0x7f972805e046 (unknown)
[component_container_mt-34]     @     0x7f974bbf5520 (unknown)
[component_container_mt-34]     @     0x55658ff7a865 std::_Sp_counted_base<>::_M_release()
[component_container_mt-34]     @     0x7f9748f56801 motion_utils::VehicleStopChecker::onOdom()
[component_container_mt-34]     @     0x7f9748f69e28 std::_Function_handler<>::_M_invoke()
[component_container_mt-34]     @     0x7f974963ea82 ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN8nav_msgs3msg9Odometry_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B
[component_container_mt-34]     @     0x7f97496af635 rclcpp::Subscription<>::handle_message()
[component_container_mt-34]     @     0x7f974c1c1ba0 rclcpp::Executor::execute_subscription()
[component_container_mt-34]     @     0x7f974c1c310e rclcpp::Executor::execute_any_executable()
[component_container_mt-34]     @     0x7f974c1c9432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-34]     @     0x7f974bed8253 (unknown)
[component_container_mt-34]     @     0x7f974bc47ac3 (unknown)
[component_container_mt-34]     @     0x7f974bcd9850 (unknown)
[component_container_mt-34]     @                0x0 (unknown)
[ERROR] [component_container_mt-34]: process has died [pid 3375, exit code -11, cmd '/home/autoware/autoware.proj/install/rclcpp_components/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=False -p wheel_radius:=0.3725 -p wheel_width:=0.215 -p wheel_base:=4.76 -p wheel_tread:=1.754 -p front_overhang:=0.9154 -p rear_overhang:=1.498 -p left_overhang:=0.273 -p right_overhang:=0.273 -p vehicle_height:=3.06 -p max_steer_angle:=0.698'].
```

So, I fixed and reused it in crosswalk function to remove unnecessary callback function.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/644fc549-102c-5c2a-beba-59fac8e744b9?project_id=prd_jt)

NOTE: [cmn_UC-F-04_到着_障害物回避:24](https://evaluation.tier4.jp/evaluation/suites/fe23a842-00b1-45c1-88b0-5741c7704da6?project_id=prd_jt) suite is out of scope.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
