### PR TITLE
fix(autoware_ekf_localizer): publish processing time detail

### DIFF
--- a/localization/autoware_ekf_localizer/README.md
+++ b/localization/autoware_ekf_localizer/README.md
@@ -54,6 +54,7 @@ This package includes the following features:
 | `ekf_twist`                       | `geometry_msgs::msg::TwistStamped`               | Estimated twist.                                      |
 | `ekf_twist_with_covariance`       | `geometry_msgs::msg::TwistWithCovarianceStamped` | The estimated twist with covariance.                  |
 | `diagnostics`                     | `diagnostics_msgs::msg::DiagnosticArray`         | The diagnostic information.                           |
+| `debug/processing_time_ms`        | `autoware::universe_utils::ProcessingTimeDetail` | The processing time information.                      |
 
 ### Published TF
 

--- a/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/ekf_localizer.hpp
@@ -22,7 +22,7 @@
 
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/logger_level_configure.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
+#include <autoware/universe_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -85,6 +85,8 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_biased_pose_cov_;
   //!< @brief diagnostics publisher
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diag_;
+  //!< @brief processing time publisher
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr pub_processing_time_;
   //!< @brief initial pose subscriber
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_initialpose_;
   //!< @brief measurement pose with covariance subscriber
@@ -123,6 +125,8 @@ private:
 
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
+
+  std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_;
 
   /**
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time
@@ -183,8 +187,6 @@ private:
   void service_trigger_node(
     const std_srvs::srv::SetBool::Request::SharedPtr req,
     std_srvs::srv::SetBool::Response::SharedPtr res);
-
-  autoware::universe_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
 
   friend class EKFLocalizerTestSuite;  // for test code
 };

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -73,8 +73,8 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   pub_biased_pose_cov_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "ekf_biased_pose_with_covariance", 1);
   pub_diag_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
-  pub_processing_time_ =
-    create_publisher<autoware::universe_utils::ProcessingTimeDetail>("~/debug/processing_time_ms", 1);
+  pub_processing_time_ = create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+    "~/debug/processing_time_ms", 1);
   sub_initialpose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "initialpose", 1, std::bind(&EKFLocalizer::callback_initial_pose, this, _1));
   sub_pose_with_cov_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -95,8 +95,7 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   ekf_module_ = std::make_unique<EKFModule>(warning_, params_);
   logger_configure_ = std::make_unique<autoware::universe_utils::LoggerLevelConfigure>(this);
 
-  time_keeper_ =
-    std::make_shared<autoware::universe_utils::TimeKeeper>(pub_processing_time_, &std::cerr);
+  time_keeper_ = std::make_shared<autoware::universe_utils::TimeKeeper>(pub_processing_time_);
 }
 
 /*


### PR DESCRIPTION
## Description
There are several tools for visualizing processing_time in `autoware_tools`.

* [processing_time_visualizer](https://github.com/autowarefoundation/autoware_tools/tree/main/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer)
* [system_performance_plotter](https://github.com/autowarefoundation/autoware_tools/tree/main/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter)

However, `autoware_ekf_localizer` currently does not publish the required topic. To use the above tools, a node needs to publish a topic with the type `autoware::universe_utils::ProcessingTimeDetail` ([link1](https://github.com/autowarefoundation/autoware.universe/blob/488df21db9132756c0ba6da1988fa6a9161b8ed3/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp#L113-L114), [link2](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_debug_msgs/msg/ProcessingTimeTree.msg)).

Therefore, this pull request adds a processing_time publisher to `autoware_ekf_localizer`

## How was this PR tested?
- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.0](https://github.com/tier4/AWSIM/releases/tag/v1.3.0)

### (1) `processing_time_visualizer`
```bash
ros2 run autoware_debug_tools processing_time_visualizer
```

![Screenshot from 2024-11-06 15-58-45](https://github.com/user-attachments/assets/24ac4ec9-2630-439b-96c5-e242fd03ee68)

![Screenshot from 2024-11-06 15-59-16](https://github.com/user-attachments/assets/9f90f142-d318-4b2f-a251-81785e8bf30b)

### (2) `system_performance_plotter`
```bash
ros2 bag record -o /path/to/result_rosbag --use-sim-time -e '.*processing_time.*'
```

and

```bash
ros2 run autoware_debug_tools processing_time_plotter /path/to/result_rosbag -c localization -s --skip_plt_show
```

The `result` directory is generated at current directory.

![localization_processing_time-24-11-06-16-02-03](https://github.com/user-attachments/assets/47e1ffd9-9111-4405-bda6-061797fdb525)

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `~/debug/processing_time_ms` | `tier4_debug_msgs::msg::ProcessingTimeTree`   | The processing time |

Under default settings, this is `/localization/pose_twist_fusion_filter/ekf_localizer/debug/processing_time_ms`.

## Effects on system behavior

None.
