### PR TITLE
feat(mrm_handler): mrm handler publish emergecy holding

### DIFF
--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -29,9 +29,9 @@
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <tier4_system_msgs/msg/emergency_holding_state.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/msg/operation_mode_availability.hpp>
-#include <tier4_system_msgs/msg/emergency_holding_state.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
 // ROS 2 core
@@ -110,7 +110,8 @@ private:
   autoware_adapi_v1_msgs::msg::MrmState mrm_state_;
   void publishMrmState();
 
-  rclcpp::Publisher<tier4_system_msgs::msg::EmergencyHoldingState>::SharedPtr pub_emergency_holding_;
+  rclcpp::Publisher<tier4_system_msgs::msg::EmergencyHoldingState>::SharedPtr
+    pub_emergency_holding_;
   void publishEmergencyHolding();
 
   // Clients

--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -31,6 +31,7 @@
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/msg/operation_mode_availability.hpp>
+#include <tier4_system_msgs/msg/emergency_holding_state.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
 // ROS 2 core
@@ -108,6 +109,9 @@ private:
 
   autoware_adapi_v1_msgs::msg::MrmState mrm_state_;
   void publishMrmState();
+
+  rclcpp::Publisher<tier4_system_msgs::msg::EmergencyHoldingState>::SharedPtr pub_emergency_holding_;
+  void publishEmergencyHolding();
 
   // Clients
   rclcpp::CallbackGroup::SharedPtr client_mrm_pull_over_group_;

--- a/system/mrm_handler/launch/mrm_handler.launch.xml
+++ b/system/mrm_handler/launch/mrm_handler.launch.xml
@@ -12,6 +12,7 @@
   <arg name="output_gear" default="/system/emergency/gear_cmd"/>
   <arg name="output_hazard" default="/system/emergency/hazard_lights_cmd"/>
   <arg name="output_mrm_state" default="/system/fail_safe/mrm_state"/>
+  <arg name="output_emergency_holding" default="/system/emergency_holding"/>
   <arg name="output_mrm_pull_over_operate" default="/system/mrm/pull_over_manager/operate"/>
   <arg name="output_mrm_comfortable_stop_operate" default="/system/mrm/comfortable_stop/operate"/>
   <arg name="output_mrm_emergency_stop_operate" default="/system/mrm/emergency_stop/operate"/>
@@ -32,6 +33,7 @@
     <remap from="~/output/gear" to="$(var output_gear)"/>
     <remap from="~/output/hazard" to="$(var output_hazard)"/>
     <remap from="~/output/mrm/state" to="$(var output_mrm_state)"/>
+    <remap from="~/output/emergency_holding" to="$(var output_emergency_holding)"/>
     <remap from="~/output/mrm/pull_over/operate" to="$(var output_mrm_pull_over_operate)"/>
     <remap from="~/output/mrm/comfortable_stop/operate" to="$(var output_mrm_comfortable_stop_operate)"/>
     <remap from="~/output/mrm/emergency_stop/operate" to="$(var output_mrm_emergency_stop_operate)"/>

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -159,7 +159,7 @@ void MrmHandler::publishEmergencyHolding()
 {
   tier4_system_msgs::msg::EmergencyHoldingState msg;
   msg.stamp = this->now();
-  msg.holding = is_emergency_holding_;
+  msg.is_holding = is_emergency_holding_;
   pub_emergency_holding_->publish(msg);
 }
 

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -49,6 +49,8 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
     create_publisher<autoware_vehicle_msgs::msg::GearCommand>("~/output/gear", rclcpp::QoS{1});
   pub_mrm_state_ =
     create_publisher<autoware_adapi_v1_msgs::msg::MrmState>("~/output/mrm/state", rclcpp::QoS{1});
+  pub_emergency_holding_ = create_publisher<tier4_system_msgs::msg::EmergencyHoldingState>(
+    "~/output/emergency_holding", rclcpp::QoS{1});
 
   // Clients
   client_mrm_pull_over_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -151,6 +153,14 @@ void MrmHandler::publishMrmState()
 {
   mrm_state_.stamp = this->now();
   pub_mrm_state_->publish(mrm_state_);
+}
+
+void MrmHandler::publishEmergencyHolding()
+{
+  tier4_system_msgs::msg::EmergencyHoldingState msg;
+  msg.stamp = this->now();
+  msg.holding = is_emergency_holding_;
+  pub_emergency_holding_->publish(msg);
 }
 
 void MrmHandler::operateMrm()
@@ -352,6 +362,7 @@ void MrmHandler::onTimer()
   publishMrmState();
   publishHazardCmd();
   publishGearCmd();
+  publishEmergencyHolding();
 }
 
 void MrmHandler::transitionTo(const int new_state)


### PR DESCRIPTION
## Description
Originally, the emergency_holding function that the system_error_monitor had was moved to the mrm_handler. However, the mrm_handler does not publish the emergency_holding state, so the emergency_holding in the hazard_status published by the hazard_status_converter is not updated.

This PR add emergency holding publisher which is publish a value of `is_emergency_holding_` .

## Related links



**Parent Issue:**
- [CompanyName internal link](https://star4.slack.com/archives/C017VB9UG1L/p1729675438504999)

Related PR
* [x] https://github.com/autowarefoundation/autoware.universe/pull/9287
* [x] https://github.com/tier4/tier4_autoware_msgs/pull/153

## How was this PR tested?
[test/update-emergency-holding-state](https://github.com/TetsuKawa/autoware/tree/test/update-emergency-holding-state) is include This PR, https://github.com/autowarefoundation/autoware.universe/pull/9287 and https://github.com/tier4/tier4_autoware_msgs/pull/153.

[Screencast from 2024年11月11日 14時34分38秒.webm](https://github.com/user-attachments/assets/0c2874c8-a2ac-471b-a137-4cfda79cd63b)

Confirmed that `/system/emergency_hoding` is published and update `emergency_hoding` in `/system/emergency/hazard_status`.

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub| `/system/emergency_holding` | `tier4_system_msgs/msg/EmergencyHoldingState`   | indicates whether mrm is in the emergency_holding state|

## Effects on system behavior

None.
