### PR TITLE
refactor(lane_change): revert "remove std::optional from lanes polygon"

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/data_structs.hpp
@@ -311,9 +311,9 @@ struct PathSafetyStatus
 
 struct LanesPolygon
 {
-  lanelet::BasicPolygon2d current;
-  lanelet::BasicPolygon2d target;
-  lanelet::BasicPolygon2d expanded_target;
+  std::optional<lanelet::BasicPolygon2d> current;
+  std::optional<lanelet::BasicPolygon2d> target;
+  std::optional<lanelet::BasicPolygon2d> expanded_target;
   lanelet::BasicPolygon2d target_neighbor;
   std::vector<lanelet::BasicPolygon2d> preceding_target;
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -140,15 +140,16 @@ std::optional<size_t> getLeadingStaticObjectIdx(
   const std::vector<ExtendedPredictedObject> & objects,
   const double object_check_min_road_shoulder_width, const double object_shiftable_ratio_threshold);
 
-lanelet::BasicPolygon2d create_polygon(
+std::optional<lanelet::BasicPolygon2d> createPolygon(
   const lanelet::ConstLanelets & lanes, const double start_dist, const double end_dist);
 
 ExtendedPredictedObject transform(
   const PredictedObject & object, const BehaviorPathPlannerParameters & common_parameters,
   const LaneChangeParameters & lane_change_parameters, const bool check_at_prepare_phase);
 
-bool is_collided_polygons_in_lanelet(
-  const std::vector<Polygon2d> & collided_polygons, const lanelet::BasicPolygon2d & lanes_polygon);
+bool isCollidedPolygonsInLanelet(
+  const std::vector<Polygon2d> & collided_polygons,
+  const std::optional<lanelet::BasicPolygon2d> & lanes_polygon);
 
 /**
  * @brief Generates expanded lanelets based on the given direction and offsets.

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -900,13 +900,12 @@ std::optional<size_t> getLeadingStaticObjectIdx(
   return leading_obj_idx;
 }
 
-lanelet::BasicPolygon2d create_polygon(
+std::optional<lanelet::BasicPolygon2d> createPolygon(
   const lanelet::ConstLanelets & lanes, const double start_dist, const double end_dist)
 {
   if (lanes.empty()) {
     return {};
   }
-
   const auto polygon_3d = lanelet::utils::getPolygonFromArcLength(lanes, start_dist, end_dist);
   return lanelet::utils::to2D(polygon_3d).basicPolygon();
 }
@@ -950,11 +949,12 @@ ExtendedPredictedObject transform(
   return extended_object;
 }
 
-bool is_collided_polygons_in_lanelet(
-  const std::vector<Polygon2d> & collided_polygons, const lanelet::BasicPolygon2d & lanes_polygon)
+bool isCollidedPolygonsInLanelet(
+  const std::vector<Polygon2d> & collided_polygons,
+  const std::optional<lanelet::BasicPolygon2d> & lanes_polygon)
 {
   const auto is_in_lanes = [&](const auto & collided_polygon) {
-    return !lanes_polygon.empty() && !boost::geometry::disjoint(collided_polygon, lanes_polygon);
+    return lanes_polygon && boost::geometry::intersects(lanes_polygon.value(), collided_polygon);
   };
 
   return std::any_of(collided_polygons.begin(), collided_polygons.end(), is_in_lanes);
@@ -1033,28 +1033,28 @@ LanesPolygon create_lanes_polygon(const CommonDataPtr & common_data_ptr)
   LanesPolygon lanes_polygon;
 
   lanes_polygon.current =
-    utils::lane_change::create_polygon(lanes->current, 0.0, std::numeric_limits<double>::max());
+    utils::lane_change::createPolygon(lanes->current, 0.0, std::numeric_limits<double>::max());
 
   lanes_polygon.target =
-    utils::lane_change::create_polygon(lanes->target, 0.0, std::numeric_limits<double>::max());
+    utils::lane_change::createPolygon(lanes->target, 0.0, std::numeric_limits<double>::max());
 
   const auto & lc_param_ptr = common_data_ptr->lc_param_ptr;
   const auto expanded_target_lanes = utils::lane_change::generateExpandedLanelets(
     lanes->target, common_data_ptr->direction, lc_param_ptr->lane_expansion_left_offset,
     lc_param_ptr->lane_expansion_right_offset);
-  lanes_polygon.expanded_target = utils::lane_change::create_polygon(
+  lanes_polygon.expanded_target = utils::lane_change::createPolygon(
     expanded_target_lanes, 0.0, std::numeric_limits<double>::max());
 
-  lanes_polygon.target_neighbor = utils::lane_change::create_polygon(
+  lanes_polygon.target_neighbor = *utils::lane_change::createPolygon(
     lanes->target_neighbor, 0.0, std::numeric_limits<double>::max());
 
   lanes_polygon.preceding_target.reserve(lanes->preceding_target.size());
   for (const auto & preceding_lane : lanes->preceding_target) {
     auto lane_polygon =
-      utils::lane_change::create_polygon(preceding_lane, 0.0, std::numeric_limits<double>::max());
+      utils::lane_change::createPolygon(preceding_lane, 0.0, std::numeric_limits<double>::max());
 
-    if (!lane_polygon.empty()) {
-      lanes_polygon.preceding_target.push_back(lane_polygon);
+    if (lane_polygon) {
+      lanes_polygon.preceding_target.push_back(*lane_polygon);
     }
   }
   return lanes_polygon;
@@ -1260,7 +1260,7 @@ bool has_blocking_target_object(
 
       // filtered_objects includes objects out of target lanes, so filter them out
       if (boost::geometry::disjoint(
-            object.initial_polygon, common_data_ptr->lanes_polygon_ptr->target)) {
+            object.initial_polygon, common_data_ptr->lanes_polygon_ptr->target.value())) {
         return false;
       }
 


### PR DESCRIPTION
Reverts autowarefoundation/autoware.universe#9267

It seems that due to the changes in autowarefoundation/autoware.universe#9267, the `autoware_behavior_path_lane_change_module` is causing build errors, which has broken `autoware.universe`. 
@zulfaqar-azmi-t4 Please address this issue. In the meantime, I have created this revert PR.

https://github.com/autowarefoundation/autoware.universe/actions/runs/11739742637/job/32704854017#step:13:30725
```
/__w/autoware.universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp: In lambda function:
/__w/autoware.universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp:1315:88: error: 'class lanelet::BasicPolygon2d' has no member named 'value'
 1315 |     return !boost::geometry::disjoint(path, common_data_ptr->lanes_polygon_ptr->target.value());
      |                                                                                        ^~~~~
/__w/autoware.universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp: In lambda function:
/__w/autoware.universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp:1322:79: error: 'class lanelet::BasicPolygon2d' has no member named 'value'
 1322 |           object.initial_polygon, common_data_ptr->lanes_polygon_ptr->current.value())) {
      |                                                                               ^~~~~
```