### PR TITLE
feat(autoware_trajectory): change interface of InterpolatedArray

### DIFF
--- a/common/autoware_trajectory/examples/example_trajectory_path_point.cpp
+++ b/common/autoware_trajectory/examples/example_trajectory_path_point.cpp
@@ -86,7 +86,7 @@ int main()
     Args(crossed.pose.position.x, crossed.pose.position.y),
     Kwargs("label"_a = "Crossed on trajectory", "color"_a = "purple"));
 
-  trajectory->longitudinal_velocity_mps(*s, trajectory->length()) = 0.0;
+  trajectory->longitudinal_velocity_mps.range(s.value(), trajectory->length()).set(0.0);
 
   std::vector<double> x;
   std::vector<double> y;

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
@@ -119,7 +119,7 @@ public:
     }
 
   public:
-    auto & operator=(const T & value)
+    void set(const T & value)
     {
       std::vector<double> & bases = parent_.bases_;
       std::vector<T> & values = parent_.values_;
@@ -154,7 +154,7 @@ public:
 
       parent_.interpolator_->build(bases, values);
 
-      return *this;
+      // return *this;
     }
   };
 
@@ -164,7 +164,7 @@ public:
    * @param end End of the range.
    * @return RangeSetter object.
    */
-  Segment operator()(double start, double end)
+  Segment range(double start, double end)
   {
     if (start < this->start() || end > this->end()) {
       RCLCPP_WARN(

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -69,8 +69,8 @@ TEST_F(TrajectoryTest, compute)
 {
   double length = trajectory->length();
 
-  trajectory->longitudinal_velocity_mps(trajectory->length() / 3.0, trajectory->length()) = 10.0;
-
+  trajectory->longitudinal_velocity_mps.range(trajectory->length() / 3.0, trajectory->length())
+    .set(10.0);
   auto point = trajectory->compute(length / 2.0);
 
   EXPECT_LT(0, point.point.pose.position.x);
@@ -85,8 +85,9 @@ TEST_F(TrajectoryTest, compute)
 TEST_F(TrajectoryTest, manipulate_velocity)
 {
   trajectory->longitudinal_velocity_mps = 10.0;
-  trajectory->longitudinal_velocity_mps(trajectory->length() / 3, 2.0 * trajectory->length() / 3) =
-    5.0;
+  trajectory->longitudinal_velocity_mps
+    .range(trajectory->length() / 3, 2.0 * trajectory->length() / 3)
+    .set(5.0);
   auto point1 = trajectory->compute(0.0);
   auto point2 = trajectory->compute(trajectory->length() / 2.0);
   auto point3 = trajectory->compute(trajectory->length());
@@ -112,9 +113,8 @@ TEST_F(TrajectoryTest, curvature)
 
 TEST_F(TrajectoryTest, restore)
 {
-  using autoware::trajectory::Trajectory;  // NOLINT
-  trajectory->longitudinal_velocity_mps(4.0, trajectory->length()) = 5.0;
-
+  using autoware::trajectory::Trajectory;
+  trajectory->longitudinal_velocity_mps.range(4.0, trajectory->length()).set(5.0);
   {
     auto points = static_cast<Trajectory<geometry_msgs::msg::Point> &>(*trajectory).restore(0);
     EXPECT_EQ(10, points.size());


### PR DESCRIPTION
## Description

Change interface of InterpolatedArray.

### before

```cpp
trajectory->longitudinal_velocity_mps(3.0, 5.0) = 0.0;
```

### after

```cpp
trajectory->longitudinal_velocity_mps.range(3.0, 5.0).set(0.0);
```

## Related links

- [TIER IV Slack Link](https://star4.slack.com/archives/C03QW0GU6P7/p1731033224610229)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
