### PR TITLE
fix(autoware_default_adapi): change subscribing steering factor topic name for obstacle avoidance and lane changes

### DIFF
--- a/system/autoware_default_adapi/src/planning.cpp
+++ b/system/autoware_default_adapi/src/planning.cpp
@@ -89,8 +89,13 @@ PlanningNode::PlanningNode(const rclcpp::NodeOptions & options) : Node("planning
     "/planning/velocity_factors/motion_velocity_planner"};
 
   std::vector<std::string> steering_factor_topics = {
-    "/planning/steering_factor/avoidance", "/planning/steering_factor/intersection",
-    "/planning/steering_factor/lane_change", "/planning/steering_factor/start_planner",
+    "/planning/steering_factor/static_obstacle_avoidance",
+    "/planning/steering_factor/dynamic_obstacle_avoidance",
+    "/planning/steering_factor/avoidance_by_lane_change",
+    "/planning/steering_factor/intersection",
+    "/planning/steering_factor/lane_change_left",
+    "/planning/steering_factor/lane_change_right",
+    "/planning/steering_factor/start_planner",
     "/planning/steering_factor/goal_planner"};
 
   sub_velocity_factors_ =


### PR DESCRIPTION
## Description

I confirmed that several pieces of information were missing from the `/api/planning/steering_factors` topic output from this package, because while the topic names under `/planning/steering_factor/*` had been changed, the corresponding topic names in autoware_default_adapi (the receiving side) had not been updated.

This PR addresses the topic name changes.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] run simulation and confirmed lane-change,avoidance module topic is published with  `/api/planning/steering_factors`
- [x] pass [TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/a108f8c3-8643-50ef-9a1e-a0d98dfc8a01?project_id=prd_jt)

## Notes for reviewers

Although I've added some topics to subscribe to, there is information that is not yet included in the /api/planning/steering_factors topic. I believe this is an issue on the publisher's side of /planning/steering_factor/*. I plan to set up the system so that the information can be output once the publishing side addresses these topics in the future. 
If you have any concerns about this approach, please let me know your suggestions.

## Interface changes

None.

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | 
|:--------------|:----------------|:--------------|
| Removed | Sub | `/planning/steering_factor/avoidance` | 
| Removed | Sub | `/planning/steering_factor/lane_change` | 
| Added | Sub | `/planning/steering_factor/static_obstacle_avoidance` | 
| Added | Sub | `/planning/steering_factor/dynamic_obstacle_avoidance` | 
| Added | Sub | `/planning/steering_factor/avoidance_by_lane_change` | 
| Added | Sub | `/planning/steering_factor/lane_change_left` | 
| Added | Sub | `/planning/steering_factor/lane_change_right` | 


## Effects on system behavior

None.
