### PR TITLE
feat(goal_planner): move goal_candidates from ThreadSafeData to GoalPlannerData

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -234,6 +234,8 @@ private:
     ModuleStatus current_status;
     BehaviorModuleOutput previous_module_output;
     BehaviorModuleOutput last_previous_module_output;  //<! previous "previous_module_output"
+    GoalCandidates goal_candidates;  //<! only the positional information of goal_candidates
+
     // collision detector
     // need to be shared_ptr to be used in planner and goal searcher
     std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map;
@@ -245,7 +247,8 @@ private:
     void update(
       const GoalPlannerParameters & parameters, const PlannerData & planner_data,
       const ModuleStatus & current_status, const BehaviorModuleOutput & previous_module_output,
-      const autoware::universe_utils::LinearRing2d & vehicle_footprint);
+      const autoware::universe_utils::LinearRing2d & vehicle_footprint,
+      const GoalCandidates & goal_candidates);
 
   private:
     void initializeOccupancyGridMap(
@@ -310,6 +313,7 @@ private:
 
   // goal searcher
   std::shared_ptr<GoalSearcherBase> goal_searcher_;
+  GoalCandidates goal_candidates_{};
 
   // NOTE: this is latest occupancy_grid_map pointer which the local planner_data on
   // onFreespaceParkingTimer thread storage may point to while calculation.
@@ -410,7 +414,7 @@ private:
   // freespace parking
   bool planFreespacePath(
     std::shared_ptr<const PlannerData> planner_data,
-    const std::shared_ptr<GoalSearcherBase> goal_searcher,
+    const std::shared_ptr<GoalSearcherBase> goal_searcher, const GoalCandidates & goal_candidates,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map);
   bool canReturnToLaneParking(const PullOverContextData & context_data);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -106,7 +106,6 @@ public:
     const std::lock_guard<std::recursive_mutex> lock(mutex_);
     pull_over_path_ = nullptr;
     pull_over_path_candidates_.clear();
-    goal_candidates_.clear();
     last_path_update_time_ = std::nullopt;
     closest_start_pose_ = std::nullopt;
     prev_data_ = PathDecisionState{};
@@ -115,6 +114,7 @@ public:
   // main --> lane/freespace
   DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, static_target_objects)
   DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, dynamic_target_objects)
+
   // main --> lane
   DEFINE_SETTER_GETTER_WITH_MUTEX(PathDecisionState, prev_data)
 
@@ -125,8 +125,6 @@ public:
   // main <--> lane/freespace
   DEFINE_GETTER_WITH_MUTEX(std::shared_ptr<PullOverPath>, pull_over_path)
   DEFINE_GETTER_WITH_MUTEX(std::optional<rclcpp::Time>, last_path_update_time)
-
-  DEFINE_SETTER_GETTER_WITH_MUTEX(GoalCandidates, goal_candidates)
   DEFINE_SETTER_GETTER_WITH_MUTEX(
     utils::path_safety_checker::CollisionCheckDebugMap, collision_check)
 
@@ -144,7 +142,6 @@ private:
     last_path_update_time_ = clock_->now();
   }
 
-  void set_no_lock(const GoalCandidates & arg) { goal_candidates_ = arg; }
   void set_no_lock(const std::vector<PullOverPath> & arg) { pull_over_path_candidates_ = arg; }
   void set_no_lock(const std::shared_ptr<PullOverPath> & arg) { set_pull_over_path_no_lock(arg); }
   void set_no_lock(const PullOverPath & arg) { set_pull_over_path_no_lock(arg); }
@@ -155,7 +152,6 @@ private:
 
   std::shared_ptr<PullOverPath> pull_over_path_{nullptr};
   std::vector<PullOverPath> pull_over_path_candidates_;
-  GoalCandidates goal_candidates_{};
   std::optional<rclcpp::Time> last_path_update_time_;
   std::optional<Pose> closest_start_pose_{};
   utils::path_safety_checker::CollisionCheckDebugMap collision_check_{};


### PR DESCRIPTION
## Description

depends https://github.com/autowarefoundation/autoware.universe/pull/9270 ,the diff is below

https://github.com/tier4/autoware.universe/compare/tier4:autoware.universe:refactor/goal-candidate...refactor/goal-candidate2

once goal_candidates are generated at main thread, they remain at the same positions, and only safety information is updated, keeping the same number. so GoalPlannerModule owns the goal_candidate and set it once to GoalPlannerData.
- main-thread --> GoalPlannerData

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/40474d60-717f-50c7-be4a-680a0e13b906?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
