### PR TITLE
perf(autoware_ndt_scan_matcher): remove evecs_, evals_ of Leaf for memory efficiency

### DIFF
--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
@@ -130,19 +130,12 @@ public:
       mean_(Eigen::Vector3d::Zero()),
       centroid_(),
       cov_(Eigen::Matrix3d::Identity()),
-      icov_(Eigen::Matrix3d::Zero()),
-      evecs_(Eigen::Matrix3d::Identity()),
-      evals_(Eigen::Vector3d::Zero())
+      icov_(Eigen::Matrix3d::Zero())
     {
     }
 
     Leaf(const Leaf & other)
-    : mean_(other.mean_),
-      centroid_(other.centroid_),
-      cov_(other.cov_),
-      icov_(other.icov_),
-      evecs_(other.evecs_),
-      evals_(other.evals_)
+    : mean_(other.mean_), centroid_(other.centroid_), cov_(other.cov_), icov_(other.icov_)
     {
       nr_points_ = other.nr_points_;
     }
@@ -151,9 +144,7 @@ public:
     : mean_(std::move(other.mean_)),
       centroid_(std::move(other.centroid_)),
       cov_(std::move(other.cov_)),
-      icov_(std::move(other.icov_)),
-      evecs_(std::move(other.evecs_)),
-      evals_(std::move(other.evals_))
+      icov_(std::move(other.icov_))
     {
       nr_points_ = other.nr_points_;
     }
@@ -164,8 +155,6 @@ public:
       centroid_ = other.centroid_;
       cov_ = other.cov_;
       icov_ = other.icov_;
-      evecs_ = other.evecs_;
-      evals_ = other.evals_;
       nr_points_ = other.nr_points_;
 
       return *this;
@@ -177,8 +166,6 @@ public:
       centroid_ = std::move(other.centroid_);
       cov_ = std::move(other.cov_);
       icov_ = std::move(other.icov_);
-      evecs_ = std::move(other.evecs_);
-      evals_ = std::move(other.evals_);
       nr_points_ = other.nr_points_;
 
       return *this;
@@ -204,22 +191,6 @@ public:
 
     Eigen::Vector3d & getMean() { return (mean_); }
 
-    /** \brief Get the eigen vectors of the voxel covariance.
-     * \note Order corresponds with \ref getEvals
-     * \return matrix whose columns contain eigen vectors
-     */
-    const Eigen::Matrix3d & getEvecs() const { return (evecs_); }
-
-    Eigen::Matrix3d & getEvecs() { return (evecs_); }
-
-    /** \brief Get the eigen values of the voxel covariance.
-     * \note Order corresponds with \ref getEvecs
-     * \return vector of eigen values
-     */
-    const Eigen::Vector3d & getEvals() const { return (evals_); }
-
-    Eigen::Vector3d & getEvals() { return (evals_); }
-
     /** \brief Get the number of points contained by this voxel.
      * \return number of points
      */
@@ -241,12 +212,6 @@ public:
 
     /** \brief Inverse of voxel covariance matrix */
     Eigen::Matrix3d icov_;
-
-    /** \brief Eigen vectors of voxel covariance matrix */
-    Eigen::Matrix3d evecs_;
-
-    /** \brief Eigen values of voxel covariance matrix */
-    Eigen::Vector3d evals_;
   };
 
   /** \brief Pointer to MultiVoxelGridCovariance leaf structure */

--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multi_voxel_grid_covariance_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multi_voxel_grid_covariance_omp_impl.hpp
@@ -441,7 +441,7 @@ void pclomp::MultiVoxelGridCovariance<PointT>::computeLeafParams(
   // Normalize Eigen Val such that max no more than 100x min.
   eigensolver.compute(leaf.cov_);
   Eigen::Matrix3d eigen_val = eigensolver.eigenvalues().asDiagonal();
-  leaf.evecs_ = eigensolver.eigenvectors();
+  Eigen::Matrix3d eigen_vec = eigensolver.eigenvectors();
 
   if (eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
     leaf.nr_points_ = -1;
@@ -457,9 +457,8 @@ void pclomp::MultiVoxelGridCovariance<PointT>::computeLeafParams(
       eigen_val(1, 1) = min_covar_eigvalue;
     }
 
-    leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse();
+    leaf.cov_ = eigen_vec * eigen_val * eigen_vec.inverse();
   }
-  leaf.evals_ = eigen_val.diagonal();
 
   leaf.icov_ = leaf.cov_.inverse();
   if (


### PR DESCRIPTION
## Description
By investigating the memory usage during scan matching, I found that the memory consumption was dominated by `std::vector<MultiVoxelGridCovariance<pcl::PointXYZ>::Leaf>` in addition to the map itself. 

The following figure shows the memory usage when executing autoware's `ndt_scan_matcher` with `sample-map-rosbag`. The bottom area corresponds to `std::vector<MultiVoxelGridCovariance<pcl::PointXYZ>::Leaf>` (7.9MB).
![Screenshot from 2024-10-15 18-32-27](https://github.com/user-attachments/assets/3bdac717-4d9c-4efc-a9c0-ddd651c50e6b)

The struct `Leaf` contains three `Eigen::Matrix3d`, and `sizeof(Leaf)` is 288, so having this for each voxel may consumes a lot of memory with large maps.

In this PR, I propose to remove `evecs_` (`Eigen::Matrix3d`) and `evals_` (`Eigen::Vector3d`) from `Leaf`. These variables are only used to calculate `cov_` and not be used directly. This will reduce `sizeof(Leaf)` from 288 to 192.

When tested with `sample-map-rosbag`, the memory usage of `std::vector<MultiVoxelGridCovariance<pcl::PointXYZ>::Leaf>` was reduced from 7.9MB to 5.2MB.

## Related links
- [Performance analysis of ndt_scan_matcher](https://tier4.atlassian.net/wiki/spaces/~6422e65c57f0c028e2f72804/pages/3344271035/ndt_scan_matcher#%E3%83%A1%E3%83%A2%E3%83%AA%E6%B6%88%E8%B2%BB%E9%87%8F) (TIER IV internal)

## How was this PR tested?
I did a regression test on https://github.com/tier4/ndt_omp and got the following result:
```
elapsed_milliseconds_ratio_mean=0.478 (current / reference)
The scores are perfectly the same.
OK
```
## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
