### PR TITLE
fix(bpp): prevent accessing nullopt

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -97,12 +97,12 @@ std::optional<double> calcDistanceToRedTrafficLight(
       }
 
       const auto & ego_pos = planner_data->self_odometry->pose.pose.position;
-      lanelet::ConstLineString3d stop_line = *(element->stopLine());
-      if (!stop_line.empty()) return std::nullopt;
-      const auto x = 0.5 * (stop_line.front().x() + stop_line.back().x());
-      const auto y = 0.5 * (stop_line.front().y() + stop_line.back().y());
-      const auto z = 0.5 * (stop_line.front().z() + stop_line.back().z());
+      const auto & stop_line = element->stopLine();
+      if (!stop_line || stop_line->empty()) return std::nullopt;
 
+      const auto x = 0.5 * (stop_line->front().x() + stop_line->back().x());
+      const auto y = 0.5 * (stop_line->front().y() + stop_line->back().y());
+      const auto z = 0.5 * (stop_line->front().z() + stop_line->back().z());
       return calcSignedArcLength(
         path.points, ego_pos, autoware::universe_utils::createPoint(x, y, z));
     }


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/9204 did not work to prevent accessing the nullopt :bow: 
This PR finally fixes it.

## Related links


**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/9204

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
We tested with real vehicle and confirmed the node didn't die in the same situation.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
