### PR TITLE
feat(autoware_test_utils): use sample_vehicle/sample_sensor_kit

### DIFF
--- a/common/autoware_test_utils/README.md
+++ b/common/autoware_test_utils/README.md
@@ -78,9 +78,11 @@ The goal of the [Autoware Planning Test Manager](https://autowarefoundation.gith
 As presented in this [PR description](https://github.com/autowarefoundation/autoware.universe/pull/9207), the user can save a snapshot of the scene to a yaml file while running Planning Simulation on the test map.
 
 ```bash
-ros2 launch autoware_test_utils psim_road_shoulder.launch.xml vehicle_model:=<vehicle-model> sensor_model:=<sensor-model>
-ros2 launch autoware_test_utils psim_intersection.launch.xml vehicle_model:=<vehicle-model> sensor_model:=<sensor-model>
+ros2 launch autoware_test_utils psim_road_shoulder.launch.xml
+ros2 launch autoware_test_utils psim_intersection.launch.xml
 ```
+
+It uses the autoware `sample_vehicle_description` and `sample_sensor_kit` by default, and `autoware_test_utils/config/test_vehicle_info.param.yaml` is exactly the same as that of `sample_vehicle_description`. If specified, `vehicle_model`/`sensor_model` argument is available.
 
 ```bash
 ros2 service call /autoware_test_utils/topic_snapshot_saver std_srvs/srv/Empty \{\}

--- a/common/autoware_test_utils/config/test_vehicle_info.param.yaml
+++ b/common/autoware_test_utils/config/test_vehicle_info.param.yaml
@@ -1,12 +1,13 @@
+# NOTE: this configuration is exactly the same as that of sample_vehicle_description
 /**:
   ros__parameters:
-    wheel_radius: 0.39
-    wheel_width: 0.42
-    wheel_base: 2.74 # between front wheel center and rear wheel center
-    wheel_tread: 1.63 # between left wheel center and right wheel center
+    wheel_radius: 0.383 # The radius of the wheel, primarily used for dead reckoning.
+    wheel_width: 0.235 # The lateral width of a wheel tire, primarily used for dead reckoning.
+    wheel_base: 2.79 # between front wheel center and rear wheel center
+    wheel_tread: 1.64 # between left wheel center and right wheel center
     front_overhang: 1.0 # between front wheel center and vehicle front
-    rear_overhang: 1.03 # between rear wheel center and vehicle rear
-    left_overhang: 0.1 # between left wheel center and vehicle left
-    right_overhang: 0.1 # between right wheel center and vehicle right
+    rear_overhang: 1.1 # between rear wheel center and vehicle rear
+    left_overhang: 0.128 # between left wheel center and vehicle left
+    right_overhang: 0.128 # between right wheel center and vehicle right
     vehicle_height: 2.5
     max_steer_angle: 0.70 # [rad]


### PR DESCRIPTION
## Description

If we specify custom vehicle_model/sensor_model in generating test yaml file, it causes confusion with the vehicle_info in autoware_test_utils in reproducing the same scene.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
