### PR TITLE
fix(/autoware_freespace_planning_algorithms): fix cppcheck unusedFunction

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -48,11 +48,6 @@ double calcReedsSheppDistance(const Pose & p1, const Pose & p2, double radius)
   return rs_space.distance(pose0, pose1);
 }
 
-void setYaw(geometry_msgs::msg::Quaternion * orientation, const double yaw)
-{
-  *orientation = autoware::universe_utils::createQuaternionFromYaw(yaw);
-}
-
 Pose calcRelativePose(const Pose & base_pose, const Pose & pose)
 {
   tf2::Transform tf_transform;


### PR DESCRIPTION
## Description

This is a fix based on cppcheck warning `unusedFunction`

```
planning/autoware_freespace_planning_algorithms/src/astar_search.cpp:51:0: style: The function 'setYaw' is never used. [unusedFunction]
void setYaw(geometry_msgs::msg::Quaternion * orientation, const double yaw)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
