### PR TITLE
fix(lane_change): extending lane change path for multiple lane change (RT1-8427)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -606,11 +606,10 @@ std::optional<PathWithLaneId> NormalLaneChange::extendPath()
     forward_path_length) {
     return std::nullopt;
   }
-  const auto is_goal_in_target = getRouteHandler()->isInGoalRouteSection(target_lanes.back());
-
   const auto dist_to_end_of_path =
     lanelet::utils::getArcCoordinates(target_lanes, path.points.back().point.pose).length;
-  if (is_goal_in_target) {
+
+  if (common_data_ptr_->lanes_ptr->target_lane_in_goal_section) {
     const auto goal_pose = getRouteHandler()->getGoalPose();
 
     const auto dist_to_goal = lanelet::utils::getArcCoordinates(target_lanes, goal_pose).length;


### PR DESCRIPTION
## Description

Lane change path is not properly extended in multiple lane change case.
This has caused the stop point to not be inserted correctly, as shown in the following two videos.

#### Case 01

https://github.com/user-attachments/assets/d313afb5-47d7-4611-9fb9-56b1c725dbdc

#### Case 02

https://github.com/user-attachments/assets/b5adfee3-75fb-4c64-9839-16634b03f1d7

This PR aims to fix this by removing ego position check and properly extending path is there's no next lane.

#### Case 01 after PR

https://github.com/user-attachments/assets/0afca695-78db-40c4-a269-c713b05f7fc0

#### Case 02 after PR

https://github.com/user-attachments/assets/ae7cf59a-ccd1-4de3-970b-6c9c65bf3f3a

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. PSIM
2. Evaluator: TBA


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
