### PR TITLE
fix(autoware_ekf_localizer): remove `timer_tf_`

### DIFF
--- a/localization/autoware_ekf_localizer/config/ekf_localizer.param.yaml
+++ b/localization/autoware_ekf_localizer/config/ekf_localizer.param.yaml
@@ -5,7 +5,6 @@
       enable_yaw_bias_estimation: true
       predict_frequency: 50.0
       tf_rate: 50.0
-      publish_tf: true
       extend_state_step: 50
 
     pose_measurement:

--- a/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/ekf_localizer.hpp
@@ -99,8 +99,6 @@ private:
   //!< @brief trigger_node service
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr service_trigger_node_;
 
-  //!< @brief timer to send transform
-  rclcpp::TimerBase::SharedPtr timer_tf_;
   //!< @brief tf broadcaster
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_br_;
   //!< @brief tf buffer
@@ -130,11 +128,6 @@ private:
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time
    */
   void timer_callback();
-
-  /**
-   * @brief publish tf for tf_rate [Hz]
-   */
-  void timer_tf_callback();
 
   /**
    * @brief set pose with covariance measurement

--- a/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/hyper_parameters.hpp
+++ b/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/hyper_parameters.hpp
@@ -31,7 +31,6 @@ public:
     ekf_rate(node->declare_parameter<double>("node.predict_frequency")),
     ekf_dt(1.0 / std::max(ekf_rate, 0.1)),
     tf_rate_(node->declare_parameter<double>("node.tf_rate")),
-    publish_tf_(node->declare_parameter<bool>("node.publish_tf")),
     enable_yaw_bias_estimation(node->declare_parameter<bool>("node.enable_yaw_bias_estimation")),
     extend_state_step(node->declare_parameter<int>("node.extend_state_step")),
     pose_frame_id(node->declare_parameter<std::string>("misc.pose_frame_id")),
@@ -76,7 +75,6 @@ public:
   const double ekf_rate;
   const double ekf_dt;
   const double tf_rate_;
-  const bool publish_tf_;
   const bool enable_yaw_bias_estimation;
   const size_t extend_state_step;
   const std::string pose_frame_id;

--- a/localization/autoware_ekf_localizer/schema/sub/node.sub_schema.json
+++ b/localization/autoware_ekf_localizer/schema/sub/node.sub_schema.json
@@ -20,11 +20,6 @@
           "description": "Frequency for tf broadcasting [Hz]",
           "default": 50.0
         },
-        "publish_tf": {
-          "type": "boolean",
-          "description": "Whether to publish tf",
-          "default": true
-        },
         "extend_state_step": {
           "type": "integer",
           "description": "Max delay step which can be dealt with in EKF. Large number increases computational cost.",
@@ -40,7 +35,6 @@
         "show_debug_info",
         "predict_frequency",
         "tf_rate",
-        "publish_tf",
         "extend_state_step",
         "enable_yaw_bias_estimation"
       ],


### PR DESCRIPTION
## Description
Currently, `autoware_ekf_localizer` has two timers: one for the Kalman filter and another for publishing the tf. The latter is unnecessary, and moreover, it's better to publish the same pose in the Kalman filter's timer callback.

Therefore, this pull request removes `timer_tf_` and related code and a parameter.

## How was this PR tested?
- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.0](https://github.com/tier4/AWSIM/releases/tag/v1.3.0)

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `publish_tf`   | `bool` | `true`         | Whether to publish tf |

## Effects on system behavior

None.
