### PR TITLE
feat(system_diagnostic_monitor): add collision detector to control yaml file

### DIFF
--- a/system/system_diagnostic_monitor/config/autoware-main.yaml
+++ b/system/system_diagnostic_monitor/config/autoware-main.yaml
@@ -68,3 +68,6 @@ units:
     type: and
     list:
       - { type: link, link: /autoware/system/service_log_checker }
+
+edits:
+  - { type: remove, path: /autoware/control/collision_detector }

--- a/system/system_diagnostic_monitor/config/control.yaml
+++ b/system/system_diagnostic_monitor/config/control.yaml
@@ -9,6 +9,7 @@ units:
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
       - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
+      - { type: link, link: /autoware/control/collision_detector }
 
   - path: /autoware/control/local
     type: and
@@ -66,3 +67,8 @@ units:
     type: diag
     node: external_cmd_converter
     name: remote_control_topic_status
+
+  - path: /autoware/control/collision_detector
+    type: diag
+    node: collision_detector
+    name: collision_detect


### PR DESCRIPTION
## Description
This PR adds the collision_detector node information to the system diagnostic monitor.

## Related links
- https://github.com/autowarefoundation/autoware.universe/issues/9145
- https://github.com/autowarefoundation/autoware_launch/pull/1215

## How was this PR tested?
Could engage in PSim, and checked that the collision_detector diagnostic is disabled with `ros2 run diagnostic_graph_utils dump_node`.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
