### PR TITLE
fix(behavior_path_planner_common): use boost intersects instead of overlaps

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -604,7 +604,7 @@ std::vector<Polygon2d> get_collided_polygons(
     const double yaw_difference = autoware::universe_utils::normalizeRadian(ego_yaw - object_yaw);
     if (std::abs(yaw_difference) > yaw_difference_th) continue;
 
-    // check overlap
+    // check intersects
     if (boost::geometry::intersects(ego_polygon, obj_polygon)) {
       debug.unsafe_reason = "overlap_polygon";
       collided_polygons.push_back(obj_polygon);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -531,7 +531,7 @@ bool checkSafetyWithIntegralPredictedPolygon(
     CollisionCheckDebugPair debug_pair = createObjectDebug(object);
     for (const auto & path : object.predicted_paths) {
       for (const auto & pose_with_poly : path.path) {
-        if (boost::geometry::overlaps(ego_integral_polygon, pose_with_poly.poly)) {
+        if (boost::geometry::intersects(ego_integral_polygon, pose_with_poly.poly)) {
           debug_pair.second.ego_predicted_path = ego_predicted_path;  // raw path
           debug_pair.second.obj_predicted_path = path.path;           // raw path
           debug_pair.second.extended_obj_polygon = pose_with_poly.poly;
@@ -605,7 +605,7 @@ std::vector<Polygon2d> get_collided_polygons(
     if (std::abs(yaw_difference) > yaw_difference_th) continue;
 
     // check overlap
-    if (boost::geometry::overlaps(ego_polygon, obj_polygon)) {
+    if (boost::geometry::intersects(ego_polygon, obj_polygon)) {
       debug.unsafe_reason = "overlap_polygon";
       collided_polygons.push_back(obj_polygon);
 
@@ -658,8 +658,8 @@ std::vector<Polygon2d> get_collided_polygons(
                       : createExtendedPolygon(
                           obj_pose_with_poly, lon_offset, lat_margin, is_stopped_object, debug);
 
-    // check overlap with extended polygon
-    if (boost::geometry::overlaps(extended_ego_polygon, extended_obj_polygon)) {
+    // check intersects with extended polygon
+    if (boost::geometry::intersects(extended_ego_polygon, extended_obj_polygon)) {
       debug.unsafe_reason = "overlap_extended_polygon";
       collided_polygons.push_back(obj_polygon);
 


### PR DESCRIPTION
## Description

need to use `intersects` instead of `overlaps` to handle `whithin` case.

![image](https://github.com/user-attachments/assets/07bd6bbb-0d75-4ade-ac33-27ae85ac3f50)

https://wandbox.org/permlink/NMQ7Tb1Ya3J4TsYM

```
#include <boost/geometry.hpp>
#include <boost/geometry/geometries/polygon.hpp>
#include <iostream>

int main() {
  using Point = boost::geometry::model::d2::point_xy<double>;
  using Polygon = boost::geometry::model::polygon<Point>;

  Polygon polygonA;
  boost::geometry::append(polygonA, Point(1.0, 1.0));
  boost::geometry::append(polygonA, Point(1.0, 2.0));
  boost::geometry::append(polygonA, Point(2.0, 2.0));
  boost::geometry::append(polygonA, Point(2.0, 1.0));
  boost::geometry::append(polygonA, Point(1.0, 1.0)); // Close the polygon

  Polygon polygonB;
  boost::geometry::append(polygonB, Point(0.0, 0.0));
  boost::geometry::append(polygonB, Point(0.0, 3.0));
  boost::geometry::append(polygonB, Point(3.0, 3.0));
  boost::geometry::append(polygonB, Point(3.0, 0.0));
  boost::geometry::append(polygonB, Point(0.0, 0.0)); // Close the polygon

  bool intersects = boost::geometry::intersects(polygonA, polygonB);
  std::cout << "polygonA intersects polygonB: " << std::boolalpha << intersects
            << std::endl;

  bool within = boost::geometry::within(polygonA, polygonB);
  std::cout << "polygonA is within polygonB: " << std::boolalpha << within
            << std::endl;

  bool overlaps = boost::geometry::overlaps(polygonA, polygonB);
  std::cout << "polygonA overlaps polygonB: " << std::boolalpha << overlaps
            << std::endl;

  overlaps = boost::geometry::overlaps(polygonB, polygonA);
  std::cout << "polygonB overlaps polygonA: " << std::boolalpha << overlaps
            << std::endl;

  bool disjoint = boost::geometry::disjoint(polygonA, polygonB);
  std::cout << "polygonA disjoint polygonB: " << std::boolalpha << disjoint
            << std::endl;

  return 0;
}
```

```
polygonA intersects polygonB: true
polygonA is within polygonB: true
polygonA overlaps polygonB: false
polygonB overlaps polygonA: false
polygonA disjoint polygonB: false
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

check red polygon (cyclist first collided predicted polygon)

before

![image](https://github.com/user-attachments/assets/bc706e77-833b-4b95-a2db-be12ce7b2514)


after

![image](https://github.com/user-attachments/assets/77807c75-a0b6-4ae1-9f37-0b2895cdf515)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
