### PR TITLE
test(behavior_path_planner_common): add unit test for path shifter

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/CMakeLists.txt
@@ -76,6 +76,14 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}
   )
 
+  ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_path_shifter
+    test/test_path_shifter.cpp
+  )
+
+  target_link_libraries(test_${PROJECT_NAME}_path_shifter
+    ${PROJECT_NAME}
+  )
+
   ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_turn_signal
     test/test_turn_signal.cpp
   )

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
@@ -162,30 +162,30 @@ private:
   // Clock
   mutable rclcpp::Clock clock_{RCL_ROS_TIME};
 
-  std::pair<std::vector<double>, std::vector<double>> calcBaseLengths(
+  std::pair<std::vector<double>, std::vector<double>> calc_base_lengths(
     const double arclength, const double shift_length, const bool offset_back) const;
 
-  static std::pair<std::vector<double>, std::vector<double>> getBaseLengthsWithoutAccelLimit(
+  static std::pair<std::vector<double>, std::vector<double>> get_base_lengths_without_accel_limit(
     const double arclength, const double shift_length, const bool offset_back);
 
-  static std::pair<std::vector<double>, std::vector<double>> getBaseLengthsWithoutAccelLimit(
+  static std::pair<std::vector<double>, std::vector<double>> get_base_lengths_without_accel_limit(
     const double arclength, const double shift_length, const double velocity,
     const double longitudinal_acc, const double total_time, const bool offset_back);
 
   /**
    * @brief Calculate path index for shift_lines and set is_index_aligned_ to true.
    */
-  void updateShiftLinesIndices(ShiftLineArray & shift_lines) const;
+  void update_shift_lines_indices(ShiftLineArray & shift_lines) const;
 
   /**
    * @brief Sort the points in order from the front of the path.
    */
-  void sortShiftLinesAlongPath(ShiftLineArray & shift_lines) const;
+  void sort_shift_lines_along_path(ShiftLineArray & shift_lines) const;
 
   /**
    * @brief Generate shifted path from reference_path_ and shift_lines_ with linear shifting.
    */
-  void applyLinearShifter(ShiftedPath * shifted_path) const;
+  void apply_linear_shifter(ShiftedPath * shifted_path) const;
 
   /**
    * @brief Generate shifted path from reference_path_ and shift_lines_ with spline_based shifting.
@@ -193,7 +193,7 @@ private:
    *          dividing the shift interval into four parts and apply a cubic spline to them.
    *          The resultant shifting shape is closed to the Clothoid curve.
    */
-  void applySplineShifter(ShiftedPath * shifted_path, const bool offset_back) const;
+  void apply_spline_shifter(ShiftedPath * shifted_path, const bool offset_back) const;
 
   ////////////////////////////////////////
   // Helper Functions
@@ -202,17 +202,20 @@ private:
   /**
    * @brief Check if the shift points are aligned in order and have no conflict range.
    */
-  bool checkShiftLinesAlignment(const ShiftLineArray & shift_lines) const;
+  bool check_shift_lines_alignment(const ShiftLineArray & shift_lines) const;
 
-  static void addLateralOffsetOnIndexPoint(ShiftedPath * path, double offset, size_t index);
+  static void add_lateral_offset_on_index_point(ShiftedPath * path, double offset, size_t index);
 
-  static void shiftBaseLength(ShiftedPath * path, double offset);
+  static void shift_base_length(ShiftedPath * path, double offset);
 
-  void setBaseOffset(const double val)
+  void set_base_offset(const double val)
   {
     RCLCPP_DEBUG(logger_, "base_offset is changed: %f -> %f", base_offset_, val);
     base_offset_ = val;
   }
+
+public:
+  friend class PathShifterTest;
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp
@@ -162,12 +162,35 @@ private:
   // Clock
   mutable rclcpp::Clock clock_{RCL_ROS_TIME};
 
+  /**
+   * @brief Calculate basic points to generate shifted path.
+   * @param arclength Longitudinal length in the Frenet coordinate.
+   * @param shift_length Lateral length in the Frenet coordinate.
+   * @param offset_back Whether to apply shifting after shift.
+   * @return First is longitudinal points, and second is lateral points.
+   */
   std::pair<std::vector<double>, std::vector<double>> calc_base_lengths(
     const double arclength, const double shift_length, const bool offset_back) const;
 
+  /**
+   * @brief Calculate basic points to generate shifted path without considering acceleration
+   * limitation.
+   * @param arclength Longitudinal length in the Frenet coordinate.
+   * @param shift_length Lateral length in the Frenet coordinate.
+   * @param offset_back Whether to apply shifting after shift.
+   * @return First is longitudinal points, and second is lateral points.
+   */
   static std::pair<std::vector<double>, std::vector<double>> get_base_lengths_without_accel_limit(
     const double arclength, const double shift_length, const bool offset_back);
 
+  /**
+   * @brief Calculate basic points to generate shifted path without considering acceleration
+   * limitation.
+   * @param arclength Longitudinal length in the Frenet coordinate.
+   * @param shift_length Lateral length in the Frenet coordinate.
+   * @param offset_back Whether to apply shifting after shift.
+   * @return First is longitudinal points, and second is lateral points.
+   */
   static std::pair<std::vector<double>, std::vector<double>> get_base_lengths_without_accel_limit(
     const double arclength, const double shift_length, const double velocity,
     const double longitudinal_acc, const double total_time, const bool offset_back);
@@ -204,8 +227,19 @@ private:
    */
   bool check_shift_lines_alignment(const ShiftLineArray & shift_lines) const;
 
+  /**
+   * @brief Add offset to specific point in shifted path.
+   * @param path Shifted path.
+   * @param offset Lateral offset.
+   * @param index Target point index.
+   */
   static void add_lateral_offset_on_index_point(ShiftedPath * path, double offset, size_t index);
 
+  /**
+   * @brief Add offset distance ti shifted path.
+   * @param path Shifted path.
+   * @param offset Lateral offset.
+   */
   static void shift_base_length(ShiftedPath * path, double offset);
 
   void set_base_offset(const double val)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
@@ -60,8 +60,8 @@ void PathShifter::setPath(const PathWithLaneId & path)
 {
   reference_path_ = path;
 
-  updateShiftLinesIndices(shift_lines_);
-  sortShiftLinesAlongPath(shift_lines_);
+  update_shift_lines_indices(shift_lines_);
+  sort_shift_lines_along_path(shift_lines_);
 }
 void PathShifter::setVelocity(const double velocity)
 {
@@ -82,16 +82,16 @@ void PathShifter::addShiftLine(const ShiftLine & line)
 {
   shift_lines_.push_back(line);
 
-  updateShiftLinesIndices(shift_lines_);
-  sortShiftLinesAlongPath(shift_lines_);
+  update_shift_lines_indices(shift_lines_);
+  sort_shift_lines_along_path(shift_lines_);
 }
 
 void PathShifter::setShiftLines(const std::vector<ShiftLine> & lines)
 {
   shift_lines_ = lines;
 
-  updateShiftLinesIndices(shift_lines_);
-  sortShiftLinesAlongPath(shift_lines_);
+  update_shift_lines_indices(shift_lines_);
+  sort_shift_lines_along_path(shift_lines_);
 }
 
 bool PathShifter::generate(
@@ -111,7 +111,7 @@ bool PathShifter::generate(
   if (shift_lines_.empty()) {
     RCLCPP_DEBUG_STREAM_THROTTLE(
       logger_, clock_, 3000, "shift_lines_ is empty. Return reference with base offset.");
-    shiftBaseLength(shifted_path, base_offset_);
+    shift_base_length(shifted_path, base_offset_);
     return true;
   }
 
@@ -133,7 +133,7 @@ bool PathShifter::generate(
   }
 
   // Check if the shift points are sorted correctly
-  if (!checkShiftLinesAlignment(shift_lines_)) {
+  if (!check_shift_lines_alignment(shift_lines_)) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to sort shift points..!!");
     return false;
   }
@@ -149,8 +149,8 @@ bool PathShifter::generate(
   }
 
   // Calculate shifted path
-  type == SHIFT_TYPE::SPLINE ? applySplineShifter(shifted_path, offset_back)
-                             : applyLinearShifter(shifted_path);
+  type == SHIFT_TYPE::SPLINE ? apply_spline_shifter(shifted_path, offset_back)
+                             : apply_linear_shifter(shifted_path);
 
   shifted_path->path.points = removeOverlapPoints(shifted_path->path.points);
   // Use orientation before shift to remove points in reverse order
@@ -173,11 +173,11 @@ bool PathShifter::generate(
   return true;
 }
 
-void PathShifter::applyLinearShifter(ShiftedPath * shifted_path) const
+void PathShifter::apply_linear_shifter(ShiftedPath * shifted_path) const
 {
   const auto arclength_arr = utils::calcPathArcLengthArray(reference_path_);
 
-  shiftBaseLength(shifted_path, base_offset_);
+  shift_base_length(shifted_path, base_offset_);
 
   constexpr double epsilon = 1.0e-8;  // to avoid 0 division
 
@@ -202,16 +202,16 @@ void PathShifter::applyLinearShifter(ShiftedPath * shifted_path) const
       }
 
       // Apply shifting.
-      addLateralOffsetOnIndexPoint(shifted_path, ith_shift_length, i);
+      add_lateral_offset_on_index_point(shifted_path, ith_shift_length, i);
     }
   }
 }
 
-void PathShifter::applySplineShifter(ShiftedPath * shifted_path, const bool offset_back) const
+void PathShifter::apply_spline_shifter(ShiftedPath * shifted_path, const bool offset_back) const
 {
   const auto arclength_arr = utils::calcPathArcLengthArray(reference_path_);
 
-  shiftBaseLength(shifted_path, base_offset_);
+  shift_base_length(shifted_path, base_offset_);
 
   constexpr double epsilon = 1.0e-8;  // to avoid 0 division
 
@@ -235,7 +235,7 @@ void PathShifter::applySplineShifter(ShiftedPath * shifted_path, const bool offs
     // TODO(Watanabe) write docs.
     // These points are defined to achieve the constant-jerk shifting (see the header description).
     const auto [base_distance, base_length] =
-      calcBaseLengths(shifting_arclength, delta_shift, offset_back);
+      calc_base_lengths(shifting_arclength, delta_shift, offset_back);
 
     RCLCPP_DEBUG(
       logger_, "base_distance = %s, base_length = %s", toStr(base_distance).c_str(),
@@ -259,7 +259,7 @@ void PathShifter::applySplineShifter(ShiftedPath * shifted_path, const bool offs
     {
       size_t i = shift_line.start_idx + 1;
       for (const auto & itr : query_length) {
-        addLateralOffsetOnIndexPoint(shifted_path, itr, i);
+        add_lateral_offset_on_index_point(shifted_path, itr, i);
         ++i;
       }
     }
@@ -267,18 +267,19 @@ void PathShifter::applySplineShifter(ShiftedPath * shifted_path, const bool offs
     if (offset_back) {
       // Apply shifting after shift
       for (size_t i = shift_line.end_idx; i < shifted_path->path.points.size(); ++i) {
-        addLateralOffsetOnIndexPoint(shifted_path, delta_shift, i);
+        add_lateral_offset_on_index_point(shifted_path, delta_shift, i);
       }
     } else {
       // Apply shifting before shift
       for (size_t i = 0; i < shift_line.start_idx + 1; ++i) {
-        addLateralOffsetOnIndexPoint(shifted_path, query_length.front(), i);
+        add_lateral_offset_on_index_point(shifted_path, query_length.front(), i);
       }
     }
   }
 }
 
-std::pair<std::vector<double>, std::vector<double>> PathShifter::getBaseLengthsWithoutAccelLimit(
+std::pair<std::vector<double>, std::vector<double>>
+PathShifter::get_base_lengths_without_accel_limit(
   const double arclength, const double shift_length, const bool offset_back)
 {
   const auto s = arclength;
@@ -291,7 +292,8 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::getBaseLengthsW
   return std::pair{base_lon, base_lat};
 }
 
-std::pair<std::vector<double>, std::vector<double>> PathShifter::getBaseLengthsWithoutAccelLimit(
+std::pair<std::vector<double>, std::vector<double>>
+PathShifter::get_base_lengths_without_accel_limit(
   const double arclength, const double shift_length, const double velocity,
   const double longitudinal_acc, const double total_time, const bool offset_back)
 {
@@ -312,7 +314,7 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::getBaseLengthsW
   return std::pair{base_lon, base_lat};
 }
 
-std::pair<std::vector<double>, std::vector<double>> PathShifter::calcBaseLengths(
+std::pair<std::vector<double>, std::vector<double>> PathShifter::calc_base_lengths(
   const double arclength, const double shift_length, const bool offset_back) const
 {
   const auto v0 = std::abs(velocity_);
@@ -324,8 +326,8 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::calcBaseLengths
 
   if (v0 < 1.0e-5 && a < acc_threshold) {
     // no need to consider acceleration limit
-    RCLCPP_DEBUG(logger_, "set velocity is zero. lateral acc limit is ignored");
-    return getBaseLengthsWithoutAccelLimit(arclength, shift_length, offset_back);
+    RCLCPP_INFO(logger_, "set velocity is zero. lateral acc limit is ignored");
+    return get_base_lengths_without_accel_limit(arclength, shift_length, offset_back);
   }
 
   const auto S = arclength;
@@ -335,10 +337,10 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::calcBaseLengths
 
   if (lateral_a_max < lateral_acc_limit_) {
     // no need to consider acceleration limit
-    RCLCPP_DEBUG_THROTTLE(
+    RCLCPP_WARN_THROTTLE(
       logger_, clock_, 3000, "No need to consider lateral acc limit. max: %f, limit: %f",
       lateral_a_max, lateral_acc_limit_);
-    return getBaseLengthsWithoutAccelLimit(S, shift_length, v0, a, T, offset_back);
+    return get_base_lengths_without_accel_limit(S, shift_length, v0, a, T, offset_back);
   }
 
   const auto tj = T / 2.0 - 2.0 * L / (lateral_acc_limit_ * T);
@@ -352,7 +354,7 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::calcBaseLengths
       logger_, clock_, 3000,
       "Acc limit is too small to be applied. Tj: %f, Ta: %f, j: %f, a_max: %f, acc_limit: %f", tj,
       ta, lat_jerk, lateral_a_max, lateral_acc_limit_);
-    return getBaseLengthsWithoutAccelLimit(S, shift_length, offset_back);
+    return get_base_lengths_without_accel_limit(S, shift_length, offset_back);
   }
 
   const auto tj3 = tj * tj * tj;
@@ -395,7 +397,7 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::calcBaseLengths
   return {base_lon, base_lat};
 }
 
-void PathShifter::updateShiftLinesIndices(ShiftLineArray & shift_lines) const
+void PathShifter::update_shift_lines_indices(ShiftLineArray & shift_lines) const
 {
   if (reference_path_.points.empty()) {
     RCLCPP_ERROR(
@@ -412,7 +414,7 @@ void PathShifter::updateShiftLinesIndices(ShiftLineArray & shift_lines) const
   }
 }
 
-bool PathShifter::checkShiftLinesAlignment(const ShiftLineArray & shift_lines) const
+bool PathShifter::check_shift_lines_alignment(const ShiftLineArray & shift_lines) const
 {
   for (const auto & l : shift_lines) {
     RCLCPP_DEBUG(logger_, "shift point = %s", toStr(l).c_str());
@@ -428,7 +430,7 @@ bool PathShifter::checkShiftLinesAlignment(const ShiftLineArray & shift_lines) c
   return true;
 }
 
-void PathShifter::sortShiftLinesAlongPath(ShiftLineArray & shift_lines) const
+void PathShifter::sort_shift_lines_along_path(ShiftLineArray & shift_lines) const
 {
   if (shift_lines.empty()) {
     RCLCPP_DEBUG_STREAM_THROTTLE(logger_, clock_, 3000, "shift_lines is empty. do nothing.");
@@ -494,10 +496,10 @@ void PathShifter::removeBehindShiftLineAndSetBaseOffset(const size_t nearest_idx
 
   setShiftLines(new_shift_lines);
 
-  setBaseOffset(new_base_offset);
+  set_base_offset(new_base_offset);
 }
 
-void PathShifter::addLateralOffsetOnIndexPoint(ShiftedPath * path, double offset, size_t index)
+void PathShifter::add_lateral_offset_on_index_point(ShiftedPath * path, double offset, size_t index)
 {
   if (fabs(offset) < 1.0e-8) {
     return;
@@ -511,12 +513,12 @@ void PathShifter::addLateralOffsetOnIndexPoint(ShiftedPath * path, double offset
   path->shift_length.at(index) += offset;
 }
 
-void PathShifter::shiftBaseLength(ShiftedPath * path, double offset)
+void PathShifter::shift_base_length(ShiftedPath * path, double offset)
 {
   constexpr double base_offset_thr = 1.0e-4;
   if (std::abs(offset) > base_offset_thr) {
     for (size_t i = 0; i < path->path.points.size(); ++i) {
-      addLateralOffsetOnIndexPoint(path, offset, i);
+      add_lateral_offset_on_index_point(path, offset, i);
     }
   }
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
@@ -326,7 +326,7 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::calc_base_lengt
 
   if (v0 < 1.0e-5 && a < acc_threshold) {
     // no need to consider acceleration limit
-    RCLCPP_INFO(logger_, "set velocity is zero. lateral acc limit is ignored");
+    RCLCPP_DEBUG(logger_, "set velocity is zero. lateral acc limit is ignored");
     return get_base_lengths_without_accel_limit(arclength, shift_length, offset_back);
   }
 
@@ -337,7 +337,7 @@ std::pair<std::vector<double>, std::vector<double>> PathShifter::calc_base_lengt
 
   if (lateral_a_max < lateral_acc_limit_) {
     // no need to consider acceleration limit
-    RCLCPP_WARN_THROTTLE(
+    RCLCPP_DEBUG_THROTTLE(
       logger_, clock_, 3000, "No need to consider lateral acc limit. max: %f, limit: %f",
       lateral_a_max, lateral_acc_limit_);
     return get_base_lengths_without_accel_limit(S, shift_length, v0, a, T, offset_back);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_shifter.cpp
@@ -1,0 +1,374 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
+
+#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <autoware_planning_msgs/msg/detail/trajectory__struct.hpp>
+
+#include <gtest/gtest.h>
+
+namespace autoware::behavior_path_planner
+{
+
+class PathShifterTest : public ::testing::Test
+{
+protected:
+  PathShifter path_shifter_;
+  ShiftedPath path;
+
+  void SetUp() override { path_shifter_.set_base_offset(0.01); }
+
+  static ShiftedPath generate_shifted_path(
+    size_t num_points, double longitdunal_interval, double lateral_interval)
+  {
+    ShiftedPath path;
+    auto trajectory =
+      autoware::test_utils::generateTrajectory<autoware_planning_msgs::msg::Trajectory>(
+        num_points, longitdunal_interval);
+
+    size_t i = 0;
+    for (auto const & point : trajectory.points) {
+      PathPointWithLaneId path_point_with_lane_id;
+      path_point_with_lane_id.point.pose = point.pose;
+      path_point_with_lane_id.point.lateral_velocity_mps = point.lateral_velocity_mps;
+      path_point_with_lane_id.point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
+      path_point_with_lane_id.point.heading_rate_rps = point.heading_rate_rps;
+      path.path.points.push_back(path_point_with_lane_id);
+      path.shift_length.push_back(static_cast<double>(i) * lateral_interval);
+      i++;
+    }
+
+    return path;
+  }
+
+  bool check_shift_lines_alignment(const ShiftLineArray & shift_lines)
+  {
+    return path_shifter_.check_shift_lines_alignment(shift_lines);
+  }
+
+  static void add_lateral_offset_on_index_point(ShiftedPath * path, double offset, size_t index)
+  {
+    PathShifter::add_lateral_offset_on_index_point(path, offset, index);
+  }
+
+  static void shift_base_length(ShiftedPath * path, double offset)
+  {
+    PathShifter::shift_base_length(path, offset);
+  }
+
+  void sort_shift_lines_along_path(ShiftLineArray & shift_lines)
+  {
+    path_shifter_.sort_shift_lines_along_path(shift_lines);
+  }
+
+  static std::pair<std::vector<double>, std::vector<double>> get_base_lengths_without_accel_limit(
+    const double arc_length, const double shift_length, const bool offset_back)
+  {
+    return PathShifter::get_base_lengths_without_accel_limit(arc_length, shift_length, offset_back);
+  }
+
+  static std::pair<std::vector<double>, std::vector<double>> get_base_lengths_without_accel_limit(
+    const double arc_length, const double shift_length, const double velocity,
+    const double longitudinal_acc, const double total_time, const bool offset_back)
+  {
+    return PathShifter::get_base_lengths_without_accel_limit(
+      arc_length, shift_length, velocity, longitudinal_acc, total_time, offset_back);
+  }
+
+  std::pair<std::vector<double>, std::vector<double>> calc_base_lengths(
+    const double arc_length, const double shift_length, const bool offset_back)
+  {
+    return path_shifter_.calc_base_lengths(arc_length, shift_length, offset_back);
+  }
+};
+
+TEST_F(PathShifterTest, initial_state)
+{
+  ShiftedPath shifted_path;
+  ShiftLineArray shift_lines;
+
+  EXPECT_DOUBLE_EQ(path_shifter_.getLastShiftLength(), path_shifter_.getBaseOffset());
+  EXPECT_FALSE(path_shifter_.getLastShiftLine().has_value());
+  EXPECT_FALSE(path_shifter_.generate(&shifted_path));
+}
+
+TEST_F(PathShifterTest, get_base_lengths_without_accel_limit)
+{
+  double arc_length = 100.0;
+  double shift_length = 20.0;
+  double velocity = 10.0;
+  double longitudinal_acc = 2.0;
+  double total_time = 10.0;
+  bool offset_back = false;
+
+  // Condition: without offset_back
+  auto result = get_base_lengths_without_accel_limit(arc_length, shift_length, offset_back);
+  std::vector<double> expected_base_lon = {0.0, 25.0, 75.0, 100.0};
+  std::vector<double> expected_base_lat = {20.0, 55.0 / 3.0, 5.0 / 3.0, 0.0};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_DOUBLE_EQ(result.first.at(i), expected_base_lon.at(i));
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+
+  result = get_base_lengths_without_accel_limit(
+    arc_length, shift_length, velocity, longitudinal_acc, total_time, offset_back);
+  expected_base_lon = {0.0, 31.25, arc_length, arc_length};
+  expected_base_lat = {shift_length, 11.0 / 12.0 * shift_length, shift_length / 12.0, 0.0};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_DOUBLE_EQ(result.first.at(i), expected_base_lon.at(i));
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+
+  // Condition: with offset_back
+  offset_back = true;
+  result = get_base_lengths_without_accel_limit(arc_length, shift_length, offset_back);
+  expected_base_lon = {0.0, 25.0, 75.0, 100.0};
+  expected_base_lat = {0.0, 5.0 / 3.0, 55.0 / 3.0, 20.0};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_DOUBLE_EQ(result.first.at(i), expected_base_lon.at(i));
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+
+  result = get_base_lengths_without_accel_limit(
+    arc_length, shift_length, velocity, longitudinal_acc, total_time, offset_back);
+  expected_base_lon = {0.0, 31.25, arc_length, arc_length};
+  expected_base_lat = {0.0, shift_length / 12.0, 11.0 / 12.0 * shift_length, shift_length};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_DOUBLE_EQ(result.first.at(i), expected_base_lon.at(i));
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+}
+
+TEST_F(PathShifterTest, calc_base_lengths)
+{
+  double arc_length = 100.0;
+  double shift_length = 20.0;
+  bool offset_back = true;
+  const double epsilon = 1e-06;
+
+  // Condition: zero velocity and zero longitudinal acceleration
+  path_shifter_.setVelocity(0.0);
+  auto result = calc_base_lengths(arc_length, shift_length, offset_back);
+
+  std::vector<double> expected_base_lon = {0.0, 25.0, 75.0, 100.0};
+  std::vector<double> expected_base_lat = {0.0, 5.0 / 3.0, 55.0 / 3.0, 20.0};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_DOUBLE_EQ(result.first.at(i), expected_base_lon.at(i));
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+
+  // Condition: zero acceleration
+  path_shifter_.setVelocity(10.0);
+  path_shifter_.setLongitudinalAcceleration(0.0);
+  result = calc_base_lengths(arc_length, shift_length, offset_back);
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_DOUBLE_EQ(result.first.at(i), expected_base_lon.at(i));
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+
+  // Condition: no shift
+  shift_length = 0.0;
+  path_shifter_.setLongitudinalAcceleration(2.0);
+  path_shifter_.setLateralAccelerationLimit(1.0);
+  result = calc_base_lengths(arc_length, shift_length, offset_back);
+
+  expected_base_lon = {0.0, 17.838137, 67.838137, 100.0};
+  expected_base_lat = {0.0, 0.0, 0.0, 0.0};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_NEAR(result.first.at(i), expected_base_lon.at(i), epsilon);
+    EXPECT_DOUBLE_EQ(result.second.at(i), expected_base_lat.at(i));
+  }
+
+  // Condition: no limitation
+  arc_length = 30.0;
+  shift_length = 5.0;
+  path_shifter_.setVelocity(6.0);
+  path_shifter_.setLongitudinalAcceleration(1.0);
+  path_shifter_.setLateralAccelerationLimit(2.0);
+  result = calc_base_lengths(arc_length, shift_length, offset_back);
+
+  expected_base_lon = {0.0, 3.6645406, 8.765561, 13.196938, 17.967602, 24.462500, 30.0};
+  expected_base_lat = {0.0, 0.113095, 1.079422, 2.5, 3.920578, 4.886904, 5.0};
+
+  ASSERT_EQ(result.first.size(), expected_base_lon.size());
+  ASSERT_EQ(result.second.size(), expected_base_lat.size());
+
+  for (size_t i = 0; i < result.first.size(); i++) {
+    EXPECT_NEAR(result.first.at(i), expected_base_lon.at(i), epsilon);
+    EXPECT_NEAR(result.second.at(i), expected_base_lat.at(i), epsilon);
+  }
+}
+
+TEST_F(PathShifterTest, check_shift_lines_alignment)
+{
+  ShiftLineArray shift_lines;
+
+  // Condition: empty shift_lines
+  EXPECT_TRUE(check_shift_lines_alignment(shift_lines));
+
+  // Condition: single shift line  aligned
+  ShiftLine shift_line;
+  shift_line.start_idx = 1;
+  shift_line.end_idx = 10;
+  shift_lines.push_back(shift_line);
+  EXPECT_TRUE(check_shift_lines_alignment(shift_lines));
+
+  // Condition: 2 shift line including inappropriate align
+  shift_line.start_idx = 10;
+  shift_line.end_idx = 4;
+  shift_lines.push_back(shift_line);
+  EXPECT_FALSE(check_shift_lines_alignment(shift_lines));
+}
+
+TEST_F(PathShifterTest, sort_shift_lines_along_path)
+{
+  ShiftLineArray shift_lines;
+  size_t i = 0;
+
+  // Condition: no shift line
+  sort_shift_lines_along_path(shift_lines);
+  EXPECT_TRUE(shift_lines.empty());
+
+  // Condition: already sorted shift line
+  ShiftLine shit_line;
+  shit_line.start_idx = 0;
+  shift_lines.push_back(shit_line);
+  shit_line.start_idx = 5;
+  shift_lines.push_back(shit_line);
+  shit_line.start_idx = 10;
+  shift_lines.push_back(shit_line);
+  sort_shift_lines_along_path(shift_lines);
+  for (const auto & shift_line : shift_lines) {
+    EXPECT_EQ(shift_line.start_idx, i * 5);
+    i++;
+  }
+
+  // Condition: unsorted shift line
+  shift_lines.clear();
+  shit_line.start_idx = 10;
+  shift_lines.push_back(shit_line);
+  shit_line.start_idx = 0;
+  shift_lines.push_back(shit_line);
+  shit_line.start_idx = 5;
+  shift_lines.push_back(shit_line);
+  sort_shift_lines_along_path(shift_lines);
+  i = 0;
+  for (const auto & shift_line : shift_lines) {
+    EXPECT_EQ(shift_line.start_idx, i * 5);
+    i++;
+  }
+}
+
+TEST_F(PathShifterTest, add_lateral_offset_on_index_point)
+{
+  auto path = generate_shifted_path(3, 0.1, 0.1);
+  size_t index = 1;
+
+  // Condition: no offset
+  double offset = 0.0;
+  add_lateral_offset_on_index_point(&path, offset, index);
+  EXPECT_DOUBLE_EQ(path.shift_length.at(index), 0.1);
+
+  // Condition: with offset
+  offset = 0.5;
+  add_lateral_offset_on_index_point(&path, offset, index);
+  EXPECT_DOUBLE_EQ(path.shift_length.at(index), 0.6);
+}
+
+TEST_F(PathShifterTest, shift_base_length)
+{
+  double lateral_interval = 0.1;
+  auto path = generate_shifted_path(3, 0.1, lateral_interval);
+  double offset = 0.1;
+
+  shift_base_length(&path, offset);
+
+  size_t i = 0;
+  for (double shift_length : path.shift_length) {
+    EXPECT_DOUBLE_EQ(shift_length, i * lateral_interval + offset);
+    i++;
+  }
+}
+
+TEST_F(PathShifterTest, generate)
+{
+  ShiftedPath shifted_path;
+
+  // Condition: no reference path
+  EXPECT_FALSE(path_shifter_.generate(&shifted_path));
+
+  // Condition: no shift lines
+  auto reference_path = autoware::test_utils::generateTrajectory<PathWithLaneId>(10, 1.0);
+  path_shifter_.setPath(reference_path);
+  EXPECT_TRUE(path_shifter_.generate(&shifted_path));
+
+  // Condition: next index of start index would be end index
+  std::vector<ShiftLine> lines;
+  ShiftLine line;
+  line.start.position = universe_utils::createPoint(0.0, 0.0, 0.0);
+  line.end.position = universe_utils::createPoint(1.1, 0.0, 0.0);
+  lines.push_back(line);
+  path_shifter_.setShiftLines(lines);
+  EXPECT_FALSE(path_shifter_.generate(&shifted_path));
+
+  // Condition: apply spline shifter
+  lines.front().start_shift_length = 0.0;
+  lines.front().end.position.x = 8.0;
+  lines.front().end_shift_length = 1.0;
+  path_shifter_.setShiftLines(lines);
+  EXPECT_TRUE(path_shifter_.generate(&shifted_path));
+
+  ASSERT_EQ(shifted_path.shift_length.size(), 10);
+  EXPECT_DOUBLE_EQ(shifted_path.shift_length.at(0), 0.02);
+  EXPECT_DOUBLE_EQ(shifted_path.shift_length.at(8), 1.0);
+
+  // Condition: apply linear
+  EXPECT_TRUE(path_shifter_.generate(&shifted_path, true, SHIFT_TYPE::LINEAR));
+  ASSERT_EQ(shifted_path.shift_length.size(), 10);
+  EXPECT_DOUBLE_EQ(shifted_path.shift_length.at(0), 0.03);
+  EXPECT_DOUBLE_EQ(shifted_path.shift_length.at(8), 1.0);
+}
+
+}  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_shifter.cpp
@@ -33,12 +33,12 @@ protected:
   void SetUp() override { path_shifter_.set_base_offset(0.01); }
 
   static ShiftedPath generate_shifted_path(
-    size_t num_points, double longitdunal_interval, double lateral_interval)
+    size_t num_points, double longitudinal_interval, double lateral_interval)
   {
     ShiftedPath path;
     auto trajectory =
       autoware::test_utils::generateTrajectory<autoware_planning_msgs::msg::Trajectory>(
-        num_points, longitdunal_interval);
+        num_points, longitudinal_interval);
 
     size_t i = 0;
     for (auto const & point : trajectory.points) {


### PR DESCRIPTION
## Description
This PR adds unit tests for `utils/path_shifter` in `behavior_path_planner_common` package.
![image](https://github.com/user-attachments/assets/8f06a92a-7623-4da4-9247-817871ae3d64)

Also some function name is changed to snake_case.

## Related links

## How was this PR tested?
Colcon test
```
6: [----------] 8 tests from PathShifterTest (1 ms total)
6: 
6: [----------] Global test environment tear-down
6: [==========] 8 tests from 1 test suite ran. (1 ms total)
6: [  PASSED  ] 8 tests.
```

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
